### PR TITLE
chore(env): NEXT_PUBLIC_DEBUG_DATE 제거

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -70,7 +70,6 @@ t3-env로 관리되며 `lib/env.ts`에서 import:
 | `NEXT_PUBLIC_SUPABASE_URL` | 클라이언트 | Supabase 프로젝트 URL |
 | `NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY` | 클라이언트 | Supabase 공개 키 |
 | `NEXT_PUBLIC_ENABLE_DEV_MODE` | 클라이언트 | 개발 모드 활성화 (이메일 로그인 등) |
-| `NEXT_PUBLIC_DEBUG_DATE` | 클라이언트 | 디버그용 날짜 오버라이드 |
 
 ## 커스텀 커맨드
 

--- a/lib/dayjs.ts
+++ b/lib/dayjs.ts
@@ -13,12 +13,8 @@ dayjs.locale("ko");
 
 const KST = "Asia/Seoul";
 
-/** KST 기준 현재 dayjs 인스턴스 (디버그 날짜 지원) */
+/** KST 기준 현재 dayjs 인스턴스 */
 function nowKST() {
-  // NEXT_PUBLIC_ 변수는 Next.js 빌드타임에 인라인 치환되므로 process.env 직접 참조
-  if (process.env.NEXT_PUBLIC_DEBUG_DATE) {
-    return dayjs(process.env.NEXT_PUBLIC_DEBUG_DATE).tz(KST);
-  }
   return dayjs().tz(KST);
 }
 

--- a/lib/env.ts
+++ b/lib/env.ts
@@ -11,7 +11,6 @@ export const env = createEnv({
   client: {
     NEXT_PUBLIC_SUPABASE_URL: z.url(),
     NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY: z.string().min(1),
-    NEXT_PUBLIC_DEBUG_DATE: z.string().optional(),
     NEXT_PUBLIC_ENABLE_DEV_MODE: z
       .string()
       .transform((v) => v === "true")
@@ -25,7 +24,6 @@ export const env = createEnv({
     NEXT_PUBLIC_SUPABASE_URL: process.env.NEXT_PUBLIC_SUPABASE_URL,
     NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY:
       process.env.NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY,
-    NEXT_PUBLIC_DEBUG_DATE: process.env.NEXT_PUBLIC_DEBUG_DATE,
     NEXT_PUBLIC_ENABLE_DEV_MODE: process.env.NEXT_PUBLIC_ENABLE_DEV_MODE,
   },
   /** CI 환경(GitHub Actions 등)이거나 SKIP_ENV_VALIDATION=true면 검증 스킵 */


### PR DESCRIPTION
## 관련 이슈

관련 이슈 없음

## 요약

로컬 테스트 전용으로 도입했던 `NEXT_PUBLIC_DEBUG_DATE` 환경변수를 코드/스키마/문서에서 완전 제거합니다. 클라이언트 번들에 인라인될 위험을 없애고, 운영/dev 배포에서 실제 현재 시각만 사용하도록 보장합니다.

## AS-IS

- `lib/dayjs.ts`의 `nowKST()`가 `process.env.NEXT_PUBLIC_DEBUG_DATE`가 설정돼 있으면 해당 값으로 시간을 오버라이드
- `lib/env.ts`의 t3-env 스키마에 `NEXT_PUBLIC_DEBUG_DATE` 정의 존재 → Vercel 환경변수로 설정 시 클라이언트 번들에 그대로 인라인 가능
- `CLAUDE.md` 환경변수 표에 "디버그용 날짜 오버라이드"로 문서화되어 있어 운영/dev에 설정해도 되는 값처럼 오해될 여지

## TO-BE

- `nowKST()`는 오직 `dayjs().tz(KST)`만 반환 (시간 오버라이드 분기 제거)
- `lib/env.ts`에서 `NEXT_PUBLIC_DEBUG_DATE` 스키마·`runtimeEnv` 매핑 모두 삭제
- `CLAUDE.md` 환경변수 표에서 해당 행 제거
- 저장소 전체 grep 결과 `NEXT_PUBLIC_DEBUG_DATE` 참조 0건

## 주요 변경 사항

- \`lib/dayjs.ts\` — \`nowKST()\`에서 DEBUG_DATE 분기 제거
- \`lib/env.ts\` — 클라이언트 env 스키마 및 \`runtimeEnv\`에서 정의 삭제
- \`CLAUDE.md\` — 환경변수 문서 테이블에서 행 삭제

## 비고

- Vercel `gigang-client-dev` / `gigang-client` 프로젝트에 혹시 `NEXT_PUBLIC_DEBUG_DATE`가 설정돼 있다면 함께 제거 권장 (코드에서 무시하지만 정리 차원)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Chores**
  * 디버그 날짜 오버라이드 환경 변수 제거. 시스템이 항상 현재 시간을 정확하게 반영하도록 변경되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->