### PR TITLE
perf(auth): 세션 쿠키 없으면 getClaims() 호출 생략

### DIFF
--- a/lib/supabase/proxy.ts
+++ b/lib/supabase/proxy.ts
@@ -2,21 +2,28 @@ import { createServerClient } from "@supabase/ssr";
 import { NextResponse, type NextRequest } from "next/server";
 import { hasEnvVars } from "../utils";
 
+/**
+ * 모든 요청에서 실행되는 인증 미들웨어.
+ * 세션 쿠키 검사 → Supabase 토큰 검증 → 비인증 유저 리다이렉트 순서로 동작한다.
+ */
 export async function updateSession(request: NextRequest) {
   let supabaseResponse = NextResponse.next({
     request,
   });
 
+  // 환경변수 미설정 시 인증 검사 생략
   if (!hasEnvVars) {
     return supabaseResponse;
   }
 
+  // 비로그인 상태에서도 접근 가능한 공개 경로 목록
   const pathname = request.nextUrl.pathname;
   const publicPaths = ["/", "/rules", "/join", "/newbie", "/races", "/records", "/terms", "/privacy", "/policy", "/settings"];
   const isPublic =
     publicPaths.includes(pathname) || pathname.startsWith("/auth");
 
-  // 세션 쿠키가 없으면 getClaims() 네트워크 호출 없이 바로 리다이렉트
+  // 세션 쿠키가 아예 없으면 Supabase 서버 호출 없이 즉시 리다이렉트 (100~700ms 절약)
+  // Supabase는 토큰이 크면 쿠키를 청크 분할함 (sb-*-auth-token.0, .1, ...)
   const hasSessionCookie = request.cookies.getAll().some(
     (c) => c.name.startsWith("sb-") && c.name.includes("-auth-token"),
   );
@@ -27,6 +34,8 @@ export async function updateSession(request: NextRequest) {
     return NextResponse.redirect(url);
   }
 
+  // 쿠키가 존재하면 Supabase 서버 클라이언트를 생성하여 토큰 유효성 검증
+  // Fluid compute 환경에서는 매 요청마다 새 클라이언트를 생성해야 함
   const supabase = createServerClient(
     process.env.NEXT_PUBLIC_SUPABASE_URL!,
     process.env.NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY!,
@@ -35,6 +44,7 @@ export async function updateSession(request: NextRequest) {
         getAll() {
           return request.cookies.getAll();
         },
+        // 토큰 갱신 시 요청/응답 양쪽 쿠키를 동기화하여 브라우저-서버 불일치 방지
         setAll(cookiesToSet) {
           cookiesToSet.forEach(({ name, value }) =>
             request.cookies.set(name, value),
@@ -50,12 +60,12 @@ export async function updateSession(request: NextRequest) {
     },
   );
 
-  // Do not run code between createServerClient and
-  // supabase.auth.getClaims(). A simple mistake could make it very hard to debug
-  // issues with users being randomly logged out.
+  // createServerClient와 getClaims() 사이에 다른 코드를 넣지 말 것.
+  // 세션 갱신 타이밍이 꼬여서 유저가 랜덤하게 로그아웃될 수 있음.
   const { data } = await supabase.auth.getClaims();
   const user = data?.claims;
 
+  // 쿠키는 있지만 토큰이 만료/무효한 경우 리다이렉트
   if (!user && !isPublic) {
     const url = request.nextUrl.clone();
     url.pathname = "/auth/login";


### PR DESCRIPTION
## Summary
- 비로그인 유저가 보호된 페이지 접근 시 `getClaims()` Supabase Auth 서버 호출(100~700ms)을 건너뛰고 즉시 리다이렉트
- `sb-*-auth-token` 쿠키 존재 여부로 사전 판단하여 네트워크 왕복 제거
- 로그인된 유저는 기존과 동일하게 `getClaims()`로 토큰 검증

### AS-IS

```bash
[proxy] getClaims /profile: 0.432ms
[proxy] getClaims /auth/login: 0.532ms
```

### TO-BE

```bash
[proxy] getClaims /auth/login: 0.532ms
```

## Summary by CodeRabbit

## 릴리스 노트

* **개선 사항**
  * 공개 경로(allowlist)와 인증 경로를 구분해, 보호된 페이지 접근 시 미인증 사용자를 더 빠르게 로그인 페이지로 리다이렉트합니다.
  * 요청의 세션 쿠키 존재 여부를 먼저 확인해 불필요한 네트워크 호출을 줄이고 응답성을 개선했습니다.
  * 기존 인증 후 재확인 로직은 유지되어 안전성을 확보합니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->