### PR TITLE
feat: 인앱브라우저 감지 및 외부 브라우저 유도

### DIFF
--- a/.claude/commands/sync-member-records.md
+++ b/.claude/commands/sync-member-records.md
@@ -1,0 +1,66 @@
+# 신규 회원 기록 동기화
+
+신규 가입 회원의 대회 기록(race_result)과 대회 참가 등록(competition_registration)을 temp 파일 기반으로 DB에 동기화합니다.
+
+## 절차
+
+### 1단계: 데이터 소스 읽기
+- `temp/기강의전당 - 마라톤-인증시트.csv` 읽기 (대회 기록)
+- `temp/대회참여현황.txt` 읽기 (대회 참가 등록)
+
+### 2단계: 회원 목록 조회
+DB에서 active 회원 전체 조회:
+```sql
+SELECT id, full_name, joined_at FROM member WHERE status = 'active' ORDER BY joined_at DESC
+```
+
+### 3단계: 매칭 및 분석
+각 회원의 full_name을 기준으로:
+
+**인증시트(CSV)에서 매칭:**
+- CSV의 "이름" 컬럼과 member.full_name 매칭
+- 동명이인 주의 (예: 김소연(네이비), 김소연(블루) 등 괄호 표기 확인)
+- 매칭된 기록의 race_date, race_name, event_type, record_time_sec 추출
+
+**참여현황(TXT)에서 매칭:**
+- 이름의 마지막 2글자(또는 고유한 부분)로 매칭
+- 대회명 → competition 테이블에서 competition_id 조회
+- event_type (Full, Half, 10K 등) 매핑
+
+### 4단계: 중복 확인
+이미 DB에 있는 기록과 비교:
+```sql
+SELECT race_name, race_date, event_type FROM race_result WHERE member_id = '{id}'
+SELECT competition_id, event_type FROM competition_registration WHERE member_id = '{id}'
+```
+
+### 5단계: INSERT 실행
+중복이 아닌 것만 INSERT. 각 INSERT 전에 내용을 사용자에게 보여주고 확인 받기.
+
+## 기록 변환 규칙
+
+**record_time_sec 계산:**
+- "HH:MM:SS" → H*3600 + M*60 + S
+- "050900" 같은 6자리 → 05:09:00으로 해석
+
+**event_type 매핑:**
+- FULL, HALF, 10K, 5K → 그대로
+- 트레일러닝 → TRAIL
+- 올림픽 (철인3종) → TRIATHLON_OLYMPIC
+- 1K TT → 1K_TT
+- 32K → 32K
+- 종목이 불명확하면 사용자에게 확인
+
+**참여현황 event_type 매핑:**
+- Full → FULL
+- Half → HALF
+- 10K → 10K
+- 100K, 50K, 37K → 그대로
+- ★ (아이언맨) → 별도 확인
+
+## 주의사항
+- 동명이인이 있으면 사용자에게 확인
+- 매칭 불확실한 이름은 건너뛰기
+- 기존에 이미 들어간 기록은 중복 INSERT 하지 않기
+- 참여현황의 대회가 competition 테이블에 없으면 건너뛰기 (신규 대회 등록은 별도)
+- CSV에서 타임스탬프/성별은 참고용, 핵심은 이름/대회명/기록/날짜/종목

--- a/app/(info)/newbie/page.tsx
+++ b/app/(info)/newbie/page.tsx
@@ -1,4 +1,5 @@
 import Link from "next/link";
+import { InAppBrowserGate } from "@/components/in-app-browser-gate";
 
 /* ─── 토글 섹션 데이터 ─── */
 
@@ -108,6 +109,7 @@ function Toggle({
 
 export default function NewbiePage() {
   return (
+    <InAppBrowserGate>
     <div className="mx-auto max-w-xl pb-28">
       {/* 1. 히어로 */}
       <section className="border-b border-border bg-white px-6 pb-9 pt-12 text-center">
@@ -358,5 +360,6 @@ export default function NewbiePage() {
         </div>
       </div>
     </div>
+    </InAppBrowserGate>
   );
 }

--- a/components/in-app-browser-gate.tsx
+++ b/components/in-app-browser-gate.tsx
@@ -1,0 +1,122 @@
+"use client";
+
+import { useEffect, useState } from "react";
+
+type InAppEnv = "kakao" | "line" | "instagram" | "facebook" | "other" | null;
+
+function detectInAppBrowser(): InAppEnv {
+  if (typeof window === "undefined") return null;
+  const ua = navigator.userAgent.toLowerCase();
+  if (ua.includes("kakaotalk")) return "kakao";
+  if (ua.includes("line/")) return "line";
+  if (ua.includes("instagram")) return "instagram";
+  if (ua.includes("fban") || ua.includes("fbav")) return "facebook";
+  // 일반적인 인앱 브라우저 감지 (WebView 힌트)
+  if (/wv\)/.test(ua) && !ua.includes("chrome")) return "other";
+  return null;
+}
+
+function isIOS(): boolean {
+  if (typeof window === "undefined") return false;
+  return /iphone|ipad|ipod/i.test(navigator.userAgent);
+}
+
+function openExternalBrowser(url: string) {
+  if (isIOS()) {
+    // iOS: Safari로 열기 시도
+    window.location.href = url;
+  } else {
+    // Android: intent:// 로 Chrome 열기
+    const intentUrl =
+      `intent://${url.replace(/^https?:\/\//, "")}#Intent;scheme=https;package=com.android.chrome;end`;
+    window.location.href = intentUrl;
+  }
+}
+
+const APP_LABELS: Record<string, string> = {
+  kakao: "카카오톡",
+  line: "라인",
+  instagram: "인스타그램",
+  facebook: "페이스북",
+  other: "앱",
+};
+
+export function InAppBrowserGate({ children }: { children: React.ReactNode }) {
+  const [inApp, setInApp] = useState<InAppEnv | null>(null);
+  const [checked, setChecked] = useState(false);
+
+  useEffect(() => {
+    setInApp(detectInAppBrowser());
+    setChecked(true);
+  }, []);
+
+  // 아직 체크 안 됨 → 깜빡임 방지를 위해 children 렌더
+  if (!checked) return <>{children}</>;
+
+  // 인앱 브라우저가 아님 → 정상 렌더
+  if (!inApp) return <>{children}</>;
+
+  const appName = APP_LABELS[inApp] ?? "앱";
+  const currentUrl = typeof window !== "undefined" ? window.location.href : "";
+
+  return (
+    <div className="flex min-h-svh flex-col items-center justify-center bg-white px-6">
+      <div className="w-full max-w-sm text-center">
+        <div className="text-5xl">🌐</div>
+        <h1 className="mt-4 text-xl font-bold text-foreground">
+          외부 브라우저에서 열어주세요
+        </h1>
+        <p className="mt-3 text-sm leading-relaxed text-muted-foreground">
+          {appName} 내부 브라우저에서는 로그인이 정상적으로
+          <br />
+          동작하지 않을 수 있습니다.
+        </p>
+
+        {/* Android: 자동 열기 버튼 */}
+        {!isIOS() && (
+          <button
+            type="button"
+            onClick={() => openExternalBrowser(currentUrl)}
+            className="mt-6 w-full rounded-xl bg-primary py-3.5 text-sm font-bold text-primary-foreground"
+          >
+            Chrome에서 열기
+          </button>
+        )}
+
+        {/* iOS: 안내 */}
+        {isIOS() && (
+          <div className="mt-6 rounded-xl border border-border bg-secondary/50 p-4 text-left">
+            <p className="text-sm font-bold text-foreground">
+              Safari에서 여는 방법
+            </p>
+            <ol className="mt-2 space-y-1.5 text-xs leading-relaxed text-muted-foreground">
+              {inApp === "kakao" ? (
+                <>
+                  <li>1. 오른쪽 하단 <strong className="text-foreground">⋯</strong> 버튼 탭</li>
+                  <li>2. <strong className="text-foreground">&quot;다른 브라우저로 열기&quot;</strong> 선택</li>
+                </>
+              ) : (
+                <>
+                  <li>1. 오른쪽 하단 <strong className="text-foreground">⋯</strong> 또는 공유 버튼 탭</li>
+                  <li>2. <strong className="text-foreground">&quot;Safari로 열기&quot;</strong> 선택</li>
+                </>
+              )}
+            </ol>
+          </div>
+        )}
+
+        {/* URL 복사 폴백 */}
+        <button
+          type="button"
+          onClick={() => {
+            navigator.clipboard.writeText(currentUrl);
+            alert("링크가 복사되었습니다. 브라우저에 붙여넣기 해주세요.");
+          }}
+          className="mt-3 w-full rounded-xl border border-border py-3 text-sm font-medium text-muted-foreground"
+        >
+          링크 복사하기
+        </button>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- 카카오톡/인스타/라인 등 인앱브라우저에서 `/newbie` 접속 시 외부 브라우저 유도 화면 표시
- Android: Chrome `intent://` URI로 자동 오픈 버튼
- iOS: Safari 열기 안내 가이드 + 링크 복사 폴백
- `/sync-member-records` 슬래시 커맨드 추가 (신규 회원 기록 동기화용)

## Test plan
- [ ] 카카오톡에서 `/newbie` 링크 열었을 때 외부 브라우저 유도 화면 표시 확인
- [ ] 일반 브라우저(Chrome/Safari)에서는 정상 페이지 표시 확인
- [ ] Android: "Chrome에서 열기" 버튼 동작 확인
- [ ] iOS: Safari 안내 + 링크 복사 버튼 동작 확인