### PR TITLE
fix(onboarding): normalize phone-based existing member lookup

### DIFF
--- a/app/actions/onboarding-mem-v2.ts
+++ b/app/actions/onboarding-mem-v2.ts
@@ -40,41 +40,40 @@ export async function onboardingCheckPhone(
   }
 
   const admin = createAdminClient();
-  const { data: list, error: listErr } = await admin
-    .from("mem_mst")
-    .select("mem_id")
-    .eq("vers", 0)
-    .eq("del_yn", false)
-    .eq("phone_no", digits)
-    .limit(2);
+  // DB phone_no 표기(하이픈·+82 등)와 무관하게 백필과 동일한 migration_v2_norm_phone 으로 매칭
+  const { data: memIds, error: rpcErr } = await admin.rpc(
+    "mem_mst_mem_ids_by_norm_phone",
+    { p_input: phoneRaw.trim() },
+  );
 
-  if (listErr) {
+  if (rpcErr) {
     return { ok: false, message: "기존 회원 확인에 실패했습니다." };
   }
-  if (list && list.length > 1) {
+  const ids = (memIds ?? []).filter(Boolean);
+  if (ids.length > 1) {
     return {
       ok: false,
       message:
         "같은 번호로 등록된 회원이 여러 명이라 관리자 확인이 필요합니다.",
     };
   }
-  const mst = list?.[0];
-  if (!mst) return { ok: true, kind: "new" };
+  const memId = ids[0];
+  if (!memId) return { ok: true, kind: "new" };
 
   const { teamId } = await getRequestTeamContext();
   const { data: rel } = await admin
     .from("team_mem_rel")
     .select("mem_st_cd")
-    .eq("mem_id", mst.mem_id)
+    .eq("mem_id", memId)
     .eq("team_id", teamId)
     .eq("vers", 0)
     .eq("del_yn", false)
     .maybeSingle();
 
   const st = rel?.mem_st_cd ?? "pending";
-  if (st === "inactive") return { ok: true, kind: "inactive", memId: mst.mem_id };
+  if (st === "inactive") return { ok: true, kind: "inactive", memId };
   if (st === "pending") return { ok: true, kind: "pending" };
-  return { ok: true, kind: "active", memId: mst.mem_id };
+  return { ok: true, kind: "active", memId };
 }
 
 /** 기존 활동 회원: OAuth만 연결(mem_mst) */

--- a/lib/supabase/database.types.ts
+++ b/lib/supabase/database.types.ts
@@ -681,6 +681,10 @@ export type Database = {
       [_ in never]: never
     }
     Functions: {
+      mem_mst_mem_ids_by_norm_phone: {
+        Args: { p_input: string }
+        Returns: string[]
+      },
       get_public_team_member_stats: {
         Args: { p_team_id: string }
         Returns: {

--- a/supabase/migrations/20260417140000_mem_mst_phone_lookup_norm.sql
+++ b/supabase/migrations/20260417140000_mem_mst_phone_lookup_norm.sql
@@ -1,0 +1,30 @@
+-- 온보딩 전화번호 확인: mem_mst.phone_no 가 하이픈/+82 등으로 저장돼도
+-- migration_v2_norm_phone(백필 P1)과 동일 규칙으로 매칭한다.
+-- 선행: public.migration_v2_norm_phone (20260404102201_v2_backfill_p1_mem_mst.sql)
+
+CREATE OR REPLACE FUNCTION public.mem_mst_mem_ids_by_norm_phone(p_input text)
+RETURNS uuid[]
+LANGUAGE sql
+STABLE
+SET search_path = public
+AS $$
+  SELECT coalesce(
+    array_agg(mem_id ORDER BY mem_id),
+    '{}'::uuid[]
+  )
+  FROM (
+    SELECT mm.mem_id
+    FROM public.mem_mst mm
+    WHERE mm.vers = 0
+      AND mm.del_yn = false
+      AND public.migration_v2_norm_phone(p_input) IS NOT NULL
+      AND public.migration_v2_norm_phone(mm.phone_no) = public.migration_v2_norm_phone(p_input)
+    LIMIT 3
+  ) s;
+$$;
+
+COMMENT ON FUNCTION public.mem_mst_mem_ids_by_norm_phone(text) IS
+  '온보딩: 전화번호 정규화 기준 mem_mst 정본 mem_id 목록(최대 3건, 중복·이상치 탐지용)';
+
+REVOKE ALL ON FUNCTION public.mem_mst_mem_ids_by_norm_phone(text) FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION public.mem_mst_mem_ids_by_norm_phone(text) TO service_role;


### PR DESCRIPTION
Use a DB-side normalized phone lookup RPC for onboarding checks so existing members are reliably detected even when phone formatting differs in stored data.

Made-with: Cursor