### PR TITLE
fix(projects): restore chart line visibility and responsive title layout

### DIFF
--- a/app/(main)/projects/page.tsx
+++ b/app/(main)/projects/page.tsx
@@ -88,8 +88,8 @@ export default async function ProjectsPage({
       <div className="flex flex-col gap-7 px-6 pb-24">
         <MonthTransitionProvider>
           {/* 이벤트명 + 월 네비게이터 */}
-          <div className="flex items-center justify-between">
-            <h2 className="text-xl font-bold">{event.evt_nm}</h2>
+          <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
+            <h2 className="text-xl font-bold break-keep">{event.evt_nm}</h2>
             <MonthNavigator
               currentMonth={selectedMonth}
               startMonth={event.stt_dt}

--- a/components/projects/crew-progress-chart.tsx
+++ b/components/projects/crew-progress-chart.tsx
@@ -30,16 +30,16 @@ export type ChartInitialData = {
 };
 
 const CHART_COLORS = [
-  "var(--sport-road-run)",
-  "var(--sport-ultra)",
-  "var(--sport-trail-run)",
-  "var(--sport-triathlon)",
-  "var(--sport-cycling)",
-  "var(--chart-1)",
-  "var(--chart-2)",
-  "var(--chart-3)",
-  "var(--chart-4)",
-  "var(--chart-5)",
+  "hsl(var(--sport-road-run))",
+  "hsl(var(--sport-ultra))",
+  "hsl(var(--sport-trail-run))",
+  "hsl(var(--sport-triathlon))",
+  "hsl(var(--sport-cycling))",
+  "var(--color-chart-1)",
+  "var(--color-chart-2)",
+  "var(--color-chart-3)",
+  "var(--color-chart-4)",
+  "var(--color-chart-5)",
 ];
 
 type ChartTooltipProps = TooltipContentProps<TooltipValueType, string | number> & {

--- a/components/projects/month-navigator.tsx
+++ b/components/projects/month-navigator.tsx
@@ -38,7 +38,7 @@ export function MonthNavigator({
   }
 
   return (
-    <div className="flex items-center justify-center gap-4">
+    <div className="shrink-0 flex items-center justify-center gap-4">
       <Button
         variant="ghost"
         size="icon-sm"


### PR DESCRIPTION
Use valid chart color tokens so Recharts lines render reliably, and stack the project title with month navigation on narrow screens to avoid truncating event names.

Made-with: Cursor