### PR TITLE
feat: comp_mst 종목 검증, 참가 현황 복구, 기록 입력 정리

### DIFF
--- a/app/actions/get-public-team-comp-reg-display-counts.ts
+++ b/app/actions/get-public-team-comp-reg-display-counts.ts
@@ -1,0 +1,38 @@
+"use server";
+
+import { createClient } from "@supabase/supabase-js";
+
+import { env } from "@/lib/env";
+import type { Database } from "@/lib/supabase/database.types";
+
+export type PublicCompRegDisplayCountRow = {
+  display_key: string;
+  cnt: number;
+};
+
+/**
+ * 비회원·로딩 등 RLS로 comp_reg_rel 상세를 못 읽을 때용: 표시 키별 인원만 (이름 없음).
+ * `get_public_team_comp_reg_display_counts` SECURITY DEFINER.
+ */
+export async function getPublicTeamCompRegDisplayCounts(
+  teamId: string,
+  compId: string,
+): Promise<{ ok: true; rows: PublicCompRegDisplayCountRow[] } | { ok: false; rows: []; message: string }> {
+  const supabase = createClient<Database>(
+    env.NEXT_PUBLIC_SUPABASE_URL,
+    env.NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY,
+  );
+  const { data, error } = await supabase.rpc("get_public_team_comp_reg_display_counts", {
+    p_team_id: teamId,
+    p_comp_id: compId,
+  });
+  if (error) {
+    console.error("get_public_team_comp_reg_display_counts:", error);
+    return { ok: false, rows: [], message: error.message };
+  }
+  const rows = (data ?? []).map((r) => ({
+    display_key: r.display_key,
+    cnt: Number(r.cnt),
+  }));
+  return { ok: true, rows };
+}

--- a/components/profile/race-record-dialog.tsx
+++ b/components/profile/race-record-dialog.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import { useState, useEffect, useMemo, useRef } from "react";
-import { useRouter } from "next/navigation";
 import { createClient } from "@/lib/supabase/client";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
@@ -64,7 +63,6 @@ export function RaceRecordDialog({
   /** 대회 등록 다이얼로그용. 없으면 「대회 추가」는 표시하지 않는다. */
   competitionRegisterMemberStatus?: MemberStatus;
 }) {
-  const router = useRouter();
   const supabase = useMemo(() => createClient(), []);
 
   // 단계 관리
@@ -739,24 +737,7 @@ export function RaceRecordDialog({
           memberStatus={competitionRegisterMemberStatus}
           stackElevated
           prefillStartDate={raceDate.trim() || undefined}
-          onCreated={() => {
-            void (async () => {
-              const d = raceDate.trim();
-              const q = searchQuery.trim();
-              if (d) {
-                setDateListLoading(true);
-                const list = await listCompetitionsByRaceDate(d);
-                setCompsForRaceDate(list as Competition[]);
-                setDateListLoading(false);
-              } else if (q) {
-                setSearchLoading(true);
-                const list = await searchCompetitions(q);
-                setSearchResults(list as Competition[]);
-                setSearchLoading(false);
-              }
-              router.refresh();
-            })();
-          }}
+          onCreated={() => {}}
         />
       )}
     </>

--- a/components/races/competition-detail-dialog.tsx
+++ b/components/races/competition-detail-dialog.tsx
@@ -27,6 +27,7 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select";
+import { getPublicTeamCompRegDisplayCounts } from "@/app/actions/get-public-team-comp-reg-display-counts";
 import { revalidateCompetitions } from "@/app/actions/revalidate-competitions";
 import { updateCompetition } from "@/app/actions/admin/manage-competition";
 import {
@@ -110,6 +111,10 @@ export function CompetitionDetailDialog({
   const [statusMessage, setStatusMessage] = useState<string | null>(null);
   const [isSaving, setIsSaving] = useState(false);
   const [participants, setParticipants] = useState<RegistrationWithMember[]>([]);
+  /** 비회원 등: RLS 우회 RPC로 표시 키별 인원만 (이름 없음) */
+  const [publicDisplayCounts, setPublicDisplayCounts] = useState<
+    { display_key: string; cnt: number }[]
+  >([]);
 
   // 관리자 수정 모드
   const isAdmin = memberStatus.status === "ready" && memberStatus.admin;
@@ -124,7 +129,7 @@ export function CompetitionDetailDialog({
 
   // 참가자 목록 로드
   const loadParticipants = useCallback(async (competitionId: string) => {
-    const { data: plan } = await supabase
+    const { data: plan, error: planErr } = await supabase
       .from("team_comp_plan_rel")
       .select("team_comp_id")
       .eq("comp_id", competitionId)
@@ -132,17 +137,29 @@ export function CompetitionDetailDialog({
       .eq("vers", 0)
       .eq("del_yn", false)
       .maybeSingle();
+    if (planErr) {
+      console.error("team_comp_plan_rel 조회 실패:", planErr);
+      setParticipants([]);
+      return;
+    }
     if (!plan) {
       setParticipants([]);
       return;
     }
-    const { data } = await supabase
+    const { data, error: regErr } = await supabase
       .from("comp_reg_rel")
-      .select("prt_role_cd, crt_at, comp_evt_cfg(comp_evt_type), mem_mst!comp_reg_rel_mem_id_fkey(mem_nm)")
+      .select(
+        "prt_role_cd, crt_at, comp_evt_cfg(comp_evt_type), mem_mst!fk_comp_reg_rel__mem_mst(mem_nm)",
+      )
       .eq("team_comp_id", plan.team_comp_id)
       .eq("vers", 0)
       .eq("del_yn", false)
       .order("crt_at", { ascending: true });
+    if (regErr) {
+      console.error("comp_reg_rel 참가자 조회 실패:", regErr);
+      setParticipants([]);
+      return;
+    }
     const mapped = (data ?? []).map((r) => {
       const row = r as unknown as {
         prt_role_cd: string;
@@ -166,6 +183,27 @@ export function CompetitionDetailDialog({
     if (!competition || !open) return;
     loadParticipants(competition.id);
   }, [competition?.id, open, loadParticipants]);
+
+  useEffect(() => {
+    if (!competition || !open) {
+      setPublicDisplayCounts([]);
+      return;
+    }
+    if (memberStatus.status === "ready") {
+      setPublicDisplayCounts([]);
+      return;
+    }
+    let cancelled = false;
+    void (async () => {
+      const res = await getPublicTeamCompRegDisplayCounts(teamId, competition.id);
+      if (cancelled) return;
+      if (res.ok) setPublicDisplayCounts(res.rows);
+      else setPublicDisplayCounts([]);
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [competition?.id, open, memberStatus.status, teamId]);
 
   // comp_evt_cfg 종목 + 스포츠 기본값 중 아직 없는 것만 (맨 아래 기타는 SelectItem 별도)
   const eventTypeOptions = useMemo(() => {
@@ -436,20 +474,22 @@ export function CompetitionDetailDialog({
           </Button>
         )}
 
-        {/* 참가자 목록 */}
-        {participants.length > 0 && (() => {
-          // 종목별 난이도 순서 (역순: 힘든 것부터)
+        {/* 참가 현황: 회원은 상세 행·이름, 비회원·온보딩 전 등은 RPC 집계만(이름 없음) */}
+        {(() => {
+          if (!competition) return null;
+
           const sportEvents = eventTypeCodesForSprtFromCmmRows(
             cmmCdRows,
             competition.sport,
           );
           const hardestFirst = [...sportEvents].reverse();
 
-          // 참가자의 표시 키 결정
           const getDisplayKey = (p: RegistrationWithMember) =>
-            p.event_type ?? (p.role === "participant" ? "미정" : roleLabels[p.role as keyof typeof roleLabels] ?? p.role);
+            p.event_type ??
+            (p.role === "participant"
+              ? "미정"
+              : roleLabels[p.role as keyof typeof roleLabels] ?? p.role);
 
-          // 정렬 우선순위: 힘든 코스 → 미정 → 응원/봉사
           const sortOrder = (key: string) => {
             const idx = hardestFirst.indexOf(key);
             if (idx !== -1) return idx;
@@ -459,21 +499,36 @@ export function CompetitionDetailDialog({
             return hardestFirst.length + 3;
           };
 
-          // 코스별 인원 집계 + 정렬
-          const eventCounts = new Map<string, number>();
-          participants.forEach(p => {
-            const key = getDisplayKey(p);
-            eventCounts.set(key, (eventCounts.get(key) ?? 0) + 1);
-          });
-          const sortedCounts = Array.from(eventCounts.entries())
-            .sort((a, b) => sortOrder(a[0]) - sortOrder(b[0]));
+          const publicTotal = publicDisplayCounts.reduce((s, r) => s + r.cnt, 0);
+          const hasMemberRows = participants.length > 0;
+          const showPublicOnly = !hasMemberRows && publicTotal > 0;
+          if (!hasMemberRows && !showPublicOnly) return null;
 
-          // 참가자를 코스별 그룹 + 선착순 정렬
-          const sortedParticipants = [...participants].sort((a, b) => {
-            const orderDiff = sortOrder(getDisplayKey(a)) - sortOrder(getDisplayKey(b));
-            if (orderDiff !== 0) return orderDiff;
-            return a.created_at.localeCompare(b.created_at);
-          });
+          let sortedCounts: [string, number][] = [];
+          let sortedParticipants: RegistrationWithMember[] = [];
+
+          if (hasMemberRows) {
+            const eventCounts = new Map<string, number>();
+            participants.forEach((p) => {
+              const key = getDisplayKey(p);
+              eventCounts.set(key, (eventCounts.get(key) ?? 0) + 1);
+            });
+            sortedCounts = Array.from(eventCounts.entries()).sort(
+              (a, b) => sortOrder(a[0]) - sortOrder(b[0]),
+            );
+            sortedParticipants = [...participants].sort((a, b) => {
+              const orderDiff = sortOrder(getDisplayKey(a)) - sortOrder(getDisplayKey(b));
+              if (orderDiff !== 0) return orderDiff;
+              return a.created_at.localeCompare(b.created_at);
+            });
+          } else {
+            sortedCounts = [...publicDisplayCounts]
+              .map((r) => [r.display_key, r.cnt] as [string, number])
+              .sort((a, b) => sortOrder(a[0]) - sortOrder(b[0]));
+          }
+
+          const totalPeople = hasMemberRows ? participants.length : publicTotal;
+          const showNameRows = memberStatus.status === "ready" && hasMemberRows;
 
           return (
             <>
@@ -481,9 +536,8 @@ export function CompetitionDetailDialog({
               <div className="flex flex-col gap-2">
                 <div className="flex items-center gap-2 text-sm font-semibold text-foreground">
                   <Users className="size-4" />
-                  참가 현황 ({participants.length}명)
+                  참가 현황 ({totalPeople}명)
                 </div>
-                {/* 코스별 인원 (힘든 순) */}
                 <div className="flex flex-wrap gap-1.5">
                   {sortedCounts.map(([event, count]) => (
                     <span
@@ -494,20 +548,21 @@ export function CompetitionDetailDialog({
                     </span>
                   ))}
                 </div>
-                {/* 참가자 이름 목록 (코스별 그룹 + 선착순) */}
-                <div className="flex flex-col gap-1.5 text-xs">
-                  {sortedCounts.map(([event]) => {
-                    const group = sortedParticipants.filter(p => getDisplayKey(p) === event);
-                    return (
-                      <div key={event} className="flex items-baseline gap-2">
-                        <span className="shrink-0 font-semibold text-foreground">{event}</span>
-                        <span className="text-muted-foreground">
-                          {group.map(p => p.member?.mem_nm ?? "이름 없음").join(", ")}
-                        </span>
-                      </div>
-                    );
-                  })}
-                </div>
+                {showNameRows && (
+                  <div className="flex flex-col gap-1.5 text-xs">
+                    {sortedCounts.map(([event]) => {
+                      const group = sortedParticipants.filter((p) => getDisplayKey(p) === event);
+                      return (
+                        <div key={event} className="flex items-baseline gap-2">
+                          <span className="shrink-0 font-semibold text-foreground">{event}</span>
+                          <span className="text-muted-foreground">
+                            {group.map((p) => p.member?.mem_nm ?? "이름 없음").join(", ")}
+                          </span>
+                        </div>
+                      );
+                    })}
+                  </div>
+                )}
               </div>
             </>
           );

--- a/lib/supabase/database.types.ts
+++ b/lib/supabase/database.types.ts
@@ -1326,6 +1326,13 @@ export type Database = {
           stt_dt: string
         }[]
       }
+      get_public_team_comp_reg_display_counts: {
+        Args: { p_comp_id: string; p_team_id: string }
+        Returns: {
+          cnt: number
+          display_key: string
+        }[]
+      }
       get_public_team_member_stats: {
         Args: { p_team_id: string }
         Returns: {

--- a/supabase/migrations/20260421180000_comp_mst_comp_sprt_cd_validate_cmm.sql
+++ b/supabase/migrations/20260421180000_comp_mst_comp_sprt_cd_validate_cmm.sql
@@ -1,0 +1,77 @@
+-- comp_mst.comp_sprt_cd: 하드코딩 CHECK 제거 → cmm_cd (그룹 COMP_SPRT_CD)와 일치할 때만 허용
+-- 신규 종목은 cmm_cd_mst만 추가하면 되고, 앱의 lib/comp-sprt-to-evt-grp.ts 이벤트 그룹 매핑은 별도 반영 필요.
+
+DO $$
+BEGIN
+  IF EXISTS (
+    SELECT 1
+    FROM public.comp_mst c
+    WHERE c.comp_sprt_cd IS NOT NULL
+      AND c.vers = 0
+      AND c.del_yn = false
+      AND NOT EXISTS (
+        SELECT 1
+        FROM public.cmm_cd_mst m
+        INNER JOIN public.cmm_cd_grp_mst g ON g.cd_grp_id = m.cd_grp_id
+        WHERE g.cd_grp_cd = 'COMP_SPRT_CD'
+          AND g.vers = 0
+          AND g.del_yn = false
+          AND g.use_yn = true
+          AND m.cd = c.comp_sprt_cd
+          AND m.vers = 0
+          AND m.del_yn = false
+          AND m.use_yn = true
+      )
+  ) THEN
+    RAISE EXCEPTION
+      'comp_mst에 comp_sprt_cd가 있으나 COMP_SPRT_CD 공통코드에 없는 행이 있습니다. 먼저 cmm_cd_mst를 맞춘 뒤 재실행하세요.';
+  END IF;
+END;
+$$;
+
+ALTER TABLE public.comp_mst DROP CONSTRAINT IF EXISTS ck_comp_mst_comp_sprt_cd;
+
+CREATE OR REPLACE FUNCTION public.comp_mst_validate_comp_sprt_cd()
+RETURNS trigger
+LANGUAGE plpgsql
+AS $$
+BEGIN
+  IF NEW.comp_sprt_cd IS NULL THEN
+    RETURN NEW;
+  END IF;
+
+  IF EXISTS (
+    SELECT 1
+    FROM public.cmm_cd_mst m
+    INNER JOIN public.cmm_cd_grp_mst g ON g.cd_grp_id = m.cd_grp_id
+    WHERE g.cd_grp_cd = 'COMP_SPRT_CD'
+      AND g.vers = 0
+      AND g.del_yn = false
+      AND g.use_yn = true
+      AND m.cd = NEW.comp_sprt_cd
+      AND m.vers = 0
+      AND m.del_yn = false
+      AND m.use_yn = true
+  ) THEN
+    RETURN NEW;
+  END IF;
+
+  RAISE EXCEPTION
+    USING
+      ERRCODE = '23514',
+      MESSAGE = format(
+        'comp_mst.comp_sprt_cd %L 은(는) 사용 중인 COMP_SPRT_CD 공통코드에 없습니다.',
+        NEW.comp_sprt_cd
+      );
+END;
+$$;
+
+COMMENT ON FUNCTION public.comp_mst_validate_comp_sprt_cd() IS
+  'comp_sprt_cd가 NULL이거나 cmm_cd_mst(COMP_SPRT_CD, vers=0, use_yn, 미삭제)에 존재하는 cd일 때만 허용.';
+
+DROP TRIGGER IF EXISTS trg_comp_mst_validate_comp_sprt_cd ON public.comp_mst;
+
+CREATE TRIGGER trg_comp_mst_validate_comp_sprt_cd
+  BEFORE INSERT OR UPDATE OF comp_sprt_cd ON public.comp_mst
+  FOR EACH ROW
+  EXECUTE FUNCTION public.comp_mst_validate_comp_sprt_cd();

--- a/supabase/migrations/20260421200000_get_public_team_comp_reg_display_counts.sql
+++ b/supabase/migrations/20260421200000_get_public_team_comp_reg_display_counts.sql
@@ -1,0 +1,45 @@
+-- 팀·대회별 참가 표시 키(코스/응원/봉사/미정)별 인원 — 이름 없이 공개(비회원 UI용). SECURITY DEFINER.
+
+CREATE OR REPLACE FUNCTION public.get_public_team_comp_reg_display_counts(
+  p_team_id uuid,
+  p_comp_id uuid
+)
+RETURNS TABLE (display_key text, cnt bigint)
+LANGUAGE sql
+STABLE
+SECURITY DEFINER
+SET search_path = public
+AS $$
+  SELECT s.display_key, count(*)::bigint AS cnt
+  FROM public.team_comp_plan_rel tcp
+  INNER JOIN public.comp_reg_rel cr
+    ON cr.team_comp_id = tcp.team_comp_id
+    AND cr.vers = 0
+    AND cr.del_yn = false
+  LEFT JOIN public.comp_evt_cfg re
+    ON re.comp_evt_id = cr.comp_evt_id
+    AND re.vers = 0
+    AND re.del_yn = false
+  CROSS JOIN LATERAL (
+    SELECT
+      CASE
+        WHEN cr.prt_role_cd = 'participant' THEN
+          COALESCE(NULLIF(upper(trim(re.comp_evt_type::text)), ''), '미정')
+        WHEN cr.prt_role_cd = 'cheering' THEN '응원'
+        WHEN cr.prt_role_cd = 'volunteer' THEN '봉사'
+        ELSE cr.prt_role_cd::text
+      END AS display_key
+  ) s
+  WHERE tcp.team_id = p_team_id
+    AND tcp.comp_id = p_comp_id
+    AND tcp.vers = 0
+    AND tcp.del_yn = false
+  GROUP BY s.display_key;
+$$;
+
+COMMENT ON FUNCTION public.get_public_team_comp_reg_display_counts(uuid, uuid) IS
+  '팀이 계획에 올린 대회의 comp_reg_rel을 표시 키(참가 코스·응원·봉사·미정)별로 집계. PII 없음.';
+
+ALTER FUNCTION public.get_public_team_comp_reg_display_counts(uuid, uuid) OWNER TO postgres;
+
+GRANT EXECUTE ON FUNCTION public.get_public_team_comp_reg_display_counts(uuid, uuid) TO anon, authenticated, service_role;


### PR DESCRIPTION
## 관련 이슈

- (없음 — 필요 시 이슈 번호를 추가해 주세요.)

## 요약

`comp_mst.comp_sprt_cd`를 공통코드와 맞추는 DB 트리거, 대회 상세 **참가 현황** 회복(잘못된 PostgREST 조인), 비회원용 집계 RPC, 기록 입력 플로우 소소 정리를 한 브랜치입니다.

## AS-IS (변경 전)

- `comp_sprt_cd`는 DB CHECK로 하드코딩된 값만 허용 → `ultra` 등 공통코드와 불일치 시 수정 불가.
- 대회 상세에서 `mem_mst!comp_reg_rel_mem_id_fkey` 등 **존재하지 않는 FK 힌트**로 참가자 조회가 실패해 참가 현황 UI가 비어 있음.
- 비회원은 RLS로 참가 상세를 볼 수 없어 집계조차 없음.
- 기록 입력에서 대회 추가 후 불필요한 재조회/`router.refresh` 호출.

## TO-BE (변경 후)

- `ck_comp_mst_comp_sprt_cd` 제거 후 **`COMP_SPRT_CD` 공통코드와 일치할 때만** 허용하는 트리거(`comp_mst_validate_comp_sprt_cd`).
- 참가자 목록: **`mem_mst!fk_comp_reg_rel__mem_mst`** 로 조인 수정, 조회 오류 시 로그.
- **`get_public_team_comp_reg_display_counts`** RPC + 서버 액션으로 표시 키별 인원만 공개 → 비회원·온보딩 전에는 **명수·칩만**, 로그인 팀원(`ready`)만 **이름 목록** 표시.
- 기록 입력 `CompetitionRegisterDialog`의 `onCreated`는 no-op으로 단순화.

## 주요 변경 파일

| 구분 | 경로 |
|------|------|
| DB | `supabase/migrations/20260421180000_comp_mst_comp_sprt_cd_validate_cmm.sql`, `20260421200000_get_public_team_comp_reg_display_counts.sql` |
| 앱 | `components/races/competition-detail-dialog.tsx`, `app/actions/get-public-team-comp-reg-display-counts.ts` |
| 프로필 | `components/profile/race-record-dialog.tsx` |
| 타입 | `lib/supabase/database.types.ts` |

## 배포·DB 주의

- 마이그레이션 **`20260421180000`**, **`20260421200000`** 를 대상 환경에 적용해야 합니다. (원격에는 MCP 등으로 일부 DDL이 이미 반영되었을 수 있음 — `schema_migrations`와 실제 객체 정합 확인 권장.)

## 체크리스트

- [ ] 대회 상세: 로그인 팀원 — 참가 현황·이름 표시
- [ ] 대회 상세: 비로그인 — 총원·evt별 칩만, 이름 없음
- [ ] `comp_sprt_cd` 업데이트(예: `ultra`) 트리거 통과
- [ ] 기록 입력 → 대회 추가 후 플로우

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 비회원 사용자도 대회별 코스별 참가 현황을 확인할 수 있습니다.
  * 대회 상세 화면에서 등록된 참가자 수를 코스별로 표시합니다.

* **개선사항**
  * 데이터베이스 검증 로직이 강화되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->