### PR TITLE
fix(utmb): fetch 실패 시 타이머 미해제 수정

### DIFF
--- a/lib/utmb.ts
+++ b/lib/utmb.ts
@@ -26,16 +26,14 @@ export async function fetchUtmbRecentRace(
   );
   if (!match) return { ok: false };
 
-  try {
-    const controller = new AbortController();
-    const timeoutId = setTimeout(() => controller.abort(), 10_000);
+  const controller = new AbortController();
+  const timeoutId = setTimeout(() => controller.abort(), 10_000);
 
+  try {
     const res = await fetch(trimmed, {
       headers: { "User-Agent": "Mozilla/5.0" },
       signal: controller.signal,
     });
-
-    clearTimeout(timeoutId);
 
     if (!res.ok) return { ok: false };
 
@@ -65,5 +63,7 @@ export async function fetchUtmbRecentRace(
     return { ok: true, raceName, raceRecord };
   } catch {
     return { ok: false };
+  } finally {
+    clearTimeout(timeoutId);
   }
 }


### PR DESCRIPTION
## Summary
- `fetchUtmbRecentRace`에서 fetch 예외 발생 시 `clearTimeout`이 호출되지 않는 문제 수정
- `clearTimeout`을 `finally` 블록으로 이동하여 성공/실패/early return 모든 경로에서 타이머 정리 보장

## 변경 내용
- `controller`, `timeoutId`를 `try` 블록 바깥으로 이동
- `clearTimeout(timeoutId)`를 `finally` 블록에 배치

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **리팩토링**
  * 타임아웃 정리 로직 개선으로 모든 상황에서 안정적으로 실행되도록 변경

<!-- end of auto-generated comment: release notes by coderabbit.ai -->