### PR TITLE
fix(projects): 기록 입력 후 크루 진행현황 그래프 자동 갱신

### DIFF
--- a/components/projects/activity-log-fab.tsx
+++ b/components/projects/activity-log-fab.tsx
@@ -24,6 +24,7 @@ export function ActivityLogFab({ evtId, memId }: ActivityLogFabProps) {
   const handleSuccess = () => {
     setOpen(false);
     router.refresh();
+    window.dispatchEvent(new Event("mileage:refresh"));
   };
 
   return (

--- a/components/projects/crew-monthly-stats.tsx
+++ b/components/projects/crew-monthly-stats.tsx
@@ -144,12 +144,12 @@ export async function CrewMonthlyStats({ evtId, month, evtStartMonth, evtEndMont
         label="총 마일리지"
       />
       <StatCard
-        value={`${avgMileage.toFixed(1)} km`}
-        label="평균 마일리지"
-      />
-      <StatCard
         value={`₩${Math.floor(partyPool).toLocaleString()}`}
         label="총 회식비 풀"
+      />
+      <StatCard
+        value={`${avgMileage.toFixed(1)} km`}
+        label="평균 마일리지"
       />
     </div>
   );

--- a/components/projects/crew-progress-chart.tsx
+++ b/components/projects/crew-progress-chart.tsx
@@ -224,6 +224,12 @@ export function CrewProgressChart({ evtId, memId, month }: CrewProgressChartProp
     load();
   }, [load]);
 
+  useEffect(() => {
+    const handler = () => load();
+    window.addEventListener("mileage:refresh", handler);
+    return () => window.removeEventListener("mileage:refresh", handler);
+  }, [load]);
+
   if (loading) {
     return <Skeleton className="h-64 w-full rounded-2xl" />;
   }


### PR DESCRIPTION
## 관련 이슈

관련 이슈 없음

## 요약

마일리지런 프로젝트 페이지에서 기록을 입력/수정해도 상단의 "크루 진행현황" 그래프가 즉시 반영되지 않는 문제를 수정하고, 월별 통계 카드 순서를 소폭 조정했다.

## AS-IS (변경 전)

- `ActivityLogFab`의 `handleSuccess`가 `router.refresh()`만 호출 → 서버 컴포넌트(`CrewMonthlyStats` 등)는 갱신되지만 클라이언트 컴포넌트인 `CrewProgressChart`는 자체 `useEffect`로 Supabase를 직접 조회하므로 props가 그대로면 **다시 fetch 되지 않음**.
- 결과: 기록 입력 직후 통계 수치는 갱신되지만 그래프는 과거 데이터 그대로 노출되고, 사용자가 수동으로 새로고침하거나 월을 변경해야 반영됨.
- 월별 통계 카드 순서: `달성인원 / 총 마일리지 / 평균 마일리지 / 총 회식비 풀`.

## TO-BE (변경 후)

- `ActivityLogFab`에서 성공 시 `window.dispatchEvent(new Event("mileage:refresh"))`를 추가 디스패치.
- `CrewProgressChart`가 `mileage:refresh` 이벤트를 listen 하여 `load()`를 재실행 → 기록 입력/수정 즉시 그래프가 최신 데이터로 갱신.
- `records-client.tsx`는 별도 라우트(`/projects/records`)라 차트가 mount 돼 있지 않아 추가 변경 불필요 (다시 진입 시 remount 되어 자연 갱신).
- 월별 통계 카드 순서: `달성인원 / 총 마일리지 / 총 회식비 풀 / 평균 마일리지` 로 교체.

## 변경 흐름 (Mermaid)

\`\`\`mermaid
sequenceDiagram
    participant U as 사용자
    participant Fab as ActivityLogFab
    participant Action as logActivity (서버 액션)
    participant Router as Next Router
    participant Chart as CrewProgressChart
    participant Stats as CrewMonthlyStats (RSC)

    U->>Fab: 기록 입력 & 저장
    Fab->>Action: logActivity()
    Action-->>Fab: { ok: true }
    Fab->>Router: router.refresh()
    Router->>Stats: 서버 컴포넌트 재조회
    Fab->>Chart: window.dispatchEvent("mileage:refresh")
    Chart->>Chart: load() 재실행 (Supabase 재조회)
    Chart-->>U: 최신 그래프 표시
\`\`\`

## 주요 변경 사항

- \`components/projects/activity-log-fab.tsx\`: 성공 콜백에서 \`mileage:refresh\` 이벤트 디스패치 추가.
- \`components/projects/crew-progress-chart.tsx\`: \`mileage:refresh\` 리스너 등록 & cleanup.
- \`components/projects/crew-monthly-stats.tsx\`: "평균 마일리지" / "총 회식비 풀" 카드 위치 교체.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 마일리지 데이터 변경 시 통계 화면이 자동으로 실시간 새로고침되어 최신 정보를 즉시 확인할 수 있음

* **개선 사항**
  * 프로젝트 통계 카드 배치 순서 최적화

<!-- end of auto-generated comment: release notes by coderabbit.ai -->