### PR TITLE
feat(settings): 버전 정보를 git tag에서 자동 반영

### DIFF
--- a/components/settings/settings-client.tsx
+++ b/components/settings/settings-client.tsx
@@ -129,7 +129,7 @@ export function SettingsClient({ isAdmin }: { isAdmin: boolean }) {
               버전 정보
             </span>
           </div>
-          <span className="text-sm text-muted-foreground">v1.0.0</span>
+          <span className="text-sm text-muted-foreground">{process.env.NEXT_PUBLIC_APP_VERSION ?? "v0.0.0"}</span>
         </div>
       </div>
 

--- a/next.config.ts
+++ b/next.config.ts
@@ -1,7 +1,19 @@
 import type { NextConfig } from "next";
+import { execSync } from "child_process";
+
+function getGitVersion(): string {
+  try {
+    return execSync("git describe --tags --abbrev=0", { encoding: "utf-8" }).trim();
+  } catch {
+    return "v0.0.0";
+  }
+}
 
 const nextConfig: NextConfig = {
   cacheComponents: true,
+  env: {
+    NEXT_PUBLIC_APP_VERSION: getGitVersion(),
+  },
   experimental: {
     serverActions: {
       bodySizeLimit: "10mb",


### PR DESCRIPTION
## 관련 이슈

관련 이슈 없음

## 요약

설정 페이지 버전 정보를 하드코딩(`v1.0.0`) 대신 git tag에서 자동으로 가져오도록 변경.

## AS-IS (변경 전)

- 설정 페이지 버전 정보가 `v1.0.0`으로 하드코딩
- 실제 프로젝트 버전(`v0.3.2`)과 불일치

## TO-BE (변경 후)

- 빌드 시 `git describe --tags --abbrev=0`으로 최신 태그 자동 감지
- `next.config.ts`에서 `NEXT_PUBLIC_APP_VERSION` 환경변수로 주입
- 새 태그 push 후 다음 빌드부터 자동 반영
- 태그 없는 환경에서는 `v0.0.0` fallback

## 주요 변경 사항

- `next.config.ts` — `getGitVersion()` 함수 추가, `env.NEXT_PUBLIC_APP_VERSION` 설정
- `components/settings/settings-client.tsx` — 하드코딩 `v1.0.0` → `process.env.NEXT_PUBLIC_APP_VERSION` 참조