### PR TITLE
fix: 대회 등록 RLS 차단 해결

### DIFF
--- a/app/actions/create-competition.ts
+++ b/app/actions/create-competition.ts
@@ -1,0 +1,59 @@
+"use server";
+
+import { revalidateTag } from "next/cache";
+import { createClient } from "@/lib/supabase/server";
+import { createAdminClient } from "@/lib/supabase/admin";
+
+interface CreateCompetitionInput {
+  title: string;
+  sport: string;
+  startDate: string;
+  endDate: string | null;
+  location: string;
+  eventTypes: string[];
+  sourceUrl: string;
+}
+
+export async function createCompetition(input: CreateCompetitionInput) {
+  // 1. 사용자 인증 확인
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  if (!user) {
+    return { ok: false, message: "로그인이 필요합니다." };
+  }
+
+  // 2. active 회원인지 확인
+  const { data: member } = await supabase
+    .from("member")
+    .select("id, status")
+    .or(`kakao_user_id.eq.${user.id},google_user_id.eq.${user.id}`)
+    .single();
+
+  if (!member || member.status !== "active") {
+    return { ok: false, message: "활성 회원만 대회를 등록할 수 있습니다." };
+  }
+
+  // 3. admin 클라이언트로 대회 INSERT (RLS 우회)
+  const admin = createAdminClient();
+  const { error } = await admin.from("competition").insert({
+    external_id: `manual:${crypto.randomUUID()}`,
+    sport: input.sport,
+    title: input.title.trim(),
+    start_date: input.startDate,
+    end_date: input.endDate || null,
+    location: input.location.trim(),
+    event_types: input.eventTypes,
+    source_url: input.sourceUrl.trim(),
+  });
+
+  if (error) {
+    console.error("대회 등록 실패:", error);
+    return { ok: false, message: "등록에 실패했습니다. 다시 시도해주세요." };
+  }
+
+  revalidateTag("competitions", "max");
+  return { ok: true, message: null };
+}

--- a/components/races/competition-register-dialog.tsx
+++ b/components/races/competition-register-dialog.tsx
@@ -2,7 +2,7 @@
 
 import { useEffect, useMemo, useState } from "react";
 import Link from "next/link";
-import { createClient } from "@/lib/supabase/client";
+import { createCompetition } from "@/app/actions/create-competition";
 import { Button } from "@/components/ui/button";
 import {
   Dialog,
@@ -40,8 +40,6 @@ export function CompetitionRegisterDialog({
   memberStatus,
   onCreated,
 }: CompetitionRegisterDialogProps) {
-  const supabase = useMemo(() => createClient(), []);
-
   const [title, setTitle] = useState("");
   const [sport, setSport] = useState("");
   const [startDate, setStartDate] = useState("");
@@ -101,21 +99,20 @@ export function CompetitionRegisterDialog({
     setIsSaving(true);
     setError(null);
 
-    const { error: insertError } = await supabase.from("competition").insert({
-      external_id: `manual:${crypto.randomUUID()}`,
+    const result = await createCompetition({
+      title,
       sport,
-      title: title.trim(),
-      start_date: startDate,
-      end_date: endDate || null,
-      location: location.trim(),
-      event_types: selectedEventTypes,
-      source_url: sourceUrl.trim(),
+      startDate,
+      endDate: endDate || null,
+      location,
+      eventTypes: selectedEventTypes,
+      sourceUrl,
     });
 
     setIsSaving(false);
 
-    if (insertError) {
-      setError("등록에 실패했습니다. 다시 시도해주세요.");
+    if (!result.ok) {
+      setError(result.message ?? "등록에 실패했습니다. 다시 시도해주세요.");
       return;
     }
 

--- a/lib/supabase/admin.ts
+++ b/lib/supabase/admin.ts
@@ -1,0 +1,17 @@
+import { createClient as createSupabaseClient } from "@supabase/supabase-js";
+
+/**
+ * Service Role 키를 사용하는 관리자 Supabase 클라이언트.
+ * 서버 액션/API 라우트에서만 사용. 절대 클라이언트에 노출하지 않을 것.
+ * RLS를 우회하므로 호출 전 반드시 인증/권한 확인 필요.
+ */
+export function createAdminClient() {
+  const url = process.env.NEXT_PUBLIC_SUPABASE_URL;
+  const key = process.env.SUPABASE_SERVICE_ROLE_KEY;
+
+  if (!url || !key) {
+    throw new Error("SUPABASE_SERVICE_ROLE_KEY가 설정되지 않았습니다.");
+  }
+
+  return createSupabaseClient(url, key);
+}


### PR DESCRIPTION
## Summary
- 대회 직접 등록 시 브라우저 클라이언트로 `competition` 테이블 INSERT → RLS 차단 문제 수정
- 서버 액션(`create-competition`) + admin 클라이언트(`lib/supabase/admin.ts`)로 전환
- 서버에서 인증/회원 확인 후 service role 키로 INSERT

## 필요 설정
- Vercel 환경변수에 `SUPABASE_SERVICE_ROLE_KEY` 추가 필요
- `.env.local`에도 동일하게 추가

## Test plan
- [ ] Vercel에 `SUPABASE_SERVICE_ROLE_KEY` 환경변수 설정
- [ ] 대회 등록 폼에서 트레일러닝 대회 등록 테스트
- [ ] 비로그인 상태에서 등록 시도 → 에러 메시지 확인