### PR TITLE
fix(ci): pr-promotion 워크플로우 기존 PR body 업데이트 누락 수정

### DIFF
--- a/.github/workflows/pr-promotion.yml
+++ b/.github/workflows/pr-promotion.yml
@@ -30,24 +30,24 @@ jobs:
           # 기존 dev→main PR 찾기
           EXISTING_PR=$(gh pr list --base main --head dev --state open --json number --jq '.[0].number')
 
-          if [ -n "$EXISTING_PR" ]; then
-            echo "✅ 기존 PR #$EXISTING_PR 발견 — 본문 업데이트"
-          else
-            echo "📝 새 PR 생성"
-            # dev→main 간 커밋 요약 생성
-            BODY=$(cat <<'EOF'
+          # dev→main 간 커밋 요약 생성
+          COMMITS_LOG=$(git log origin/main..origin/dev --oneline --no-merges)
+          BODY=$(cat <<EOF
           ## Summary
 
           dev 브랜치의 변경사항을 main으로 머지합니다.
 
           ### Commits
 
+          ${COMMITS_LOG}
           EOF
           )
-            COMMITS_LOG=$(git log origin/main..origin/dev --oneline --no-merges)
-            BODY="${BODY}
-          ${COMMITS_LOG}"
 
+          if [ -n "$EXISTING_PR" ]; then
+            echo "✅ 기존 PR #$EXISTING_PR 발견 — 본문 업데이트"
+            gh pr edit "$EXISTING_PR" --body "$BODY"
+          else
+            echo "📝 새 PR 생성"
             gh pr create \
               --base main \
               --head dev \


### PR DESCRIPTION
## 관련 이슈

관련 이슈 없음

## 요약

`pr-promotion` 워크플로우에서 기존 dev→main PR이 있을 때 body를 업데이트하지 않던 버그를 수정합니다.

## AS-IS (변경 전)

- 기존 dev→main PR이 존재하면 `echo "✅ 기존 PR 발견"` 메시지만 출력하고 종료
- **`gh pr edit`로 PR body를 업데이트하는 코드가 누락**되어 있어, 새 커밋이 머지되어도 PR 본문이 갱신되지 않음
- BODY 생성 로직이 `else` (새 PR 생성) 블록 안에만 존재

## TO-BE (변경 후)

- BODY 생성 로직을 if/else 앞으로 추출하여 공통화
- 기존 PR 발견 시 `gh pr edit "$EXISTING_PR" --body "$BODY"`로 본문 업데이트
- 새 PR 생성 시에도 동일한 BODY 변수 재사용

## 변경 흐름 (Mermaid)

```mermaid
flowchart TD
    A[PR merged to dev] --> B[BODY 생성 — 커밋 로그 수집]
    B --> C{기존 dev→main PR 존재?}
    C -->|Yes| D["gh pr edit #N --body BODY"]
    C -->|No| E[gh pr create --body BODY]
```

## 주요 변경 파일

- `.github/workflows/pr-promotion.yml`