### PR TITLE
feat: reorganize records into category tabs

### DIFF
--- a/app/(main)/records/page.tsx
+++ b/app/(main)/records/page.tsx
@@ -8,11 +8,13 @@ const supabase = createClient(
   process.env.NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY!,
 );
 
-const TIME_EVENT_TYPES = [
-  { value: "5K", label: "5K" },
+const MARATHON_EVENTS = [
   { value: "10K", label: "10K" },
   { value: "HALF", label: "하프마라톤" },
   { value: "FULL", label: "풀마라톤" },
+] as const;
+
+const NO_GENDER_EVENTS = [
   { value: "TRIATHLON", label: "철인3종" },
 ] as const;
 
@@ -40,67 +42,69 @@ async function RecordsContent() {
       ),
   ]);
 
-  // Build time-based rankings
-  const timeEvents = TIME_EVENT_TYPES.map((evt) => {
-    const rows = (pbData ?? [])
-      .filter((r) => r.event_type === evt.value)
-      .map((r) => {
-        const member = r.member as unknown as {
-          full_name: string;
-          gender: string;
-        };
-        return {
-          name: member.full_name,
-          gender: member.gender,
-          record: secondsToTimeString(r.record_time_sec),
-          raceName: r.race_name,
-          sortKey: r.record_time_sec,
-        };
+  function buildRows(eventTypes: readonly { value: string; label: string }[]) {
+    return eventTypes.map((evt) => {
+      const rows = (pbData ?? [])
+        .filter((r) => r.event_type === evt.value)
+        .map((r) => {
+          const member = r.member as unknown as {
+            full_name: string;
+            gender: string;
+          };
+          return {
+            name: member.full_name,
+            gender: member.gender,
+            record: secondsToTimeString(r.record_time_sec),
+            raceName: r.race_name,
+            sortKey: r.record_time_sec,
+          };
+        });
+
+      const toEntry = (r: (typeof rows)[number], i: number) => ({
+        rank: i + 1,
+        name: r.name,
+        record: r.record,
+        raceName: r.raceName,
+        utmbProfileUrl: null,
       });
 
-    const male = rows
-      .filter((r) => r.gender === "male")
-      .sort((a, b) => a.sortKey - b.sortKey)
-      .slice(0, 10)
-      .map((r, i) => ({
-        rank: i + 1,
-        name: r.name,
-        record: r.record,
-        raceName: r.raceName,
-        utmbProfileUrl: null,
-      }));
+      return {
+        eventType: evt.value,
+        label: evt.label,
+        male: rows
+          .filter((r) => r.gender === "male")
+          .sort((a, b) => a.sortKey - b.sortKey)
+          .slice(0, 10)
+          .map(toEntry),
+        female: rows
+          .filter((r) => r.gender === "female")
+          .sort((a, b) => a.sortKey - b.sortKey)
+          .slice(0, 10)
+          .map(toEntry),
+        all: rows
+          .sort((a, b) => a.sortKey - b.sortKey)
+          .slice(0, 10)
+          .map(toEntry),
+      };
+    });
+  }
 
-    const female = rows
-      .filter((r) => r.gender === "female")
-      .sort((a, b) => a.sortKey - b.sortKey)
-      .slice(0, 10)
-      .map((r, i) => ({
-        rank: i + 1,
-        name: r.name,
-        record: r.record,
-        raceName: r.raceName,
-        utmbProfileUrl: null,
-      }));
-
-    return { eventType: evt.value, label: evt.label, male, female };
-  });
+  const marathonEvents = buildRows(MARATHON_EVENTS);
+  const noGenderEvents = buildRows(NO_GENDER_EVENTS);
 
   // Build UTMB rankings
-  const utmbRows = (utmbData ?? []).map((r) => {
-    const member = r.member as unknown as {
-      full_name: string;
-      gender: string;
-    };
-    return {
-      name: member.full_name,
-      gender: member.gender,
-      index: r.utmb_index,
-      url: r.utmb_profile_url,
-    };
-  });
-
-  const utmbMale = utmbRows
-    .filter((r) => r.gender === "male")
+  const utmbAll = (utmbData ?? [])
+    .map((r) => {
+      const member = r.member as unknown as {
+        full_name: string;
+        gender: string;
+      };
+      return {
+        name: member.full_name,
+        index: r.utmb_index,
+        url: r.utmb_profile_url,
+      };
+    })
     .sort((a, b) => b.index - a.index)
     .slice(0, 10)
     .map((r, i) => ({
@@ -111,29 +115,38 @@ async function RecordsContent() {
       utmbProfileUrl: r.url,
     }));
 
-  const utmbFemale = utmbRows
-    .filter((r) => r.gender === "female")
-    .sort((a, b) => b.index - a.index)
-    .slice(0, 10)
-    .map((r, i) => ({
-      rank: i + 1,
-      name: r.name,
-      record: String(r.index),
-      raceName: null,
-      utmbProfileUrl: r.url,
-    }));
+  const serialized = {
+    categories: [
+      {
+        key: "marathon",
+        label: "마라톤",
+        hasGender: true,
+        events: marathonEvents,
+      },
+      {
+        key: "triathlon",
+        label: "철인3종",
+        hasGender: false,
+        events: noGenderEvents,
+      },
+      {
+        key: "trail",
+        label: "트레일러닝",
+        hasGender: false,
+        events: [
+          {
+            eventType: "UTMB",
+            label: "UTMB Index",
+            male: [],
+            female: [],
+            all: utmbAll,
+          },
+        ],
+      },
+    ],
+  };
 
-  const serialized = [
-    ...timeEvents,
-    {
-      eventType: "UTMB",
-      label: "UTMB Index",
-      male: utmbMale,
-      female: utmbFemale,
-    },
-  ];
-
-  return <RecordsClient data={serialized} />;
+  return <RecordsClient data={serialized.categories} />;
 }
 
 function RecordsSkeleton() {

--- a/app/(main)/records/records-client.tsx
+++ b/app/(main)/records/records-client.tsx
@@ -16,6 +16,14 @@ type EventData = {
   label: string;
   male: RankingEntry[];
   female: RankingEntry[];
+  all: RankingEntry[];
+};
+
+type Category = {
+  key: string;
+  label: string;
+  hasGender: boolean;
+  events: EventData[];
 };
 
 function MedalBadge({ rank }: { rank: number }) {
@@ -36,67 +44,110 @@ function MedalBadge({ rank }: { rank: number }) {
   );
 }
 
-export function RecordsClient({ data }: { data: EventData[] }) {
+export function RecordsClient({ data }: { data: Category[] }) {
+  const [selectedCategory, setSelectedCategory] = useState(
+    data[0]?.key ?? "marathon",
+  );
   const [selectedEvent, setSelectedEvent] = useState(
-    data[0]?.eventType ?? "5K",
+    data[0]?.events[0]?.eventType ?? "10K",
   );
   const [selectedGender, setSelectedGender] = useState<"male" | "female">(
     "male",
   );
 
-  const current = data.find((d) => d.eventType === selectedEvent);
-  const entries =
-    selectedGender === "male" ? current?.male : current?.female;
+  const category = data.find((c) => c.key === selectedCategory);
+  const currentEvent = category?.events.find(
+    (e) => e.eventType === selectedEvent,
+  );
+
+  const entries = category?.hasGender
+    ? selectedGender === "male"
+      ? currentEvent?.male
+      : currentEvent?.female
+    : currentEvent?.all;
+
   const isUtmb = selectedEvent === "UTMB";
+
+  function handleCategoryChange(key: string) {
+    setSelectedCategory(key);
+    const cat = data.find((c) => c.key === key);
+    if (cat?.events[0]) {
+      setSelectedEvent(cat.events[0].eventType);
+    }
+    setSelectedGender("male");
+  }
 
   return (
     <div className="flex flex-col gap-4">
-      {/* Distance Filter Pills */}
-      <div className="flex flex-wrap gap-2 px-6">
-        {data.map((evt) => (
+      {/* Category Tabs */}
+      <div className="flex gap-2 px-6">
+        {data.map((cat) => (
           <button
-            key={evt.eventType}
+            key={cat.key}
             type="button"
-            onClick={() => setSelectedEvent(evt.eventType)}
+            onClick={() => handleCategoryChange(cat.key)}
             className={cn(
               "rounded-full px-4 py-2 text-[13px] font-medium transition-colors",
-              selectedEvent === evt.eventType
+              selectedCategory === cat.key
                 ? "bg-foreground text-background"
                 : "border-[1.5px] border-border text-muted-foreground",
             )}
           >
-            {evt.label}
+            {cat.label}
           </button>
         ))}
       </div>
 
-      {/* Gender Tabs */}
-      <div className="flex items-center gap-0 px-6 py-2">
-        <button
-          type="button"
-          onClick={() => setSelectedGender("male")}
-          className={cn(
-            "flex-1 rounded-lg py-2 text-sm font-medium transition-colors",
-            selectedGender === "male"
-              ? "bg-foreground text-background"
-              : "text-muted-foreground",
-          )}
-        >
-          남성
-        </button>
-        <button
-          type="button"
-          onClick={() => setSelectedGender("female")}
-          className={cn(
-            "flex-1 rounded-lg py-2 text-sm font-medium transition-colors",
-            selectedGender === "female"
-              ? "bg-foreground text-background"
-              : "text-muted-foreground",
-          )}
-        >
-          여성
-        </button>
-      </div>
+      {/* Event Sub-tabs (only if category has multiple events) */}
+      {category && category.events.length > 1 && (
+        <div className="flex gap-2 px-6">
+          {category.events.map((evt) => (
+            <button
+              key={evt.eventType}
+              type="button"
+              onClick={() => setSelectedEvent(evt.eventType)}
+              className={cn(
+                "rounded-full px-3 py-1.5 text-xs font-medium transition-colors",
+                selectedEvent === evt.eventType
+                  ? "bg-muted-foreground/20 text-foreground"
+                  : "text-muted-foreground",
+              )}
+            >
+              {evt.label}
+            </button>
+          ))}
+        </div>
+      )}
+
+      {/* Gender Tabs (only for categories with gender) */}
+      {category?.hasGender && (
+        <div className="flex items-center gap-0 px-6 py-2">
+          <button
+            type="button"
+            onClick={() => setSelectedGender("male")}
+            className={cn(
+              "flex-1 rounded-lg py-2 text-sm font-medium transition-colors",
+              selectedGender === "male"
+                ? "bg-foreground text-background"
+                : "text-muted-foreground",
+            )}
+          >
+            남성
+          </button>
+          <button
+            type="button"
+            onClick={() => setSelectedGender("female")}
+            className={cn(
+              "flex-1 rounded-lg py-2 text-sm font-medium transition-colors",
+              selectedGender === "female"
+                ? "bg-foreground text-background"
+                : "text-muted-foreground",
+            )}
+          >
+            여성
+          </button>
+        </div>
+      )}
 
       {/* Rank List */}
       <div className="flex flex-col px-6 pt-2">
@@ -106,7 +157,6 @@ export function RecordsClient({ data }: { data: EventData[] }) {
               key={`${entry.rank}-${entry.name}`}
               className="flex items-center gap-4 border-b border-border py-4 last:border-b-0"
             >
-              {/* Medal or Number */}
               {entry.rank <= 3 ? (
                 <MedalBadge rank={entry.rank} />
               ) : (
@@ -115,7 +165,6 @@ export function RecordsClient({ data }: { data: EventData[] }) {
                 </span>
               )}
 
-              {/* Info */}
               <div className="flex min-w-0 flex-1 flex-col gap-0.5">
                 <span className="text-[15px] font-semibold text-foreground">
                   {entry.name}
@@ -140,7 +189,6 @@ export function RecordsClient({ data }: { data: EventData[] }) {
                 )}
               </div>
 
-              {/* Time */}
               <span
                 className={cn(
                   "shrink-0 font-mono text-lg font-bold",


### PR DESCRIPTION
## Summary
- 5K 종목 제거
- 카테고리 탭 구성: 마라톤(10K/하프/풀) | 철인3종 | 트레일러닝(UTMB)
- 마라톤만 남녀 구분, 나머지는 통합 랭킹

## Test plan
- [ ] 마라톤 탭: 10K/하프/풀 서브탭 + 남성/여성 전환 확인
- [ ] 철인3종 탭: 성별 탭 없이 통합 랭킹 표시 확인
- [ ] 트레일러닝 탭: UTMB Index 통합 랭킹 표시 확인