### PR TITLE
fix(projects): 월 전환 시 로딩 상태 미표시 문제 해결

### DIFF
--- a/app/(main)/projects/page.tsx
+++ b/app/(main)/projects/page.tsx
@@ -8,6 +8,7 @@ import { currentMonthKST, prevMonthStr } from "@/lib/dayjs";
 import { MileageIntro } from "@/components/projects/mileage-intro";
 import { MileageRulesButton } from "@/components/projects/mileage-rules-button";
 import { MonthNavigator } from "@/components/projects/month-navigator";
+import { MonthTransitionProvider, TransitionOverlay } from "@/components/projects/month-transition";
 import { CrewProgressChartServer } from "@/components/projects/crew-progress-chart-server";
 import { JoinSection } from "@/components/projects/join-section";
 import { RandomReview } from "@/components/projects/random-review";
@@ -85,72 +86,76 @@ export default async function ProjectsPage({
     <div className="flex flex-col gap-0">
       <PageHeader title="프로젝트" />
       <div className="flex flex-col gap-7 px-6 pb-24">
-        {/* 이벤트명 + 월 네비게이터 */}
-        <div className="flex items-center justify-between">
-          <h2 className="text-xl font-bold">{event.evt_nm}</h2>
-          <MonthNavigator
-            currentMonth={selectedMonth}
-            startMonth={event.stt_dt}
-            endMonth={event.end_dt}
-          />
-        </div>
+        <MonthTransitionProvider>
+          {/* 이벤트명 + 월 네비게이터 */}
+          <div className="flex items-center justify-between">
+            <h2 className="text-xl font-bold">{event.evt_nm}</h2>
+            <MonthNavigator
+              currentMonth={selectedMonth}
+              startMonth={event.stt_dt}
+              endMonth={event.end_dt}
+            />
+          </div>
 
-        {/* 미참여 시 소개 */}
-        {!isParticipant && <MileageIntro />}
+          {/* 미참여 시 소개 */}
+          {!isParticipant && <MileageIntro />}
 
-        {/* 참여 신청 섹션 */}
-        {showJoin && (
-          <JoinSection
-            evtId={event.evt_id}
-            evtStartMonth={event.stt_dt}
-            evtEndMonth={event.end_dt}
-            existingPrt={participation}
-          />
-        )}
+          {/* 참여 신청 섹션 */}
+          {showJoin && (
+            <JoinSection
+              evtId={event.evt_id}
+              evtStartMonth={event.stt_dt}
+              evtEndMonth={event.end_dt}
+              existingPrt={participation}
+            />
+          )}
 
-        {/* 크루 진행현황 */}
-        <Suspense fallback={<Skeleton className="h-64 w-full rounded-2xl" />}>
-          <CrewProgressChartServer
-            evtId={event.evt_id}
-            memId={isParticipant ? member!.id : undefined}
-            month={selectedMonth}
-            evtStartMonth={event.stt_dt}
-            evtEndMonth={event.end_dt}
-          />
-        </Suspense>
-        <Suspense fallback={null}>
-          <RandomReview evtId={event.evt_id} />
-        </Suspense>
-        <Suspense fallback={<Skeleton className="h-32 w-full rounded-2xl" />}>
-          <CrewMonthlyStats evtId={event.evt_id} month={selectedMonth} evtStartMonth={event.stt_dt} evtEndMonth={event.end_dt} />
-        </Suspense>
-
-        {/* 참여자 전용 */}
-        {isParticipant && member && (
-          <>
-            <Suspense fallback={<Skeleton className="h-40 w-full rounded-2xl" />}>
-              <MyStatus evtId={event.evt_id} memId={member.id} month={selectedMonth} evtStartMonth={event.stt_dt} evtEndMonth={event.end_dt} />
-            </Suspense>
-            <Suspense fallback={<Skeleton className="h-20 w-full rounded-2xl" />}>
-              <RefundStatus
+          {/* 월별 동적 콘텐츠 — 전환 시 opacity 처리 */}
+          <TransitionOverlay className="flex flex-col gap-7">
+            <Suspense fallback={<Skeleton className="h-64 w-full rounded-2xl" />}>
+              <CrewProgressChartServer
                 evtId={event.evt_id}
-                memId={member.id}
+                memId={isParticipant ? member!.id : undefined}
+                month={selectedMonth}
                 evtStartMonth={event.stt_dt}
                 evtEndMonth={event.end_dt}
-                month={selectedMonth}
               />
             </Suspense>
-            <Suspense fallback={<Skeleton className="h-40 w-full rounded-2xl" />}>
-              <MySportChart evtId={event.evt_id} memId={member.id} month={selectedMonth} evtStartMonth={event.stt_dt} evtEndMonth={event.end_dt} />
+            <Suspense fallback={null}>
+              <RandomReview evtId={event.evt_id} />
             </Suspense>
-            <Suspense fallback={<Skeleton className="h-48 w-full rounded-2xl" />}>
-              <MyActivityList evtId={event.evt_id} memId={member.id} month={selectedMonth} evtStartMonth={event.stt_dt} evtEndMonth={event.end_dt} />
+            <Suspense fallback={<Skeleton className="h-32 w-full rounded-2xl" />}>
+              <CrewMonthlyStats evtId={event.evt_id} month={selectedMonth} evtStartMonth={event.stt_dt} evtEndMonth={event.end_dt} />
             </Suspense>
-            <ActivityLogFab evtId={event.evt_id} memId={member.id} />
-          </>
-        )}
 
-        <MileageRulesButton />
+            {/* 참여자 전용 */}
+            {isParticipant && member && (
+              <>
+                <Suspense fallback={<Skeleton className="h-40 w-full rounded-2xl" />}>
+                  <MyStatus evtId={event.evt_id} memId={member.id} month={selectedMonth} evtStartMonth={event.stt_dt} evtEndMonth={event.end_dt} />
+                </Suspense>
+                <Suspense fallback={<Skeleton className="h-20 w-full rounded-2xl" />}>
+                  <RefundStatus
+                    evtId={event.evt_id}
+                    memId={member.id}
+                    evtStartMonth={event.stt_dt}
+                    evtEndMonth={event.end_dt}
+                    month={selectedMonth}
+                  />
+                </Suspense>
+                <Suspense fallback={<Skeleton className="h-40 w-full rounded-2xl" />}>
+                  <MySportChart evtId={event.evt_id} memId={member.id} month={selectedMonth} evtStartMonth={event.stt_dt} evtEndMonth={event.end_dt} />
+                </Suspense>
+                <Suspense fallback={<Skeleton className="h-48 w-full rounded-2xl" />}>
+                  <MyActivityList evtId={event.evt_id} memId={member.id} month={selectedMonth} evtStartMonth={event.stt_dt} evtEndMonth={event.end_dt} />
+                </Suspense>
+                <ActivityLogFab evtId={event.evt_id} memId={member.id} />
+              </>
+            )}
+          </TransitionOverlay>
+
+          <MileageRulesButton />
+        </MonthTransitionProvider>
       </div>
     </div>
   );

--- a/components/projects/month-navigator.tsx
+++ b/components/projects/month-navigator.tsx
@@ -1,9 +1,10 @@
 "use client";
 
 import { useRouter, useSearchParams } from "next/navigation";
-import { ChevronLeft, ChevronRight } from "lucide-react";
+import { ChevronLeft, ChevronRight, Loader2 } from "lucide-react";
 import { prevMonthStr, nextMonthStr } from "@/lib/dayjs";
 import { Button } from "@/components/ui/button";
+import { useMonthTransition } from "./month-transition";
 
 export function MonthNavigator({
   currentMonth,
@@ -16,6 +17,7 @@ export function MonthNavigator({
 }) {
   const router = useRouter();
   const searchParams = useSearchParams();
+  const { isPending, startTransition } = useMonthTransition();
 
   const displayMonth = Number(currentMonth.split("-")[1]);
   const label = `${displayMonth}월`;
@@ -30,7 +32,9 @@ export function MonthNavigator({
   function navigate(month: string) {
     const params = new URLSearchParams(searchParams.toString());
     params.set("month", month);
-    router.push(`?${params.toString()}`, { scroll: false });
+    startTransition(() => {
+      router.push(`?${params.toString()}`, { scroll: false });
+    });
   }
 
   return (
@@ -39,20 +43,24 @@ export function MonthNavigator({
         variant="ghost"
         size="icon-sm"
         onClick={() => navigate(prevMonth)}
-        disabled={!hasPrev}
+        disabled={!hasPrev || isPending}
         className="text-muted-foreground active:bg-secondary disabled:opacity-30"
         aria-label="이전 달"
       >
         <ChevronLeft className="size-5" />
       </Button>
       <span className="min-w-[3rem] text-center text-lg font-bold">
-        {label}
+        {isPending ? (
+          <Loader2 className="mx-auto size-5 animate-spin text-muted-foreground" />
+        ) : (
+          label
+        )}
       </span>
       <Button
         variant="ghost"
         size="icon-sm"
         onClick={() => navigate(nextMonth)}
-        disabled={!hasNext}
+        disabled={!hasNext || isPending}
         className="text-muted-foreground active:bg-secondary disabled:opacity-30"
         aria-label="다음 달"
       >

--- a/components/projects/month-transition.tsx
+++ b/components/projects/month-transition.tsx
@@ -1,0 +1,51 @@
+"use client";
+
+import {
+  createContext,
+  useContext,
+  useTransition,
+  type ReactNode,
+} from "react";
+import { cn } from "@/lib/utils";
+
+const MonthTransitionContext = createContext<{
+  isPending: boolean;
+  startTransition: React.TransitionStartFunction;
+}>({
+  isPending: false,
+  startTransition: (cb) => cb(),
+});
+
+export function useMonthTransition() {
+  return useContext(MonthTransitionContext);
+}
+
+export function MonthTransitionProvider({ children }: { children: ReactNode }) {
+  const [isPending, startTransition] = useTransition();
+  return (
+    <MonthTransitionContext.Provider value={{ isPending, startTransition }}>
+      {children}
+    </MonthTransitionContext.Provider>
+  );
+}
+
+export function TransitionOverlay({
+  children,
+  className,
+}: {
+  children: ReactNode;
+  className?: string;
+}) {
+  const { isPending } = useMonthTransition();
+  return (
+    <div
+      className={cn(
+        "transition-opacity duration-200",
+        isPending && "pointer-events-none opacity-50",
+        className,
+      )}
+    >
+      {children}
+    </div>
+  );
+}


### PR DESCRIPTION
## 관련 이슈

관련 이슈 없음

## 요약

프로젝트 페이지에서 월 전환 시 로딩 피드백이 전혀 없던 문제를 `useTransition` 기반 pending UI로 해결한다.
네비게이터에 스피너 표시 + 콘텐츠 영역 opacity 페이드로 전환 중임을 시각적으로 전달한다.

## AS-IS (변경 전)

- 월 화살표 클릭 시 `router.push`로 searchParams만 변경
- Next.js soft navigation으로 `loading.tsx`가 트리거되지 않음 (같은 page 내 searchParams 변경은 "같은 페이지"로 취급)
- 서버 재렌더 완료까지 **아무런 로딩 피드백 없이** 이전 화면이 그대로 유지됨
- 사용자 입장에서 버튼이 안 먹는 것처럼 보임

## TO-BE (변경 후)

- `useTransition`으로 `router.push`를 감싸 pending 상태 관리
- **네비게이터**: 월 라벨 → `Loader2` 스피너로 교체, 좌우 버튼 비활성화
- **콘텐츠 영역**: `TransitionOverlay`로 래핑하여 opacity 50% + pointer-events 차단
- 서버 응답 도착 시 즉시 전체 복원

## 변경 흐름 (Mermaid)

```mermaid
sequenceDiagram
    participant U as 사용자
    participant MN as MonthNavigator
    participant CTX as MonthTransitionContext
    participant TO as TransitionOverlay
    participant S as Server

    U->>MN: 월 화살표 클릭
    MN->>CTX: startTransition(router.push)
    CTX-->>MN: isPending = true
    CTX-->>TO: isPending = true
    MN->>MN: 스피너 표시 + 버튼 disabled
    TO->>TO: opacity 50% + pointer-events none
    MN->>S: 새 searchParams로 서버 요청
    S-->>CTX: 새 UI 준비 완료
    CTX-->>MN: isPending = false (새 월 라벨)
    CTX-->>TO: isPending = false (새 콘텐츠)
```

## 주요 변경 파일

| 파일 | 변경 내용 |
|------|----------|
| `components/projects/month-transition.tsx` | **신규** — `MonthTransitionProvider` (context) + `TransitionOverlay` (opacity wrapper) |
| `components/projects/month-navigator.tsx` | `useMonthTransition()` hook 사용, 스피너 + 버튼 비활성화 추가 |
| `app/(main)/projects/page.tsx` | Provider로 감싸고 동적 콘텐츠를 `TransitionOverlay`로 래핑 |