### PR TITLE
feat(onboarding): 한글 이름 validation 추가

### DIFF
--- a/app/(protected)/onboarding/page.tsx
+++ b/app/(protected)/onboarding/page.tsx
@@ -26,12 +26,6 @@ async function OnboardingContent({
     redirect(safeNext === "/onboarding" ? "/" : safeNext);
   }
 
-  const initialFullName =
-    user.user_metadata?.full_name ??
-    user.user_metadata?.name ??
-    user.user_metadata?.nickname ??
-    "";
-
   // OAuth 프로필 사진 URL 추출 (카카오: avatar_url/picture, 구글: picture/avatar_url)
   const initialAvatarUrl =
     user.user_metadata?.picture ??
@@ -45,7 +39,7 @@ async function OnboardingContent({
           userId={user.id}
           provider={user.app_metadata?.provider as "kakao" | "google"}
           email={user.email}
-          initialFullName={initialFullName}
+
           initialAvatarUrl={initialAvatarUrl}
           kakaoChatPassword={env.KAKAO_CHAT_PASSWORD ?? ""}
         />

--- a/components/auth/member-onboarding-form.tsx
+++ b/components/auth/member-onboarding-form.tsx
@@ -43,7 +43,6 @@ import { digitsOnly, formatPhone, isValidPhone } from "@/lib/phone-utils";
 type MemberOnboardingFormProps = {
   userId: string;
   provider: "kakao" | "google";
-  initialFullName?: string | null;
   email?: string | null;
   initialAvatarUrl?: string | null;
   kakaoChatPassword?: string;
@@ -65,7 +64,7 @@ const KAKAO_OPEN_CHAT_URL = "https://open.kakao.com/o/grnMFGng";
 export function MemberOnboardingForm({
   userId: _userId,
   provider,
-  initialFullName,
+
   email,
   initialAvatarUrl,
   kakaoChatPassword,
@@ -79,7 +78,7 @@ export function MemberOnboardingForm({
       : "/";
   const form = useForm<MemberOnboardingValues>({
     defaultValues: {
-      fullName: initialFullName ?? "",
+      fullName: "",
       gender: "",
       birthday: "",
       phone: "",

--- a/components/auth/member-onboarding-form.tsx
+++ b/components/auth/member-onboarding-form.tsx
@@ -347,7 +347,19 @@ export function MemberOnboardingForm({
                     <FormField
                       control={form.control}
                       name="fullName"
-                      rules={{ required: "이름을 입력해 주세요." }}
+                      rules={{
+                        required: "이름을 입력해 주세요.",
+                        validate: (value) => {
+                          const trimmed = value.trim();
+                          if (!/^[가-힣]+$/.test(trimmed))
+                            return "한글 이름만 입력해 주세요";
+                          if (trimmed.length < 2)
+                            return "이름은 2자 이상 입력해 주세요";
+                          if (trimmed.length > 5)
+                            return "이름은 5자 이하로 입력해 주세요";
+                          return true;
+                        },
+                      }}
                       render={({ field }) => (
                         <FormItem>
                           <FormLabel>이름</FormLabel>

--- a/lib/validations/member.ts
+++ b/lib/validations/member.ts
@@ -4,9 +4,18 @@ import type { Enums } from "@/lib/supabase/database.types";
 /** DB gender enum + 빈 문자열(미선택) 허용 */
 const genderValues = ["male", "female", ""] as const;
 
+/** 한글 이름 검증 (2~5자, 한글만) */
+export const koreanNameSchema = z
+  .string()
+  .trim()
+  .min(1, "이름을 입력해 주세요")
+  .regex(/^[가-힣]+$/, "한글 이름만 입력해 주세요")
+  .min(2, "이름은 2자 이상 입력해 주세요")
+  .max(5, "이름은 5자 이하로 입력해 주세요");
+
 /** 프로필 수정 폼 */
 export const profileEditSchema = z.object({
-  full_name: z.string().min(1, "이름을 입력해 주세요"),
+  full_name: koreanNameSchema,
   gender: z.enum(genderValues),
   birthday: z.string(),
   email: z


### PR DESCRIPTION
## 관련 이슈

관련 이슈 없음

## 요약

온보딩 시 이름 입력에 한국인 이름 기준 validation을 추가하여, 영문·숫자·특수문자 입력이나 비정상적 길이를 방지한다.

## AS-IS (변경 전)

- 온보딩 폼 `fullName` 필드: `required`만 적용 → 공백 1자, 영문, 숫자 등 모두 통과
- `profileEditSchema.full_name`: `z.string().min(1)` → 동일하게 아무 문자나 허용
- 잘못된 이름이 DB에 그대로 저장되는 문제

## TO-BE (변경 후)

- **공통 Zod 스키마** `koreanNameSchema` 추가 (`lib/validations/member.ts`)
  - 한글만 허용 (`/^[가-힣]+$/`)
  - 2~5자 제한
  - 자동 trim
- **온보딩 폼**: `fullName` 필드에 inline validate로 동일 규칙 적용
- **프로필 편집 폼**: `profileEditSchema.full_name`이 `koreanNameSchema` 사용 → 자동 적용

## 주요 변경 사항

- `lib/validations/member.ts` — `koreanNameSchema` 추가, `profileEditSchema`에 적용
- `components/auth/member-onboarding-form.tsx` — `fullName` validate 강화

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * 사용자 이름 입력 필드의 유효성 검사를 강화했습니다. 한글 문자만 입력 가능하며, 최소 2자 이상 최대 5자 이하로 제한됩니다. 입력 조건에 맞지 않을 경우 구체적인 오류 메시지를 표시합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->