### PR TITLE
feat(profile): 기록 입력에서 대회 날짜로 조회·대회 추가 연동

### DIFF
--- a/app/(main)/profile/page.tsx
+++ b/app/(main)/profile/page.tsx
@@ -86,7 +86,18 @@ async function ProfileContent() {
         <PaceChart records={(raceResults ?? []).map((r) => ({ event_type: (Array.isArray(r.comp_evt_cfg) ? r.comp_evt_cfg[0] : r.comp_evt_cfg)?.comp_evt_type?.toUpperCase() ?? "", record_time_sec: r.rec_time_sec, race_name: r.race_nm, race_date: r.race_dt }))} />
 
         {/* 기록 입력 */}
-        <RaceRecordSection memberId={member.id} teamId={teamId} />
+        <RaceRecordSection
+          memberId={member.id}
+          teamId={teamId}
+          competitionRegisterMemberStatus={{
+            status: "ready",
+            userId: user.id,
+            memberId: member.id,
+            fullName: member.full_name,
+            email: user.email ?? null,
+            admin: member.admin,
+          }}
+        />
       </div>
   );
 }

--- a/app/actions/search-competitions.ts
+++ b/app/actions/search-competitions.ts
@@ -34,3 +34,40 @@ export async function searchCompetitions(query: string): Promise<SearchCompetiti
     event_types: (((row as unknown as { comp_evt_cfg?: { comp_evt_type: string | null }[] }).comp_evt_cfg ?? []).map((e) => e.comp_evt_type?.toUpperCase()).filter(Boolean) as string[]),
   }));
 }
+
+const RACE_DATE_RE = /^\d{4}-\d{2}-\d{2}$/;
+
+/**
+ * 대회 시작일~종료일 구간에 해당 날짜가 포함되는 대회 목록 (기록 입력용).
+ * `end_dt`가 없으면 `stt_dt` 하루만 해당하는 것으로 본다.
+ */
+export async function listCompetitionsByRaceDate(raceDate: string): Promise<SearchCompetition[]> {
+  const d = raceDate.trim();
+  if (!RACE_DATE_RE.test(d)) return [];
+  const supabase = await createClient();
+  const { data, error } = await supabase
+    .from("comp_mst")
+    .select("comp_id, comp_nm, stt_dt, end_dt, loc_nm, comp_sprt_cd, comp_evt_cfg(comp_evt_type)")
+    .lte("stt_dt", d)
+    .eq("vers", 0)
+    .eq("del_yn", false)
+    .order("stt_dt", { ascending: false })
+    .limit(200);
+
+  if (error) return [];
+
+  type Row = NonNullable<typeof data>[number];
+  return (data ?? [])
+    .filter((row: Row) => {
+      const end = row.end_dt ?? row.stt_dt;
+      return end >= d;
+    })
+    .map((row) => ({
+      id: row.comp_id,
+      title: row.comp_nm,
+      start_date: row.stt_dt,
+      location: row.loc_nm,
+      sport: row.comp_sprt_cd,
+      event_types: (((row as unknown as { comp_evt_cfg?: { comp_evt_type: string | null }[] }).comp_evt_cfg ?? []).map((e) => e.comp_evt_type?.toUpperCase()).filter(Boolean) as string[]),
+    }));
+}

--- a/components/profile/race-record-dialog.tsx
+++ b/components/profile/race-record-dialog.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState, useEffect, useMemo, useRef } from "react";
+import { useRouter } from "next/navigation";
 import { createClient } from "@/lib/supabase/client";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
@@ -15,8 +16,10 @@ import { cn } from "@/lib/utils";
 import { timeStringToSeconds, secondsToTime } from "@/lib/dayjs";
 import { buildEventTypeOptionList, sanitizeAsciiUpperCompEvtTypeInput } from "@/lib/comp-evt-type";
 import { resolveSportConfig } from "@/components/races/sport-config";
-import { searchCompetitions } from "@/app/actions/search-competitions";
+import { listCompetitionsByRaceDate, searchCompetitions } from "@/app/actions/search-competitions";
 import { saveRaceRecord } from "@/app/actions/save-race-record";
+import { CompetitionRegisterDialog } from "@/components/races/competition-register-dialog";
+import type { MemberStatus } from "@/components/races/types";
 
 /** 기타(직접 입력) 선택 시 사용 */
 const EVENT_TYPE_OTHER = "__OTHER__";
@@ -44,13 +47,17 @@ export function RaceRecordDialog({
   open,
   onOpenChange,
   onSaved,
+  competitionRegisterMemberStatus,
 }: {
   memberId: string;
   teamId: string;
   open: boolean;
   onOpenChange: (open: boolean) => void;
   onSaved: () => void;
+  /** 대회 등록 다이얼로그용. 없으면 「대회 추가」는 표시하지 않는다. */
+  competitionRegisterMemberStatus?: MemberStatus;
 }) {
+  const router = useRouter();
   const supabase = useMemo(() => createClient(), []);
 
   // 단계 관리
@@ -63,10 +70,14 @@ export function RaceRecordDialog({
   // 선택된 대회
   const [selectedComp, setSelectedComp] = useState<Competition | null>(null);
 
-  // 전체 대회 검색 (자동완성)
+  // 대회 날짜 + 이름 검색 / 자동완성
+  const [raceDate, setRaceDate] = useState("");
+  const [compsForRaceDate, setCompsForRaceDate] = useState<Competition[]>([]);
+  const [dateListLoading, setDateListLoading] = useState(false);
   const [searchQuery, setSearchQuery] = useState("");
   const [searchResults, setSearchResults] = useState<Competition[]>([]);
   const [searchLoading, setSearchLoading] = useState(false);
+  const [registerOpen, setRegisterOpen] = useState(false);
   const searchInputRef = useRef<HTMLInputElement | null>(null);
   const dialogContentRef = useRef<HTMLDivElement | null>(null);
 
@@ -112,8 +123,12 @@ export function RaceRecordDialog({
     if (open) {
       setStep(1);
       setSelectedComp(null);
+      setRaceDate("");
+      setCompsForRaceDate([]);
+      setDateListLoading(false);
       setSearchQuery("");
       setSearchResults([]);
+      setRegisterOpen(false);
       setSelectedEventType("");
       setCustomEventType("");
       setTotalTime("");
@@ -180,8 +195,34 @@ export function RaceRecordDialog({
     setLoadingComps(false);
   }
 
-  // 검색어 디바운스 후 전체 대회 검색
+  // 대회 날짜 선택 시 해당 구간 대회 목록
   useEffect(() => {
+    const d = raceDate.trim();
+    if (!d) {
+      setCompsForRaceDate([]);
+      setDateListLoading(false);
+      return;
+    }
+    let cancelled = false;
+    setDateListLoading(true);
+    void (async () => {
+      const list = await listCompetitionsByRaceDate(d);
+      if (!cancelled) {
+        setCompsForRaceDate(list as Competition[]);
+        setDateListLoading(false);
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [raceDate]);
+
+  // 날짜 미선택일 때만 이름으로 전체 대회 검색(자동완성)
+  useEffect(() => {
+    if (raceDate.trim()) {
+      setSearchResults([]);
+      return;
+    }
     if (!searchQuery.trim()) {
       setSearchResults([]);
       return;
@@ -193,11 +234,19 @@ export function RaceRecordDialog({
       setSearchLoading(false);
     }, 300);
     return () => clearTimeout(t);
-  }, [searchQuery]);
+  }, [searchQuery, raceDate]);
+
+  const filteredByDateAndName = useMemo(() => {
+    const q = searchQuery.trim().toLowerCase();
+    if (!q) return compsForRaceDate;
+    return compsForRaceDate.filter((c) => c.title.toLowerCase().includes(q));
+  }, [compsForRaceDate, searchQuery]);
 
   // 대회 선택 — 참가한 대회면 참가 종목 고정으로 바로 step 3, 검색 대회는 step 2(종목 선택)
   function handleSelectCompetition(comp: Competition) {
     setSelectedComp(comp);
+    setRaceDate("");
+    setCompsForRaceDate([]);
     setSearchQuery("");
     setSearchResults([]);
     const registered = (comp.registeredEventType ?? "").trim().toUpperCase();
@@ -318,6 +367,7 @@ export function RaceRecordDialog({
   }, [scrollSearchInputAboveKeyboard]);
 
   return (
+    <>
     <Dialog open={open} onOpenChange={onOpenChange}>
       <DialogContent ref={dialogContentRef} className="max-h-[85vh] overflow-y-auto sm:max-w-lg">
         <DialogHeader>
@@ -373,10 +423,26 @@ export function RaceRecordDialog({
             )}
 
             <div className="border-t border-border pt-3">
-              <label className="mb-1.5 block text-xs font-medium text-muted-foreground">대회 검색</label>
+              <label className="mb-1.5 block text-xs font-medium text-muted-foreground">
+                대회 날짜
+              </label>
+              <Input
+                type="date"
+                max="9999-12-31"
+                value={raceDate}
+                onChange={(e) => setRaceDate(e.target.value)}
+                className="mb-3"
+              />
+              <label className="mb-1.5 block text-xs font-medium text-muted-foreground">
+                대회 검색
+              </label>
               <Input
                 ref={searchInputRef}
-                placeholder="대회명으로 검색 (전체 목록)"
+                placeholder={
+                  raceDate.trim()
+                    ? "대회명으로 목록 좁히기 (선택)"
+                    : "대회명으로 검색 (전체 목록)"
+                }
                 value={searchQuery}
                 onChange={(e) => setSearchQuery(e.target.value)}
                 onFocus={() => {
@@ -385,26 +451,98 @@ export function RaceRecordDialog({
                 }}
                 className="mb-2"
               />
-              {searchLoading && (
-                <p className="text-xs text-muted-foreground">검색 중...</p>
-              )}
-              {!searchLoading && searchResults.length > 0 && (
-                <div className="max-h-48 space-y-1 overflow-y-auto rounded-lg border border-border p-2">
-                  {searchResults.map((comp) => (
-                    <Button
-                      key={comp.id}
-                      type="button"
-                      variant="ghost"
-                      onClick={() => handleSelectCompetition(comp)}
-                      className="h-auto w-full flex-col items-start gap-0.5 px-3 py-2 hover:bg-muted/50"
-                    >
-                      <p className="font-medium">{comp.title}</p>
+
+              {raceDate.trim() ? (
+                <>
+                  {dateListLoading && (
+                    <p className="text-xs text-muted-foreground">목록 불러오는 중...</p>
+                  )}
+                  {!dateListLoading && compsForRaceDate.length === 0 && (
+                    <div className="flex flex-col gap-2 rounded-lg border border-dashed border-border p-3">
                       <p className="text-xs text-muted-foreground">
-                        {comp.start_date} &middot; {comp.location ?? "-"}
+                        이 날짜에 해당하는 대회가 없습니다. 대회를 추가한 뒤 다시 선택해 주세요.
                       </p>
-                    </Button>
-                  ))}
-                </div>
+                      {competitionRegisterMemberStatus && (
+                        <Button
+                          type="button"
+                          variant="secondary"
+                          size="sm"
+                          className="w-full"
+                          onClick={() => setRegisterOpen(true)}
+                        >
+                          대회 추가
+                        </Button>
+                      )}
+                    </div>
+                  )}
+                  {!dateListLoading &&
+                    compsForRaceDate.length > 0 &&
+                    filteredByDateAndName.length === 0 && (
+                      <p className="text-xs text-muted-foreground">
+                        이름과 일치하는 대회가 없습니다. 검색어를 바꿔 보세요.
+                      </p>
+                    )}
+                  {!dateListLoading && filteredByDateAndName.length > 0 && (
+                    <div className="max-h-48 space-y-1 overflow-y-auto rounded-lg border border-border p-2">
+                      {filteredByDateAndName.map((comp) => (
+                        <Button
+                          key={comp.id}
+                          type="button"
+                          variant="ghost"
+                          onClick={() => handleSelectCompetition(comp)}
+                          className="h-auto w-full flex-col items-start gap-0.5 px-3 py-2 hover:bg-muted/50"
+                        >
+                          <p className="font-medium">{comp.title}</p>
+                          <p className="text-xs text-muted-foreground">
+                            {comp.start_date} &middot; {comp.location ?? "-"}
+                          </p>
+                        </Button>
+                      ))}
+                    </div>
+                  )}
+                </>
+              ) : (
+                <>
+                  {searchLoading && (
+                    <p className="text-xs text-muted-foreground">검색 중...</p>
+                  )}
+                  {!searchLoading && searchQuery.trim() && searchResults.length === 0 && (
+                    <div className="flex flex-col gap-2 rounded-lg border border-dashed border-border p-3">
+                      <p className="text-xs text-muted-foreground">
+                        검색 결과가 없습니다.
+                      </p>
+                      {competitionRegisterMemberStatus && (
+                        <Button
+                          type="button"
+                          variant="secondary"
+                          size="sm"
+                          className="w-full"
+                          onClick={() => setRegisterOpen(true)}
+                        >
+                          대회 추가
+                        </Button>
+                      )}
+                    </div>
+                  )}
+                  {!searchLoading && searchResults.length > 0 && (
+                    <div className="max-h-48 space-y-1 overflow-y-auto rounded-lg border border-border p-2">
+                      {searchResults.map((comp) => (
+                        <Button
+                          key={comp.id}
+                          type="button"
+                          variant="ghost"
+                          onClick={() => handleSelectCompetition(comp)}
+                          className="h-auto w-full flex-col items-start gap-0.5 px-3 py-2 hover:bg-muted/50"
+                        >
+                          <p className="font-medium">{comp.title}</p>
+                          <p className="text-xs text-muted-foreground">
+                            {comp.start_date} &middot; {comp.location ?? "-"}
+                          </p>
+                        </Button>
+                      ))}
+                    </div>
+                  )}
+                </>
               )}
             </div>
           </div>
@@ -566,5 +704,28 @@ export function RaceRecordDialog({
         )}
       </DialogContent>
     </Dialog>
+
+      {competitionRegisterMemberStatus && (
+        <CompetitionRegisterDialog
+          open={registerOpen}
+          onOpenChange={setRegisterOpen}
+          memberStatus={competitionRegisterMemberStatus}
+          stackElevated
+          prefillStartDate={raceDate.trim() || undefined}
+          onCreated={() => {
+            void (async () => {
+              const d = raceDate.trim();
+              if (d) {
+                setDateListLoading(true);
+                const list = await listCompetitionsByRaceDate(d);
+                setCompsForRaceDate(list as Competition[]);
+                setDateListLoading(false);
+              }
+              router.refresh();
+            })();
+          }}
+        />
+      )}
+    </>
   );
 }

--- a/components/profile/race-record-dialog.tsx
+++ b/components/profile/race-record-dialog.tsx
@@ -78,6 +78,8 @@ export function RaceRecordDialog({
   const [searchResults, setSearchResults] = useState<Competition[]>([]);
   const [searchLoading, setSearchLoading] = useState(false);
   const [registerOpen, setRegisterOpen] = useState(false);
+  /** 날짜 검색 목록에서 대회를 고를 때 선택한 달력일(race_dt). 비어 있으면 대회 시작일 사용 */
+  const [recordRaceDayFromCalendar, setRecordRaceDayFromCalendar] = useState("");
   const searchInputRef = useRef<HTMLInputElement | null>(null);
   const dialogContentRef = useRef<HTMLDivElement | null>(null);
 
@@ -129,6 +131,7 @@ export function RaceRecordDialog({
       setSearchQuery("");
       setSearchResults([]);
       setRegisterOpen(false);
+      setRecordRaceDayFromCalendar("");
       setSelectedEventType("");
       setCustomEventType("");
       setTotalTime("");
@@ -243,7 +246,15 @@ export function RaceRecordDialog({
   }, [compsForRaceDate, searchQuery]);
 
   // 대회 선택 — 참가한 대회면 참가 종목 고정으로 바로 step 3, 검색 대회는 step 2(종목 선택)
-  function handleSelectCompetition(comp: Competition) {
+  function handleSelectCompetition(
+    comp: Competition,
+    opts?: { useCalendarPickForRecordDate?: boolean },
+  ) {
+    const pickedDay =
+      opts?.useCalendarPickForRecordDate && raceDate.trim()
+        ? raceDate.trim()
+        : "";
+    setRecordRaceDayFromCalendar(pickedDay);
     setSelectedComp(comp);
     setRaceDate("");
     setCompsForRaceDate([]);
@@ -272,19 +283,22 @@ export function RaceRecordDialog({
     if (step === 3) {
       if (selectedComp?.registeredEventType) {
         setSelectedComp(null);
+        setRecordRaceDayFromCalendar("");
         setStep(1);
       } else {
         setStep(2);
       }
     } else if (step === 2) {
       setSelectedComp(null);
+      setRecordRaceDayFromCalendar("");
       setStep(1);
     }
   }
 
   // 대회 정보 (DB에서 선택한 대회만)
   const competitionTitle = selectedComp?.title ?? "";
-  const competitionDate = selectedComp?.start_date ?? "";
+  const competitionDate =
+    recordRaceDayFromCalendar.trim() || selectedComp?.start_date || "";
   const eventType =
     selectedEventType === EVENT_TYPE_OTHER
       ? sanitizeAsciiUpperCompEvtTypeInput(customEventType).trim()
@@ -452,27 +466,31 @@ export function RaceRecordDialog({
                 className="mb-2"
               />
 
+              {competitionRegisterMemberStatus && (
+                <Button
+                  type="button"
+                  variant="secondary"
+                  size="sm"
+                  className="mb-2 w-full"
+                  onClick={() => setRegisterOpen(true)}
+                >
+                  대회 추가
+                </Button>
+              )}
+
               {raceDate.trim() ? (
                 <>
                   {dateListLoading && (
                     <p className="text-xs text-muted-foreground">목록 불러오는 중...</p>
                   )}
                   {!dateListLoading && compsForRaceDate.length === 0 && (
-                    <div className="flex flex-col gap-2 rounded-lg border border-dashed border-border p-3">
+                    <div className="rounded-lg border border-dashed border-border p-3">
                       <p className="text-xs text-muted-foreground">
-                        이 날짜에 해당하는 대회가 없습니다. 대회를 추가한 뒤 다시 선택해 주세요.
+                        이 날짜에 해당하는 대회가 없습니다.
+                        {competitionRegisterMemberStatus
+                          ? " 대회 추가로 등록한 뒤 다시 선택해 주세요."
+                          : ""}
                       </p>
-                      {competitionRegisterMemberStatus && (
-                        <Button
-                          type="button"
-                          variant="secondary"
-                          size="sm"
-                          className="w-full"
-                          onClick={() => setRegisterOpen(true)}
-                        >
-                          대회 추가
-                        </Button>
-                      )}
                     </div>
                   )}
                   {!dateListLoading &&
@@ -480,6 +498,9 @@ export function RaceRecordDialog({
                     filteredByDateAndName.length === 0 && (
                       <p className="text-xs text-muted-foreground">
                         이름과 일치하는 대회가 없습니다. 검색어를 바꿔 보세요.
+                        {competitionRegisterMemberStatus
+                          ? " 원하는 대회가 없으면 대회 추가를 이용해 주세요."
+                          : ""}
                       </p>
                     )}
                   {!dateListLoading && filteredByDateAndName.length > 0 && (
@@ -489,7 +510,11 @@ export function RaceRecordDialog({
                           key={comp.id}
                           type="button"
                           variant="ghost"
-                          onClick={() => handleSelectCompetition(comp)}
+                          onClick={() =>
+                            handleSelectCompetition(comp, {
+                              useCalendarPickForRecordDate: true,
+                            })
+                          }
                           className="h-auto w-full flex-col items-start gap-0.5 px-3 py-2 hover:bg-muted/50"
                         >
                           <p className="font-medium">{comp.title}</p>
@@ -507,21 +532,13 @@ export function RaceRecordDialog({
                     <p className="text-xs text-muted-foreground">검색 중...</p>
                   )}
                   {!searchLoading && searchQuery.trim() && searchResults.length === 0 && (
-                    <div className="flex flex-col gap-2 rounded-lg border border-dashed border-border p-3">
+                    <div className="rounded-lg border border-dashed border-border p-3">
                       <p className="text-xs text-muted-foreground">
                         검색 결과가 없습니다.
+                        {competitionRegisterMemberStatus
+                          ? " 대회 추가로 등록해 보세요."
+                          : ""}
                       </p>
-                      {competitionRegisterMemberStatus && (
-                        <Button
-                          type="button"
-                          variant="secondary"
-                          size="sm"
-                          className="w-full"
-                          onClick={() => setRegisterOpen(true)}
-                        >
-                          대회 추가
-                        </Button>
-                      )}
                     </div>
                   )}
                   {!searchLoading && searchResults.length > 0 && (
@@ -554,8 +571,7 @@ export function RaceRecordDialog({
             <div className="flex flex-col gap-3">
               <p className="text-sm font-medium">{selectedComp.title}</p>
               <p className="text-xs text-muted-foreground">
-                {selectedComp.start_date} &middot;{" "}
-                {selectedComp.location ?? "-"}
+                {competitionDate} &middot; {selectedComp.location ?? "-"}
               </p>
 
               {/* 종목 선택 */}
@@ -715,11 +731,17 @@ export function RaceRecordDialog({
           onCreated={() => {
             void (async () => {
               const d = raceDate.trim();
+              const q = searchQuery.trim();
               if (d) {
                 setDateListLoading(true);
                 const list = await listCompetitionsByRaceDate(d);
                 setCompsForRaceDate(list as Competition[]);
                 setDateListLoading(false);
+              } else if (q) {
+                setSearchLoading(true);
+                const list = await searchCompetitions(q);
+                setSearchResults(list as Competition[]);
+                setSearchLoading(false);
               }
               router.refresh();
             })();

--- a/components/profile/race-record-section.tsx
+++ b/components/profile/race-record-section.tsx
@@ -6,13 +6,16 @@ import { CardItem } from "@/components/ui/card";
 import { SectionLabel } from "@/components/common/typography";
 import { RaceRecordDialog } from "./race-record-dialog";
 import { RaceHistoryDialog } from "./race-history-dialog";
+import type { MemberStatus } from "@/components/races/types";
 
 export function RaceRecordSection({
   memberId,
   teamId,
+  competitionRegisterMemberStatus,
 }: {
   memberId: string;
   teamId: string;
+  competitionRegisterMemberStatus?: MemberStatus;
 }) {
   const [recordOpen, setRecordOpen] = useState(false);
   const [historyOpen, setHistoryOpen] = useState(false);
@@ -48,6 +51,7 @@ export function RaceRecordSection({
         teamId={teamId}
         open={recordOpen}
         onOpenChange={setRecordOpen}
+        competitionRegisterMemberStatus={competitionRegisterMemberStatus}
         onSaved={() => {
           setRecordOpen(false);
           router.refresh();

--- a/components/races/competition-register-dialog.tsx
+++ b/components/races/competition-register-dialog.tsx
@@ -48,6 +48,10 @@ interface CompetitionRegisterDialogProps {
   onOpenChange: (open: boolean) => void;
   memberStatus: MemberStatus;
   onCreated: () => void;
+  /** 다른 다이얼로그 위에 겹쳐 표시할 때 오버레이·콘텐츠 z-index 상향 */
+  stackElevated?: boolean;
+  /** 열 때 시작일(YYYY-MM-DD) 미리 채움 */
+  prefillStartDate?: string;
 }
 
 export function CompetitionRegisterDialog({
@@ -55,6 +59,8 @@ export function CompetitionRegisterDialog({
   onOpenChange,
   memberStatus,
   onCreated,
+  stackElevated = false,
+  prefillStartDate,
 }: CompetitionRegisterDialogProps) {
   const {
     register,
@@ -83,8 +89,13 @@ export function CompetitionRegisterDialog({
 
   // 다이얼로그 열릴 때 폼 초기화
   useEffect(() => {
-    if (open) reset(defaultValues);
-  }, [open, reset]);
+    if (open) {
+      reset({
+        ...defaultValues,
+        ...(prefillStartDate?.trim() ? { startDate: prefillStartDate.trim() } : {}),
+      });
+    }
+  }, [open, prefillStartDate, reset]);
 
   const toggleEventType = (type: string) => {
     const current = selectedEventTypes;
@@ -118,7 +129,13 @@ export function CompetitionRegisterDialog({
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent className="max-h-[85vh] overflow-y-auto sm:max-w-lg">
+      <DialogContent
+        overlayClassName={stackElevated ? "z-[60]" : undefined}
+        className={cn(
+          "max-h-[85vh] overflow-y-auto sm:max-w-lg",
+          stackElevated && "z-[60]",
+        )}
+      >
         <DialogHeader>
           <DialogTitle>대회 등록</DialogTitle>
           <DialogDescription>

--- a/components/ui/dialog.tsx
+++ b/components/ui/dialog.tsx
@@ -24,12 +24,17 @@ const DialogOverlay = React.forwardRef<
 ));
 DialogOverlay.displayName = DialogPrimitive.Overlay.displayName;
 
+type DialogContentProps = React.ComponentPropsWithoutRef<typeof DialogPrimitive.Content> & {
+  /** 오버레이에만 적용 (중첩 다이얼로그 등에서 z-index 조정용) */
+  overlayClassName?: string;
+};
+
 const DialogContent = React.forwardRef<
   React.ElementRef<typeof DialogPrimitive.Content>,
-  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Content>
->(({ className, children, ...props }, ref) => (
+  DialogContentProps
+>(({ className, overlayClassName, children, ...props }, ref) => (
   <DialogPortal>
-    <DialogOverlay />
+    <DialogOverlay className={overlayClassName} />
     <DialogPrimitive.Content
       ref={ref}
       className={cn(


### PR DESCRIPTION
- as-is : 대회 이름을 검색하면 자동완성으로 목록을 보여주는데 검색하기 어려움
  예) 2026 서울동아마라톤 대회를 '동마'로 검색 시 목록에 나오지않음

- to-be : 대회 날짜 선택하여 검색 가능, 목록에서 이름으로 필터링 가능
  대회가 등록되지 않았을 시 대회추가 버튼 (대회탭의 추가팝업과 동일)


- 대회 날짜 선택 시 stt_dt~end_dt 구간 대회 목록(listCompetitionsByRaceDate)

- 동일 스크롤 목록 UI, 이름 입력으로 목록만 클라이언트 필터

- 결과 없을 때 대회 추가(등록 다이얼로그, 시작일 프리필, 중첩 z-index)

- DialogContent에 overlayClassName 옵션 추가

Made-with: Cursor

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 경기 날짜별 검색 기능 추가 - 경기 기록 입력 시 특정 날짜의 경기를 검색할 수 있습니다.
  * 프로필에서 경기 직접 추가 가능 - 새로운 경기를 등록할 수 있는 기능이 추가되었습니다.
  * 개선된 검색 UI - 경기명 검색과 날짜별 검색을 함께 지원합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->