### PR TITLE
ci: dev→main 자동 PR 생성 워크플로우 추가

### DIFF
--- a/.github/workflows/pr-promotion.yml
+++ b/.github/workflows/pr-promotion.yml
@@ -1,0 +1,56 @@
+name: Promote dev → main
+
+on:
+  pull_request:
+    types: [closed]
+    branches: [dev]
+  workflow_dispatch:
+
+concurrency:
+  group: pr-promotion
+  cancel-in-progress: true
+
+jobs:
+  create-or-update-pr:
+    if: github.event.pull_request.merged == true || github.event_name == 'workflow_dispatch'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Create or update PR
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          # 기존 dev→main PR 찾기
+          EXISTING_PR=$(gh pr list --base main --head dev --state open --json number --jq '.[0].number')
+
+          if [ -n "$EXISTING_PR" ]; then
+            echo "✅ 기존 PR #$EXISTING_PR 발견 — 본문 업데이트"
+          else
+            echo "📝 새 PR 생성"
+            # dev→main 간 커밋 요약 생성
+            BODY=$(cat <<'EOF'
+          ## Summary
+
+          dev 브랜치의 변경사항을 main으로 머지합니다.
+
+          ### Commits
+
+          EOF
+          )
+            COMMITS_LOG=$(git log origin/main..origin/dev --oneline --no-merges)
+            BODY="${BODY}
+          ${COMMITS_LOG}"
+
+            gh pr create \
+              --base main \
+              --head dev \
+              --title "chore: merge dev into main" \
+              --body "$BODY"
+          fi


### PR DESCRIPTION
## 관련 이슈

관련 이슈 없음

## 요약

dev 브랜치에 PR이 머지될 때 자동으로 dev→main PR을 생성하는 GitHub Actions 워크플로우를 추가합니다.

## AS-IS (변경 전)

- dev→main 머지를 수동으로 PR 생성해야 함
- main 반영이 누락되거나 지연될 수 있음

## TO-BE (변경 후)

- dev에 PR 머지 시 자동으로 dev→main PR 생성
- 이미 열린 PR이 있으면 재사용 (중복 생성 방지)
- `workflow_dispatch`로 수동 실행도 가능
- 커밋 목록을 PR 본문에 자동 포함

## 주요 변경 사항

- `.github/workflows/pr-promotion.yml` 신규 추가