### PR TITLE
feat: race_result 테이블 + PB View 전환

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,8 @@ next-env.d.ts
 
 # claude code
 .claude/settings.local.json
+
+# python (uv)
+.venv/
+__pycache__/
+*.pyc

--- a/app/(main)/page.tsx
+++ b/app/(main)/page.tsx
@@ -41,7 +41,7 @@ async function HomeContent() {
       .select("*", { count: "exact", head: true })
       .gte("start_date", today),
     supabase
-      .from("personal_best")
+      .from("personal_best_view")
       .select(
         "event_type, record_time_sec, race_name, updated_at, member:member_id(full_name)",
       )

--- a/app/(main)/records/page.tsx
+++ b/app/(main)/records/page.tsx
@@ -31,7 +31,7 @@ function secondsToTimeString(totalSeconds: number): string {
 async function RecordsContent() {
   const [{ data: pbData }, { data: utmbData }] = await Promise.all([
     supabase
-      .from("personal_best")
+      .from("personal_best_view")
       .select(
         "event_type, record_time_sec, race_name, member:member_id(full_name, gender)",
       ),

--- a/supabase/migrations/20260307120000_create_race_result.sql
+++ b/supabase/migrations/20260307120000_create_race_result.sql
@@ -1,0 +1,47 @@
+-- race_result: 모든 대회 기록을 저장하는 테이블
+create table public.race_result (
+  id uuid primary key default gen_random_uuid(),
+  member_id uuid not null references public.member(id) on delete cascade,
+  event_type varchar not null,
+  record_time_sec integer not null,
+  race_name varchar not null,
+  race_date date not null,
+  created_at timestamptz not null default now()
+);
+
+-- 성능용 복합 인덱스
+create index race_result_member_event on public.race_result(member_id, event_type);
+
+-- RLS 활성화
+alter table public.race_result enable row level security;
+
+-- 누구나 조회 가능 (anon + authenticated)
+create policy "anyone_select" on public.race_result
+  for select using (true);
+
+-- 로그인한 사용자: 본인 데이터 삽입
+create policy "own_insert" on public.race_result
+  for insert to authenticated
+  with check (member_id = auth.uid());
+
+-- 로그인한 사용자: 본인 데이터 수정
+create policy "own_update" on public.race_result
+  for update to authenticated
+  using (member_id = auth.uid())
+  with check (member_id = auth.uid());
+
+-- 로그인한 사용자: 본인 데이터 삭제
+create policy "own_delete" on public.race_result
+  for delete to authenticated
+  using (member_id = auth.uid());
+
+-- 종목별 개인 최고기록 View (기강의전당용)
+create view public.personal_best_view as
+select distinct on (member_id, event_type)
+  member_id,
+  event_type,
+  record_time_sec,
+  race_name,
+  race_date
+from public.race_result
+order by member_id, event_type, record_time_sec asc;


### PR DESCRIPTION
## Summary
- `race_result` 테이블 생성 (모든 대회 기록 저장)
- `personal_best_view` View 생성 (종목별 최고기록 자동 추출)
- 기강의전당, 홈페이지 쿼리를 `personal_best` → `personal_best_view`로 변경
- 엑셀에서 매칭된 109건 데이터 DB에 업로드 완료

## 변경 파일
- `supabase/migrations/20260307120000_create_race_result.sql` - 테이블/인덱스/RLS/View
- `app/(main)/records/page.tsx` - 쿼리 소스 변경
- `app/(main)/page.tsx` - RECENT RECORDS 쿼리 소스 변경
- `.gitignore` - Python 관련 항목 추가

## Test plan
- [ ] 기강의전당 페이지에서 랭킹 정상 표시 확인
- [ ] 홈 페이지 RECENT RECORDS 정상 표시 확인
- [ ] race_result 테이블에 109건 데이터 확인