### PR TITLE
debug(admin): RLS 역할 진단용 키 prefix 및 noFilter 카운트 추가

### DIFF
--- a/app/actions/admin/get-admin-stats.ts
+++ b/app/actions/admin/get-admin-stats.ts
@@ -4,6 +4,7 @@ import { createAdminClient } from "@/lib/supabase/admin";
 import { verifyAdmin } from "@/lib/queries/member";
 import { currentMonthKST, nextMonthStr } from "@/lib/dayjs";
 import { getRequestTeamContext } from "@/lib/queries/request-team";
+import { env } from "@/lib/env";
 
 export type AdminStats = {
   totalCount: number;
@@ -12,11 +13,7 @@ export type AdminStats = {
   activeProjectCount: number;
   activeEventCount: number;
   pendingParticipationCount: number;
-  _debug?: {
-    teamId: string;
-    teamCd: string;
-    errors: Record<string, unknown>;
-  };
+  _debug?: Record<string, unknown>;
 };
 
 export async function getAdminStats(): Promise<AdminStats> {
@@ -24,8 +21,12 @@ export async function getAdminStats(): Promise<AdminStats> {
   if (!me) throw new Error("권한이 없습니다");
 
   const { teamId, teamCd } = await getRequestTeamContext();
-  console.log("[getAdminStats] teamId:", teamId, "teamCd:", teamCd);
   const admin = createAdminClient();
+
+  // 디버그: RLS 역할 확인 — team_id 필터 없이 카운트
+  const noFilter = await admin.from("team_mem_rel").select("*", { count: "exact", head: true });
+  const keyPrefix = env.SUPABASE_SERVICE_ROLE_KEY.slice(0, 20);
+  console.log("[getAdminStats] teamId:", teamId, "keyPrefix:", keyPrefix, "noFilterCount:", noFilter.count, "noFilterError:", noFilter.error);
 
   const [total, competitions, records, activeProjects, activeEvents, pendingPrt] = await Promise.all([
     admin
@@ -81,6 +82,9 @@ export async function getAdminStats(): Promise<AdminStats> {
     _debug: {
       teamId,
       teamCd,
+      keyPrefix,
+      noFilterCount: noFilter.count,
+      noFilterError: noFilter.error,
       errors: {
         total: total.error,
         activeProjects: activeProjects.error,


### PR DESCRIPTION
## 요약

service_role 키가 실제로 동작하는지 확인용 진단 추가.

- `env.SUPABASE_SERVICE_ROLE_KEY` 앞 20자 로깅
- `team_mem_rel` 필터 없이 카운트 (service_role=104+, anon=0)
- `_debug` 응답에 `keyPrefix`, `noFilterCount` 포함

> ⚠️ 임시. 확인 후 제거.