### PR TITLE
chore: CODEOWNERS 파일 추가

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @Canada-Joose @froggy1014 @LHG4650 @team-gigang @wnsals1346


### PR DESCRIPTION
## Summary
- `.github/CODEOWNERS` 파일 추가
- 모든 파일에 대해 @Canada-Joose @froggy1014 @LHG4650 @team-gigang @wnsals1346 를 코드 오너로 지정

## Test plan
- [ ] PR 생성 시 리뷰어가 자동 지정되는지 확인