### PR TITLE
fix: 참가 신청/취소 시 기강대회 목록 실시간 갱신

### DIFF
--- a/components/races/race-list-view.tsx
+++ b/components/races/race-list-view.tsx
@@ -121,6 +121,7 @@ export function RaceListView({
       .select("id, competition_id, member_id, role, event_type, created_at").single();
     if (error) return { ok: false as const, message: "신청에 실패했습니다." };
     setRegistrationsByCompetitionId(prev => ({ ...prev, [competitionId]: data as CompetitionRegistration }));
+    setRegCounts(prev => ({ ...prev, [competitionId]: (prev[competitionId] ?? 0) + 1 }));
     return { ok: true as const, message: "참가 신청 완료" };
   };
 
@@ -139,6 +140,13 @@ export function RaceListView({
     const { error } = await supabase.from("competition_registration").delete().eq("id", registrationId);
     if (error) return { ok: false as const, message: "취소에 실패했습니다." };
     setRegistrationsByCompetitionId(prev => { const next = { ...prev }; delete next[competitionId]; return next; });
+    const newCount = (regCounts[competitionId] ?? 1) - 1;
+    setRegCounts(prev => ({ ...prev, [competitionId]: newCount }));
+    // 마지막 참가자가 취소하면 기강대회 목록 갱신
+    if (newCount <= 0) {
+      await revalidateCompetitions();
+      window.location.reload();
+    }
     return { ok: true as const, message: "취소 완료" };
   };
 


### PR DESCRIPTION
## Summary
- 참가 신청/취소 시 `regCounts` 상태를 실시간 갱신하여 "N명 참여" 표시 즉시 반영
- 마지막 참가자가 취소하면 `revalidateCompetitions()` 호출 후 페이지 새로고침하여 기강대회 탭에서 자동 제거

## Test plan
- [ ] 대회에 참가 신청 후 참여 인원 수가 즉시 반영되는지 확인
- [ ] 마지막 참가자가 취소 시 기강대회 탭에서 해당 대회가 사라지는지 확인