### PR TITLE
feat: 팀 일반 회원도 대회 등록(createCompetition) 가능

### DIFF
--- a/app/actions/create-competition.ts
+++ b/app/actions/create-competition.ts
@@ -21,7 +21,7 @@ interface CreateCompetitionInput {
 export async function createCompetition(input: CreateCompetitionInput) {
   const { member } = await getCurrentMember();
   if (!member) {
-    return { ok: false, message: "로그인 후 팀에 가입한 회원만 등록할 수 있습니다." };
+    return { ok: false, message: "회원만 등록할 수 있습니다." };
   }
 
   const cmmRows = await getCachedCmmCdRows();

--- a/app/actions/create-competition.ts
+++ b/app/actions/create-competition.ts
@@ -5,7 +5,7 @@ import { compEvtTypeContainsHangul } from "@/lib/comp-evt-type";
 import { todayKST } from "@/lib/dayjs";
 import { createAdminClient } from "@/lib/supabase/admin";
 import { getCachedCmmCdRows, isValidCompSprtCd } from "@/lib/queries/cmm-cd-cached";
-import { verifyAdmin } from "@/lib/queries/member";
+import { getCurrentMember } from "@/lib/queries/member";
 
 interface CreateCompetitionInput {
   title: string;
@@ -19,9 +19,9 @@ interface CreateCompetitionInput {
 }
 
 export async function createCompetition(input: CreateCompetitionInput) {
-  const adminUser = await verifyAdmin();
-  if (!adminUser) {
-    return { ok: false, message: "권한이 없습니다" };
+  const { member } = await getCurrentMember();
+  if (!member) {
+    return { ok: false, message: "로그인 후 팀에 가입한 회원만 등록할 수 있습니다." };
   }
 
   const cmmRows = await getCachedCmmCdRows();


### PR DESCRIPTION
배경
대회 탭·기록 입력·어드민 등에서 쓰는 createCompetition이 verifyAdmin()만 통과해 팀 owner/admin만 등록할 수 있었음.

변경

verifyAdmin() → getCurrentMember()로 전환해, 해당 팀에 소속된 로그인 회원이면 대회 신규 등록 가능.
대회 삭제/관리 등 기존 manage-competition 등의 관리자 전용 동작은 그대로 verifyAdmin 유지.
비회원/미가입 시 에러 메시지 문구 정리 (feb2a10).
커밋

91f292d — Allow any team member to create competitions via createCompetition.
feb2a10 — Shorten createCompetition error message when the caller is not a team member.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Bug Fixes**
  * 대회 생성 권한 요구사항을 조정했습니다. 이제 관리자뿐만 아니라 회원도 대회를 등록할 수 있습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->