### PR TITLE
fix(projects): 기록 입력/수정 Sheet 패딩 및 닫기 버튼 정리

### DIFF
--- a/app/(info)/projects/records/records-client.tsx
+++ b/app/(info)/projects/records/records-client.tsx
@@ -266,8 +266,8 @@ export function RecordsClient({ evtId, memId, evtStartDt, evtEndDt }: Props) {
 
       {/* 수정 Sheet */}
       <Sheet open={editTarget !== null} onOpenChange={(open) => !open && setEditTarget(null)}>
-        <SheetContent side="bottom" className="max-h-[90svh] overflow-y-auto rounded-t-2xl">
-          <SheetHeader>
+        <SheetContent side="bottom" className="max-h-[90svh] overflow-y-auto rounded-t-2xl px-6" showCloseButton={false}>
+          <SheetHeader className="px-0 pt-4 pb-0">
             <SheetTitle>기록 수정</SheetTitle>
           </SheetHeader>
           {editTarget && (

--- a/components/projects/activity-log-fab.tsx
+++ b/components/projects/activity-log-fab.tsx
@@ -41,9 +41,10 @@ export function ActivityLogFab({ evtId, memId }: ActivityLogFabProps) {
       <Sheet open={open} onOpenChange={setOpen}>
         <SheetContent
           side="bottom"
-          className="max-h-[90svh] overflow-y-auto rounded-t-2xl"
+          className="max-h-[90svh] overflow-y-auto rounded-t-2xl px-6"
+          showCloseButton={false}
         >
-          <SheetHeader className="mb-4">
+          <SheetHeader className="px-0 pt-4 pb-0">
             <SheetTitle>기록 입력</SheetTitle>
           </SheetHeader>
           <ActivityLogForm


### PR DESCRIPTION
## 관련 이슈

관련 이슈 없음

## 요약

마일리지런 기록 입력/수정 Sheet의 좌우 패딩 누락 수정 및 불필요한 닫기 버튼 제거

## AS-IS (변경 전)

- 기록 입력/수정 Sheet에 좌우 패딩이 없어 폼 필드가 화면 끝까지 붙어 표시
- SheetHeader의 `mb-4` + SheetContent `gap-4`로 제목과 폼 사이 이중 간격
- 닫기(X) 버튼이 표시되지만 오버레이 클릭으로도 닫을 수 있어 중복

## TO-BE (변경 후)

- SheetContent에 `px-6` 적용하여 좌우 패딩 확보
- SheetHeader 패딩을 `px-0 pt-4 pb-0`으로 조정하여 간격 정리
- `showCloseButton={false}`로 닫기 버튼 제거 (오버레이 클릭으로 닫기 유지)

## 주요 변경 파일

- `components/projects/activity-log-fab.tsx` — 기록 입력 Sheet
- `app/(info)/projects/records/records-client.tsx` — 기록 수정 Sheet