### PR TITLE
test(admin): 서버 액션 응답에 _debug 진단 정보 포함

### DIFF
--- a/app/actions/admin/get-admin-stats.ts
+++ b/app/actions/admin/get-admin-stats.ts
@@ -12,6 +12,11 @@ export type AdminStats = {
   activeProjectCount: number;
   activeEventCount: number;
   pendingParticipationCount: number;
+  _debug?: {
+    teamId: string;
+    teamCd: string;
+    errors: Record<string, unknown>;
+  };
 };
 
 export async function getAdminStats(): Promise<AdminStats> {
@@ -66,19 +71,23 @@ export async function getAdminStats(): Promise<AdminStats> {
       .eq("evt_team_mst.team_id", teamId),
   ]);
 
-  const result = {
+  const result: AdminStats = {
     totalCount: total.count ?? 0,
     monthlyCompetitionCount: competitions.count ?? 0,
     recentRecordCount: records.count ?? 0,
     activeProjectCount: activeProjects.count ?? 0,
     activeEventCount: activeEvents.count ?? 0,
     pendingParticipationCount: pendingPrt.count ?? 0,
+    _debug: {
+      teamId,
+      teamCd,
+      errors: {
+        total: total.error,
+        activeProjects: activeProjects.error,
+        activeEvents: activeEvents.error,
+        pendingPrt: pendingPrt.error,
+      },
+    },
   };
-  console.log("[getAdminStats] results:", result, "errors:", {
-    total: total.error,
-    activeProjects: activeProjects.error,
-    activeEvents: activeEvents.error,
-    pendingPrt: pendingPrt.error,
-  });
   return result;
 }


### PR DESCRIPTION
## 요약

Vercel 함수 로그 없이 서버 액션 응답 payload에서 직접 teamId, 쿼리 에러 확인.

## 변경

- `AdminStats` 타입에 `_debug` 옵셔널 필드 추가
- 응답에 `teamId`, `teamCd`, 쿼리별 에러 포함

> ⚠️ 임시 디버그 코드. 원인 파악 후 즉시 제거.