### PR TITLE
fix(projects): 비로그인 시 로그인 페이지로 리다이렉트

### DIFF
--- a/app/(main)/projects/page.tsx
+++ b/app/(main)/projects/page.tsx
@@ -1,3 +1,4 @@
+import { redirect } from "next/navigation";
 import { Suspense } from "react";
 import { Skeleton } from "@/components/ui/skeleton";
 import { PageHeader } from "@/components/common/page-header";
@@ -23,6 +24,7 @@ export default async function ProjectsPage({
   searchParams: Promise<{ month?: string }>;
 }) {
   const { user, member, supabase } = await getCurrentMember();
+  if (!user) redirect("/auth/login");
   const { teamId } = await getRequestTeamContext();
 
   // ACTIVE 이벤트 조회 (1개)


### PR DESCRIPTION
## 요약

프로젝트 탭에서 비로그인 사용자가 접근 시 RLS로 이벤트 조회가 안 되는 문제 해결. 로그인 페이지로 리다이렉트 처리.