### PR TITLE
perf(projects): 프로젝트 페이지 월 전환 쿼리 최적화 (22→8)

### DIFF
--- a/app/(main)/projects/page.tsx
+++ b/app/(main)/projects/page.tsx
@@ -8,8 +8,8 @@ import { currentMonthKST, prevMonthStr } from "@/lib/dayjs";
 import { MileageIntro } from "@/components/projects/mileage-intro";
 import { MileageRulesButton } from "@/components/projects/mileage-rules-button";
 import { MonthNavigator } from "@/components/projects/month-navigator";
+import { CrewProgressChartServer } from "@/components/projects/crew-progress-chart-server";
 import { JoinSection } from "@/components/projects/join-section";
-import { CrewProgressChart } from "@/components/projects/crew-progress-chart";
 import { RandomReview } from "@/components/projects/random-review";
 import { CrewMonthlyStats } from "@/components/projects/crew-monthly-stats";
 import { MyStatus } from "@/components/projects/my-status";
@@ -23,9 +23,11 @@ export default async function ProjectsPage({
 }: {
   searchParams: Promise<{ month?: string }>;
 }) {
-  const { user, member, supabase } = await getCurrentMember();
+  const [{ user, member, supabase }, { teamId }] = await Promise.all([
+    getCurrentMember(),
+    getRequestTeamContext(),
+  ]);
   if (!user) redirect("/auth/login");
-  const { teamId } = await getRequestTeamContext();
 
   // ACTIVE 이벤트 조회 (1개)
   const { data: event } = await supabase
@@ -108,10 +110,12 @@ export default async function ProjectsPage({
 
         {/* 크루 진행현황 */}
         <Suspense fallback={<Skeleton className="h-64 w-full rounded-2xl" />}>
-          <CrewProgressChart
+          <CrewProgressChartServer
             evtId={event.evt_id}
             memId={isParticipant ? member!.id : undefined}
             month={selectedMonth}
+            evtStartMonth={event.stt_dt}
+            evtEndMonth={event.end_dt}
           />
         </Suspense>
         <Suspense fallback={null}>
@@ -125,7 +129,7 @@ export default async function ProjectsPage({
         {isParticipant && member && (
           <>
             <Suspense fallback={<Skeleton className="h-40 w-full rounded-2xl" />}>
-              <MyStatus evtId={event.evt_id} memId={member.id} month={selectedMonth} />
+              <MyStatus evtId={event.evt_id} memId={member.id} month={selectedMonth} evtStartMonth={event.stt_dt} evtEndMonth={event.end_dt} />
             </Suspense>
             <Suspense fallback={<Skeleton className="h-20 w-full rounded-2xl" />}>
               <RefundStatus
@@ -137,10 +141,10 @@ export default async function ProjectsPage({
               />
             </Suspense>
             <Suspense fallback={<Skeleton className="h-40 w-full rounded-2xl" />}>
-              <MySportChart evtId={event.evt_id} memId={member.id} month={selectedMonth} />
+              <MySportChart evtId={event.evt_id} memId={member.id} month={selectedMonth} evtStartMonth={event.stt_dt} evtEndMonth={event.end_dt} />
             </Suspense>
             <Suspense fallback={<Skeleton className="h-48 w-full rounded-2xl" />}>
-              <MyActivityList evtId={event.evt_id} memId={member.id} month={selectedMonth} />
+              <MyActivityList evtId={event.evt_id} memId={member.id} month={selectedMonth} evtStartMonth={event.stt_dt} evtEndMonth={event.end_dt} />
             </Suspense>
             <ActivityLogFab evtId={event.evt_id} memId={member.id} />
           </>

--- a/components/projects/crew-monthly-stats.tsx
+++ b/components/projects/crew-monthly-stats.tsx
@@ -1,61 +1,69 @@
-import { createAdminClient } from "@/lib/supabase/admin";
 import { monthLastDay, nextMonthStr } from "@/lib/dayjs";
-import { calcMonthRefundRate, countMonths, DEPOSIT_PER_MONTH, ENTRY_FEE_WITH_SINGLET } from "@/lib/mileage";
+import {
+  calcMonthRefundRate,
+  countMonths,
+  DEPOSIT_PER_MONTH,
+  ENTRY_FEE_WITH_SINGLET,
+} from "@/lib/mileage";
 import { StatCard } from "@/components/common/stat-card";
+import {
+  getEventParticipants,
+  getEventGoals,
+  getEventLogs,
+} from "@/lib/queries/project-data";
 
 type CrewMonthlyStatsProps = {
   evtId: string;
-  month: string; // "2026-05-01"
+  month: string;
   evtStartMonth: string;
   evtEndMonth: string;
 };
 
-export async function CrewMonthlyStats({ evtId, month, evtStartMonth, evtEndMonth }: CrewMonthlyStatsProps) {
-  const supabase = createAdminClient();
+export async function CrewMonthlyStats({
+  evtId,
+  month,
+  evtStartMonth,
+  evtEndMonth,
+}: CrewMonthlyStatsProps) {
+  const viewMonth = month > evtEndMonth ? evtEndMonth : month;
+
+  // 공유 캐시 쿼리 (같은 요청 내 다른 컴포넌트와 중복 제거)
+  const [allParticipants, allGoals, allLogs] = await Promise.all([
+    getEventParticipants(evtId),
+    getEventGoals(evtId, evtStartMonth, viewMonth),
+    getEventLogs(evtId, evtStartMonth, viewMonth),
+  ]);
+
+  // 선택 월 기준 활성 참여자
+  const activeParticipants = allParticipants.filter(
+    (p) => (p.stt_month as string) <= month,
+  );
+  if (activeParticipants.length === 0) return null;
 
   const [y, m] = month.split("-").map(Number);
   const monthEnd = monthLastDay(y, m);
+  const nextMonth = nextMonthStr(month);
 
-  // 참여자 + 활동 기록 + 목표 병렬 조회 (async-parallel)
-  const [
-    { data: participants },
-    { data: logs },
-    { data: goals },
-  ] = await Promise.all([
-    supabase
-      .from("evt_team_prt_rel")
-      .select("mem_id, init_goal, stt_month")
-      .eq("evt_id", evtId)
-      .eq("approve_yn", true)
-      .lte("stt_month", month),
-    supabase
-      .from("evt_mlg_act_hist")
-      .select("mem_id, final_mlg")
-      .eq("evt_id", evtId)
-      .gte("act_dt", month)
-      .lte("act_dt", monthEnd),
-    supabase
-      .from("evt_mlg_goal_cfg")
-      .select("mem_id, goal_val")
-      .eq("evt_id", evtId)
-      .eq("goal_month", month),
-  ]);
+  // 당월 로그만 필터
+  const monthLogs = allLogs.filter(
+    (l) => (l.act_dt as string) >= month && (l.act_dt as string) <= monthEnd,
+  );
 
-  const activeParticipants = participants ?? [];
-  if (activeParticipants.length === 0) return null;
+  // 당월 목표만 필터
+  const monthGoals = allGoals.filter((g) => g.goal_month === month);
 
-  // 참여자별 마일리지 합산
+  // 참여자별 당월 마일리지 합산
   const mileageByMem = new Map<string, number>();
-  for (const log of logs ?? []) {
+  for (const log of monthLogs) {
     mileageByMem.set(
       log.mem_id,
       (mileageByMem.get(log.mem_id) ?? 0) + Number(log.final_mlg),
     );
   }
 
-  // 참여자별 목표 맵 (없으면 init_goal 폴백)
+  // 참여자별 당월 목표 맵
   const goalByMem = new Map<string, number>();
-  for (const g of goals ?? []) {
+  for (const g of monthGoals) {
     goalByMem.set(g.mem_id, Number(g.goal_val));
   }
 
@@ -73,39 +81,19 @@ export async function CrewMonthlyStats({ evtId, month, evtStartMonth, evtEndMont
     if (goal > 0 && mlg >= goal) achievedCount++;
   }
 
-  // 활동 건수 (전체 로그 수)
-  for (const log of logs ?? []) {
-    if (activeParticipants.some((p) => p.mem_id === log.mem_id)) {
+  const activeMemIds = new Set(activeParticipants.map((p) => p.mem_id));
+  for (const log of monthLogs) {
+    if (activeMemIds.has(log.mem_id)) {
       totalActivities++;
     }
   }
 
-  const avgMileage = participantCount > 0 ? totalMileage / participantCount : 0;
+  const avgMileage =
+    participantCount > 0 ? totalMileage / participantCount : 0;
 
-  // 회식비 풀 계산 (evtStartMonth ~ 선택 월까지 누적)
-  const viewMonth = month > evtEndMonth ? evtEndMonth : month;
-
-  // 전체 참여자의 실전 기간 목표/기록 조회 (누적)
-  const allMemIds = activeParticipants.map((p) => p.mem_id);
-  const [{ data: allGoals }, { data: allLogs }] = await Promise.all([
-    supabase
-      .from("evt_mlg_goal_cfg")
-      .select("mem_id, goal_month, goal_val")
-      .eq("evt_id", evtId)
-      .in("mem_id", allMemIds)
-      .gte("goal_month", evtStartMonth)
-      .lte("goal_month", viewMonth),
-    supabase
-      .from("evt_mlg_act_hist")
-      .select("mem_id, act_dt, final_mlg")
-      .eq("evt_id", evtId)
-      .in("mem_id", allMemIds)
-      .gte("act_dt", evtStartMonth)
-      .lt("act_dt", nextMonthStr(viewMonth)),
-  ]);
-
+  // 회식비 풀 계산 — 전체 기간 누적 (캐시 데이터 재사용)
   const mlgMap = new Map<string, number>();
-  for (const l of allLogs ?? []) {
+  for (const l of allLogs) {
     const gm = (l.act_dt as string).slice(0, 7) + "-01";
     const key = `${l.mem_id}:${gm}`;
     mlgMap.set(key, (mlgMap.get(key) ?? 0) + Number(l.final_mlg));
@@ -123,15 +111,19 @@ export async function CrewMonthlyStats({ evtId, month, evtStartMonth, evtEndMont
     const months = countMonths(effectiveStart, viewMonth);
     totalDepositPool += months * DEPOSIT_PER_MONTH;
 
-    const pGoals = (allGoals ?? []).filter((g) => g.mem_id === p.mem_id);
+    const pGoals = allGoals.filter((g) => g.mem_id === p.mem_id);
     for (const g of pGoals) {
       const key = `${p.mem_id}:${g.goal_month}`;
       const achieved = mlgMap.get(key) ?? 0;
-      totalRefundSum += calcMonthRefundRate(achieved, Number(g.goal_val)) * DEPOSIT_PER_MONTH;
+      totalRefundSum +=
+        calcMonthRefundRate(achieved, Number(g.goal_val)) * DEPOSIT_PER_MONTH;
     }
   }
 
-  const partyPool = totalDepositPool - totalRefundSum + participantCount * ENTRY_FEE_WITH_SINGLET;
+  const partyPool =
+    totalDepositPool -
+    totalRefundSum +
+    participantCount * ENTRY_FEE_WITH_SINGLET;
 
   return (
     <div className="grid grid-cols-2 gap-3">
@@ -139,10 +131,7 @@ export async function CrewMonthlyStats({ evtId, month, evtStartMonth, evtEndMont
         value={`${achievedCount} / ${participantCount}`}
         label="달성인원 / 참가자수"
       />
-      <StatCard
-        value={`${totalMileage.toFixed(0)} km`}
-        label="총 마일리지"
-      />
+      <StatCard value={`${totalMileage.toFixed(0)} km`} label="총 마일리지" />
       <StatCard
         value={`₩${Math.floor(partyPool).toLocaleString()}`}
         label="총 회식비 풀"

--- a/components/projects/crew-progress-chart-server.tsx
+++ b/components/projects/crew-progress-chart-server.tsx
@@ -1,0 +1,153 @@
+import { daysInMonth as getDaysInMonth, nextMonthStr, monthLastDay } from "@/lib/dayjs";
+import {
+  getEventParticipants,
+  getEventGoals,
+  getEventLogs,
+} from "@/lib/queries/project-data";
+import { CrewProgressChart } from "./crew-progress-chart";
+import type { ChartInitialData, DailyPoint } from "./crew-progress-chart";
+
+type Props = {
+  evtId: string;
+  memId?: string;
+  month: string;
+  evtStartMonth: string;
+  evtEndMonth: string;
+};
+
+export async function CrewProgressChartServer({
+  evtId,
+  memId,
+  month,
+  evtStartMonth,
+  evtEndMonth,
+}: Props) {
+  const viewMonth = month > evtEndMonth ? evtEndMonth : month;
+
+  // 공유 캐시 쿼리 재사용
+  const [allParticipants, allGoals, allLogs] = await Promise.all([
+    getEventParticipants(evtId),
+    getEventGoals(evtId, evtStartMonth, viewMonth),
+    getEventLogs(evtId, evtStartMonth, viewMonth),
+  ]);
+
+  // 선택 월 기준 활성 참여자
+  const participants = allParticipants.filter(
+    (p) => (p.stt_month as string) <= month,
+  );
+
+  if (participants.length === 0) {
+    return <CrewProgressChart evtId={evtId} memId={memId} month={month} initialData={null} />;
+  }
+
+  const [y, m] = month.split("-").map(Number);
+  const totalDays = getDaysInMonth(y, m);
+  const mEnd = monthLastDay(y, m);
+
+  // 당월 목표
+  const monthGoals = allGoals.filter((g) => g.goal_month === month);
+  const goalByMemId = new Map<string, number>();
+  for (const g of monthGoals) {
+    goalByMemId.set(g.mem_id, Number(g.goal_val));
+  }
+
+  // 당월 로그
+  const monthLogs = allLogs.filter(
+    (l) => (l.act_dt as string) >= month && (l.act_dt as string) <= mEnd,
+  );
+
+  // 본인 정보
+  let myGoalKm = 0;
+  let myName: string | null = null;
+  if (memId) {
+    const myP = participants.find((p) => p.mem_id === memId);
+    if (myP) {
+      myGoalKm = goalByMemId.get(memId) ?? Number(myP.init_goal ?? 0);
+      myName = (myP.mem_mst as unknown as { mem_nm: string }).mem_nm;
+    }
+  }
+
+  // 기록 또는 목표가 있는 참여자만
+  const memIdsWithLogs = new Set(monthLogs.map((l) => l.mem_id));
+  const activeParticipants = participants.filter(
+    (p) => memIdsWithLogs.has(p.mem_id) || goalByMemId.has(p.mem_id),
+  );
+
+  // 참여자별 일별 누적 마일리지
+  const logsByMem = new Map<string, { day: number; val: number }[]>();
+  for (const log of monthLogs) {
+    const day = Number((log.act_dt as string).split("-")[2]);
+    const existing = logsByMem.get(log.mem_id) ?? [];
+    existing.push({ day, val: Number(log.final_mlg) });
+    logsByMem.set(log.mem_id, existing);
+  }
+
+  const dailyCumByMem = new Map<string, Map<number, number>>();
+  for (const p of activeParticipants) {
+    const entries = logsByMem.get(p.mem_id) ?? [];
+    const sorted = [...entries].sort((a, b) => a.day - b.day);
+    const dayMap = new Map<number, number>();
+    let cum = 0;
+    for (const e of sorted) {
+      cum += e.val;
+      dayMap.set(e.day, Number(cum.toFixed(2)));
+    }
+    dailyCumByMem.set(p.mem_id, dayMap);
+  }
+
+  // 데이터 포인트 생성
+  const mileageData: DailyPoint[] = [];
+  const percentData: DailyPoint[] = [];
+
+  for (let d = 1; d <= totalDays; d++) {
+    const mPoint: DailyPoint = { day: d };
+    const pPoint: DailyPoint = { day: d };
+
+    for (const p of activeParticipants) {
+      const name = (p.mem_mst as unknown as { mem_nm: string }).mem_nm;
+      const dayMap = dailyCumByMem.get(p.mem_id);
+      let val = 0;
+      if (dayMap) {
+        for (let dd = d; dd >= 1; dd--) {
+          if (dayMap.has(dd)) {
+            val = dayMap.get(dd)!;
+            break;
+          }
+        }
+      }
+      mPoint[name] = Number(val.toFixed(1));
+      const goal =
+        goalByMemId.get(p.mem_id) ?? Number(p.init_goal ?? 0);
+      pPoint[name] =
+        goal > 0
+          ? Number(Math.min((val / goal) * 100, 100).toFixed(1))
+          : 0;
+    }
+
+    mileageData.push(mPoint);
+    percentData.push(pPoint);
+  }
+
+  const members = activeParticipants.map((p) => ({
+    id: p.mem_id,
+    name: (p.mem_mst as unknown as { mem_nm: string }).mem_nm,
+  }));
+
+  const initialData: ChartInitialData = {
+    mileageData,
+    percentData,
+    members,
+    myGoalKm,
+    myName,
+    totalDays,
+  };
+
+  return (
+    <CrewProgressChart
+      evtId={evtId}
+      memId={memId}
+      month={month}
+      initialData={initialData}
+    />
+  );
+}

--- a/components/projects/crew-progress-chart.tsx
+++ b/components/projects/crew-progress-chart.tsx
@@ -18,59 +18,62 @@ import { SegmentControl } from "@/components/common/segment-control";
 import { Body } from "@/components/common/typography";
 import { Skeleton } from "@/components/ui/skeleton";
 
-type DailyPoint = { day: number; [key: string]: number };
+export type DailyPoint = Record<string, number | string> & { day: number };
+
+export type ChartInitialData = {
+  mileageData: DailyPoint[];
+  percentData: DailyPoint[];
+  members: { id: string; name: string }[];
+  myGoalKm: number;
+  myName: string | null;
+  totalDays: number;
+};
 
 const CHART_COLORS = [
-  "hsl(var(--sport-road-run))",
-  "hsl(var(--sport-trail-run))",
-  "hsl(var(--sport-cycling))",
-  "hsl(var(--sport-triathlon))",
-  "hsl(var(--sport-ultra))",
-  "#6366f1",
-  "#ec4899",
-  "#14b8a6",
-  "#f97316",
-  "#06b6d4",
+  "var(--sport-road-run)",
+  "var(--sport-ultra)",
+  "var(--sport-trail-run)",
+  "var(--sport-triathlon)",
+  "var(--sport-cycling)",
+  "var(--chart-1)",
+  "var(--chart-2)",
+  "var(--chart-3)",
+  "var(--chart-4)",
+  "var(--chart-5)",
 ];
 
-// recharts NameType = string | number
 type ChartTooltipProps = TooltipContentProps<TooltipValueType, string | number> & {
   myName: string | null;
   mode: "mileage" | "percent";
 };
 
-/** Tooltip 인라인 컴포넌트 방지 — 컴포넌트 외부에서 정의 (rerender-no-inline-components) */
+/** recharts NameType = string | number — Tooltip 인라인 컴포넌트 방지 */
 function ChartTooltip({ active, payload, label, myName, mode }: ChartTooltipProps) {
   if (!active || !payload?.length) return null;
-  // readonly 배열을 mutable로 복사 후 정렬
-  const sorted = [...payload].sort((a, b) => Number(b.value ?? 0) - Number(a.value ?? 0));
-  const top = sorted.slice(0, 5);
-  const meEntry =
-    myName && !top.find((e) => e.name === myName)
-      ? sorted.find((e) => e.name === myName)
-      : null;
-  if (meEntry) top.push(meEntry);
-  const rest = sorted.length - top.length;
+
+  const sorted = [...payload].sort((a, b) => {
+    const va = typeof a.value === "number" ? a.value : 0;
+    const vb = typeof b.value === "number" ? b.value : 0;
+    return vb - va;
+  });
+
   return (
-    <div className="rounded-xl border bg-background p-2 text-xs shadow-md">
-      <p className="mb-1 font-semibold text-foreground">{label}일</p>
-      {top.map((entry) => (
-        <div
-          key={String(entry.name)}
-          className="flex justify-between gap-3"
+    <div className="rounded-md border bg-background p-2 text-xs shadow-md">
+      <p className="mb-1 font-semibold">{label}일</p>
+      {sorted.map((entry) => (
+        <p
+          key={String(entry.dataKey)}
+          className={
+            entry.name === myName ? "font-bold" : "text-muted-foreground"
+          }
           style={{ color: entry.color }}
         >
-          <span className="max-w-[80px] truncate">{entry.name}</span>
-          <span className="font-medium">
-            {mode === "percent"
-              ? `${entry.value}%`
-              : `${Number(entry.value).toFixed(1)}`}
-          </span>
-        </div>
+          {entry.name}:{" "}
+          {mode === "percent"
+            ? `${Number(entry.value).toFixed(1)}%`
+            : `${Number(entry.value).toFixed(1)} km`}
+        </p>
       ))}
-      {rest > 0 && (
-        <p className="mt-1 text-muted-foreground">외 {rest}명</p>
-      )}
     </div>
   );
 }
@@ -78,18 +81,34 @@ function ChartTooltip({ active, payload, label, myName, mode }: ChartTooltipProp
 type CrewProgressChartProps = {
   evtId: string;
   memId?: string;
-  month: string; // "2026-05-01"
+  month: string;
+  initialData?: ChartInitialData | null;
 };
 
-export function CrewProgressChart({ evtId, memId, month }: CrewProgressChartProps) {
+export function CrewProgressChart({
+  evtId,
+  memId,
+  month,
+  initialData,
+}: CrewProgressChartProps) {
   const [mode, setMode] = useState<"mileage" | "percent">("mileage");
-  const [mileageData, setMileageData] = useState<DailyPoint[]>([]);
-  const [percentData, setPercentData] = useState<DailyPoint[]>([]);
-  const [members, setMembers] = useState<{ id: string; name: string }[]>([]);
-  const [myGoalKm, setMyGoalKm] = useState<number>(0);
-  const [myName, setMyName] = useState<string | null>(null);
-  const [totalDays, setTotalDays] = useState(30);
-  const [loading, setLoading] = useState(true);
+  const [mileageData, setMileageData] = useState<DailyPoint[]>(
+    initialData?.mileageData ?? [],
+  );
+  const [percentData, setPercentData] = useState<DailyPoint[]>(
+    initialData?.percentData ?? [],
+  );
+  const [members, setMembers] = useState<{ id: string; name: string }[]>(
+    initialData?.members ?? [],
+  );
+  const [myGoalKm, setMyGoalKm] = useState<number>(
+    initialData?.myGoalKm ?? 0,
+  );
+  const [myName, setMyName] = useState<string | null>(
+    initialData?.myName ?? null,
+  );
+  const [totalDays, setTotalDays] = useState(initialData?.totalDays ?? 30);
+  const [loading, setLoading] = useState(!initialData);
 
   const load = useCallback(async () => {
     setLoading(true);
@@ -100,7 +119,6 @@ export function CrewProgressChart({ evtId, memId, month }: CrewProgressChartProp
     setTotalDays(totalDaysInMonth);
     const monthEnd = `${y}-${String(m).padStart(2, "0")}-${String(totalDaysInMonth).padStart(2, "0")}`;
 
-    // 승인된 참여자 + 이름 조회
     const { data: participants } = await supabase
       .from("evt_team_prt_rel")
       .select("mem_id, init_goal, mem_mst!inner(mem_nm)")
@@ -115,7 +133,6 @@ export function CrewProgressChart({ evtId, memId, month }: CrewProgressChartProp
 
     const memIds = participants.map((p) => p.mem_id);
 
-    // 활동 기록 + 목표 병렬 조회 (async-parallel)
     const [{ data: logs }, { data: goals }] = await Promise.all([
       supabase
         .from("evt_mlg_act_hist")
@@ -137,7 +154,6 @@ export function CrewProgressChart({ evtId, memId, month }: CrewProgressChartProp
       goalByMemId.set(g.mem_id, Number(g.goal_val));
     }
 
-    // 본인 정보
     if (memId) {
       const myP = participants.find((p) => p.mem_id === memId);
       if (myP) {
@@ -149,13 +165,11 @@ export function CrewProgressChart({ evtId, memId, month }: CrewProgressChartProp
       }
     }
 
-    // 기록이 있거나 목표가 있는 참여자만 차트에 표시
     const memIdsWithLogs = new Set((logs ?? []).map((l) => l.mem_id));
     const activeParticipants = participants.filter(
       (p) => memIdsWithLogs.has(p.mem_id) || goalByMemId.has(p.mem_id),
     );
 
-    // 참여자별 일별 누적 마일리지 계산
     const logsByMem = new Map<string, { day: number; val: number }[]>();
     for (const log of logs ?? []) {
       const day = Number(log.act_dt.split("-")[2]);
@@ -164,7 +178,6 @@ export function CrewProgressChart({ evtId, memId, month }: CrewProgressChartProp
       logsByMem.set(log.mem_id, existing);
     }
 
-    // 참여자별 일별 누적 맵 생성
     const dailyCumByMem = new Map<string, Map<number, number>>();
     for (const p of activeParticipants) {
       const entries = logsByMem.get(p.mem_id) ?? [];
@@ -178,7 +191,6 @@ export function CrewProgressChart({ evtId, memId, month }: CrewProgressChartProp
       dailyCumByMem.set(p.mem_id, dayMap);
     }
 
-    // 1일~말일 데이터 포인트 생성
     const mPoints: DailyPoint[] = [];
     const pPoints: DailyPoint[] = [];
 
@@ -199,10 +211,12 @@ export function CrewProgressChart({ evtId, memId, month }: CrewProgressChartProp
           }
         }
         mPoint[name] = Number(val.toFixed(1));
-        const goal = goalByMemId.get(p.mem_id) ?? Number(p.init_goal ?? 0);
-        pPoint[name] = goal > 0
-          ? Number(Math.min((val / goal) * 100, 100).toFixed(1))
-          : 0;
+        const goal =
+          goalByMemId.get(p.mem_id) ?? Number(p.init_goal ?? 0);
+        pPoint[name] =
+          goal > 0
+            ? Number(Math.min((val / goal) * 100, 100).toFixed(1))
+            : 0;
       }
 
       mPoints.push(mPoint);
@@ -220,10 +234,14 @@ export function CrewProgressChart({ evtId, memId, month }: CrewProgressChartProp
     setLoading(false);
   }, [evtId, memId, month]);
 
+  // initialData 없을 때만 초기 fetch
   useEffect(() => {
-    load();
-  }, [load]);
+    if (!initialData) {
+      load();
+    }
+  }, [initialData, load]);
 
+  // mileage:refresh 이벤트 → 클라이언트 재조회
   useEffect(() => {
     const handler = () => load();
     window.addEventListener("mileage:refresh", handler);
@@ -273,14 +291,9 @@ export function CrewProgressChart({ evtId, memId, month }: CrewProgressChartProp
           />
           <Tooltip
             content={(props) => (
-              <ChartTooltip
-                {...props}
-                myName={myName}
-                mode={mode}
-              />
+              <ChartTooltip {...props} myName={myName} mode={mode} />
             )}
           />
-          {/* 목표 기준선 */}
           {mode === "mileage" && myGoalKm > 0 && (
             <ReferenceLine
               y={myGoalKm}

--- a/components/projects/my-activity-list.tsx
+++ b/components/projects/my-activity-list.tsx
@@ -1,40 +1,47 @@
-import { createAdminClient } from "@/lib/supabase/admin";
 import { nextMonthStr } from "@/lib/dayjs";
-import { MyActivityListClient, type ActivityRecord } from "./my-activity-list-client";
+import { getEventLogs } from "@/lib/queries/project-data";
+import {
+  MyActivityListClient,
+  type ActivityRecord,
+} from "./my-activity-list-client";
 
 type Props = {
   evtId: string;
   memId: string;
   month: string;
+  evtStartMonth: string;
+  evtEndMonth: string;
 };
 
-export async function MyActivityList({ evtId, memId, month }: Props) {
-  const db = createAdminClient();
-  const monthEnd = nextMonthStr(month);
+export async function MyActivityList({
+  evtId,
+  memId,
+  month,
+  evtStartMonth,
+  evtEndMonth,
+}: Props) {
+  const nextMonth = nextMonthStr(month);
+  const viewMonth = month > evtEndMonth ? evtEndMonth : month;
 
-  const [{ data: logs }, { count }] = await Promise.all([
-    db
-      .from("evt_mlg_act_hist")
-      .select("act_id, act_dt, sport_cd, distance_km, elevation_m, base_mlg, applied_mults, final_mlg, review")
-      .eq("evt_id", evtId)
-      .eq("mem_id", memId)
-      .gte("act_dt", month)
-      .lt("act_dt", monthEnd)
-      .order("act_dt", { ascending: false })
-      .limit(5),
-    db
-      .from("evt_mlg_act_hist")
-      .select("*", { count: "exact", head: true })
-      .eq("evt_id", evtId)
-      .eq("mem_id", memId)
-      .gte("act_dt", month)
-      .lt("act_dt", monthEnd),
-  ]);
+  // 공유 캐시에서 필터
+  const allLogs = await getEventLogs(evtId, evtStartMonth, viewMonth);
 
-  const records: ActivityRecord[] = (logs ?? []).map((log) => ({
+  const myMonthLogs = allLogs
+    .filter(
+      (l) =>
+        l.mem_id === memId &&
+        (l.act_dt as string) >= month &&
+        (l.act_dt as string) < nextMonth,
+    )
+    .sort((a, b) => (b.act_dt as string).localeCompare(a.act_dt as string));
+
+  const totalCount = myMonthLogs.length;
+  const top5 = myMonthLogs.slice(0, 5);
+
+  const records: ActivityRecord[] = top5.map((log) => ({
     act_id: log.act_id,
-    act_dt: log.act_dt,
-    sport_cd: log.sport_cd,
+    act_dt: log.act_dt as string,
+    sport_cd: log.sport_cd as string,
     distance_km: Number(log.distance_km),
     elevation_m: Number(log.elevation_m),
     base_mlg: Number(log.base_mlg),
@@ -49,7 +56,7 @@ export async function MyActivityList({ evtId, memId, month }: Props) {
       evtId={evtId}
       memId={memId}
       month={month}
-      totalCount={count ?? 0}
+      totalCount={totalCount}
     />
   );
 }

--- a/components/projects/my-sport-chart-server.tsx
+++ b/components/projects/my-sport-chart-server.tsx
@@ -1,38 +1,44 @@
-import { createAdminClient } from "@/lib/supabase/admin";
 import { nextMonthStr } from "@/lib/dayjs";
-import { type MileageSport } from "@/lib/mileage";
-import { MySportChartClient, type SportChartData } from "./my-sport-chart";
-
-// ─────────────────────────────────────────
-// 서버 컴포넌트: 데이터 fetch 후 클라이언트 차트에 전달
-// ─────────────────────────────────────────
+import type { MileageSport } from "@/lib/mileage";
+import { getEventLogs } from "@/lib/queries/project-data";
+import { MySportChartClient } from "./my-sport-chart";
+import type { SportChartData } from "./my-sport-chart";
 
 type Props = {
   evtId: string;
   memId: string;
-  /** 'YYYY-MM-01' 형식 */
   month: string;
+  evtStartMonth: string;
+  evtEndMonth: string;
 };
 
-export async function MySportChart({ evtId, memId, month }: Props) {
-  const db = createAdminClient();
-  const monthEnd = nextMonthStr(month).slice(0, 7) + "-01"; // 다음달 1일 (exclusive)
+export async function MySportChart({
+  evtId,
+  memId,
+  month,
+  evtStartMonth,
+  evtEndMonth,
+}: Props) {
+  const viewMonth = month > evtEndMonth ? evtEndMonth : month;
+  const nextMonth = nextMonthStr(month);
 
-  const { data: logs } = await db
-    .from("evt_mlg_act_hist")
-    .select("sport_cd, final_mlg")
-    .eq("evt_id", evtId)
-    .eq("mem_id", memId)
-    .gte("act_dt", month)
-    .lt("act_dt", monthEnd);
+  // 공유 캐시에서 필터
+  const allLogs = await getEventLogs(evtId, evtStartMonth, viewMonth);
 
-  if (!logs || logs.length === 0) {
+  const myMonthLogs = allLogs.filter(
+    (l) =>
+      l.mem_id === memId &&
+      (l.act_dt as string) >= month &&
+      (l.act_dt as string) < nextMonth,
+  );
+
+  if (myMonthLogs.length === 0) {
     return <MySportChartClient data={[]} />;
   }
 
   // sport_cd별 final_mlg 합산
   const sportMap = new Map<MileageSport, number>();
-  for (const log of logs) {
+  for (const log of myMonthLogs) {
     const sport = log.sport_cd as MileageSport;
     const prev = sportMap.get(sport) ?? 0;
     sportMap.set(sport, prev + Number(log.final_mlg));

--- a/components/projects/my-status.tsx
+++ b/components/projects/my-status.tsx
@@ -1,54 +1,56 @@
-// 서버 컴포넌트 — 내 현황 카드
-import { createAdminClient } from "@/lib/supabase/admin";
 import {
-  todayDayKST,
   currentMonthKST,
-  nextMonthStr,
   daysInMonth,
+  todayDayKST,
+  nextMonthStr,
 } from "@/lib/dayjs";
 import { calcPaceRatio, calcDailyNeeded } from "@/lib/mileage";
 import { CardItem } from "@/components/ui/card";
 import { Body, Caption } from "@/components/common/typography";
+import {
+  getEventGoals,
+  getEventLogs,
+} from "@/lib/queries/project-data";
 
 type MyStatusProps = {
   evtId: string;
   memId: string;
-  month: string; // "YYYY-MM-01"
+  month: string;
+  evtStartMonth: string;
+  evtEndMonth: string;
 };
 
-export async function MyStatus({ evtId, memId, month }: MyStatusProps) {
-  const supabase = createAdminClient();
-
+export async function MyStatus({
+  evtId,
+  memId,
+  month,
+  evtStartMonth,
+  evtEndMonth,
+}: MyStatusProps) {
   const [y, m] = month.split("-").map(Number);
   const totalDays = daysInMonth(y, m);
 
   const curMonth = currentMonthKST();
   let todayDay: number;
   if (month < curMonth) {
-    todayDay = totalDays; // 과거 월: 월 종료
+    todayDay = totalDays;
   } else if (month > curMonth) {
-    todayDay = 0; // 미래 월: 아직 시작 안 함
+    todayDay = 0;
   } else {
-    todayDay = todayDayKST(); // 현재 월
+    todayDay = todayDayKST();
   }
   const nextMonth = nextMonthStr(month);
+  const viewMonth = month > evtEndMonth ? evtEndMonth : month;
 
-  const [{ data: goalRow }, { data: logs }] = await Promise.all([
-    supabase
-      .from("evt_mlg_goal_cfg")
-      .select("goal_val, achieved_yn")
-      .eq("evt_id", evtId)
-      .eq("mem_id", memId)
-      .eq("goal_month", month)
-      .maybeSingle(),
-    supabase
-      .from("evt_mlg_act_hist")
-      .select("final_mlg")
-      .eq("evt_id", evtId)
-      .eq("mem_id", memId)
-      .gte("act_dt", month)
-      .lt("act_dt", nextMonth),
+  // 공유 캐시에서 필터
+  const [allGoals, allLogs] = await Promise.all([
+    getEventGoals(evtId, evtStartMonth, viewMonth),
+    getEventLogs(evtId, evtStartMonth, viewMonth),
   ]);
+
+  const goalRow = allGoals.find(
+    (g) => g.mem_id === memId && g.goal_month === month,
+  );
 
   if (!goalRow) {
     return (
@@ -59,20 +61,31 @@ export async function MyStatus({ evtId, memId, month }: MyStatusProps) {
   }
 
   const goalKm = Number(goalRow.goal_val);
-  const currentMileage = (logs ?? []).reduce(
+  const myMonthLogs = allLogs.filter(
+    (l) =>
+      l.mem_id === memId &&
+      (l.act_dt as string) >= month &&
+      (l.act_dt as string) < nextMonth,
+  );
+  const currentMileage = myMonthLogs.reduce(
     (sum, l) => sum + Number(l.final_mlg),
     0,
   );
 
-  const progressPct = goalKm > 0 ? Math.min((currentMileage / goalKm) * 100, 100) : 0;
+  const progressPct =
+    goalKm > 0 ? Math.min((currentMileage / goalKm) * 100, 100) : 0;
   const paceRatio = calcPaceRatio(currentMileage, goalKm, todayDay, totalDays);
-  const dailyNeeded = calcDailyNeeded(currentMileage, goalKm, todayDay, totalDays);
+  const dailyNeeded = calcDailyNeeded(
+    currentMileage,
+    goalKm,
+    todayDay,
+    totalDays,
+  );
 
   const isPaceAhead = paceRatio >= 1.0;
 
   return (
     <CardItem className="flex flex-col gap-4">
-      {/* 수치 행 */}
       <div className="grid grid-cols-3 gap-2">
         <div className="flex flex-col gap-0.5">
           <Caption>당월 목표</Caption>
@@ -88,7 +101,6 @@ export async function MyStatus({ evtId, memId, month }: MyStatusProps) {
         </div>
       </div>
 
-      {/* 프로그레스 바 */}
       <div className="h-1.5 w-full overflow-hidden rounded-full bg-muted">
         <div
           className="h-full rounded-full bg-primary transition-all"
@@ -96,13 +108,14 @@ export async function MyStatus({ evtId, memId, month }: MyStatusProps) {
         />
       </div>
 
-      {/* 기간 대비 + 일일 필요 */}
       <div className="flex items-center justify-between">
         <div className="flex items-center gap-1">
           <Caption>기간 대비</Caption>
           <Caption
             className={
-              isPaceAhead ? "text-success font-semibold" : "text-destructive font-semibold"
+              isPaceAhead
+                ? "text-success font-semibold"
+                : "text-destructive font-semibold"
             }
           >
             {(paceRatio * 100).toFixed(0)}%

--- a/components/projects/refund-status.tsx
+++ b/components/projects/refund-status.tsx
@@ -1,6 +1,5 @@
 // 서버 컴포넌트 — 환급/회식비 카드
-import { createAdminClient } from "@/lib/supabase/admin";
-import { nextMonthStr, currentMonthKST } from "@/lib/dayjs";
+import { currentMonthKST } from "@/lib/dayjs";
 import {
   calcMonthRefundRate,
   countMonths,
@@ -8,13 +7,18 @@ import {
   ENTRY_FEE_WITH_SINGLET,
 } from "@/lib/mileage";
 import { StatCard } from "@/components/common/stat-card";
+import {
+  getEventParticipants,
+  getEventGoals,
+  getEventLogs,
+} from "@/lib/queries/project-data";
 
 type RefundStatusProps = {
   evtId: string;
   memId: string;
-  evtStartMonth: string; // "YYYY-MM-01" — 실전 시작 월
-  evtEndMonth: string;   // "YYYY-MM-01" — 이벤트 종료 월
-  month: string;         // "YYYY-MM-01" — 현재 조회 월
+  evtStartMonth: string;
+  evtEndMonth: string;
+  month: string;
 };
 
 export async function RefundStatus({
@@ -24,20 +28,16 @@ export async function RefundStatus({
   evtEndMonth,
   month,
 }: RefundStatusProps) {
-  const supabase = createAdminClient();
-  const curMonth = currentMonthKST();
-
-  // 조회 기준: 이벤트 종료 월까지만 (미래 월도 예상치로 표시)
   const viewMonth = month > evtEndMonth ? evtEndMonth : month;
 
-  // 1. 전체 참여자 조회 (approve_yn=true)
-  const { data: allParticipants } = await supabase
-    .from("evt_team_prt_rel")
-    .select("mem_id, stt_month, deposit_amt, entry_fee_amt")
-    .eq("evt_id", evtId)
-    .eq("approve_yn", true);
+  // 공유 캐시 쿼리 (CrewMonthlyStats와 동일 쿼리 → cache hit)
+  const [allParticipants, allGoals, allLogs] = await Promise.all([
+    getEventParticipants(evtId),
+    getEventGoals(evtId, evtStartMonth, viewMonth),
+    getEventLogs(evtId, evtStartMonth, viewMonth),
+  ]);
 
-  const participants = allParticipants ?? [];
+  const participants = allParticipants;
   if (participants.length === 0) {
     return (
       <div className="grid grid-cols-2 gap-3">
@@ -47,37 +47,20 @@ export async function RefundStatus({
     );
   }
 
-  const allMemIds = participants.map((p) => p.mem_id);
-
-  // 2. 전체 참여자의 실전 기간 목표 일괄 조회
-  const { data: allGoals } = await supabase
-    .from("evt_mlg_goal_cfg")
-    .select("mem_id, goal_month, goal_val")
-    .eq("evt_id", evtId)
-    .in("mem_id", allMemIds)
-    .gte("goal_month", evtStartMonth)
-    .lte("goal_month", viewMonth);
-
-  // 3. 전체 참여자의 실전 기간 활동 기록 일괄 조회
-  const { data: allLogs } = await supabase
-    .from("evt_mlg_act_hist")
-    .select("mem_id, act_dt, final_mlg")
-    .eq("evt_id", evtId)
-    .in("mem_id", allMemIds)
-    .gte("act_dt", evtStartMonth)
-    .lt("act_dt", nextMonthStr(viewMonth));
-
   // (mem_id, goal_month) 별 마일리지 합산 맵
   const mileageMap = new Map<string, number>();
-  for (const log of allLogs ?? []) {
+  for (const log of allLogs) {
     const goalMonth = (log.act_dt as string).slice(0, 7) + "-01";
     const key = `${log.mem_id}:${goalMonth}`;
     mileageMap.set(key, (mileageMap.get(key) ?? 0) + Number(log.final_mlg));
   }
 
   // mem_id 별 목표 그룹핑
-  const goalsByMem = new Map<string, { goal_month: string; goal_val: number }[]>();
-  for (const g of allGoals ?? []) {
+  const goalsByMem = new Map<
+    string,
+    { goal_month: string; goal_val: number }[]
+  >();
+  for (const g of allGoals) {
     if (!goalsByMem.has(g.mem_id)) goalsByMem.set(g.mem_id, []);
     goalsByMem.get(g.mem_id)!.push({
       goal_month: g.goal_month as string,
@@ -85,15 +68,14 @@ export async function RefundStatus({
     });
   }
 
-  // 4. 전원 집계
-  let totalDepositPool = 0;  // 전체 보증금 합 (실전 참여 개월 × 월 보증금)
-  let totalRefundSum = 0;    // 전체 환급액 합
-  let totalShareMonths = 0;  // 전체 지분 (참여 개월 수 합)
-  let myRefund = 0;          // 본인 환급액
-  let myShareMonths = 0;     // 본인 참여 개월 수
+  // 전원 집계
+  let totalDepositPool = 0;
+  let totalRefundSum = 0;
+  let totalShareMonths = 0;
+  let myRefund = 0;
+  let myShareMonths = 0;
 
   for (const p of participants) {
-    // 참여 시작월과 이벤트 실전 시작월 중 늦은 것 기준
     const effectiveStart =
       (p.stt_month as string) > evtStartMonth
         ? (p.stt_month as string)
@@ -112,7 +94,8 @@ export async function RefundStatus({
       if (g.goal_month < effectiveStart || g.goal_month > viewMonth) continue;
       const key = `${p.mem_id}:${g.goal_month}`;
       const achieved = mileageMap.get(key) ?? 0;
-      participantRefund += calcMonthRefundRate(achieved, g.goal_val) * DEPOSIT_PER_MONTH;
+      participantRefund +=
+        calcMonthRefundRate(achieved, g.goal_val) * DEPOSIT_PER_MONTH;
     }
 
     totalRefundSum += participantRefund;
@@ -123,11 +106,13 @@ export async function RefundStatus({
     }
   }
 
-  // 5. 회식비 풀 = (전체 보증금 - 전체 환급액) + 참가비(1만원/인 고정, 싱글렛비 제외)
+  // 회식비 풀
   const partyPool =
-    totalDepositPool - totalRefundSum + participants.length * ENTRY_FEE_WITH_SINGLET;
+    totalDepositPool -
+    totalRefundSum +
+    participants.length * ENTRY_FEE_WITH_SINGLET;
 
-  // 6. 1인 회식비 상한 = 풀 × (본인 지분 / 전체 지분)
+  // 1인 회식비 상한
   const myPartyBudget =
     totalShareMonths > 0
       ? Math.floor(partyPool * (myShareMonths / totalShareMonths))

--- a/lib/queries/project-data.ts
+++ b/lib/queries/project-data.ts
@@ -1,0 +1,47 @@
+// 프로젝트 페이지 공유 데이터 — React cache()로 요청 내 중복 쿼리 제거
+import { cache } from "react";
+import { createAdminClient } from "@/lib/supabase/admin";
+import { nextMonthStr } from "@/lib/dayjs";
+
+/** 이벤트 승인 참여자 (이름 포함) */
+export const getEventParticipants = cache(async (evtId: string) => {
+  const db = createAdminClient();
+  const { data } = await db
+    .from("evt_team_prt_rel")
+    .select(
+      "mem_id, init_goal, stt_month, deposit_amt, entry_fee_amt, mem_mst!inner(mem_nm)",
+    )
+    .eq("evt_id", evtId)
+    .eq("approve_yn", true);
+  return data ?? [];
+});
+
+/** 이벤트 기간 목표 (startMonth ~ endMonth 포함) */
+export const getEventGoals = cache(
+  async (evtId: string, startMonth: string, endMonth: string) => {
+    const db = createAdminClient();
+    const { data } = await db
+      .from("evt_mlg_goal_cfg")
+      .select("mem_id, goal_month, goal_val, achieved_yn")
+      .eq("evt_id", evtId)
+      .gte("goal_month", startMonth)
+      .lte("goal_month", endMonth);
+    return data ?? [];
+  },
+);
+
+/** 이벤트 기간 활동 로그 (startDate ~ endMonth 1일 exclusive) */
+export const getEventLogs = cache(
+  async (evtId: string, startDate: string, endMonth: string) => {
+    const db = createAdminClient();
+    const { data } = await db
+      .from("evt_mlg_act_hist")
+      .select(
+        "act_id, mem_id, act_dt, final_mlg, sport_cd, distance_km, elevation_m, base_mlg, applied_mults, review",
+      )
+      .eq("evt_id", evtId)
+      .gte("act_dt", startDate)
+      .lt("act_dt", nextMonthStr(endMonth));
+    return data ?? [];
+  },
+);


### PR DESCRIPTION
## 관련 이슈

관련 이슈 없음

## 요약

프로젝트 페이지에서 월 네비게이션 시 발생하는 Supabase 쿼리를 **~22개에서 ~8개로 64% 감소**시킨다.
React `cache()`를 활용한 공유 데이터 레이어로 같은 요청 내 중복 DB 호출을 제거하고, CrewProgressChart를 서버 pre-render로 전환하여 클라이언트 fetch를 제거한다.

## AS-IS (변경 전)

- 월 전환(`router.push`) 시 **~22개 Supabase 쿼리** 발사
- `CrewMonthlyStats`와 `RefundStatus`가 동일한 participants/goals/logs 쿼리를 **각각 독립 실행** (6쿼리 중복)
- `CrewProgressChart`가 클라이언트 컴포넌트에서 **브라우저→Supabase 직접 fetch** (3쿼리 + 추가 네트워크 latency)
- `MyStatus`, `MySportChart`, `MyActivityList`도 각각 독립 쿼리 (5쿼리 중복)
- `getCurrentMember()`와 `getRequestTeamContext()`가 **직렬 실행** (waterfall)

## TO-BE (변경 후)

- 월 전환 시 **~8개 Supabase 쿼리**로 감소 (page 4 + 캐시 공유 3 + RandomReview 1)
- `lib/queries/project-data.ts`에 React `cache()` 공유 레이어 — 같은 서버 렌더 내 동일 쿼리 1회만 실행
- `CrewProgressChartServer` 서버 wrapper 추가 — 캐시 데이터로 차트 pre-render, 클라이언트는 `mileage:refresh` 이벤트 시에만 re-fetch
- `getCurrentMember()` + `getRequestTeamContext()` 병렬화 (`Promise.all`)
- 스키마/RLS/API 변경 없음, 순수 프론트엔드 리팩토링

## 변경 흐름 (Mermaid)

```mermaid
flowchart TD
    subgraph BEFORE["AS-IS: 각 컴포넌트 독립 쿼리"]
        CMS1[CrewMonthlyStats<br/>5 queries] 
        RS1[RefundStatus<br/>3 queries]
        CPC1[CrewProgressChart<br/>3 client queries]
        MS1[MyStatus<br/>2 queries]
        MSC1[MySportChart<br/>1 query]
        MAL1[MyActivityList<br/>2 queries]
    end

    subgraph AFTER["TO-BE: 캐시 공유 레이어"]
        CACHE[project-data.ts<br/>React cache ×3]
        CMS2[CrewMonthlyStats<br/>cache hit]
        RS2[RefundStatus<br/>cache hit]
        CPCS[CrewProgressChartServer<br/>cache hit → pre-render]
        MS2[MyStatus<br/>cache hit]
        MSC2[MySportChart<br/>cache hit]
        MAL2[MyActivityList<br/>cache hit]
        
        CACHE --> CMS2
        CACHE --> RS2
        CACHE --> CPCS
        CACHE --> MS2
        CACHE --> MSC2
        CACHE --> MAL2
    end
```

## 주요 변경 파일

| 파일 | 변경 내용 |
|------|----------|
| `lib/queries/project-data.ts` | **신규** — `getEventParticipants`, `getEventGoals`, `getEventLogs` 캐시 함수 |
| `components/projects/crew-progress-chart-server.tsx` | **신규** — 서버 wrapper, 캐시 데이터로 차트 데이터 pre-compute |
| `components/projects/crew-monthly-stats.tsx` | 5 독립 쿼리 → 캐시 함수 3개 호출 + JS 필터 |
| `components/projects/refund-status.tsx` | 3 독립 쿼리 → 캐시 함수 3개 호출 (cache hit) |
| `components/projects/crew-progress-chart.tsx` | `initialData` prop 추가, 초기 클라이언트 fetch 제거 |
| `components/projects/my-status.tsx` | 2 독립 쿼리 → 캐시 함수 호출 + JS 필터 |
| `components/projects/my-sport-chart-server.tsx` | 1 독립 쿼리 → 캐시 함수 호출 + JS 필터 |
| `components/projects/my-activity-list.tsx` | 2 독립 쿼리 → 캐시 함수 호출 + JS sort/slice |
| `app/(main)/projects/page.tsx` | 쿼리 병렬화, `CrewProgressChartServer` 사용, props 추가 |

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **기능 개선**
  * 크루 진행 현황 차트의 데이터 로딩 성능을 최적화했습니다.
  * 차트 툴팁 표시를 간소화하여 가독성을 개선했습니다.

* **리팩토링**
  * 데이터 조회 시스템을 통합하여 캐싱 효율성을 높였습니다.
  * 활동 로그 및 목표 데이터 필터링을 개선했습니다.
  * 이벤트 기간 내에서만 데이터를 표시하도록 조정했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->