### PR TITLE
fix(races): enforce date-first competition flow for record input

### DIFF
--- a/app/actions/create-competition.ts
+++ b/app/actions/create-competition.ts
@@ -2,6 +2,7 @@
 
 import { revalidateTag } from "next/cache";
 import { compEvtTypeContainsHangul } from "@/lib/comp-evt-type";
+import { todayKST } from "@/lib/dayjs";
 import { createAdminClient } from "@/lib/supabase/admin";
 import { getCachedCmmCdRows, isValidCompSprtCd } from "@/lib/queries/cmm-cd-cached";
 import { verifyAdmin } from "@/lib/queries/member";
@@ -14,6 +15,7 @@ interface CreateCompetitionInput {
   location: string;
   eventTypes: string[];
   sourceUrl: string;
+  datePolicy?: "future-only" | "allow-past";
 }
 
 export async function createCompetition(input: CreateCompetitionInput) {
@@ -25,6 +27,14 @@ export async function createCompetition(input: CreateCompetitionInput) {
   const cmmRows = await getCachedCmmCdRows();
   if (!isValidCompSprtCd(cmmRows, input.sport.trim())) {
     return { ok: false, message: "유효하지 않은 종목입니다." };
+  }
+
+  const datePolicy = input.datePolicy ?? "future-only";
+  if (datePolicy === "future-only" && input.startDate < todayKST()) {
+    return {
+      ok: false,
+      message: "지난 대회는 기록 입력에서 추가해 주세요.",
+    };
   }
 
   // 3. admin 클라이언트로 대회 INSERT (RLS 우회)

--- a/components/profile/race-record-dialog.tsx
+++ b/components/profile/race-record-dialog.tsx
@@ -22,7 +22,7 @@ import {
   eventTypeCodesForSprtFromCmmRows,
   type CachedCmmCdRow,
 } from "@/lib/queries/cmm-cd-cached";
-import { listCompetitionsByRaceDate, searchCompetitions } from "@/app/actions/search-competitions";
+import { listCompetitionsByRaceDate } from "@/app/actions/search-competitions";
 import { saveRaceRecord } from "@/app/actions/save-race-record";
 import { CompetitionRegisterDialog } from "@/components/races/competition-register-dialog";
 import type { MemberStatus } from "@/components/races/types";
@@ -80,8 +80,6 @@ export function RaceRecordDialog({
   const [compsForRaceDate, setCompsForRaceDate] = useState<Competition[]>([]);
   const [dateListLoading, setDateListLoading] = useState(false);
   const [searchQuery, setSearchQuery] = useState("");
-  const [searchResults, setSearchResults] = useState<Competition[]>([]);
-  const [searchLoading, setSearchLoading] = useState(false);
   const [registerOpen, setRegisterOpen] = useState(false);
   /** 날짜 검색 목록에서 대회를 고를 때 선택한 달력일(race_dt). 비어 있으면 대회 시작일 사용 */
   const [recordRaceDayFromCalendar, setRecordRaceDayFromCalendar] = useState("");
@@ -137,7 +135,6 @@ export function RaceRecordDialog({
       setCompsForRaceDate([]);
       setDateListLoading(false);
       setSearchQuery("");
-      setSearchResults([]);
       setRegisterOpen(false);
       setRecordRaceDayFromCalendar("");
       setSelectedEventType("");
@@ -228,25 +225,6 @@ export function RaceRecordDialog({
     };
   }, [raceDate]);
 
-  // 날짜 미선택일 때만 이름으로 전체 대회 검색(자동완성)
-  useEffect(() => {
-    if (raceDate.trim()) {
-      setSearchResults([]);
-      return;
-    }
-    if (!searchQuery.trim()) {
-      setSearchResults([]);
-      return;
-    }
-    const t = setTimeout(async () => {
-      setSearchLoading(true);
-      const list = await searchCompetitions(searchQuery);
-      setSearchResults(list as Competition[]);
-      setSearchLoading(false);
-    }, 300);
-    return () => clearTimeout(t);
-  }, [searchQuery, raceDate]);
-
   const filteredByDateAndName = useMemo(() => {
     const q = searchQuery.trim().toLowerCase();
     if (!q) return compsForRaceDate;
@@ -267,7 +245,6 @@ export function RaceRecordDialog({
     setRaceDate("");
     setCompsForRaceDate([]);
     setSearchQuery("");
-    setSearchResults([]);
     const registered = (comp.registeredEventType ?? "").trim().toUpperCase();
     setSelectedEventType(registered);
     setCustomEventType("");
@@ -307,6 +284,7 @@ export function RaceRecordDialog({
   const competitionTitle = selectedComp?.title ?? "";
   const competitionDate =
     recordRaceDayFromCalendar.trim() || selectedComp?.start_date || "";
+  const hasRaceDate = Boolean(raceDate.trim());
   const eventType =
     selectedEventType === EVENT_TYPE_OTHER
       ? sanitizeAsciiUpperCompEvtTypeInput(customEventType).trim()
@@ -461,9 +439,9 @@ export function RaceRecordDialog({
               <Input
                 ref={searchInputRef}
                 placeholder={
-                  raceDate.trim()
+                  hasRaceDate
                     ? "대회명으로 목록 좁히기 (선택)"
-                    : "대회명으로 검색 (전체 목록)"
+                    : "대회 날짜를 먼저 선택해 주세요"
                 }
                 value={searchQuery}
                 onChange={(e) => setSearchQuery(e.target.value)}
@@ -471,6 +449,7 @@ export function RaceRecordDialog({
                   setTimeout(scrollSearchInputAboveKeyboard, 350);
                   setTimeout(scrollSearchInputAboveKeyboard, 600);
                 }}
+                disabled={!hasRaceDate}
                 className="mb-2"
               />
 
@@ -481,12 +460,21 @@ export function RaceRecordDialog({
                   size="sm"
                   className="mb-2 w-full"
                   onClick={() => setRegisterOpen(true)}
+                  disabled={!hasRaceDate}
                 >
                   대회 추가
                 </Button>
               )}
 
-              {raceDate.trim() ? (
+              {!hasRaceDate && (
+                <div className="rounded-lg border border-dashed border-border p-3">
+                  <p className="text-xs text-muted-foreground">
+                    대회 날짜를 먼저 선택해 주세요. 날짜 선택 후 대회 검색과 추가가 가능합니다.
+                  </p>
+                </div>
+              )}
+
+              {hasRaceDate && (
                 <>
                   {dateListLoading && (
                     <p className="text-xs text-muted-foreground">목록 불러오는 중...</p>
@@ -523,40 +511,6 @@ export function RaceRecordDialog({
                               useCalendarPickForRecordDate: true,
                             })
                           }
-                          className="h-auto w-full flex-col items-start gap-0.5 px-3 py-2 hover:bg-muted/50"
-                        >
-                          <p className="font-medium">{comp.title}</p>
-                          <p className="text-xs text-muted-foreground">
-                            {comp.start_date} &middot; {comp.location ?? "-"}
-                          </p>
-                        </Button>
-                      ))}
-                    </div>
-                  )}
-                </>
-              ) : (
-                <>
-                  {searchLoading && (
-                    <p className="text-xs text-muted-foreground">검색 중...</p>
-                  )}
-                  {!searchLoading && searchQuery.trim() && searchResults.length === 0 && (
-                    <div className="rounded-lg border border-dashed border-border p-3">
-                      <p className="text-xs text-muted-foreground">
-                        검색 결과가 없습니다.
-                        {competitionRegisterMemberStatus
-                          ? " 대회 추가로 등록해 보세요."
-                          : ""}
-                      </p>
-                    </div>
-                  )}
-                  {!searchLoading && searchResults.length > 0 && (
-                    <div className="max-h-48 space-y-1 overflow-y-auto rounded-lg border border-border p-2">
-                      {searchResults.map((comp) => (
-                        <Button
-                          key={comp.id}
-                          type="button"
-                          variant="ghost"
-                          onClick={() => handleSelectCompetition(comp)}
                           className="h-auto w-full flex-col items-start gap-0.5 px-3 py-2 hover:bg-muted/50"
                         >
                           <p className="font-medium">{comp.title}</p>
@@ -735,6 +689,7 @@ export function RaceRecordDialog({
           open={registerOpen}
           onOpenChange={setRegisterOpen}
           memberStatus={competitionRegisterMemberStatus}
+          datePolicy="allow-past"
           stackElevated
           prefillStartDate={raceDate.trim() || undefined}
           onCreated={() => {}}

--- a/components/races/competition-register-dialog.tsx
+++ b/components/races/competition-register-dialog.tsx
@@ -7,8 +7,11 @@ import { zodResolver } from "@hookform/resolvers/zod";
 import { createCompetition } from "@/app/actions/create-competition";
 import {
   competitionRegisterSchema,
+  competitionRegisterSchemaAllowPast,
+  type CompetitionRegisterDatePolicy,
   type CompetitionRegisterValues,
 } from "@/lib/validations/competition";
+import { todayKST } from "@/lib/dayjs";
 import {
   buildEventTypeOptionList,
   COMP_EVT_TYPE_OTHER,
@@ -82,6 +85,8 @@ interface CompetitionRegisterDialogProps {
   stackElevated?: boolean;
   /** 열 때 시작일(YYYY-MM-DD) 미리 채움 */
   prefillStartDate?: string;
+  /** 날짜 정책: 대회 탭은 미래/당일만, 기록 입력은 과거 허용 */
+  datePolicy?: CompetitionRegisterDatePolicy;
 }
 
 export function CompetitionRegisterDialog({
@@ -92,7 +97,16 @@ export function CompetitionRegisterDialog({
   onCreated,
   stackElevated = false,
   prefillStartDate,
+  datePolicy = "future-only",
 }: CompetitionRegisterDialogProps) {
+  const registerSchema = useMemo(
+    () =>
+      datePolicy === "allow-past"
+        ? competitionRegisterSchemaAllowPast
+        : competitionRegisterSchema,
+    [datePolicy],
+  );
+
   const {
     register,
     handleSubmit,
@@ -103,7 +117,7 @@ export function CompetitionRegisterDialog({
     formState: { errors, isSubmitting },
   } = useForm<CompetitionRegisterValues>({
     defaultValues,
-    resolver: zodResolver(competitionRegisterSchema),
+    resolver: zodResolver(registerSchema),
   });
 
   const sport = watch("sport");
@@ -181,6 +195,7 @@ export function CompetitionRegisterDialog({
       location: data.location,
       eventTypes,
       sourceUrl: data.sourceUrl,
+      datePolicy,
     });
 
     if (!result.ok) {
@@ -204,9 +219,13 @@ export function CompetitionRegisterDialog({
         )}
       >
         <DialogHeader>
-          <DialogTitle>대회 등록</DialogTitle>
+          <DialogTitle>
+            {datePolicy === "allow-past" ? "대회 추가" : "대회 등록"}
+          </DialogTitle>
           <DialogDescription>
-            등록되지 않은 대회를 직접 등록합니다.
+            {datePolicy === "allow-past"
+              ? "기록 입력을 위해 등록되지 않은 대회를 추가합니다."
+              : "앞으로 참가할 대회를 등록합니다."}
           </DialogDescription>
         </DialogHeader>
 
@@ -269,10 +288,16 @@ export function CompetitionRegisterDialog({
               <Input
                 id="comp-start"
                 type="date"
+                min={datePolicy === "future-only" ? todayKST() : undefined}
                 max="9999-12-31"
                 {...register("startDate")}
               />
               {errors.startDate && <p className="text-xs text-destructive">{errors.startDate.message}</p>}
+              {datePolicy === "future-only" && (
+                <p className="text-xs text-muted-foreground">
+                  지난 대회는 기록 입력에서 추가해 주세요.
+                </p>
+              )}
             </div>
             <div className="flex flex-col gap-1.5">
               <Label htmlFor="comp-end">종료일</Label>

--- a/components/races/race-list-view.tsx
+++ b/components/races/race-list-view.tsx
@@ -576,6 +576,7 @@ export function RaceListView({
         open={registerOpen}
         onOpenChange={setRegisterOpen}
         memberStatus={memberStatus}
+        datePolicy="future-only"
         onCreated={async () => {
           await revalidateCompetitions();
           router.refresh();

--- a/lib/validations/competition.ts
+++ b/lib/validations/competition.ts
@@ -1,5 +1,6 @@
 import { z } from "zod";
 import type { Enums } from "@/lib/supabase/database.types";
+import { todayKST } from "@/lib/dayjs";
 import {
   COMP_EVT_TYPE_OTHER,
   compEvtTypeContainsHangul,
@@ -7,8 +8,11 @@ import {
   sanitizeAsciiUpperCompEvtTypeInput,
 } from "@/lib/comp-evt-type";
 
+export type CompetitionRegisterDatePolicy = "future-only" | "allow-past";
+
 /** 대회 등록 폼 — 종목은 COMP_SPRT_CD, 코스는 공통코드+기타(직접입력) */
-export const competitionRegisterSchema = z
+function buildCompetitionRegisterSchema(datePolicy: CompetitionRegisterDatePolicy) {
+  const baseSchema = z
   .object({
     title: z.string().min(1, "대회명을 입력해 주세요"),
     sport: z.string().min(1, "종목을 선택해 주세요"),
@@ -46,6 +50,19 @@ export const competitionRegisterSchema = z
       path: ["selectedEventTypes"],
     },
   );
+
+  if (datePolicy === "allow-past") {
+    return baseSchema;
+  }
+
+  return baseSchema.refine((data) => data.startDate >= todayKST(), {
+    message: "지난 대회는 기록 입력에서 추가해 주세요.",
+    path: ["startDate"],
+  });
+}
+
+export const competitionRegisterSchema = buildCompetitionRegisterSchema("future-only");
+export const competitionRegisterSchemaAllowPast = buildCompetitionRegisterSchema("allow-past");
 
 export type CompetitionRegisterValues = z.infer<
   typeof competitionRegisterSchema


### PR DESCRIPTION
## Summary
- 대회 등록 팝업에 날짜 정책 컨텍스트를 추가해 대회탭은 당일/미래만, 기록입력은 과거 포함 등록 가능하도록 분리했습니다.
- 기록입력에서 날짜 미선택 시 대회명 검색과 대회 추가를 비활성화하고, 날짜를 먼저 선택하도록 안내 문구를 표시합니다.
- 서버 액션과 폼 검증 모두 동일 정책을 적용해 UI 우회 시에도 규칙이 일관되게 유지되도록 했습니다.

## Test plan
- [ ] 대회탭에서 어제 날짜로 대회 등록 시도 시 등록이 차단되고 안내 문구가 보인다.
- [ ] 대회탭에서 오늘/미래 날짜로는 정상 등록된다.
- [ ] 기록입력에서 날짜 미선택 상태일 때 검색 입력/대회 추가 버튼이 비활성화된다.
- [ ] 기록입력에서 날짜 선택 후 해당 날짜 목록 조회, 이름 필터, 과거 대회 추가가 정상 동작한다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리즈 노트

* **새로운 기능**
  * 과거 대회를 기록 입력에서 추가할 수 있도록 지원
  * 날짜 선택 후 대회 검색 가능하도록 개선

* **개선 사항**
  * 일반 대회 등록 시 미래 날짜만 허용

<!-- end of auto-generated comment: release notes by coderabbit.ai -->