### PR TITLE
style(auth): 카카오 로그인 버튼 우선 배치

### DIFF
--- a/components/auth/login-form.tsx
+++ b/components/auth/login-form.tsx
@@ -66,17 +66,6 @@ export function LoginForm({
       <div className="flex w-full flex-col gap-3">
         <button
           type="button"
-          onClick={() => handleOAuthLogin("google")}
-          disabled={oauthProvider !== null}
-          className="flex h-[52px] w-full items-center justify-center gap-2 rounded-xl border-[1.5px] border-border text-base font-semibold text-foreground transition-opacity disabled:opacity-50"
-        >
-          <Image src="/google.webp" alt="Google" width={20} height={20} />
-          <span>
-            {oauthProvider === "google" ? "연결 중..." : "Google로 시작하기"}
-          </span>
-        </button>
-        <button
-          type="button"
           onClick={() => handleOAuthLogin("kakao")}
           disabled={oauthProvider !== null}
           className="flex h-[52px] w-full items-center justify-center gap-2 rounded-xl bg-[#FEE500] text-base font-semibold text-[#191919] transition-opacity disabled:opacity-50"
@@ -84,6 +73,17 @@ export function LoginForm({
           <Image src="/kakao.png" alt="Kakao" width={20} height={20} />
           <span>
             {oauthProvider === "kakao" ? "연결 중..." : "카카오로 시작하기"}
+          </span>
+        </button>
+        <button
+          type="button"
+          onClick={() => handleOAuthLogin("google")}
+          disabled={oauthProvider !== null}
+          className="flex h-[52px] w-full items-center justify-center gap-2 rounded-xl border-[1.5px] border-border text-base font-semibold text-foreground transition-opacity disabled:opacity-50"
+        >
+          <Image src="/google.webp" alt="Google" width={20} height={20} />
+          <span>
+            {oauthProvider === "google" ? "연결 중..." : "Google로 시작하기"}
           </span>
         </button>
         {error && <p className="text-center text-sm text-destructive">{error}</p>}


### PR DESCRIPTION
## Summary

로그인 화면에서 카카오 로그인 버튼을 첫 번째로, 구글 로그인 버튼을 두 번째로 순서를 변경합니다.

> 기존 [#32](https://github.com/Gigang-ST/gigang-client/pull/32)에서 분리한 PR입니다.

주요 사용자층이 카카오 계정을 주로 사용하므로 카카오를 우선 배치합니다.