### PR TITLE
feat: add homescreen icon support

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -9,6 +9,16 @@ export const metadata: Metadata = {
   metadataBase: new URL(SITE_URL),
   title: siteContent.metadata.title,
   description: siteContent.metadata.description,
+  icons: {
+    icon: [
+      { url: "/favicon-16x16.png", sizes: "16x16", type: "image/png" },
+      { url: "/favicon-32x32.png", sizes: "32x32", type: "image/png" },
+      { url: "/favicon-96x96.png", sizes: "96x96", type: "image/png" },
+    ],
+    apple: [
+      { url: "/apple-icon-180x180.png", sizes: "180x180", type: "image/png" },
+    ],
+  },
   openGraph: {
     title: siteContent.metadata.title,
     description: siteContent.metadata.description,

--- a/app/manifest.ts
+++ b/app/manifest.ts
@@ -1,0 +1,27 @@
+import type { MetadataRoute } from "next";
+
+export default function manifest(): MetadataRoute.Manifest {
+  return {
+    name: "기강",
+    short_name: "기강",
+    description:
+      "운동을 좋아하는 사람들이 모여 만든 스포츠 팀. 러닝, 자전거, 수영, 여행을 함께합니다.",
+    start_url: "/",
+    display: "standalone",
+    background_color: "#ffffff",
+    theme_color: "#000000",
+    icons: [
+      { src: "/android-icon-36x36.png", sizes: "36x36", type: "image/png" },
+      { src: "/android-icon-48x48.png", sizes: "48x48", type: "image/png" },
+      { src: "/android-icon-72x72.png", sizes: "72x72", type: "image/png" },
+      { src: "/android-icon-96x96.png", sizes: "96x96", type: "image/png" },
+      { src: "/android-icon-144x144.png", sizes: "144x144", type: "image/png" },
+      {
+        src: "/android-icon-192x192.png",
+        sizes: "192x192",
+        type: "image/png",
+      },
+      { src: "/ms-icon-310x310.png", sizes: "310x310", type: "image/png" },
+    ],
+  };
+}


### PR DESCRIPTION
## Summary
- `app/manifest.ts` 추가: Android 홈 화면 추가 시 기강 로고 아이콘 + 이름 표시
- `app/layout.tsx` icons 메타데이터 추가: iOS Safari 홈 화면 추가 시 apple-touch-icon 설정
- `proxy.ts` middleware matcher에 `manifest.webmanifest` 제외 추가 (미인증 상태에서도 manifest 접근 가능)

## Test plan
- [ ] Android Chrome → 메뉴 → "홈 화면에 추가" → 기강 로고 아이콘 확인
- [ ] iOS Safari → 공유 → "홈 화면에 추가" → 기강 로고 아이콘 확인