### PR TITLE
refactor(projects): split monthly and cumulative project queries

### DIFF
--- a/.claude/docs/database-abbreviation-dictionary.md
+++ b/.claude/docs/database-abbreviation-dictionary.md
@@ -16,9 +16,12 @@
 | `dt` | 날짜 |
 | `at` | 일시 |
 | `stt` | start 시작 |
+| `stts` | status 상태 |
 | `aply` | apply 적용 |
+| `aprv` | approve 승인 |
 | `yn` | 불리언 플래그 |
 | `amt` | 금액 |
+| `mth` | month 월 |
 | `id` | 식별자 |
 
 ## 도메인 약어
@@ -30,6 +33,8 @@
 | `rec` | record (기록) |
 | `fee` | fee (회비) |
 | `evt` | event (이벤트) |
+| `mlg` | mileage (마일리지) |
+| `sprt` | sport (종목/스포츠) |
 | `ttl` | title (칭호) |
 | `pay` | payment (납부) |
 | `attd` | attendance (출석/참석) |
@@ -72,4 +77,5 @@
 - `title`은 `ttl`로 통일한다.
 - `payment`는 `pay`로 통일한다.
 - `*_cd` 기본 의미는 공통코드 참조다.
+- 고정된 폐쇄형 값셋은 `*_enm`을 우선 사용한다.
 - 단, `team_cd`처럼 외부/업무 식별 목적의 유니크 코드는 예외로 허용한다.

--- a/.claude/docs/database-schema-v2-event-domain.md
+++ b/.claude/docs/database-schema-v2-event-domain.md
@@ -35,8 +35,8 @@ evt_mlg_goal_cfg  evt_mlg_act_hist
 | `evt_type_cd` | `varchar(20)` | Y | 이벤트 유형 코드 (`MILEAGE_RUN` 등) |
 | `stt_dt` | `date` | Y | 시작일 |
 | `end_dt` | `date` | Y | 종료일 |
-| `status_cd` | `varchar(20)` | Y | 상태 (`READY` / `ACTIVE` / `CLOSED`), 기본값 `READY` |
-| `desc` | `text` | N | 설명 |
+| `stts_enm` | `evt_stts_enm` | Y | 상태 enum (`READY` / `ACTIVE` / `CLOSED`), 기본값 `READY` |
+| `desc_txt` | `text` | N | 설명 |
 | `created_at` | `timestamptz` | Y | 기본값 `now()` |
 | `updated_at` | `timestamptz` | Y | 기본값 `now()` |
 
@@ -52,14 +52,14 @@ evt_mlg_goal_cfg  evt_mlg_act_hist
 | `prt_id` | `uuid` | Y | PK |
 | `evt_id` | `uuid` | Y | FK → `evt_team_mst.evt_id` |
 | `mem_id` | `uuid` | Y | FK → `mem_mst.mem_id` |
-| `stt_month` | `date` | Y | 참여 시작월 (ex: `2026-04-01`). 연습기간 가입이면 연습월부터 |
+| `stt_mth` | `date` | Y | 참여 시작월 (ex: `2026-04-01`). 연습기간 가입이면 연습월부터 |
 | `init_goal` | `integer` | Y | 초기 목표 마일리지 (50/100/자유) |
 | `deposit_amt` | `integer` | Y | 보증금 (잔여 실전 개월 × 1만원) |
 | `entry_fee_amt` | `integer` | Y | 참가비 (싱글렛 보유: 1만, 미보유: 2만) |
 | `singlet_fee_amt` | `integer` | Y | 싱글렛비 (현재 미사용, 0 고정) |
 | `has_singlet_yn` | `boolean` | Y | 싱글렛 보유 여부, 기본값 `false` |
-| `approve_yn` | `boolean` | Y | 운영진 승인 여부, 기본값 `false` |
-| `approved_at` | `timestamptz` | N | 승인 일시 |
+| `aprv_yn` | `boolean` | Y | 운영진 승인 여부, 기본값 `false` |
+| `aprv_at` | `timestamptz` | N | 승인 일시 |
 | `created_at` | `timestamptz` | Y | 기본값 `now()` |
 | `updated_at` | `timestamptz` | Y | 기본값 `now()` |
 
@@ -76,7 +76,7 @@ evt_mlg_goal_cfg  evt_mlg_act_hist
 | `goal_id` | `uuid` | Y | PK |
 | `evt_id` | `uuid` | Y | FK → `evt_team_mst.evt_id` |
 | `mem_id` | `uuid` | Y | FK → `mem_mst.mem_id` |
-| `goal_month` | `date` | Y | 대상월 (ex: `2026-05-01`) |
+| `goal_mth` | `date` | Y | 대상월 (ex: `2026-05-01`) |
 | `goal_val` | `integer` | Y | 목표 마일리지 (정수) |
 | `achieved_yn` | `boolean` | Y | 달성 여부, 기본값 `false` |
 | `created_at` | `timestamptz` | Y | 기본값 `now()` |
@@ -85,7 +85,7 @@ evt_mlg_goal_cfg  evt_mlg_act_hist
 핵심 제약:
 - PK: `goal_id`
 - FK: `evt_id` → `evt_team_mst(evt_id)`, `mem_id` → `mem_mst(mem_id)`
-- UK: `(evt_id, mem_id, goal_month)` — 이벤트 × 회원 × 월 유일
+- UK: `(evt_id, mem_id, goal_mth)` — 이벤트 × 회원 × 월 유일
 
 목표 자동상향 규칙 (연습기간 제외, 실전 기간만):
 - 달성 시: 목표 < 50 → +10, 50~99 → +15, 100+ → +20
@@ -100,7 +100,7 @@ evt_mlg_goal_cfg  evt_mlg_act_hist
 | `evt_id` | `uuid` | Y | FK → `evt_team_mst.evt_id` |
 | `mem_id` | `uuid` | Y | FK → `mem_mst.mem_id` |
 | `act_dt` | `date` | Y | 활동 날짜 |
-| `sport_cd` | `varchar(20)` | Y | 종목 (`RUNNING` / `TRAIL` / `CYCLING` / `SWIMMING`) |
+| `sprt_enm` | `evt_mlg_sprt_enm` | Y | 종목 enum (`RUNNING` / `TRAIL` / `CYCLING` / `SWIMMING`) |
 | `distance_km` | `numeric(6,2)` | Y | 거리 (km) |
 | `elevation_m` | `numeric(7,1)` | N | 상승고도 (m), 수영은 null |
 | `base_mlg` | `numeric(6,2)` | Y | 기본 마일리지 (배율 적용 전) |

--- a/app/(info)/admin/events/admin-events-client.tsx
+++ b/app/(info)/admin/events/admin-events-client.tsx
@@ -23,7 +23,7 @@ type ActiveEvent = {
   evt_type_cd: string;
   stt_dt: string;
   end_dt: string;
-  status_cd: string;
+  stts_enm: string;
 };
 
 type Multiplier = {
@@ -70,12 +70,12 @@ export function AdminEventsClient({ teamId }: { teamId: string }) {
     // 활성 이벤트 조회 (ACTIVE 우선, 없으면 최근 이벤트)
     const { data: evts } = await supabase
       .from("evt_team_mst")
-      .select("evt_id, evt_nm, evt_type_cd, stt_dt, end_dt, status_cd")
+      .select("evt_id, evt_nm, evt_type_cd, stt_dt, end_dt, stts_enm")
       .eq("team_id", teamId)
       .order("created_at", { ascending: false });
 
     const activeEvt =
-      (evts ?? []).find((e) => e.status_cd === "ACTIVE") ??
+      (evts ?? []).find((e) => e.stts_enm === "ACTIVE") ??
       (evts ?? [])[0] ??
       null;
 
@@ -321,17 +321,17 @@ export function AdminEventsClient({ teamId }: { teamId: string }) {
             <Body className="font-semibold">{activeEvent.evt_nm}</Body>
             <Badge
               variant={
-                activeEvent.status_cd === "ACTIVE"
+                activeEvent.stts_enm === "ACTIVE"
                   ? "default"
-                  : activeEvent.status_cd === "CLOSED"
+                  : activeEvent.stts_enm === "CLOSED"
                     ? "outline"
                     : "secondary"
               }
               className="text-[11px]"
             >
-              {activeEvent.status_cd === "ACTIVE"
+              {activeEvent.stts_enm === "ACTIVE"
                 ? "진행중"
-                : activeEvent.status_cd === "CLOSED"
+                : activeEvent.stts_enm === "CLOSED"
                   ? "종료"
                   : "준비중"}
             </Badge>

--- a/app/(info)/admin/participations/admin-participations-client.tsx
+++ b/app/(info)/admin/participations/admin-participations-client.tsx
@@ -31,7 +31,7 @@ type ActiveEvent = {
   evt_nm: string;
   stt_dt: string;
   end_dt: string;
-  status_cd: string;
+  stts_enm: string;
 };
 
 type Participant = {
@@ -39,14 +39,14 @@ type Participant = {
   evt_id: string;
   mem_id: string;
   mem_nm: string | null;
-  stt_month: string;
+  stt_mth: string;
   init_goal: number;
   deposit_amt: number;
   entry_fee_amt: number;
   singlet_fee_amt: number;
   has_singlet_yn: boolean;
-  approve_yn: boolean;
-  approved_at: string | null;
+  aprv_yn: boolean;
+  aprv_at: string | null;
   created_at: string;
 };
 
@@ -65,7 +65,7 @@ export function AdminParticipationsClient({ teamId }: { teamId: string }) {
   const [processingId, setProcessingId] = useState<string | null>(null);
   const [editingPrt, setEditingPrt] = useState<Participant | null>(null);
   const [editForm, setEditForm] = useState({
-    stt_month: "",
+    stt_mth: "",
     init_goal: 0,
     deposit_amt: 0,
     entry_fee_amt: 0,
@@ -80,12 +80,12 @@ export function AdminParticipationsClient({ teamId }: { teamId: string }) {
     // 활성 이벤트 조회
     const { data: evts } = await supabase
       .from("evt_team_mst")
-      .select("evt_id, evt_nm, stt_dt, end_dt, status_cd")
+      .select("evt_id, evt_nm, stt_dt, end_dt, stts_enm")
       .eq("team_id", teamId)
       .order("created_at", { ascending: false });
 
     const activeEvt =
-      (evts ?? []).find((e) => e.status_cd === "ACTIVE") ??
+      (evts ?? []).find((e) => e.stts_enm === "ACTIVE") ??
       (evts ?? [])[0] ??
       null;
 
@@ -96,7 +96,7 @@ export function AdminParticipationsClient({ teamId }: { teamId: string }) {
       const { data: prtData } = await supabase
         .from("evt_team_prt_rel")
         .select(
-          "prt_id, evt_id, mem_id, stt_month, init_goal, deposit_amt, entry_fee_amt, singlet_fee_amt, has_singlet_yn, approve_yn, approved_at, created_at",
+          "prt_id, evt_id, mem_id, stt_mth, init_goal, deposit_amt, entry_fee_amt, singlet_fee_amt, has_singlet_yn, aprv_yn, aprv_at, created_at",
         )
         .eq("evt_id", activeEvt.evt_id)
         .order("created_at", { ascending: false });
@@ -140,7 +140,7 @@ export function AdminParticipationsClient({ teamId }: { teamId: string }) {
       setParticipants((prev) =>
         prev.map((p) =>
           p.prt_id === prtId
-            ? { ...p, approve_yn: true, approved_at: new Date().toISOString() }
+            ? { ...p, aprv_yn: true, aprv_at: new Date().toISOString() }
             : p,
         ),
       );
@@ -169,7 +169,7 @@ export function AdminParticipationsClient({ teamId }: { teamId: string }) {
     if (result.ok) {
       setParticipants((prev) =>
         prev.map((p) =>
-          p.prt_id === prtId ? { ...p, approve_yn: false, approved_at: null } : p,
+          p.prt_id === prtId ? { ...p, aprv_yn: false, aprv_at: null } : p,
         ),
       );
     } else {
@@ -193,7 +193,7 @@ export function AdminParticipationsClient({ teamId }: { teamId: string }) {
   const openEdit = (prt: Participant) => {
     setEditingPrt(prt);
     setEditForm({
-      stt_month: prt.stt_month,
+      stt_mth: prt.stt_mth,
       init_goal: prt.init_goal,
       deposit_amt: prt.deposit_amt,
       entry_fee_amt: prt.entry_fee_amt,
@@ -220,7 +220,7 @@ export function AdminParticipationsClient({ teamId }: { teamId: string }) {
   };
 
   const filteredList = participants.filter((p) =>
-    tab === "pending" ? !p.approve_yn : p.approve_yn,
+    tab === "pending" ? !p.aprv_yn : p.aprv_yn,
   );
 
   if (loading) {
@@ -248,17 +248,17 @@ export function AdminParticipationsClient({ teamId }: { teamId: string }) {
             <Body className="font-semibold">{activeEvent.evt_nm}</Body>
             <Badge
               variant={
-                activeEvent.status_cd === "ACTIVE"
+                activeEvent.stts_enm === "ACTIVE"
                   ? "default"
-                  : activeEvent.status_cd === "CLOSED"
+                  : activeEvent.stts_enm === "CLOSED"
                     ? "outline"
                     : "secondary"
               }
               className="text-[11px]"
             >
-              {activeEvent.status_cd === "ACTIVE"
+              {activeEvent.stts_enm === "ACTIVE"
                 ? "진행중"
-                : activeEvent.status_cd === "CLOSED"
+                : activeEvent.stts_enm === "CLOSED"
                   ? "종료"
                   : "준비중"}
             </Badge>
@@ -300,7 +300,7 @@ export function AdminParticipationsClient({ teamId }: { teamId: string }) {
                       </Badge>
                     )}
                   </div>
-                  {!prt.approve_yn && (
+                  {!prt.aprv_yn && (
                     <div className="flex gap-1.5">
                       <Button
                         size="sm"
@@ -323,7 +323,7 @@ export function AdminParticipationsClient({ teamId }: { teamId: string }) {
                       </Button>
                     </div>
                   )}
-                  {prt.approve_yn && (
+                  {prt.aprv_yn && (
                     <div className="flex items-center gap-1.5">
                       <Badge variant="default" className="text-[11px]">
                         승인완료
@@ -366,7 +366,7 @@ export function AdminParticipationsClient({ teamId }: { teamId: string }) {
                 <div className="grid grid-cols-2 gap-x-4 gap-y-2">
                   <ParticipantInfoItem
                     label="시작월"
-                    value={prt.stt_month?.slice(0, 7) ?? "-"}
+                    value={prt.stt_mth?.slice(0, 7) ?? "-"}
                   />
                   <ParticipantInfoItem
                     label="초기 목표"
@@ -384,10 +384,10 @@ export function AdminParticipationsClient({ teamId }: { teamId: string }) {
                     label="싱글렛"
                     value={prt.has_singlet_yn ? "있음" : "없음"}
                   />
-                  {prt.approve_yn && prt.approved_at && (
+                  {prt.aprv_yn && prt.aprv_at && (
                     <ParticipantInfoItem
                       label="승인일"
-                      value={prt.approved_at.slice(0, 10)}
+                      value={prt.aprv_at.slice(0, 10)}
                     />
                   )}
                 </div>
@@ -420,8 +420,8 @@ export function AdminParticipationsClient({ teamId }: { teamId: string }) {
                 <Input
                   type="date"
                   max="9999-12-31"
-                  value={editForm.stt_month}
-                  onChange={(e) => setEditForm({ ...editForm, stt_month: e.target.value })}
+                  value={editForm.stt_mth}
+                  onChange={(e) => setEditForm({ ...editForm, stt_mth: e.target.value })}
                   className="h-12 rounded-xl border-[1.5px] text-[15px]"
                 />
               </div>

--- a/app/(info)/admin/projects/admin-projects-client.tsx
+++ b/app/(info)/admin/projects/admin-projects-client.tsx
@@ -30,8 +30,8 @@ type Event = {
   evt_type_cd: string;
   stt_dt: string;
   end_dt: string;
-  status_cd: string;
-  desc: string | null;
+  stts_enm: string;
+  desc_txt: string | null;
   created_at: string;
 };
 
@@ -71,8 +71,8 @@ export function AdminProjectsClient({ teamId }: { teamId: string }) {
     evt_type_cd: "MILEAGE_RUN",
     stt_dt: "",
     end_dt: "",
-    status_cd: "READY",
-    desc: "",
+    stts_enm: "READY",
+    desc_txt: "",
   });
 
   const loadEvents = useCallback(async () => {
@@ -80,7 +80,7 @@ export function AdminProjectsClient({ teamId }: { teamId: string }) {
     const supabase = createClient();
     const { data } = await supabase
       .from("evt_team_mst")
-      .select("evt_id, evt_nm, evt_type_cd, stt_dt, end_dt, status_cd, desc, created_at")
+      .select("evt_id, evt_nm, evt_type_cd, stt_dt, end_dt, stts_enm, desc_txt, created_at")
       .eq("team_id", teamId)
       .order("created_at", { ascending: false });
 
@@ -100,8 +100,8 @@ export function AdminProjectsClient({ teamId }: { teamId: string }) {
         evt_type_cd: selected.evt_type_cd,
         stt_dt: selected.stt_dt,
         end_dt: selected.end_dt,
-        status_cd: selected.status_cd,
-        desc: selected.desc ?? "",
+        stts_enm: selected.stts_enm,
+        desc_txt: selected.desc_txt ?? "",
       });
     }
   }, [mode, selected]);
@@ -121,8 +121,8 @@ export function AdminProjectsClient({ teamId }: { teamId: string }) {
       evt_type_cd: "MILEAGE_RUN",
       stt_dt: "",
       end_dt: "",
-      status_cd: "READY",
-      desc: "",
+      stts_enm: "READY",
+      desc_txt: "",
     });
     setMode("create");
   };
@@ -134,8 +134,8 @@ export function AdminProjectsClient({ teamId }: { teamId: string }) {
       evt_type_cd: evt.evt_type_cd,
       stt_dt: evt.stt_dt,
       end_dt: evt.end_dt,
-      status_cd: evt.status_cd,
-      desc: evt.desc ?? "",
+      stts_enm: evt.stts_enm,
+      desc_txt: evt.desc_txt ?? "",
     });
     setMode("edit");
   };
@@ -161,8 +161,8 @@ export function AdminProjectsClient({ teamId }: { teamId: string }) {
       evt_type_cd: form.evt_type_cd,
       stt_dt: form.stt_dt,
       end_dt: form.end_dt,
-      status_cd: form.status_cd,
-      desc: form.desc || null,
+      stts_enm: form.stts_enm,
+      desc_txt: form.desc_txt || null,
     };
 
     const result =
@@ -274,8 +274,8 @@ export function AdminProjectsClient({ teamId }: { teamId: string }) {
         <div className="flex flex-col gap-2">
           <label className="text-sm font-medium text-foreground">상태</label>
           <Select
-            value={form.status_cd}
-            onValueChange={(v) => setForm({ ...form, status_cd: v })}
+            value={form.stts_enm}
+            onValueChange={(v) => setForm({ ...form, stts_enm: v })}
           >
             <SelectTrigger className="h-12 rounded-xl border-[1.5px] text-[15px]">
               <SelectValue />
@@ -294,8 +294,8 @@ export function AdminProjectsClient({ teamId }: { teamId: string }) {
         <div className="flex flex-col gap-2">
           <label className="text-sm font-medium text-foreground">설명 (선택)</label>
           <textarea
-            value={form.desc}
-            onChange={(e) => setForm({ ...form, desc: e.target.value })}
+            value={form.desc_txt}
+            onChange={(e) => setForm({ ...form, desc_txt: e.target.value })}
             placeholder="이벤트 설명을 입력하세요"
             rows={3}
             className={cn(
@@ -333,7 +333,7 @@ export function AdminProjectsClient({ teamId }: { teamId: string }) {
 
       <div className="flex flex-col gap-3">
         {events.map((evt) => {
-          const badge = STATUS_BADGE[evt.status_cd] ?? STATUS_BADGE.READY;
+          const badge = STATUS_BADGE[evt.stts_enm] ?? STATUS_BADGE.READY;
           return (
             <CardItem key={evt.evt_id} className="flex flex-col gap-3">
               <div className="flex items-start justify-between gap-3">
@@ -352,9 +352,9 @@ export function AdminProjectsClient({ teamId }: { teamId: string }) {
                   <span className="text-[13px] text-muted-foreground">
                     {evt.stt_dt} ~ {evt.end_dt}
                   </span>
-                  {evt.desc && (
+                  {evt.desc_txt && (
                     <span className="line-clamp-2 text-[13px] text-muted-foreground">
-                      {evt.desc}
+                      {evt.desc_txt}
                     </span>
                   )}
                 </div>

--- a/app/(info)/projects/records/page.tsx
+++ b/app/(info)/projects/records/page.tsx
@@ -16,7 +16,7 @@ export default async function ProjectRecordsPage() {
     .from("evt_team_mst")
     .select("evt_id, evt_nm, stt_dt, end_dt")
     .eq("team_id", teamId)
-    .eq("status_cd", "ACTIVE")
+    .eq("stts_enm", "ACTIVE")
     .maybeSingle();
 
   if (!event) redirect("/projects");
@@ -24,10 +24,10 @@ export default async function ProjectRecordsPage() {
   // 참여 여부 확인
   const { data: prt } = await supabase
     .from("evt_team_prt_rel")
-    .select("approve_yn")
+    .select("aprv_yn")
     .eq("evt_id", event.evt_id)
     .eq("mem_id", member.id)
-    .eq("approve_yn", true)
+    .eq("aprv_yn", true)
     .maybeSingle();
 
   if (!prt) redirect("/projects");

--- a/app/(info)/projects/records/records-client.tsx
+++ b/app/(info)/projects/records/records-client.tsx
@@ -32,7 +32,7 @@ import { ActivityLogForm } from "@/components/projects/activity-log-form";
 type ActivityRecord = {
   act_id: string;
   act_dt: string;
-  sport_cd: string;
+  sprt_enm: string;
   distance_km: number;
   elevation_m: number | null;
   base_mlg: number;
@@ -98,7 +98,7 @@ export function RecordsClient({ evtId, memId, evtStartDt, evtEndDt }: Props) {
 
     const { data } = await supabase
       .from("evt_mlg_act_hist")
-      .select("act_id, act_dt, sport_cd, distance_km, elevation_m, base_mlg, applied_mults, final_mlg, review")
+      .select("act_id, act_dt, sprt_enm, distance_km, elevation_m, base_mlg, applied_mults, final_mlg, review")
       .eq("evt_id", evtId)
       .eq("mem_id", memId)
       .gte("act_dt", month)
@@ -182,7 +182,7 @@ export function RecordsClient({ evtId, memId, evtStartDt, evtEndDt }: Props) {
                     <div className="flex items-center gap-2">
                       <Body className="font-semibold">{record.act_dt}</Body>
                       <Badge variant="secondary" className="text-[11px]">
-                        {MILEAGE_SPORT_LABELS[record.sport_cd as MileageSport] ?? record.sport_cd}
+                        {MILEAGE_SPORT_LABELS[record.sprt_enm as MileageSport] ?? record.sprt_enm}
                       </Badge>
                     </div>
                     <Body className="font-semibold">{record.final_mlg.toFixed(1)}</Body>
@@ -247,7 +247,7 @@ export function RecordsClient({ evtId, memId, evtStartDt, evtEndDt }: Props) {
               {deleteTarget && (
                 <>
                   {deleteTarget.act_dt}{" "}
-                  {MILEAGE_SPORT_LABELS[deleteTarget.sport_cd as MileageSport]}{" "}
+                  {MILEAGE_SPORT_LABELS[deleteTarget.sprt_enm as MileageSport]}{" "}
                   {deleteTarget.distance_km.toFixed(1)}km 기록을 삭제하시겠습니까?
                 </>
               )}

--- a/app/(main)/projects/page.tsx
+++ b/app/(main)/projects/page.tsx
@@ -114,6 +114,7 @@ export default async function ProjectsPage({
           <TransitionOverlay className="flex flex-col gap-7">
             <Suspense fallback={<Skeleton className="h-64 w-full rounded-2xl" />}>
               <CrewProgressChartServer
+                key={selectedMonth}
                 evtId={event.evt_id}
                 memId={isParticipant ? member!.id : undefined}
                 month={selectedMonth}

--- a/app/(main)/projects/page.tsx
+++ b/app/(main)/projects/page.tsx
@@ -33,9 +33,9 @@ export default async function ProjectsPage({
   // ACTIVE 이벤트 조회 (1개)
   const { data: event } = await supabase
     .from("evt_team_mst")
-    .select("evt_id, evt_nm, stt_dt, end_dt, status_cd")
+    .select("evt_id, evt_nm, stt_dt, end_dt, stts_enm")
     .eq("team_id", teamId)
-    .eq("status_cd", "ACTIVE")
+    .eq("stts_enm", "ACTIVE")
     .maybeSingle();
 
   // 이벤트 없음 — 소개 + 규칙만 표시
@@ -66,18 +66,18 @@ export default async function ProjectsPage({
         : event.stt_dt;
 
   // 로그인한 멤버의 참여 정보 조회
-  let participation: { approve_yn: boolean } | null = null;
+  let participation: { aprv_yn: boolean } | null = null;
   if (member) {
     const { data: prt } = await supabase
       .from("evt_team_prt_rel")
-      .select("approve_yn")
+      .select("aprv_yn")
       .eq("evt_id", event.evt_id)
       .eq("mem_id", member.id)
       .maybeSingle();
     participation = prt ?? null;
   }
 
-  const isParticipant = participation !== null && participation.approve_yn === true;
+  const isParticipant = participation !== null && participation.aprv_yn === true;
 
   // 비로그인이면 신청 섹션 미표시
   const showJoin = user !== null && !isParticipant;

--- a/app/actions/admin/get-admin-stats.ts
+++ b/app/actions/admin/get-admin-stats.ts
@@ -59,7 +59,7 @@ export async function getAdminStats(): Promise<AdminStats> {
       .from("evt_team_mst")
       .select("*", { count: "exact", head: true })
       .eq("team_id", teamId)
-      .eq("status_cd", "ACTIVE"),
+      .eq("stts_enm", "ACTIVE"),
     admin
       .from("evt_mlg_mult_cfg")
       .select("evt_id, evt_team_mst!inner(team_id)", { count: "exact", head: true })
@@ -68,7 +68,7 @@ export async function getAdminStats(): Promise<AdminStats> {
     admin
       .from("evt_team_prt_rel")
       .select("evt_id, evt_team_mst!inner(team_id)", { count: "exact", head: true })
-      .eq("approve_yn", false)
+      .eq("aprv_yn", false)
       .eq("evt_team_mst.team_id", teamId),
   ]);
 

--- a/app/actions/admin/manage-mileage.ts
+++ b/app/actions/admin/manage-mileage.ts
@@ -14,8 +14,8 @@ export async function createEvent(input: {
   evt_type_cd: string;
   stt_dt: string;
   end_dt: string;
-  status_cd: string;
-  desc: string | null;
+  stts_enm: string;
+  desc_txt: string | null;
 }) {
   const admin = await verifyAdmin();
   if (!admin) return { ok: false, message: "권한이 없습니다" };
@@ -29,8 +29,8 @@ export async function createEvent(input: {
     evt_type_cd: input.evt_type_cd,
     stt_dt: input.stt_dt,
     end_dt: input.end_dt,
-    status_cd: input.status_cd,
-    desc: input.desc?.trim() || null,
+    stts_enm: input.stts_enm,
+    desc_txt: input.desc_txt?.trim() || null,
   });
 
   if (error) return { ok: false, message: "이벤트 생성에 실패했습니다" };
@@ -44,8 +44,8 @@ export async function updateEvent(
     evt_type_cd: string;
     stt_dt: string;
     end_dt: string;
-    status_cd: string;
-    desc: string | null;
+    stts_enm: string;
+    desc_txt: string | null;
   },
 ) {
   const admin = await verifyAdmin();
@@ -60,8 +60,8 @@ export async function updateEvent(
       evt_type_cd: input.evt_type_cd,
       stt_dt: input.stt_dt,
       end_dt: input.end_dt,
-      status_cd: input.status_cd,
-      desc: input.desc?.trim() || null,
+      stts_enm: input.stts_enm,
+      desc_txt: input.desc_txt?.trim() || null,
       updated_at: dayjs().toISOString(),
     })
     .eq("evt_id", evtId);
@@ -177,8 +177,8 @@ export async function approveParticipation(prtId: string) {
   const { error } = await db
     .from("evt_team_prt_rel")
     .update({
-      approve_yn: true,
-      approved_at: dayjs().toISOString(),
+      aprv_yn: true,
+      aprv_at: dayjs().toISOString(),
       updated_at: dayjs().toISOString(),
     })
     .eq("prt_id", prtId);
@@ -220,7 +220,7 @@ export async function rejectParticipation(prtId: string) {
 export async function updateParticipation(
   prtId: string,
   input: {
-    stt_month: string;
+    stt_mth: string;
     init_goal: number;
     deposit_amt: number;
     entry_fee_amt: number;
@@ -236,7 +236,7 @@ export async function updateParticipation(
   const { error } = await db
     .from("evt_team_prt_rel")
     .update({
-      stt_month: input.stt_month,
+      stt_mth: input.stt_mth,
       init_goal: input.init_goal,
       deposit_amt: input.deposit_amt,
       entry_fee_amt: input.entry_fee_amt,
@@ -259,8 +259,8 @@ export async function revokeApproval(prtId: string) {
   const { error } = await db
     .from("evt_team_prt_rel")
     .update({
-      approve_yn: false,
-      approved_at: null,
+      aprv_yn: false,
+      aprv_at: null,
       updated_at: dayjs().toISOString(),
     })
     .eq("prt_id", prtId);

--- a/app/actions/mileage-run.ts
+++ b/app/actions/mileage-run.ts
@@ -31,7 +31,7 @@ import { activityLogSchema } from "@/lib/validations/mileage";
 
 export interface ActivityLogInput {
   act_dt: string; // 'YYYY-MM-DD'
-  sport_cd: MileageSport;
+  sprt_enm: MileageSport;
   distance_km: number;
   elevation_m: number;
   applied_mult_ids: string[]; // evt_mlg_mult_cfg.mult_id 배열
@@ -130,7 +130,7 @@ async function buildAppliedMults(
 
 /**
  * 마일리지런 프로젝트 참여 신청.
- * - approve_yn: false 로 INSERT (관리자 승인 대기)
+ * - aprv_yn: false 로 INSERT (관리자 승인 대기)
  * - 잔여 개월 × DEPOSIT_PER_MONTH + ENTRY_FEE (+ singlet fee) 로 deposit_amt 계산
  * - 당월 initGoal 목표 자동 생성
  */
@@ -168,8 +168,8 @@ export async function joinProject(
   const { error: prtError } = await db.from("evt_team_prt_rel").insert({
     evt_id: evtId,
     mem_id: member.id,
-    approve_yn: false,
-    stt_month: curMonth,
+    aprv_yn: false,
+    stt_mth: curMonth,
     init_goal: initGoal,
     deposit_amt: depositAmt,
     entry_fee_amt: entryFeeAmt,
@@ -185,13 +185,13 @@ export async function joinProject(
   }
 
   // 시작월~종료월까지 전체 목표 미리 생성 (init_goal)
-  const goalRows: { evt_id: string; mem_id: string; goal_month: string; goal_val: number; achieved_yn: boolean }[] = [];
+  const goalRows: { evt_id: string; mem_id: string; goal_mth: string; goal_val: number; achieved_yn: boolean }[] = [];
   let m = curMonth;
   while (m <= evtEndMonth) {
     goalRows.push({
       evt_id: evtId,
       mem_id: member.id,
-      goal_month: m,
+      goal_mth: m,
       goal_val: initGoal,
       achieved_yn: false,
     });
@@ -247,7 +247,7 @@ export async function logActivity(
   if (multErr) return { ok: false, message: multErr };
 
   const baseMlg = roundMileage(
-    calcBaseMileage(validInput.sport_cd, validInput.distance_km, validInput.elevation_m),
+    calcBaseMileage(validInput.sprt_enm, validInput.distance_km, validInput.elevation_m),
   );
   const finalMlg = roundMileage(calcFinalMileage(baseMlg, multValues));
 
@@ -256,7 +256,7 @@ export async function logActivity(
     evt_id: evtId,
     mem_id: member.id,
     act_dt: validInput.act_dt,
-    sport_cd: validInput.sport_cd,
+    sprt_enm: validInput.sprt_enm,
     distance_km: validInput.distance_km,
     elevation_m: validInput.elevation_m,
     base_mlg: baseMlg,
@@ -322,7 +322,7 @@ export async function updateActivity(
   if (multErr) return { ok: false, message: multErr };
 
   const baseMlg = roundMileage(
-    calcBaseMileage(validInput.sport_cd, validInput.distance_km, validInput.elevation_m),
+    calcBaseMileage(validInput.sprt_enm, validInput.distance_km, validInput.elevation_m),
   );
   const finalMlg = roundMileage(calcFinalMileage(baseMlg, multValues));
 
@@ -330,7 +330,7 @@ export async function updateActivity(
     .from("evt_mlg_act_hist")
     .update({
       act_dt: validInput.act_dt,
-      sport_cd: validInput.sport_cd,
+      sprt_enm: validInput.sprt_enm,
       distance_km: validInput.distance_km,
       elevation_m: validInput.elevation_m,
       base_mlg: baseMlg,
@@ -486,10 +486,10 @@ async function recalcGoalsFromMonth(
   // 해당 참여자의 전체 목표 조회 (월순)
   const { data: goals } = await db
     .from("evt_mlg_goal_cfg")
-    .select("goal_id, goal_month, goal_val")
+    .select("goal_id, goal_mth, goal_val")
     .eq("evt_id", evtId)
     .eq("mem_id", memId)
-    .order("goal_month", { ascending: true });
+    .order("goal_mth", { ascending: true });
 
   if (!goals || goals.length === 0) return;
 
@@ -512,7 +512,7 @@ async function recalcGoalsFromMonth(
   for (let i = 1; i < goals.length; i++) {
     const prev = goals[i - 1];
     const cur = goals[i];
-    const prevMonth = prev.goal_month as string;
+    const prevMonth = prev.goal_mth as string;
     const prevGoalVal = Number(prev.goal_val);
 
     // 연습기간이면 목표 상향 없이 이전 값 유지

--- a/components/projects/activity-log-form.tsx
+++ b/components/projects/activity-log-form.tsx
@@ -47,7 +47,7 @@ export type ActivityLogFormProps = {
   editData?: {
     act_id: string;
     act_dt: string;
-    sport_cd: string;
+    sprt_enm: string;
     distance_km: number;
     elevation_m: number | null;
     applied_mults: { mult_id: string; mult_nm: string; mult_val: number }[] | null;
@@ -97,7 +97,7 @@ export function ActivityLogForm({
     resolver: zodResolver(activityLogSchema),
     defaultValues: {
       act_dt: editData?.act_dt ?? today,
-      sport_cd: (editData?.sport_cd as MileageSport) ?? "RUNNING",
+      sprt_enm: (editData?.sprt_enm as MileageSport) ?? "RUNNING",
       distance_km: editData?.distance_km ?? (undefined as unknown as number),
       elevation_m: editData?.elevation_m ?? 0,
       applied_mult_ids: initialMultIds,
@@ -105,7 +105,7 @@ export function ActivityLogForm({
     },
   });
 
-  const sportCd = watch("sport_cd");
+  const sprtEnm = watch("sprt_enm");
   const distanceKm = watch("distance_km");
   const elevationM = watch("elevation_m");
   const actDt = watch("act_dt");
@@ -141,7 +141,7 @@ export function ActivityLogForm({
 
   const dist = Number(distanceKm) || 0;
   const elev = Number(elevationM) || 0;
-  const baseMileage = dist > 0 ? roundMileage(calcBaseMileage(sportCd, dist, elev)) : 0;
+  const baseMileage = dist > 0 ? roundMileage(calcBaseMileage(sprtEnm, dist, elev)) : 0;
   const finalMileage =
     dist > 0
       ? roundMileage(calcFinalMileage(baseMileage, activeMults.map((m) => m.mult_val)))
@@ -159,7 +159,7 @@ export function ActivityLogForm({
       // 서버 액션 타입으로 변환 (default 값 명시 적용)
       const input: ActivityLogInput = {
         act_dt: values.act_dt,
-        sport_cd: values.sport_cd as MileageSport,
+        sprt_enm: values.sprt_enm as MileageSport,
         distance_km: values.distance_km as number,
         elevation_m: values.elevation_m ?? 0,
         applied_mult_ids: selectedMultIds,
@@ -201,14 +201,14 @@ export function ActivityLogForm({
 
       {/* 종목 */}
       <div className="flex flex-col gap-1.5">
-        <Label htmlFor="sport_cd">종목</Label>
+        <Label htmlFor="sprt_enm">종목</Label>
         <Controller
           control={control}
-          name="sport_cd"
+          name="sprt_enm"
           render={({ field }) => (
             <Select value={field.value} onValueChange={field.onChange}>
               <SelectTrigger
-                id="sport_cd"
+                id="sprt_enm"
                 className="h-12 rounded-xl border-[1.5px] text-[15px]"
               >
                 <SelectValue />
@@ -225,8 +225,8 @@ export function ActivityLogForm({
             </Select>
           )}
         />
-        {errors.sport_cd && (
-          <p className="text-sm text-destructive">{errors.sport_cd.message}</p>
+        {errors.sprt_enm && (
+          <p className="text-sm text-destructive">{errors.sprt_enm.message}</p>
         )}
       </div>
 
@@ -248,7 +248,7 @@ export function ActivityLogForm({
       </div>
 
       {/* 상승고도 — 수영 선택 시 hidden */}
-      {sportCd !== "SWIMMING" && (
+      {sprtEnm !== "SWIMMING" && (
         <div className="flex flex-col gap-1.5">
           <Label htmlFor="elevation_m">상승고도 (m, 선택)</Label>
           <Input

--- a/components/projects/crew-monthly-stats.tsx
+++ b/components/projects/crew-monthly-stats.tsx
@@ -1,4 +1,3 @@
-import { monthLastDay, nextMonthStr } from "@/lib/dayjs";
 import {
   calcMonthRefundRate,
   countMonths,
@@ -8,8 +7,10 @@ import {
 import { StatCard } from "@/components/common/stat-card";
 import {
   getEventParticipants,
-  getEventGoals,
-  getEventLogs,
+  getEventGoalsCumulative,
+  getEventGoalsMonthly,
+  getEventLogsCumulative,
+  getEventLogsMonthly,
 } from "@/lib/queries/project-data";
 
 type CrewMonthlyStatsProps = {
@@ -27,30 +28,21 @@ export async function CrewMonthlyStats({
 }: CrewMonthlyStatsProps) {
   const viewMonth = month > evtEndMonth ? evtEndMonth : month;
 
-  // 공유 캐시 쿼리 (같은 요청 내 다른 컴포넌트와 중복 제거)
-  const [allParticipants, allGoals, allLogs] = await Promise.all([
-    getEventParticipants(evtId),
-    getEventGoals(evtId, evtStartMonth, viewMonth),
-    getEventLogs(evtId, evtStartMonth, viewMonth),
-  ]);
+  // 당월 지표 + 누적 금액 지표를 분리 조회
+  const [allParticipants, monthGoals, monthLogs, cumulativeGoals, cumulativeLogs] =
+    await Promise.all([
+      getEventParticipants(evtId),
+      getEventGoalsMonthly(evtId, month),
+      getEventLogsMonthly(evtId, month),
+      getEventGoalsCumulative(evtId, evtStartMonth, viewMonth),
+      getEventLogsCumulative(evtId, evtStartMonth, viewMonth),
+    ]);
 
   // 선택 월 기준 활성 참여자
   const activeParticipants = allParticipants.filter(
     (p) => (p.stt_month as string) <= month,
   );
   if (activeParticipants.length === 0) return null;
-
-  const [y, m] = month.split("-").map(Number);
-  const monthEnd = monthLastDay(y, m);
-  const nextMonth = nextMonthStr(month);
-
-  // 당월 로그만 필터
-  const monthLogs = allLogs.filter(
-    (l) => (l.act_dt as string) >= month && (l.act_dt as string) <= monthEnd,
-  );
-
-  // 당월 목표만 필터
-  const monthGoals = allGoals.filter((g) => g.goal_month === month);
 
   // 참여자별 당월 마일리지 합산
   const mileageByMem = new Map<string, number>();
@@ -70,7 +62,6 @@ export async function CrewMonthlyStats({
   // 통계 계산
   const participantCount = activeParticipants.length;
   let totalMileage = 0;
-  let totalActivities = 0;
   let achievedCount = 0;
 
   for (const p of activeParticipants) {
@@ -81,19 +72,12 @@ export async function CrewMonthlyStats({
     if (goal > 0 && mlg >= goal) achievedCount++;
   }
 
-  const activeMemIds = new Set(activeParticipants.map((p) => p.mem_id));
-  for (const log of monthLogs) {
-    if (activeMemIds.has(log.mem_id)) {
-      totalActivities++;
-    }
-  }
-
   const avgMileage =
     participantCount > 0 ? totalMileage / participantCount : 0;
 
   // 회식비 풀 계산 — 전체 기간 누적 (캐시 데이터 재사용)
   const mlgMap = new Map<string, number>();
-  for (const l of allLogs) {
+  for (const l of cumulativeLogs) {
     const gm = (l.act_dt as string).slice(0, 7) + "-01";
     const key = `${l.mem_id}:${gm}`;
     mlgMap.set(key, (mlgMap.get(key) ?? 0) + Number(l.final_mlg));
@@ -111,7 +95,7 @@ export async function CrewMonthlyStats({
     const months = countMonths(effectiveStart, viewMonth);
     totalDepositPool += months * DEPOSIT_PER_MONTH;
 
-    const pGoals = allGoals.filter((g) => g.mem_id === p.mem_id);
+    const pGoals = cumulativeGoals.filter((g) => g.mem_id === p.mem_id);
     for (const g of pGoals) {
       const key = `${p.mem_id}:${g.goal_month}`;
       const achieved = mlgMap.get(key) ?? 0;

--- a/components/projects/crew-monthly-stats.tsx
+++ b/components/projects/crew-monthly-stats.tsx
@@ -40,7 +40,7 @@ export async function CrewMonthlyStats({
 
   // 선택 월 기준 활성 참여자
   const activeParticipants = allParticipants.filter(
-    (p) => (p.stt_month as string) <= month,
+    (p) => (p.stt_mth as string) <= month,
   );
   if (activeParticipants.length === 0) return null;
 
@@ -88,8 +88,8 @@ export async function CrewMonthlyStats({
 
   for (const p of activeParticipants) {
     const effectiveStart =
-      (p.stt_month as string) > evtStartMonth
-        ? (p.stt_month as string)
+      (p.stt_mth as string) > evtStartMonth
+        ? (p.stt_mth as string)
         : evtStartMonth;
     if (effectiveStart > viewMonth) continue;
     const months = countMonths(effectiveStart, viewMonth);
@@ -97,8 +97,8 @@ export async function CrewMonthlyStats({
 
     const pGoals = cumulativeGoals.filter((g) => g.mem_id === p.mem_id);
     for (const g of pGoals) {
-      if (g.goal_month < effectiveStart || g.goal_month > viewMonth) continue;
-      const key = `${p.mem_id}:${g.goal_month}`;
+      if (g.goal_mth < effectiveStart || g.goal_mth > viewMonth) continue;
+      const key = `${p.mem_id}:${g.goal_mth}`;
       const achieved = mlgMap.get(key) ?? 0;
       totalRefundSum +=
         calcMonthRefundRate(achieved, Number(g.goal_val)) * DEPOSIT_PER_MONTH;

--- a/components/projects/crew-monthly-stats.tsx
+++ b/components/projects/crew-monthly-stats.tsx
@@ -97,6 +97,7 @@ export async function CrewMonthlyStats({
 
     const pGoals = cumulativeGoals.filter((g) => g.mem_id === p.mem_id);
     for (const g of pGoals) {
+      if (g.goal_month < effectiveStart || g.goal_month > viewMonth) continue;
       const key = `${p.mem_id}:${g.goal_month}`;
       const achieved = mlgMap.get(key) ?? 0;
       totalRefundSum +=

--- a/components/projects/crew-progress-chart-server.tsx
+++ b/components/projects/crew-progress-chart-server.tsx
@@ -1,8 +1,8 @@
-import { daysInMonth as getDaysInMonth, nextMonthStr, monthLastDay } from "@/lib/dayjs";
+import { daysInMonth as getDaysInMonth, monthLastDay } from "@/lib/dayjs";
 import {
   getEventParticipants,
-  getEventGoals,
-  getEventLogs,
+  getEventGoalsMonthly,
+  getEventLogsMonthly,
 } from "@/lib/queries/project-data";
 import { CrewProgressChart } from "./crew-progress-chart";
 import type { ChartInitialData, DailyPoint } from "./crew-progress-chart";
@@ -19,16 +19,12 @@ export async function CrewProgressChartServer({
   evtId,
   memId,
   month,
-  evtStartMonth,
-  evtEndMonth,
 }: Props) {
-  const viewMonth = month > evtEndMonth ? evtEndMonth : month;
-
-  // 공유 캐시 쿼리 재사용
+  // 당월 데이터만 조회
   const [allParticipants, allGoals, allLogs] = await Promise.all([
     getEventParticipants(evtId),
-    getEventGoals(evtId, evtStartMonth, viewMonth),
-    getEventLogs(evtId, evtStartMonth, viewMonth),
+    getEventGoalsMonthly(evtId, month),
+    getEventLogsMonthly(evtId, month),
   ]);
 
   // 선택 월 기준 활성 참여자

--- a/components/projects/crew-progress-chart-server.tsx
+++ b/components/projects/crew-progress-chart-server.tsx
@@ -29,7 +29,7 @@ export async function CrewProgressChartServer({
 
   // 선택 월 기준 활성 참여자
   const participants = allParticipants.filter(
-    (p) => (p.stt_month as string) <= month,
+    (p) => (p.stt_mth as string) <= month,
   );
 
   if (participants.length === 0) {
@@ -41,7 +41,7 @@ export async function CrewProgressChartServer({
   const mEnd = monthLastDay(y, m);
 
   // 당월 목표
-  const monthGoals = allGoals.filter((g) => g.goal_month === month);
+  const monthGoals = allGoals.filter((g) => g.goal_mth === month);
   const goalByMemId = new Map<string, number>();
   for (const g of monthGoals) {
     goalByMemId.set(g.mem_id, Number(g.goal_val));

--- a/components/projects/crew-progress-chart.tsx
+++ b/components/projects/crew-progress-chart.tsx
@@ -123,8 +123,8 @@ export function CrewProgressChart({
       .from("evt_team_prt_rel")
       .select("mem_id, init_goal, mem_mst!inner(mem_nm)")
       .eq("evt_id", evtId)
-      .eq("approve_yn", true)
-      .lte("stt_month", month);
+      .eq("aprv_yn", true)
+      .lte("stt_mth", month);
 
     if (!participants || participants.length === 0) {
       setLoading(false);
@@ -146,7 +146,7 @@ export function CrewProgressChart({
         .select("mem_id, goal_val")
         .eq("evt_id", evtId)
         .in("mem_id", memIds)
-        .eq("goal_month", month),
+        .eq("goal_mth", month),
     ]);
 
     const goalByMemId = new Map<string, number>();

--- a/components/projects/crew-progress-chart.tsx
+++ b/components/projects/crew-progress-chart.tsx
@@ -263,7 +263,7 @@ export function CrewProgressChart({
   }
 
   return (
-    <div className="flex flex-col gap-3">
+    <div className="flex flex-col gap-3 outline-none **:outline-none">
       <SegmentControl
         segments={[
           { value: "mileage", label: "마일리지" },
@@ -273,7 +273,7 @@ export function CrewProgressChart({
         onValueChange={setMode}
       />
 
-      <ResponsiveContainer width="100%" height={240}>
+      <ResponsiveContainer width="100%" height={240} className="outline-none">
         <LineChart data={chartData}>
           <CartesianGrid strokeDasharray="3 3" stroke="var(--border)" />
           <XAxis

--- a/components/projects/join-section.tsx
+++ b/components/projects/join-section.tsx
@@ -21,7 +21,7 @@ type JoinSectionProps = {
   evtStartMonth: string; // "2026-05-01"
   evtEndMonth: string;   // "2026-09-01"
   existingPrt: {
-    approve_yn: boolean;
+    aprv_yn: boolean;
   } | null;
 };
 
@@ -40,7 +40,7 @@ export function JoinSection({
   const [submitting, setSubmitting] = useState(false);
 
   // 승인 대기 중
-  if (existingPrt && !existingPrt.approve_yn) {
+  if (existingPrt && !existingPrt.aprv_yn) {
     return (
       <CardItem className="p-5 text-center">
         <Caption className="text-foreground font-semibold block mb-1">

--- a/components/projects/my-activity-list-client.tsx
+++ b/components/projects/my-activity-list-client.tsx
@@ -11,7 +11,7 @@ import { ChevronRight } from "lucide-react";
 export type ActivityRecord = {
   act_id: string;
   act_dt: string;
-  sport_cd: string;
+  sprt_enm: string;
   distance_km: number;
   elevation_m: number;
   base_mlg: number;
@@ -55,7 +55,7 @@ export function MyActivityListClient({
                 <div className="flex items-center gap-2">
                   <Caption className="text-foreground">{record.act_dt}</Caption>
                   <Badge variant="secondary" className="text-[11px]">
-                    {MILEAGE_SPORT_LABELS[record.sport_cd as MileageSport] ?? record.sport_cd}
+                    {MILEAGE_SPORT_LABELS[record.sprt_enm as MileageSport] ?? record.sprt_enm}
                   </Badge>
                 </div>
                 {record.review && (

--- a/components/projects/my-activity-list.tsx
+++ b/components/projects/my-activity-list.tsx
@@ -38,7 +38,7 @@ export async function MyActivityList({
   const records: ActivityRecord[] = top5.map((log) => ({
     act_id: log.act_id,
     act_dt: log.act_dt as string,
-    sport_cd: log.sport_cd as string,
+    sprt_enm: log.sprt_enm as string,
     distance_km: Number(log.distance_km),
     elevation_m: Number(log.elevation_m),
     base_mlg: Number(log.base_mlg),

--- a/components/projects/my-activity-list.tsx
+++ b/components/projects/my-activity-list.tsx
@@ -1,5 +1,5 @@
 import { nextMonthStr } from "@/lib/dayjs";
-import { getEventLogs } from "@/lib/queries/project-data";
+import { getEventLogsMonthly } from "@/lib/queries/project-data";
 import {
   MyActivityListClient,
   type ActivityRecord,
@@ -17,14 +17,11 @@ export async function MyActivityList({
   evtId,
   memId,
   month,
-  evtStartMonth,
-  evtEndMonth,
 }: Props) {
   const nextMonth = nextMonthStr(month);
-  const viewMonth = month > evtEndMonth ? evtEndMonth : month;
 
-  // 공유 캐시에서 필터
-  const allLogs = await getEventLogs(evtId, evtStartMonth, viewMonth);
+  // 당월 로그만 조회
+  const allLogs = await getEventLogsMonthly(evtId, month);
 
   const myMonthLogs = allLogs
     .filter(

--- a/components/projects/my-sport-chart-server.tsx
+++ b/components/projects/my-sport-chart-server.tsx
@@ -1,6 +1,6 @@
 import { nextMonthStr } from "@/lib/dayjs";
 import type { MileageSport } from "@/lib/mileage";
-import { getEventLogs } from "@/lib/queries/project-data";
+import { getEventLogsMonthly } from "@/lib/queries/project-data";
 import { MySportChartClient } from "./my-sport-chart";
 import type { SportChartData } from "./my-sport-chart";
 
@@ -16,14 +16,11 @@ export async function MySportChart({
   evtId,
   memId,
   month,
-  evtStartMonth,
-  evtEndMonth,
 }: Props) {
-  const viewMonth = month > evtEndMonth ? evtEndMonth : month;
   const nextMonth = nextMonthStr(month);
 
-  // 공유 캐시에서 필터
-  const allLogs = await getEventLogs(evtId, evtStartMonth, viewMonth);
+  // 당월 로그만 조회
+  const allLogs = await getEventLogsMonthly(evtId, month);
 
   const myMonthLogs = allLogs.filter(
     (l) =>

--- a/components/projects/my-sport-chart-server.tsx
+++ b/components/projects/my-sport-chart-server.tsx
@@ -33,10 +33,10 @@ export async function MySportChart({
     return <MySportChartClient data={[]} />;
   }
 
-  // sport_cd별 final_mlg 합산
+  // sprt_enm별 final_mlg 합산
   const sportMap = new Map<MileageSport, number>();
   for (const log of myMonthLogs) {
-    const sport = log.sport_cd as MileageSport;
+    const sport = log.sprt_enm as MileageSport;
     const prev = sportMap.get(sport) ?? 0;
     sportMap.set(sport, prev + Number(log.final_mlg));
   }

--- a/components/projects/my-sport-chart.tsx
+++ b/components/projects/my-sport-chart.tsx
@@ -80,9 +80,9 @@ export function MySportChartClient({ data }: MySportChartClientProps) {
   }));
 
   return (
-    <div className="flex flex-col gap-4">
+    <div className="flex flex-col gap-4 outline-none **:outline-none">
       {/* 도넛 차트 */}
-      <ResponsiveContainer width="100%" height={200}>
+      <ResponsiveContainer width="100%" height={200} className="outline-none">
         <PieChart>
           <Pie
             data={chartData}

--- a/components/projects/my-status.tsx
+++ b/components/projects/my-status.tsx
@@ -45,7 +45,7 @@ export async function MyStatus({
   ]);
 
   const goalRow = allGoals.find(
-    (g) => g.mem_id === memId && g.goal_month === month,
+    (g) => g.mem_id === memId && g.goal_mth === month,
   );
 
   if (!goalRow) {

--- a/components/projects/my-status.tsx
+++ b/components/projects/my-status.tsx
@@ -8,8 +8,8 @@ import { calcPaceRatio, calcDailyNeeded } from "@/lib/mileage";
 import { CardItem } from "@/components/ui/card";
 import { Body, Caption } from "@/components/common/typography";
 import {
-  getEventGoals,
-  getEventLogs,
+  getEventGoalsMonthly,
+  getEventLogsMonthly,
 } from "@/lib/queries/project-data";
 
 type MyStatusProps = {
@@ -24,8 +24,6 @@ export async function MyStatus({
   evtId,
   memId,
   month,
-  evtStartMonth,
-  evtEndMonth,
 }: MyStatusProps) {
   const [y, m] = month.split("-").map(Number);
   const totalDays = daysInMonth(y, m);
@@ -40,12 +38,10 @@ export async function MyStatus({
     todayDay = todayDayKST();
   }
   const nextMonth = nextMonthStr(month);
-  const viewMonth = month > evtEndMonth ? evtEndMonth : month;
-
-  // 공유 캐시에서 필터
+  // 당월 데이터만 조회
   const [allGoals, allLogs] = await Promise.all([
-    getEventGoals(evtId, evtStartMonth, viewMonth),
-    getEventLogs(evtId, evtStartMonth, viewMonth),
+    getEventGoalsMonthly(evtId, month),
+    getEventLogsMonthly(evtId, month),
   ]);
 
   const goalRow = allGoals.find(

--- a/components/projects/random-review.tsx
+++ b/components/projects/random-review.tsx
@@ -14,7 +14,7 @@ export async function RandomReview({ evtId }: RandomReviewProps) {
 
   const { data: reviews } = await supabase
     .from("evt_mlg_act_hist")
-    .select("act_id, review, mem_id, act_dt, sport_cd, distance_km, mem_mst!inner(mem_nm)")
+    .select("act_id, review, mem_id, act_dt, sprt_enm, distance_km, mem_mst!inner(mem_nm)")
     .eq("evt_id", evtId)
     .not("review", "is", null)
     .neq("review", "")
@@ -32,7 +32,7 @@ export async function RandomReview({ evtId }: RandomReviewProps) {
     <div className="flex flex-col gap-2">
       {picks.map((item) => {
         const name = (item.mem_mst as unknown as { mem_nm: string }).mem_nm;
-        const sport = MILEAGE_SPORT_LABELS[item.sport_cd as MileageSport] ?? item.sport_cd;
+        const sport = MILEAGE_SPORT_LABELS[item.sprt_enm as MileageSport] ?? item.sprt_enm;
         const dist = Number(item.distance_km);
         return (
           <div

--- a/components/projects/refund-status.tsx
+++ b/components/projects/refund-status.tsx
@@ -9,8 +9,8 @@ import {
 import { StatCard } from "@/components/common/stat-card";
 import {
   getEventParticipants,
-  getEventGoals,
-  getEventLogs,
+  getEventGoalsCumulative,
+  getEventLogsCumulative,
 } from "@/lib/queries/project-data";
 
 type RefundStatusProps = {
@@ -33,8 +33,8 @@ export async function RefundStatus({
   // 공유 캐시 쿼리 (CrewMonthlyStats와 동일 쿼리 → cache hit)
   const [allParticipants, allGoals, allLogs] = await Promise.all([
     getEventParticipants(evtId),
-    getEventGoals(evtId, evtStartMonth, viewMonth),
-    getEventLogs(evtId, evtStartMonth, viewMonth),
+    getEventGoalsCumulative(evtId, evtStartMonth, viewMonth),
+    getEventLogsCumulative(evtId, evtStartMonth, viewMonth),
   ]);
 
   const participants = allParticipants;

--- a/components/projects/refund-status.tsx
+++ b/components/projects/refund-status.tsx
@@ -47,7 +47,7 @@ export async function RefundStatus({
     );
   }
 
-  // (mem_id, goal_month) 별 마일리지 합산 맵
+  // (mem_id, goal_mth) 별 마일리지 합산 맵
   const mileageMap = new Map<string, number>();
   for (const log of allLogs) {
     const goalMonth = (log.act_dt as string).slice(0, 7) + "-01";
@@ -58,12 +58,12 @@ export async function RefundStatus({
   // mem_id 별 목표 그룹핑
   const goalsByMem = new Map<
     string,
-    { goal_month: string; goal_val: number }[]
+    { goal_mth: string; goal_val: number }[]
   >();
   for (const g of allGoals) {
     if (!goalsByMem.has(g.mem_id)) goalsByMem.set(g.mem_id, []);
     goalsByMem.get(g.mem_id)!.push({
-      goal_month: g.goal_month as string,
+      goal_mth: g.goal_mth as string,
       goal_val: Number(g.goal_val),
     });
   }
@@ -77,8 +77,8 @@ export async function RefundStatus({
 
   for (const p of participants) {
     const effectiveStart =
-      (p.stt_month as string) > evtStartMonth
-        ? (p.stt_month as string)
+      (p.stt_mth as string) > evtStartMonth
+        ? (p.stt_mth as string)
         : evtStartMonth;
 
     if (effectiveStart > viewMonth) continue;
@@ -91,8 +91,8 @@ export async function RefundStatus({
     let participantRefund = 0;
 
     for (const g of goals) {
-      if (g.goal_month < effectiveStart || g.goal_month > viewMonth) continue;
-      const key = `${p.mem_id}:${g.goal_month}`;
+      if (g.goal_mth < effectiveStart || g.goal_mth > viewMonth) continue;
+      const key = `${p.mem_id}:${g.goal_mth}`;
       const achieved = mileageMap.get(key) ?? 0;
       participantRefund +=
         calcMonthRefundRate(achieved, g.goal_val) * DEPOSIT_PER_MONTH;

--- a/lib/queries/project-data.ts
+++ b/lib/queries/project-data.ts
@@ -16,31 +16,58 @@ export const getEventParticipants = cache(async (evtId: string) => {
   return data ?? [];
 });
 
-/** 이벤트 기간 목표 (startMonth ~ endMonth 포함) */
-export const getEventGoals = cache(
+/** 이벤트 당월 목표 */
+export const getEventGoalsMonthly = cache(async (evtId: string, month: string) => {
+  const db = createAdminClient();
+  const { data } = await db
+    .from("evt_mlg_goal_cfg")
+    .select("mem_id, goal_month, goal_val, achieved_yn")
+    .eq("evt_id", evtId)
+    .eq("goal_month", month);
+  return data ?? [];
+});
+
+/** 이벤트 누적 목표 (startMonth ~ endMonth 포함) */
+export const getEventGoalsCumulative = cache(
   async (evtId: string, startMonth: string, endMonth: string) => {
     const db = createAdminClient();
+    const queryStart = startMonth <= endMonth ? startMonth : endMonth;
     const { data } = await db
       .from("evt_mlg_goal_cfg")
       .select("mem_id, goal_month, goal_val, achieved_yn")
       .eq("evt_id", evtId)
-      .gte("goal_month", startMonth)
+      .gte("goal_month", queryStart)
       .lte("goal_month", endMonth);
     return data ?? [];
   },
 );
 
-/** 이벤트 기간 활동 로그 (startDate ~ endMonth 1일 exclusive) */
-export const getEventLogs = cache(
+/** 이벤트 당월 활동 로그 (month ~ nextMonth 1일 exclusive) */
+export const getEventLogsMonthly = cache(async (evtId: string, month: string) => {
+  const db = createAdminClient();
+  const { data } = await db
+    .from("evt_mlg_act_hist")
+    .select(
+      "act_id, mem_id, act_dt, final_mlg, sport_cd, distance_km, elevation_m, base_mlg, applied_mults, review",
+    )
+    .eq("evt_id", evtId)
+    .gte("act_dt", month)
+    .lt("act_dt", nextMonthStr(month));
+  return data ?? [];
+});
+
+/** 이벤트 누적 활동 로그 (startDate ~ endMonth 1일 exclusive) */
+export const getEventLogsCumulative = cache(
   async (evtId: string, startDate: string, endMonth: string) => {
     const db = createAdminClient();
+    const queryStart = startDate <= endMonth ? startDate : endMonth;
     const { data } = await db
       .from("evt_mlg_act_hist")
       .select(
         "act_id, mem_id, act_dt, final_mlg, sport_cd, distance_km, elevation_m, base_mlg, applied_mults, review",
       )
       .eq("evt_id", evtId)
-      .gte("act_dt", startDate)
+      .gte("act_dt", queryStart)
       .lt("act_dt", nextMonthStr(endMonth));
     return data ?? [];
   },

--- a/lib/queries/project-data.ts
+++ b/lib/queries/project-data.ts
@@ -9,10 +9,10 @@ export const getEventParticipants = cache(async (evtId: string) => {
   const { data } = await db
     .from("evt_team_prt_rel")
     .select(
-      "mem_id, init_goal, stt_month, deposit_amt, entry_fee_amt, mem_mst!inner(mem_nm)",
+      "mem_id, init_goal, stt_mth, deposit_amt, entry_fee_amt, mem_mst!inner(mem_nm)",
     )
     .eq("evt_id", evtId)
-    .eq("approve_yn", true);
+    .eq("aprv_yn", true);
   return data ?? [];
 });
 
@@ -21,9 +21,9 @@ export const getEventGoalsMonthly = cache(async (evtId: string, month: string) =
   const db = createAdminClient();
   const { data } = await db
     .from("evt_mlg_goal_cfg")
-    .select("mem_id, goal_month, goal_val, achieved_yn")
+    .select("mem_id, goal_mth, goal_val, achieved_yn")
     .eq("evt_id", evtId)
-    .eq("goal_month", month);
+    .eq("goal_mth", month);
   return data ?? [];
 });
 
@@ -34,10 +34,10 @@ export const getEventGoalsCumulative = cache(
     const queryStart = startMonth <= endMonth ? startMonth : endMonth;
     const { data } = await db
       .from("evt_mlg_goal_cfg")
-      .select("mem_id, goal_month, goal_val, achieved_yn")
+      .select("mem_id, goal_mth, goal_val, achieved_yn")
       .eq("evt_id", evtId)
-      .gte("goal_month", queryStart)
-      .lte("goal_month", endMonth);
+      .gte("goal_mth", queryStart)
+      .lte("goal_mth", endMonth);
     return data ?? [];
   },
 );
@@ -48,7 +48,7 @@ export const getEventLogsMonthly = cache(async (evtId: string, month: string) =>
   const { data } = await db
     .from("evt_mlg_act_hist")
     .select(
-      "act_id, mem_id, act_dt, final_mlg, sport_cd, distance_km, elevation_m, base_mlg, applied_mults, review",
+      "act_id, mem_id, act_dt, final_mlg, sprt_enm, distance_km, elevation_m, base_mlg, applied_mults, review",
     )
     .eq("evt_id", evtId)
     .gte("act_dt", month)
@@ -64,7 +64,7 @@ export const getEventLogsCumulative = cache(
     const { data } = await db
       .from("evt_mlg_act_hist")
       .select(
-        "act_id, mem_id, act_dt, final_mlg, sport_cd, distance_km, elevation_m, base_mlg, applied_mults, review",
+        "act_id, mem_id, act_dt, final_mlg, sprt_enm, distance_km, elevation_m, base_mlg, applied_mults, review",
       )
       .eq("evt_id", evtId)
       .gte("act_dt", queryStart)

--- a/lib/supabase/database.types.ts
+++ b/lib/supabase/database.types.ts
@@ -257,7 +257,7 @@ export type Database = {
           final_mlg: number
           mem_id: string
           review: string | null
-          sport_cd: string
+          sprt_enm: string
           updated_at: string
         }
         Insert: {
@@ -272,7 +272,7 @@ export type Database = {
           final_mlg: number
           mem_id: string
           review?: string | null
-          sport_cd: string
+          sprt_enm: string
           updated_at?: string
         }
         Update: {
@@ -287,7 +287,7 @@ export type Database = {
           final_mlg?: number
           mem_id?: string
           review?: string | null
-          sport_cd?: string
+          sprt_enm?: string
           updated_at?: string
         }
         Relationships: [
@@ -313,7 +313,7 @@ export type Database = {
           created_at: string
           evt_id: string
           goal_id: string
-          goal_month: string
+          goal_mth: string
           goal_val: number
           mem_id: string
           updated_at: string
@@ -323,7 +323,7 @@ export type Database = {
           created_at?: string
           evt_id: string
           goal_id?: string
-          goal_month: string
+          goal_mth: string
           goal_val: number
           mem_id: string
           updated_at?: string
@@ -333,7 +333,7 @@ export type Database = {
           created_at?: string
           evt_id?: string
           goal_id?: string
-          goal_month?: string
+          goal_mth?: string
           goal_val?: number
           mem_id?: string
           updated_at?: string
@@ -402,36 +402,36 @@ export type Database = {
       evt_team_mst: {
         Row: {
           created_at: string
-          desc: string | null
+          desc_txt: string | null
           end_dt: string
           evt_id: string
           evt_nm: string
           evt_type_cd: string
-          status_cd: string
+          stts_enm: string
           stt_dt: string
           team_id: string
           updated_at: string
         }
         Insert: {
           created_at?: string
-          desc?: string | null
+          desc_txt?: string | null
           end_dt: string
           evt_id?: string
           evt_nm: string
           evt_type_cd: string
-          status_cd?: string
+          stts_enm?: string
           stt_dt: string
           team_id: string
           updated_at?: string
         }
         Update: {
           created_at?: string
-          desc?: string | null
+          desc_txt?: string | null
           end_dt?: string
           evt_id?: string
           evt_nm?: string
           evt_type_cd?: string
-          status_cd?: string
+          stts_enm?: string
           stt_dt?: string
           team_id?: string
           updated_at?: string
@@ -448,8 +448,8 @@ export type Database = {
       }
       evt_team_prt_rel: {
         Row: {
-          approve_yn: boolean
-          approved_at: string | null
+          aprv_at: string | null
+          aprv_yn: boolean
           created_at: string
           deposit_amt: number
           entry_fee_amt: number
@@ -459,12 +459,12 @@ export type Database = {
           mem_id: string
           prt_id: string
           singlet_fee_amt: number
-          stt_month: string
+          stt_mth: string
           updated_at: string
         }
         Insert: {
-          approve_yn?: boolean
-          approved_at?: string | null
+          aprv_at?: string | null
+          aprv_yn?: boolean
           created_at?: string
           deposit_amt: number
           entry_fee_amt: number
@@ -474,12 +474,12 @@ export type Database = {
           mem_id: string
           prt_id?: string
           singlet_fee_amt?: number
-          stt_month: string
+          stt_mth: string
           updated_at?: string
         }
         Update: {
-          approve_yn?: boolean
-          approved_at?: string | null
+          aprv_at?: string | null
+          aprv_yn?: boolean
           created_at?: string
           deposit_amt?: number
           entry_fee_amt?: number
@@ -489,7 +489,7 @@ export type Database = {
           mem_id?: string
           prt_id?: string
           singlet_fee_amt?: number
-          stt_month?: string
+          stt_mth?: string
           updated_at?: string
         }
         Relationships: [

--- a/lib/validations/mileage.ts
+++ b/lib/validations/mileage.ts
@@ -1,14 +1,14 @@
 import { z } from "zod";
 
-/** 마일리지런 활동 종목 코드 */
-const SPORT_CD_KEYS = ["RUNNING", "TRAIL", "CYCLING", "SWIMMING"] as const;
+/** 마일리지런 활동 종목 enum 값 */
+const SPRT_ENM_KEYS = ["RUNNING", "TRAIL", "CYCLING", "SWIMMING"] as const;
 
 /** 활동 로그 등록 폼 */
 export const activityLogSchema = z.object({
   act_dt: z
     .string()
     .regex(/^\d{4}-\d{2}-\d{2}$/, "날짜 형식이 올바르지 않습니다"),
-  sport_cd: z.enum(SPORT_CD_KEYS, { message: "종목을 선택해 주세요" }),
+  sprt_enm: z.enum(SPRT_ENM_KEYS, { message: "종목을 선택해 주세요" }),
   distance_km: z.number().positive("거리를 입력해주세요"),
   elevation_m: z.number().min(0).default(0),
   applied_mult_ids: z.array(z.string().uuid()).default([]),

--- a/supabase/migrations/20260420193000_evt_column_rename_and_enums.sql
+++ b/supabase/migrations/20260420193000_evt_column_rename_and_enums.sql
@@ -27,9 +27,10 @@ END $$;
 -- evt_team_mst
 ALTER TABLE public.evt_team_mst RENAME COLUMN "desc" TO desc_txt;
 ALTER TABLE public.evt_team_mst RENAME COLUMN status_cd TO stts_enm;
+ALTER TABLE public.evt_team_mst ALTER COLUMN stts_enm DROP DEFAULT;
 ALTER TABLE public.evt_team_mst
   ALTER COLUMN stts_enm TYPE public.evt_stts_enm
-  USING stts_enm::public.evt_stts_enm;
+  USING stts_enm::text::public.evt_stts_enm;
 ALTER TABLE public.evt_team_mst
   ALTER COLUMN stts_enm SET DEFAULT 'READY'::public.evt_stts_enm;
 
@@ -45,7 +46,7 @@ ALTER TABLE public.evt_mlg_goal_cfg RENAME COLUMN goal_month TO goal_mth;
 ALTER TABLE public.evt_mlg_act_hist RENAME COLUMN sport_cd TO sprt_enm;
 ALTER TABLE public.evt_mlg_act_hist
   ALTER COLUMN sprt_enm TYPE public.evt_mlg_sprt_enm
-  USING sprt_enm::public.evt_mlg_sprt_enm;
+  USING sprt_enm::text::public.evt_mlg_sprt_enm;
 
 -- comments
 COMMENT ON COLUMN public.evt_team_mst.stts_enm IS '상태 enum (READY/ACTIVE/CLOSED)';

--- a/supabase/migrations/20260420193000_evt_column_rename_and_enums.sql
+++ b/supabase/migrations/20260420193000_evt_column_rename_and_enums.sql
@@ -1,0 +1,57 @@
+-- 이벤트 도메인 네이밍 정합성 정리
+-- - *_cd(공통코드) / *_enm(enum) 규칙 정렬
+-- - evt_mlg_act_hist.sprt_enm enum 전환
+-- - evt_team_mst.stts_enm enum 전환
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1
+    FROM pg_type
+    WHERE typnamespace = 'public'::regnamespace
+      AND typname = 'evt_stts_enm'
+  ) THEN
+    CREATE TYPE public.evt_stts_enm AS ENUM ('READY', 'ACTIVE', 'CLOSED');
+  END IF;
+
+  IF NOT EXISTS (
+    SELECT 1
+    FROM pg_type
+    WHERE typnamespace = 'public'::regnamespace
+      AND typname = 'evt_mlg_sprt_enm'
+  ) THEN
+    CREATE TYPE public.evt_mlg_sprt_enm AS ENUM ('RUNNING', 'TRAIL', 'CYCLING', 'SWIMMING');
+  END IF;
+END $$;
+
+-- evt_team_mst
+ALTER TABLE public.evt_team_mst RENAME COLUMN "desc" TO desc_txt;
+ALTER TABLE public.evt_team_mst RENAME COLUMN status_cd TO stts_enm;
+ALTER TABLE public.evt_team_mst
+  ALTER COLUMN stts_enm TYPE public.evt_stts_enm
+  USING stts_enm::public.evt_stts_enm;
+ALTER TABLE public.evt_team_mst
+  ALTER COLUMN stts_enm SET DEFAULT 'READY'::public.evt_stts_enm;
+
+-- evt_team_prt_rel
+ALTER TABLE public.evt_team_prt_rel RENAME COLUMN stt_month TO stt_mth;
+ALTER TABLE public.evt_team_prt_rel RENAME COLUMN approve_yn TO aprv_yn;
+ALTER TABLE public.evt_team_prt_rel RENAME COLUMN approved_at TO aprv_at;
+
+-- evt_mlg_goal_cfg
+ALTER TABLE public.evt_mlg_goal_cfg RENAME COLUMN goal_month TO goal_mth;
+
+-- evt_mlg_act_hist
+ALTER TABLE public.evt_mlg_act_hist RENAME COLUMN sport_cd TO sprt_enm;
+ALTER TABLE public.evt_mlg_act_hist
+  ALTER COLUMN sprt_enm TYPE public.evt_mlg_sprt_enm
+  USING sprt_enm::public.evt_mlg_sprt_enm;
+
+-- comments
+COMMENT ON COLUMN public.evt_team_mst.stts_enm IS '상태 enum (READY/ACTIVE/CLOSED)';
+COMMENT ON COLUMN public.evt_team_mst.desc_txt IS '설명';
+COMMENT ON COLUMN public.evt_team_prt_rel.stt_mth IS '참여 시작월 (ex: 2026-05-01)';
+COMMENT ON COLUMN public.evt_team_prt_rel.aprv_yn IS '운영진 입금확인 승인 여부';
+COMMENT ON COLUMN public.evt_team_prt_rel.aprv_at IS '승인 일시';
+COMMENT ON COLUMN public.evt_mlg_goal_cfg.goal_mth IS '대상월 (ex: 2026-05-01)';
+COMMENT ON COLUMN public.evt_mlg_act_hist.sprt_enm IS '종목 enum (RUNNING/TRAIL/CYCLING/SWIMMING)';


### PR DESCRIPTION
## Summary
- 프로젝트 데이터 쿼리를 월별(`getEventLogsMonthly`/`getEventGoalsMonthly`)과 누적(`getEventLogsCumulative`/`getEventGoalsCumulative`)으로 분리해 조회 의도를 명확히 했습니다.
- 당월 UI(내 기록/내 상태/종목 차트/크루 진행 차트/월 통계)는 월별 쿼리만 사용하도록 전환해 연습월에서도 기록이 정상 노출되도록 수정했습니다.
- 금액 지표(환급 예정금/회식비 풀/지원금)는 누적 쿼리를 유지하고, 누적 쿼리의 시작 범위 역전(min start) 방어를 추가해 경계 월 조회 안정성을 보강했습니다.

## Test plan
- [ ] 연습월(이벤트 시작 전월)에서 `프로젝트` 페이지의 크루 차트/내 기록/종목 차트가 DB 기록과 일치해 노출되는지 확인
- [ ] 이벤트 시작월/이후 월 전환 시 당월 데이터만 노출되고 빈 상태가 비정상적으로 뜨지 않는지 확인
- [ ] `총 회식비 풀`, `환급 예정금`, `회식비 지원금(예상)`이 기존 누적 정책대로 계산되는지 확인
- [ ] 월 전환 시 차트가 이전 월 상태를 유지하지 않고 `selectedMonth` 기준으로 갱신되는지 확인

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **개선 사항**
  * 월별 데이터 조회 최적화로 더 빠른 월 전환 성능 제공
  * 월별 통계 및 활동 데이터 조회 구조 개선으로 불필요한 데이터 로드 제거
  * 누적 통계 계산 로직 개선으로 정확한 환급금 및 예산 정보 표시

* **리팩토링**
  * 데이터 조회 쿼리 분리로 월별 및 누적 데이터 관리 구조 정리
  * 불필요한 매개변수 제거로 컴포넌트 로직 단순화

<!-- end of auto-generated comment: release notes by coderabbit.ai -->