### PR TITLE
fix: mise env 태스크 정리 및 vercel link 에러 메시지 개선

### DIFF
--- a/docs/setup.md
+++ b/docs/setup.md
@@ -8,7 +8,7 @@
 | [Docker Desktop](https://www.docker.com/products/docker-desktop/) | O | Supabase 로컬 실행 |
 | [mise](https://mise.jdx.dev/) | O | 도구 버전 관리 (Node, Supabase CLI 등) |
 | [Supabase CLI](https://supabase.com/docs/guides/local-development/cli/getting-started) | O | 로컬 DB 및 마이그레이션 관리 |
-| [Vercel CLI](https://vercel.com/docs/cli) | 선택 | 환경변수 pull (팀 Vercel 접근 권한 필요) |
+| [Vercel CLI](https://vercel.com/docs/cli) | O | 환경변수 pull (팀 Vercel 접근 권한 필요) |
 
 > **mise**를 설치하면 Node.js, Supabase CLI 등 필요한 도구가 `mise install` 한 번으로 자동 설치됩니다.
 

--- a/mise.toml
+++ b/mise.toml
@@ -20,6 +20,11 @@ if ! command -v supabase &> /dev/null; then
   exit 1
 fi
 
+if ! command -v vercel &> /dev/null; then
+  echo "❌ Vercel CLI가 설치되어 있지 않습니다. 'mise install'을 먼저 실행하세요"
+  exit 1
+fi
+
 SB_OUT=$(supabase status -o json 2>&1 || true)
 if ! echo "$SB_OUT" | grep -q '"API_URL"'; then
   echo "❌ supabase가 실행 중이 아닙니다. 'supabase start'를 먼저 실행하세요"
@@ -37,17 +42,19 @@ if ! vercel whoami &> /dev/null; then
 fi
 
 # 1/3 Vercel preview env
-vercel env pull .env.development --environment=preview 2>/dev/null || {
-  echo "❌ Vercel preview 환경변수 가져오기 실패. 'vercel login' 후 다시 시도하세요"
+if ! PREVIEW_ERR=$(vercel env pull .env.development --environment=preview 2>&1); then
+  echo "❌ Vercel preview 환경변수 가져오기 실패"
+  echo "$PREVIEW_ERR"
   exit 1
-}
+fi
 echo "✅ .env.development 생성 완료"
 
 # 2/3 Vercel production env
-vercel env pull .env.production --environment=production 2>/dev/null || {
-  echo "❌ Vercel production 환경변수 가져오기 실패. 'vercel login' 후 다시 시도하세요"
+if ! PROD_ERR=$(vercel env pull .env.production --environment=production 2>&1); then
+  echo "❌ Vercel production 환경변수 가져오기 실패"
+  echo "$PROD_ERR"
   exit 1
-}
+fi
 echo "✅ .env.production 생성 완료"
 
 # 3/3 Supabase local env


### PR DESCRIPTION
## 배경

`.vercel` 디렉토리가 없는 상태에서 `mise run env:all`을 실행하면 `vercel env pull`이 `not_linked` 에러를 반환하는데, 기존 에러 메시지는 "vercel login'을 먼저 실행하세요"로 안내하고 있었습니다.

실제 원인은 `vercel link`가 안 되어 있는 것인데, 로그인 문제로 오인하게 만들어 불필요한 삽질을 유발했습니다.

## 변경 내용

### mise.toml
- **`env:local`, `env:preview`, `env:production` 개별 태스크 제거** → `env:all` 하나로 통합
  - Vercel 권한이 필수이므로 개별 태스크가 존재할 이유 없음
- **`vercel link` 누락 감지 추가** — `.vercel/project.json` 존재 여부를 사전 체크하여 정확한 에러 메시지 제공
- **`.env.development.local` 생성 순서를 마지막으로 이동** — Supabase, Vercel 모두 준비된 후에 파일 생성 시작

### docs/setup.md
- 환경변수 테이블에서 개별 `mise run` 명령어 컬럼 제거 (env:all로 통합)
- 셋업 순서에 `vercel link` 단계 추가

## 사전 확인 순서 (변경 후)

```
1. supabase CLI 설치 여부
2. supabase 실행 여부
3. vercel link 여부 (.vercel/project.json)
4. vercel 인증 여부 (vercel whoami)
→ 모두 통과 시 파일 생성 시작
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * 환경변수 가이드를 간소화하고, Vercel 연동(최초 링크) 절차 및 모든 환경파일을 한 번에 생성하는 안내로 업데이트

* **Chores**
  * 여러 환경파일 생성 절차를 단일 명령으로 통합해 설정을 단순화
  * Vercel CLI 존재 및 프로젝트 연동 여부를 사전 검증하도록 절차 강화
  * Vercel 관련 오류 출력 개선으로 실패 원인 파악 용이화
<!-- end of auto-generated comment: release notes by coderabbit.ai -->