### PR TITLE
chore: .gitignore에 환경 변수 파일 패턴 추가

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -55,3 +55,7 @@ next-env.d.ts
 # local data
 /temp/
 /.playwright-mcp/
+
+# environment variable 
+.env
+.env.*


### PR DESCRIPTION
## Summary
- `.env`, `.env.*` 파일이 실수로 커밋되지 않도록 `.gitignore`에 패턴 추가

## Test plan
- [ ] `.env` 파일이 `git status`에 표시되지 않는지 확인