### PR TITLE
test(admin): 관리 대시보드 stats 디버그 로그 추가

### DIFF
--- a/app/actions/admin/get-admin-stats.ts
+++ b/app/actions/admin/get-admin-stats.ts
@@ -18,7 +18,8 @@ export async function getAdminStats(): Promise<AdminStats> {
   const me = await verifyAdmin();
   if (!me) throw new Error("권한이 없습니다");
 
-  const { teamId } = await getRequestTeamContext();
+  const { teamId, teamCd } = await getRequestTeamContext();
+  console.log("[getAdminStats] teamId:", teamId, "teamCd:", teamCd);
   const admin = createAdminClient();
 
   const [total, competitions, records, activeProjects, activeEvents, pendingPrt] = await Promise.all([
@@ -27,7 +28,11 @@ export async function getAdminStats(): Promise<AdminStats> {
       .select("*", { count: "exact", head: true })
       .eq("team_id", teamId)
       .eq("vers", 0)
-      .eq("del_yn", false),
+      .eq("del_yn", false)
+      .then((res) => {
+        if (res.error) console.error("[getAdminStats] team_mem_rel error:", res.error, "teamId:", teamId);
+        return res;
+      }),
     (() => {
       const monthStart = currentMonthKST();
       const monthEnd = nextMonthStr(monthStart);
@@ -61,7 +66,7 @@ export async function getAdminStats(): Promise<AdminStats> {
       .eq("evt_team_mst.team_id", teamId),
   ]);
 
-  return {
+  const result = {
     totalCount: total.count ?? 0,
     monthlyCompetitionCount: competitions.count ?? 0,
     recentRecordCount: records.count ?? 0,
@@ -69,4 +74,11 @@ export async function getAdminStats(): Promise<AdminStats> {
     activeEventCount: activeEvents.count ?? 0,
     pendingParticipationCount: pendingPrt.count ?? 0,
   };
+  console.log("[getAdminStats] results:", result, "errors:", {
+    total: total.error,
+    activeProjects: activeProjects.error,
+    activeEvents: activeEvents.error,
+    pendingPrt: pendingPrt.error,
+  });
+  return result;
 }

--- a/lib/queries/request-team.ts
+++ b/lib/queries/request-team.ts
@@ -64,5 +64,6 @@ export async function resolveTeamContextFromHost(
 export const getRequestTeamContext = cache(async (): Promise<RequestTeamContext> => {
   const h = await headers();
   const host = h.get("x-forwarded-host") ?? h.get("host");
+  console.log("[getRequestTeamContext] host:", host, "x-forwarded-host:", h.get("x-forwarded-host"), "host-header:", h.get("host"));
   return resolveTeamContextFromHost(host);
 });


### PR DESCRIPTION
## 관련 이슈

관련 이슈 없음 (배포 환경 디버깅)

## 요약

`dev.gigang.team` 배포 환경에서 admin 대시보드의 team_id 필터 쿼리가 0을 반환하는 문제를 진단하기 위한 임시 디버그 로그 추가.

## AS-IS (변경 전)

- 배포 환경에서 회원 관리(0), 활성 프로젝트(0), 활성 이벤트(0) 카운터가 모두 0으로 표시
- 로컬에서는 정상 동작 (회원 104명, 프로젝트 1, 이벤트 2)
- `team_id` 필터가 없는 쿼리(이번 달 대회: 19, 전체 기록: 166)는 정상
- **원인 추적 불가** — Vercel 함수 로그에 디버그 정보 없음

## TO-BE (변경 후)

- `getRequestTeamContext()`: host 헤더 값 로깅 (`x-forwarded-host`, `host`)
- `getAdminStats()`: 해석된 `teamId`/`teamCd` 값 로깅
- `team_mem_rel` 쿼리 에러 개별 로깅
- 최종 결과 + 모든 team_id 쿼리 에러 상태 로깅

## 주요 변경 파일

- `app/actions/admin/get-admin-stats.ts` — stats 결과/에러 로깅
- `lib/queries/request-team.ts` — host 헤더 로깅

> ⚠️ 임시 디버그 코드. 원인 파악 후 제거 예정.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Chores
  * 내부 로깅 및 디버깅 개선

---

**참고**: 이번 업데이트는 내부 개선사항으로, 사용자에게 보이는 기능상 변화는 없습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->