### PR TITLE
docs: 회비 시스템 설계 문서 작성 (v1.0~v1.6)

### DIFF
--- a/docs/design/2026-03-26-회비시스템.md
+++ b/docs/design/2026-03-26-회비시스템.md
@@ -527,8 +527,6 @@ CREATE INDEX idx_deposit_tx_member ON deposit_transactions(member_id);
 
 ### 서버 액션 / API
 
-| 기능 | 경로 | 설명 |
-|------|------|------|
 모든 액션은 **모임장(`member.is_leader = true`)만** 호출 가능합니다. 서버 액션 내부에서 권한 확인 필수.
 
 | 기능 | 경로 | 설명 |
@@ -743,12 +741,15 @@ app/
 ```sql
 -- 모임장 판별 헬퍼 함수 (반복 사용)
 -- SECURITY DEFINER: 함수 소유자(postgres) 권한으로 실행됨
+-- SET search_path = '': 공격자가 public 스키마에 악의적인 member 테이블을 생성해
+--   정규화되지 않은 테이블 참조를 가로채는 search_path 하이재킹을 방지합니다.
 -- 전제: member 테이블에 RLS가 없거나, 함수 소유자가 RLS를 우회할 수 있어야 합니다.
 -- member 테이블에 RLS를 추가할 경우 이 함수의 소유자에 대한 bypass 정책을 함께 설정하세요.
 CREATE OR REPLACE FUNCTION is_leader()
-RETURNS boolean LANGUAGE sql SECURITY DEFINER AS $$
+RETURNS boolean LANGUAGE sql SECURITY DEFINER
+SET search_path = '' AS $$
   SELECT EXISTS (
-    SELECT 1 FROM member WHERE id = auth.uid() AND is_leader = true
+    SELECT 1 FROM public.member WHERE id = auth.uid() AND is_leader = true
   );
 $$;
 
@@ -793,24 +794,33 @@ CREATE POLICY "모임장 전체" ON dues_month_close_log FOR ALL USING (is_leade
 -- 회원의 납부 요약 (프로필용)
 -- member_due_records는 본인 SELECT 권한 있음 → transaction_id를 직접 조회 가능
 -- 이 RPC는 transaction_id로 dues_transactions의 날짜/금액만 노출하기 위해 사용
+-- SET search_path = '': search_path 하이재킹 방지
+-- 소유권 검증: auth.uid()의 member_due_records에 연결된 transaction_id인지 확인하여
+--   임의 UUID로 타인 거래를 조회하는 것을 차단합니다.
 CREATE OR REPLACE FUNCTION get_my_due_transaction(p_transaction_id uuid)
 RETURNS TABLE (transaction_date date, amount int)
-LANGUAGE sql SECURITY DEFINER AS $$
-  SELECT transaction_date, amount
-  FROM dues_transactions
-  WHERE id = p_transaction_id;
+LANGUAGE sql SECURITY DEFINER
+SET search_path = '' AS $$
+  SELECT dt.transaction_date, dt.amount
+  FROM public.dues_transactions dt
+  -- 반드시 호출자(auth.uid())의 member_due_records에 연결된 거래만 반환
+  INNER JOIN public.member_due_records mdr
+    ON mdr.transaction_id = dt.id
+    AND mdr.member_id = auth.uid()
+  WHERE dt.id = p_transaction_id;
 $$;
 -- 프로필 최근 납부일 조회 흐름:
 -- 1. member_due_records에서 본인의 paid/covered_by_deposit 레코드를 조회 (직접 SELECT 가능)
 -- 2. 가장 최근 레코드의 transaction_id를 가져옴
--- 3. get_my_due_transaction(transaction_id)로 날짜/금액 조회
+-- 3. get_my_due_transaction(transaction_id)로 날짜/금액 조회 (본인 거래 아니면 빈 결과 반환)
 
 -- 회원의 예치금 변동 내역 (display_reason만 노출)
 CREATE OR REPLACE FUNCTION get_my_deposit_history(p_limit int DEFAULT 20)
 RETURNS TABLE (amount int, type deposit_transaction_type, year_month text, display_reason text, created_at timestamptz)
-LANGUAGE sql SECURITY DEFINER AS $$
+LANGUAGE sql SECURITY DEFINER
+SET search_path = '' AS $$
   SELECT amount, type, year_month, display_reason, created_at
-  FROM deposit_transactions
+  FROM public.deposit_transactions
   WHERE member_id = auth.uid()
   ORDER BY created_at DESC
   LIMIT p_limit;


### PR DESCRIPTION
## 개요

기강 크루 회비 관리 시스템의 전체 설계 문서를 작성했습니다.

## 주요 설계 내용

### 회비 정책
- 월 2,000원, 선불 납부 (해당 월 중 납부)
- 초과 납부 시 예치금으로 적립 → 익월부터 자동 차감
- 가입 당월 자동 면제, 다음 달부터 부과
- 예치금 환불은 오프라인(카카오톡) 처리, 시스템 UI 없음

### 데이터 수집
- 카카오뱅크 xlsx 파일 비정기 업로드 (`KAKAOBANK_XLSX_PASSWORD` 환경변수로 복호화)
- 모든 입금은 기본 회비(`due`) 분류 → 모임장이 명시적으로 변경 시에만 다른 카테고리
- 중복 거래 처리: SHA-256 해시(파일 단위) + UNIQUE 제약(거래 단위)으로 기간 겹침 안전 처리

### 권한
- 회비 관련 모든 기능은 `member.is_leader = true` 모임장 전용
- 회원은 본인 미납 내역·예치금 잔액만 프로필에서 열람 가능

### 자동화
- Vercel Cron Job으로 매월 1일 자동 마감 (예치금 차감 → 미납 확정)

### DB 스키마 (참고용)
- 7개 신규 테이블 설계 + SQL DDL, RLS 정책, RPC 함수 포함
- DB 실제 구현은 백엔드 담당자에게 일임

## 문서 경로

`docs/design/2026-03-26-회비시스템.md`

## 관련 이슈

Closes #44

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * 회비 시스템 설계 문서 추가: 리더 전용 관리 워크플로우, 회비/면제 정책, 예치금 처리 및 미납 흐름, 은행 거래 엑셀 업로드 기반 거래 파싱·중복/매칭 규칙, 업로드 롤백·수동 매칭·월 마감 절차, 관리자 대시보드 및 거래·회원 화면 범위와 노출 정책을 포함한 포괄적 설계서가 추가되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->