### PR TITLE
feat: 프로필 사진 지원 및 날짜 입력 연도 제한

### DIFF
--- a/app/(info)/profile/edit/page.tsx
+++ b/app/(info)/profile/edit/page.tsx
@@ -155,6 +155,7 @@ export default function ProfileEditPage() {
         <label className="text-sm font-medium text-foreground">생년월일</label>
         <Input
           type="date"
+          max="9999-12-31"
           value={profile.birthday}
           onChange={(e) =>
             setProfile({ ...profile, birthday: e.target.value })

--- a/app/(main)/profile/page.tsx
+++ b/app/(main)/profile/page.tsx
@@ -24,7 +24,7 @@ async function ProfileContent() {
   const { data: member } = await supabase
     .from("member")
     .select(
-      "id, full_name, gender, birthday, phone, email, bank_name, bank_account, joined_at, status",
+      "id, full_name, gender, birthday, phone, email, bank_name, bank_account, joined_at, status, avatar_url",
     )
     .or(`kakao_user_id.eq.${user.id},google_user_id.eq.${user.id}`)
     .maybeSingle();
@@ -71,9 +71,18 @@ async function ProfileContent() {
     <div className="flex flex-col gap-6 px-6 pb-6">
         {/* Profile Card */}
         <div className="flex items-center gap-4 rounded-2xl border-[1.5px] border-border p-5">
-          <div className="flex size-16 shrink-0 items-center justify-center rounded-full bg-primary/10">
-            <User className="size-7 text-primary" />
-          </div>
+          {member.avatar_url ? (
+            <img
+              src={member.avatar_url}
+              alt={member.full_name}
+              className="size-16 shrink-0 rounded-full object-cover"
+              referrerPolicy="no-referrer"
+            />
+          ) : (
+            <div className="flex size-16 shrink-0 items-center justify-center rounded-full bg-primary/10">
+              <User className="size-7 text-primary" />
+            </div>
+          )}
           <div className="flex min-w-0 flex-1 flex-col gap-1">
             <span className="text-[17px] font-bold text-foreground">
               {member.full_name}

--- a/app/(protected)/onboarding/page.tsx
+++ b/app/(protected)/onboarding/page.tsx
@@ -43,6 +43,12 @@ async function OnboardingContent({
     user.user_metadata?.nickname ??
     "";
 
+  // OAuth 프로필 사진 URL 추출 (카카오: avatar_url/picture, 구글: picture/avatar_url)
+  const initialAvatarUrl =
+    user.user_metadata?.picture ??
+    user.user_metadata?.avatar_url ??
+    null;
+
   return (
     <div className="flex min-h-svh w-full items-center justify-center bg-white px-6">
       <div className="w-full max-w-sm">
@@ -51,6 +57,7 @@ async function OnboardingContent({
           provider={user.app_metadata?.provider as "kakao" | "google"}
           email={user.email}
           initialFullName={initialFullName}
+          initialAvatarUrl={initialAvatarUrl}
         />
       </div>
     </div>

--- a/components/auth/member-onboarding-form.tsx
+++ b/components/auth/member-onboarding-form.tsx
@@ -37,6 +37,7 @@ type MemberOnboardingFormProps = {
   provider: "kakao" | "google";
   initialFullName?: string | null;
   email?: string | null;
+  initialAvatarUrl?: string | null;
 };
 
 type MemberOnboardingValues = {
@@ -55,6 +56,7 @@ export function MemberOnboardingForm({
   provider,
   initialFullName,
   email,
+  initialAvatarUrl,
 }: MemberOnboardingFormProps) {
   const router = useRouter();
   const searchParams = useSearchParams();
@@ -95,9 +97,15 @@ export function MemberOnboardingForm({
     setRejoinLoading(true);
     const supabase = createClient();
     const column = provider === "kakao" ? "kakao_user_id" : "google_user_id";
+    const updateFields: Record<string, unknown> = {
+      status: "pending",
+      [column]: userId,
+      updated_at: new Date().toISOString(),
+    };
+    if (initialAvatarUrl) updateFields.avatar_url = initialAvatarUrl;
     const { error } = await supabase
       .from("member")
-      .update({ status: "pending", [column]: userId, updated_at: new Date().toISOString() })
+      .update(updateFields)
       .eq("id", inactiveMemberId);
     setRejoinLoading(false);
     if (error) {
@@ -155,9 +163,12 @@ export function MemberOnboardingForm({
       }
 
       const column = provider === "kakao" ? "kakao_user_id" : "google_user_id";
+      // 기존 회원 연동 시 avatar_url이 없으면 OAuth 프로필 사진 저장
+      const linkFields: Record<string, unknown> = { [column]: userId };
+      if (initialAvatarUrl) linkFields.avatar_url = initialAvatarUrl;
       const { error: linkError } = await supabase
         .from("member")
-        .update({ [column]: userId })
+        .update(linkFields)
         .eq("id", existingMember.id);
 
       if (linkError) {
@@ -203,6 +214,7 @@ export function MemberOnboardingForm({
       status: "active",
       admin: false,
       joined_at: new Date().toISOString().slice(0, 10),
+      avatar_url: initialAvatarUrl,
     });
 
     if (error) {
@@ -390,7 +402,7 @@ export function MemberOnboardingForm({
                         <FormItem>
                           <FormLabel>생년월일</FormLabel>
                           <FormControl>
-                        <Input type="date" {...field} />
+                        <Input type="date" max="9999-12-31" {...field} />
                           </FormControl>
                           <FormMessage />
                         </FormItem>

--- a/components/profile/race-record-dialog.tsx
+++ b/components/profile/race-record-dialog.tsx
@@ -362,6 +362,7 @@ export function RaceRecordDialog({
                   <label className="text-sm font-medium">대회 날짜</label>
                   <Input
                     type="date"
+                    max="9999-12-31"
                     value={manualDate}
                     onChange={(e) => setManualDate(e.target.value)}
                   />

--- a/components/races/competition-detail-dialog.tsx
+++ b/components/races/competition-detail-dialog.tsx
@@ -259,11 +259,11 @@ export function CompetitionDetailDialog({
             </div>
             <div className="flex flex-col gap-1.5">
               <Label>시작일</Label>
-              <Input type="date" value={editStartDate} onChange={e => setEditStartDate(e.target.value)} />
+              <Input type="date" max="9999-12-31" value={editStartDate} onChange={e => setEditStartDate(e.target.value)} />
             </div>
             <div className="flex flex-col gap-1.5">
               <Label>종료일</Label>
-              <Input type="date" value={editEndDate} onChange={e => setEditEndDate(e.target.value)} />
+              <Input type="date" max="9999-12-31" value={editEndDate} onChange={e => setEditEndDate(e.target.value)} />
             </div>
             <div className="flex flex-col gap-1.5">
               <Label>장소</Label>

--- a/components/races/competition-register-dialog.tsx
+++ b/components/races/competition-register-dialog.tsx
@@ -175,6 +175,7 @@ export function CompetitionRegisterDialog({
               <Input
                 id="comp-start"
                 type="date"
+                max="9999-12-31"
                 value={startDate}
                 onChange={e => setStartDate(e.target.value)}
               />
@@ -184,6 +185,7 @@ export function CompetitionRegisterDialog({
               <Input
                 id="comp-end"
                 type="date"
+                max="9999-12-31"
                 value={endDate}
                 onChange={e => setEndDate(e.target.value)}
               />


### PR DESCRIPTION
## Summary
- member 테이블에 avatar_url 컬럼 추가 (DB 반영 완료)
- 카카오/구글 OAuth 로그인 시 프로필 사진 URL 자동 저장 (신규가입, 기존회원 연동, 재가입 모두 대응)
- 프로필 페이지에서 프로필 사진 표시 (없으면 기본 User 아이콘 유지)
- 모든 date input에 max="9999-12-31" 추가하여 연도 6자리 입력 방지 (7개소)

## Test plan
- [ ] 카카오 로그인 후 프로필 페이지에서 프로필 사진 표시 확인
- [ ] 구글 로그인 후 프로필 사진 표시 확인
- [ ] 신규 회원가입 시 avatar_url 저장 확인
- [ ] 모든 날짜 입력 필드에서 연도 4자리 제한 확인