### PR TITLE
ci: visual-diff, baseline-screenshots 워크플로우 임시 비활성화

### DIFF
--- a/.github/workflows/baseline-screenshots.yml
+++ b/.github/workflows/baseline-screenshots.yml
@@ -1,8 +1,9 @@
 name: Baseline Screenshots
 
 on:
-  push:
-    branches: [main]
+  workflow_dispatch: # 임시 비활성화 — 수동 실행만 가능
+  # push:
+  #   branches: [main]
 
 concurrency:
   group: baseline-screenshots

--- a/.github/workflows/visual-diff.yml
+++ b/.github/workflows/visual-diff.yml
@@ -1,8 +1,9 @@
 name: Visual Diff
 
 on:
-  pull_request:
-    branches: [main]
+  workflow_dispatch: # 임시 비활성화 — 수동 실행만 가능
+  # pull_request:
+  #   branches: [main]
 
 concurrency:
   group: visual-diff-${{ github.head_ref }}


### PR DESCRIPTION
## Summary
- `baseline-screenshots.yml` — `push` 트리거 주석 처리
- `visual-diff.yml` — `pull_request` 트리거 주석 처리
- 두 워크플로우 모두 `workflow_dispatch`(수동 실행)만 유지

## Test plan
- [ ] PR 머지 후 새 PR 생성 시 visual-diff 워크플로우가 자동 실행되지 않는지 확인
- [ ] main 푸시 시 baseline-screenshots 워크플로우가 자동 실행되지 않는지 확인

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added performance optimization guides addressing tab transition loading delays and query efficiency improvements.

* **Chores**
  * Updated GitHub configuration for code ownership and automated reviewer assignment.
  * Modified GitHub Actions workflows to manual execution.
  * Configured Netlify deployment setup and build pipeline.
  * Updated environment variable and build configuration files.

* **Revert**
  * Removed member records synchronization command specification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->