### PR TITLE
fix(profile): 기록 카드 긴 대회명 텍스트 오버플로우 ellipsis 처리

### DIFF
--- a/components/profile/personal-best-grid.tsx
+++ b/components/profile/personal-best-grid.tsx
@@ -170,7 +170,7 @@ export function PersonalBestGrid({ bestRecords, utmbData, memberId }: Props) {
           return (
             <div
               key={evt}
-              className={`flex flex-col gap-1 rounded-xl p-4 ${i < 2 ? "border-[1.5px] border-border" : "bg-secondary"}`}
+              className={`flex min-w-0 flex-col gap-1 rounded-xl p-4 ${i < 2 ? "border-[1.5px] border-border" : "bg-secondary"}`}
             >
               <span className="text-xs font-semibold text-primary">
                 {evt}
@@ -190,13 +190,13 @@ export function PersonalBestGrid({ bestRecords, utmbData, memberId }: Props) {
           type="button"
           variant="secondary"
           onClick={() => handleUtmbOpenChange(true)}
-          className="h-auto flex-col items-start gap-1 rounded-xl p-4 active:scale-[0.98]"
+          className="h-auto min-w-0 flex-col items-start gap-1 rounded-xl p-4 active:scale-[0.98]"
         >
           <span className="text-xs font-semibold text-primary">UTMB</span>
           <span className="font-mono text-xl font-bold text-foreground">
             {utmb ? utmb.utmb_index : "--"}
           </span>
-          <span className="truncate text-[11px] text-muted-foreground">
+          <span className="w-full truncate text-[11px] text-muted-foreground">
             {utmb?.recent_race_name ? utmb.recent_race_name : utmb ? "" : "탭하여 연동"}
           </span>
         </Button>
@@ -275,7 +275,7 @@ export function PersonalBestGrid({ bestRecords, utmbData, memberId }: Props) {
                 {recentRaceName && (
                   <div className="flex flex-col gap-0.5 border-t border-border pt-3">
                     <span className="text-xs text-muted-foreground">최근 대회</span>
-                    <span className="text-sm font-medium text-foreground">
+                    <span className="truncate text-sm font-medium text-foreground">
                       {recentRaceName}
                     </span>
                     {recentRaceRecord && (


### PR DESCRIPTION
## 관련 이슈

관련 이슈 없음

## 요약

프로필 페이지 기록 카드(PB, UTMB)에서 긴 대회명이 카드 영역을 벗어나는 오버플로우 버그를 수정합니다.

## AS-IS (변경 전)

- PB 카드(FULL/HALF/10K)와 UTMB 카드에서 `truncate` 클래스가 적용되어 있지만, 부모 flex 컨테이너에 `min-w-0`가 없어 **실제로 ellipsis가 작동하지 않음**
- UTMB Button 내부 span이 너비 제약 없이 텍스트가 버튼 밖으로 넘침
- UTMB Dialog의 최근 대회명(`recentRaceName`)에 **오버플로우 처리가 전혀 없음**

## TO-BE (변경 후)

- PB 카드 div에 `min-w-0` 추가 → grid 셀 내에서 truncate 정상 작동
- UTMB Button에 `min-w-0` 추가 + span에 `w-full` 추가 → 버튼 내부 텍스트 ellipsis 정상 작동
- UTMB Dialog의 `recentRaceName`에 `truncate` 추가 → 긴 대회명 말줄임 처리

## 주요 변경 사항

- `components/profile/personal-best-grid.tsx`: 4곳 CSS 클래스 수정