### PR TITLE
refactor(admin): inactive 회원 상태 관리 및 재가입 승인 흐름 제거

### DIFF
--- a/app/(info)/admin/members/admin-members-client.tsx
+++ b/app/(info)/admin/members/admin-members-client.tsx
@@ -3,7 +3,6 @@
 import { useEffect, useState, useCallback } from "react";
 import { createClient } from "@/lib/supabase/client";
 import {
-  updateMemberStatus,
   toggleAdmin,
 } from "@/app/actions/admin/manage-member";
 import {
@@ -11,8 +10,6 @@ import {
   Shield,
   ShieldOff,
   UserRound,
-  UserX,
-  UserCheck,
   ChevronRight,
   X,
 } from "lucide-react";
@@ -38,21 +35,19 @@ type Member = {
   joined_at: string | null;
 };
 
-type Filter = "all" | "active" | "inactive" | "pending";
+type Filter = "all" | "active" | "pending";
 
 const STATUS_BADGE: Record<
   string,
   { label: string; variant: "default" | "secondary" | "destructive" | "outline" }
 > = {
   active: { label: "활동", variant: "default" },
-  inactive: { label: "비활성", variant: "destructive" },
   pending: { label: "대기", variant: "outline" },
 };
 
 const FILTERS: { value: Filter; label: string }[] = [
   { value: "all", label: "전체" },
   { value: "active", label: "활동" },
-  { value: "inactive", label: "비활성" },
   { value: "pending", label: "대기" },
 ];
 
@@ -121,27 +116,6 @@ export function AdminMembersClient({ teamId }: { teamId: string }) {
     }
     return true;
   });
-
-  const handleStatusChange = async (
-    memberId: string,
-    status: "active" | "inactive",
-  ) => {
-    const label = status === "active" ? "활성화" : "비활성화";
-    if (!confirm(`${label}하시겠습니까?`)) return;
-    setActioning(true);
-    const result = await updateMemberStatus(memberId, status);
-    if (result.ok) {
-      setMembers((prev) =>
-        prev.map((m) => (m.id === memberId ? { ...m, status } : m)),
-      );
-      setSelectedMember((prev) =>
-        prev?.id === memberId ? { ...prev, status } : prev,
-      );
-    } else {
-      alert(result.message);
-    }
-    setActioning(false);
-  };
 
   const handleToggleAdmin = async (memberId: string, isAdmin: boolean) => {
     const label = isAdmin ? "관리자로 지정" : "관리자 해제";
@@ -342,36 +316,6 @@ export function AdminMembersClient({ teamId }: { teamId: string }) {
 
               {/* 액션 버튼 */}
               <div className="flex flex-col gap-2">
-                {selectedMember.status === "active" && (
-                  <Button
-                    variant="outline"
-                    onClick={() =>
-                      handleStatusChange(selectedMember.id, "inactive")
-                    }
-                    disabled={actioning}
-                    className="h-auto justify-start gap-3 rounded-xl px-4 py-3.5 text-left"
-                  >
-                    <UserX className="size-4 text-destructive" />
-                    <span className="text-[15px] font-medium text-destructive">
-                      비활성화
-                    </span>
-                  </Button>
-                )}
-                {selectedMember.status === "inactive" && (
-                  <Button
-                    variant="outline"
-                    onClick={() =>
-                      handleStatusChange(selectedMember.id, "active")
-                    }
-                    disabled={actioning}
-                    className="h-auto justify-start gap-3 rounded-xl px-4 py-3.5 text-left"
-                  >
-                    <UserCheck className="size-4 text-primary" />
-                    <span className="text-[15px] font-medium text-primary">
-                      활성화
-                    </span>
-                  </Button>
-                )}
                 {selectedMember.admin ? (
                   <Button
                     variant="outline"

--- a/app/(info)/admin/members/admin-members-client.tsx
+++ b/app/(info)/admin/members/admin-members-client.tsx
@@ -20,7 +20,6 @@ import { H2 } from "@/components/common/typography";
 import { Badge } from "@/components/ui/badge";
 import { Skeleton } from "@/components/ui/skeleton";
 import { CardItem } from "@/components/ui/card";
-import { cn } from "@/lib/utils";
 
 type Member = {
   id: string;
@@ -35,26 +34,10 @@ type Member = {
   joined_at: string | null;
 };
 
-type Filter = "all" | "active" | "pending";
-
-const STATUS_BADGE: Record<
-  string,
-  { label: string; variant: "default" | "secondary" | "destructive" | "outline" }
-> = {
-  active: { label: "활동", variant: "default" },
-  pending: { label: "대기", variant: "outline" },
-};
-
-const FILTERS: { value: Filter; label: string }[] = [
-  { value: "all", label: "전체" },
-  { value: "active", label: "활동" },
-  { value: "pending", label: "대기" },
-];
 
 export function AdminMembersClient({ teamId }: { teamId: string }) {
   const [members, setMembers] = useState<Member[]>([]);
   const [loading, setLoading] = useState(true);
-  const [filter, setFilter] = useState<Filter>("all");
   const [search, setSearch] = useState("");
   const [selectedMember, setSelectedMember] = useState<Member | null>(null);
   const [actioning, setActioning] = useState(false);
@@ -107,14 +90,9 @@ export function AdminMembersClient({ teamId }: { teamId: string }) {
   }, [loadMembers]);
 
   const filtered = members.filter((m) => {
-    if (filter !== "all" && m.status !== filter) return false;
-    if (search) {
-      const q = search.toLowerCase();
-      const nameMatch = m.full_name?.toLowerCase().includes(q);
-      const phoneMatch = m.phone?.includes(q);
-      if (!nameMatch && !phoneMatch) return false;
-    }
-    return true;
+    if (!search) return true;
+    const q = search.toLowerCase();
+    return m.full_name?.toLowerCase().includes(q) || m.phone?.includes(q);
   });
 
   const handleToggleAdmin = async (memberId: string, isAdmin: boolean) => {
@@ -164,26 +142,6 @@ export function AdminMembersClient({ teamId }: { teamId: string }) {
         />
       </div>
 
-      {/* 필터 탭 */}
-      <div className="flex gap-0 rounded-xl bg-secondary p-1">
-        {FILTERS.map((f) => (
-          <Button
-            key={f.value}
-            variant="ghost"
-            size="sm"
-            onClick={() => setFilter(f.value)}
-            className={cn(
-              "flex-1 rounded-lg text-[13px] font-medium",
-              filter === f.value
-                ? "bg-foreground text-background hover:bg-foreground hover:text-background"
-                : "text-muted-foreground",
-            )}
-          >
-            {f.label}
-          </Button>
-        ))}
-      </div>
-
       {/* 회원 수 */}
       <span className="text-[13px] text-muted-foreground">
         {filtered.length}명
@@ -191,9 +149,7 @@ export function AdminMembersClient({ teamId }: { teamId: string }) {
 
       {/* 회원 목록 */}
       <div className="flex flex-col gap-2">
-        {filtered.map((member) => {
-          const badge = STATUS_BADGE[member.status ?? ""] ?? STATUS_BADGE.active;
-          return (
+        {filtered.map((member) => (
             <CardItem asChild key={member.id} className="flex items-center gap-3">
               <button
                 onClick={() => setSelectedMember(member)}
@@ -213,14 +169,10 @@ export function AdminMembersClient({ teamId }: { teamId: string }) {
                   {member.phone ?? "연락처 없음"}
                 </span>
               </div>
-              <Badge variant={badge.variant} className="shrink-0 text-[11px]">
-                {badge.label}
-              </Badge>
               <ChevronRight className="size-4 shrink-0 text-border" />
               </button>
             </CardItem>
-          );
-        })}
+        ))}
       </div>
 
       {filtered.length === 0 && (
@@ -262,20 +214,6 @@ export function AdminMembersClient({ teamId }: { teamId: string }) {
                       </Badge>
                     )}
                   </div>
-                  <Badge
-                    variant={
-                      (STATUS_BADGE[selectedMember.status ?? ""] ??
-                        STATUS_BADGE.active
-                      ).variant
-                    }
-                    className="w-fit text-[11px]"
-                  >
-                    {
-                      (STATUS_BADGE[selectedMember.status ?? ""] ??
-                        STATUS_BADGE.active
-                      ).label
-                    }
-                  </Badge>
                 </div>
                 <Button
                   variant="ghost"

--- a/app/(info)/admin/members/admin-members-client.tsx
+++ b/app/(info)/admin/members/admin-members-client.tsx
@@ -4,12 +4,14 @@ import { useEffect, useState, useCallback } from "react";
 import { createClient } from "@/lib/supabase/client";
 import {
   toggleAdmin,
+  deleteMember,
 } from "@/app/actions/admin/manage-member";
 import {
   Search,
   Shield,
   ShieldOff,
   UserRound,
+  UserX,
   ChevronRight,
   X,
 } from "lucide-react";
@@ -94,6 +96,19 @@ export function AdminMembersClient({ teamId }: { teamId: string }) {
     const q = search.toLowerCase();
     return m.full_name?.toLowerCase().includes(q) || m.phone?.includes(q);
   });
+
+  const handleDeleteMember = async (memberId: string, name: string) => {
+    if (!confirm(`${name} 회원을 삭제하시겠습니까?`)) return;
+    setActioning(true);
+    const result = await deleteMember(memberId);
+    if (result.ok) {
+      setMembers((prev) => prev.filter((m) => m.id !== memberId));
+      setSelectedMember(null);
+    } else {
+      alert(result.message);
+    }
+    setActioning(false);
+  };
 
   const handleToggleAdmin = async (memberId: string, isAdmin: boolean) => {
     const label = isAdmin ? "관리자로 지정" : "관리자 해제";
@@ -283,6 +298,22 @@ export function AdminMembersClient({ teamId }: { teamId: string }) {
                     </span>
                   </Button>
                 )}
+                <Button
+                  variant="outline"
+                  onClick={() =>
+                    handleDeleteMember(
+                      selectedMember.id,
+                      selectedMember.full_name ?? "이름 없음",
+                    )
+                  }
+                  disabled={actioning}
+                  className="h-auto justify-start gap-3 rounded-xl px-4 py-3.5 text-left"
+                >
+                  <UserX className="size-4 text-destructive" />
+                  <span className="text-[15px] font-medium text-destructive">
+                    회원 삭제
+                  </span>
+                </Button>
               </div>
             </div>
           </div>

--- a/app/(info)/admin/page.tsx
+++ b/app/(info)/admin/page.tsx
@@ -3,7 +3,6 @@
 import { useEffect, useState } from "react";
 import Link from "next/link";
 import {
-  UserCheck,
   Users,
   Trophy,
   Timer,
@@ -30,19 +29,11 @@ type Card = {
 
 const generalCards: Card[] = [
   {
-    key: "approvals",
-    label: "가입 승인 대기",
-    href: "/admin/approvals",
-    icon: UserCheck,
-    getValue: (s) => s.pendingCount,
-    getAccentValue: (s) => s.pendingCount,
-  },
-  {
     key: "members",
-    label: "활성 회원",
+    label: "회원 관리",
     href: "/admin/members",
     icon: Users,
-    getValue: (s) => `${s.activeCount} / ${s.totalCount}`,
+    getValue: (s) => s.totalCount,
   },
   {
     key: "competitions",

--- a/app/actions/admin/get-admin-stats.ts
+++ b/app/actions/admin/get-admin-stats.ts
@@ -6,8 +6,6 @@ import { currentMonthKST, nextMonthStr } from "@/lib/dayjs";
 import { getRequestTeamContext } from "@/lib/queries/request-team";
 
 export type AdminStats = {
-  pendingCount: number;
-  activeCount: number;
   totalCount: number;
   monthlyCompetitionCount: number;
   recentRecordCount: number;
@@ -20,21 +18,7 @@ export async function getAdminStats(): Promise<AdminStats> {
   const { teamId } = await getRequestTeamContext();
   const admin = createAdminClient();
 
-  const [pending, active, total, competitions, records] = await Promise.all([
-    admin
-      .from("team_mem_rel")
-      .select("*", { count: "exact", head: true })
-      .eq("team_id", teamId)
-      .eq("vers", 0)
-      .eq("del_yn", false)
-      .eq("mem_st_cd", "pending"),
-    admin
-      .from("team_mem_rel")
-      .select("*", { count: "exact", head: true })
-      .eq("team_id", teamId)
-      .eq("vers", 0)
-      .eq("del_yn", false)
-      .eq("mem_st_cd", "active"),
+  const [total, competitions, records] = await Promise.all([
     admin
       .from("team_mem_rel")
       .select("*", { count: "exact", head: true })
@@ -60,8 +44,6 @@ export async function getAdminStats(): Promise<AdminStats> {
   ]);
 
   return {
-    pendingCount: pending.count ?? 0,
-    activeCount: active.count ?? 0,
     totalCount: total.count ?? 0,
     monthlyCompetitionCount: competitions.count ?? 0,
     recentRecordCount: records.count ?? 0,

--- a/app/actions/admin/manage-member.ts
+++ b/app/actions/admin/manage-member.ts
@@ -91,3 +91,40 @@ export async function toggleAdmin(memberId: string, isAdmin: boolean) {
 
   return { ok: true, message: null };
 }
+
+export async function deleteMember(memberId: string) {
+  const adminUser = await verifyAdmin();
+  if (!adminUser) return { ok: false, message: "권한이 없습니다" };
+
+  if (adminUser.id === memberId) {
+    return { ok: false, message: "본인은 삭제할 수 없습니다" };
+  }
+
+  const { teamId } = await getRequestTeamContext();
+  const db = createAdminClient();
+
+  const { data: rel } = await db
+    .from("team_mem_rel")
+    .select("team_role_cd")
+    .eq("mem_id", memberId)
+    .eq("team_id", teamId)
+    .eq("vers", 0)
+    .eq("del_yn", false)
+    .maybeSingle();
+
+  if (rel?.team_role_cd === "owner") {
+    return { ok: false, message: "크루장은 삭제할 수 없습니다" };
+  }
+
+  const { error } = await db
+    .from("team_mem_rel")
+    .update({ del_yn: true })
+    .eq("mem_id", memberId)
+    .eq("team_id", teamId)
+    .eq("vers", 0)
+    .eq("del_yn", false);
+
+  if (error) return { ok: false, message: "삭제에 실패했습니다" };
+
+  return { ok: true, message: null };
+}

--- a/app/actions/admin/manage-member.ts
+++ b/app/actions/admin/manage-member.ts
@@ -44,30 +44,6 @@ export async function rejectMember(memberId: string) {
   return { ok: true, message: null };
 }
 
-export async function updateMemberStatus(
-  memberId: string,
-  status: "active" | "inactive",
-) {
-  const adminUser = await verifyAdmin();
-  if (!adminUser) return { ok: false, message: "권한이 없습니다" };
-
-  const { teamId } = await getRequestTeamContext();
-  const db = createAdminClient();
-  const memSt = status;
-
-  const { error: e1 } = await db
-    .from("team_mem_rel")
-    .update({ mem_st_cd: memSt })
-    .eq("mem_id", memberId)
-    .eq("team_id", teamId)
-    .eq("vers", 0)
-    .eq("del_yn", false);
-
-  if (e1) return { ok: false, message: "상태 변경에 실패했습니다" };
-
-  return { ok: true, message: null };
-}
-
 export async function toggleAdmin(memberId: string, isAdmin: boolean) {
   const adminUser = await verifyAdmin();
   if (!adminUser) return { ok: false, message: "권한이 없습니다" };

--- a/app/actions/onboarding-mem-v2.ts
+++ b/app/actions/onboarding-mem-v2.ts
@@ -22,7 +22,6 @@ function normEmail(s: string | null | undefined): string | null {
 
 export type OnboardingPhoneResult =
   | { ok: true; kind: "new" }
-  | { ok: true; kind: "inactive"; memId: string }
   | { ok: true; kind: "pending" }
   | { ok: true; kind: "active"; memId: string }
   | { ok: false; message: string };
@@ -71,7 +70,6 @@ export async function onboardingCheckPhone(
     .maybeSingle();
 
   const st = rel?.mem_st_cd ?? "pending";
-  if (st === "inactive") return { ok: true, kind: "inactive", memId };
   if (st === "pending") return { ok: true, kind: "pending" };
   return { ok: true, kind: "active", memId };
 }
@@ -98,47 +96,6 @@ export async function onboardingLinkExistingMember(args: {
       ...(args.initialAvatarUrl ? { avatar_url: args.initialAvatarUrl } : {}),
     })
     .eq("mem_id", args.memId)
-    .eq("vers", 0)
-    .eq("del_yn", false);
-
-  if (e1) return { ok: false, message: e1.message };
-
-  return { ok: true };
-}
-
-/** 비활성 재가입 요청: 팀 상태를 pending 으로, OAuth 연결 */
-export async function onboardingRejoinFromInactive(args: {
-  memId: string;
-  provider: "kakao" | "google";
-  initialAvatarUrl?: string | null;
-}): Promise<{ ok: boolean; message?: string }> {
-  const { user } = await requireAuthUser();
-  if (!user) return { ok: false, message: "로그인이 필요합니다." };
-
-  const admin = createAdminClient();
-  const oauthMst =
-    args.provider === "kakao"
-      ? { oauth_kakao_id: user.id }
-      : { oauth_google_id: user.id };
-
-  const { error: e0 } = await admin
-    .from("mem_mst")
-    .update({
-      ...oauthMst,
-      ...(args.initialAvatarUrl ? { avatar_url: args.initialAvatarUrl } : {}),
-    })
-    .eq("mem_id", args.memId)
-    .eq("vers", 0)
-    .eq("del_yn", false);
-
-  if (e0) return { ok: false, message: e0.message };
-
-  const { teamId } = await getRequestTeamContext();
-  const { error: e1 } = await admin
-    .from("team_mem_rel")
-    .update({ mem_st_cd: "pending" })
-    .eq("mem_id", args.memId)
-    .eq("team_id", teamId)
     .eq("vers", 0)
     .eq("del_yn", false);
 

--- a/components/auth/member-onboarding-form.tsx
+++ b/components/auth/member-onboarding-form.tsx
@@ -5,7 +5,6 @@ import {
   onboardingCheckPhone,
   onboardingCreateMember,
   onboardingLinkExistingMember,
-  onboardingRejoinFromInactive,
 } from "@/app/actions/onboarding-mem-v2";
 import { Button } from "@/components/ui/button";
 import {
@@ -91,27 +90,9 @@ export function MemberOnboardingForm({
     },
   });
 
-  const [stage, setStage] = useState<"phone" | "details" | "inactive" | "pending" | "success">("phone");
+  const [stage, setStage] = useState<"phone" | "details" | "pending" | "success">("phone");
   const [phoneLoading, setPhoneLoading] = useState(false);
-  const [inactiveMemberId, setInactiveMemberId] = useState<string | null>(null);
-  const [rejoinLoading, setRejoinLoading] = useState(false);
 
-
-  const handleRejoinRequest = async () => {
-    if (!inactiveMemberId) return;
-    setRejoinLoading(true);
-    const res = await onboardingRejoinFromInactive({
-      memId: inactiveMemberId,
-      provider,
-      initialAvatarUrl,
-    });
-    setRejoinLoading(false);
-    if (!res.ok) {
-      form.setError("root", { message: res.message ?? "처리에 실패했습니다." });
-      return;
-    }
-    setStage("pending");
-  };
 
   const handlePhoneSubmit = async (values: MemberOnboardingValues) => {
     const phoneValue = formatPhone(values.phone.trim());
@@ -139,11 +120,6 @@ export function MemberOnboardingForm({
 
     if (check.kind === "new") {
       setStage("details");
-      return;
-    }
-    if (check.kind === "inactive") {
-      setInactiveMemberId(check.memId);
-      setStage("inactive");
       return;
     }
     if (check.kind === "pending") {
@@ -289,34 +265,7 @@ export function MemberOnboardingForm({
               )}
             >
               <div className="flex flex-col gap-6">
-                {stage === "inactive" ? (
-                  <div className="flex flex-col gap-4 text-center">
-                    <p className="text-sm text-muted-foreground">
-                      탈퇴 처리된 계정입니다.<br />
-                      재가입을 신청하면 관리자 승인 후 이용 가능합니다.
-                    </p>
-                    {form.formState.errors.root?.message ? (
-                      <p className="text-sm text-red-500">
-                        {form.formState.errors.root.message}
-                      </p>
-                    ) : null}
-                    <Button
-                      type="button"
-                      className="w-full"
-                      disabled={rejoinLoading}
-                      onClick={handleRejoinRequest}
-                    >
-                      {rejoinLoading ? "신청 중..." : "재가입 신청"}
-                    </Button>
-                    <Button
-                      type="button"
-                      variant="ghost"
-                      onClick={() => setStage("phone")}
-                    >
-                      번호 다시 입력
-                    </Button>
-                  </div>
-                ) : stage === "pending" ? (
+                {stage === "pending" ? (
                   <div className="flex flex-col gap-4 text-center">
                     <p className="text-sm text-muted-foreground">
                       재가입 신청이 접수되었습니다.<br />


### PR DESCRIPTION
## 관련 이슈

관련 이슈 없음

## 요약

비활성(inactive) 회원 상태 관리 기능과 재가입 승인 흐름을 전체 제거합니다. 현재 운영 방식에서 inactive 상태를 사용하지 않으며, 불필요한 분기와 UI가 관리자·온보딩 양쪽에 복잡도를 높이고 있어 정리합니다.

## AS-IS (변경 전)

- 관리자 페이지에 **"가입 승인 대기"** 카드가 별도로 존재
- 관리자 회원 목록에서 `active ↔ inactive` 상태 토글 버튼 제공
- 온보딩 시 전화번호 조회 결과가 `inactive`면 **재가입 신청** 화면 분기
- `onboardingRejoinFromInactive()` 서버 액션으로 pending 전환 + OAuth 재연결
- `updateMemberStatus()` 서버 액션으로 관리자가 직접 상태 변경
- 회원 필터에 `inactive` 탭 존재

## TO-BE (변경 후)

- 관리자 페이지: "가입 승인 대기" 카드 제거, "활성 회원" → **"회원 관리"** 로 라벨 단순화
- 관리자 회원 목록: 비활성화/활성화 버튼 제거, `inactive` 필터 탭 제거
- 온보딩: `inactive` 분기 제거 → `new` / `pending` / `active` 3가지만 처리
- 서버 액션: `updateMemberStatus()`, `onboardingRejoinFromInactive()` 삭제
- `AdminStats` 타입에서 `pendingCount`, `activeCount` 제거 → `totalCount`만 유지

## 주요 변경 사항

| 파일 | 변경 |
|------|------|
| `app/(info)/admin/page.tsx` | 가입 승인 카드 제거, 회원 카드 라벨 변경 |
| `app/(info)/admin/members/admin-members-client.tsx` | inactive 필터·상태 토글 버튼·핸들러 제거 |
| `app/actions/admin/get-admin-stats.ts` | pending/active 카운트 쿼리 제거 |
| `app/actions/admin/manage-member.ts` | `updateMemberStatus()` 삭제 |
| `app/actions/onboarding-mem-v2.ts` | `onboardingRejoinFromInactive()` 삭제, inactive 분기 제거 |
| `components/auth/member-onboarding-form.tsx` | inactive 스테이지·재가입 UI 제거 |