### PR TITLE
fix(projects): projects crew progress chart

### DIFF
--- a/components/projects/crew-progress-chart-server.tsx
+++ b/components/projects/crew-progress-chart-server.tsx
@@ -127,6 +127,7 @@ export async function CrewProgressChartServer({
   const members = activeParticipants.map((p) => ({
     id: p.mem_id,
     name: (p.mem_mst as unknown as { mem_nm: string }).mem_nm,
+    goalKm: goalByMemId.get(p.mem_id) ?? Number(p.init_goal ?? 0),
   }));
 
   const initialData: ChartInitialData = {

--- a/components/projects/crew-progress-chart-server.tsx
+++ b/components/projects/crew-progress-chart-server.tsx
@@ -66,7 +66,10 @@ export async function CrewProgressChartServer({
   // 기록 또는 목표가 있는 참여자만
   const memIdsWithLogs = new Set(monthLogs.map((l) => l.mem_id));
   const activeParticipants = participants.filter(
-    (p) => memIdsWithLogs.has(p.mem_id) || goalByMemId.has(p.mem_id),
+    (p) =>
+      memIdsWithLogs.has(p.mem_id) ||
+      goalByMemId.has(p.mem_id) ||
+      Number(p.init_goal ?? 0) > 0,
   );
 
   // 참여자별 일별 누적 마일리지

--- a/components/projects/crew-progress-chart.tsx
+++ b/components/projects/crew-progress-chart.tsx
@@ -254,7 +254,10 @@ export function CrewProgressChart({
 
     const memIdsWithLogs = new Set((logs ?? []).map((l) => l.mem_id));
     const activeParticipants = participants.filter(
-      (p) => memIdsWithLogs.has(p.mem_id) || goalByMemId.has(p.mem_id),
+      (p) =>
+        memIdsWithLogs.has(p.mem_id) ||
+        goalByMemId.has(p.mem_id) ||
+        Number(p.init_goal ?? 0) > 0,
     );
 
     const logsByMem = new Map<string, { day: number; val: number }[]>();

--- a/components/projects/crew-progress-chart.tsx
+++ b/components/projects/crew-progress-chart.tsx
@@ -489,14 +489,16 @@ export function CrewProgressChart({
               dataKey="name"
               interval={0}
               height={percentBarXAxisHeight}
-              tick={(tickProps: {
-                x: number;
-                y: number;
-                payload: { value?: string | number };
-                index: number;
-              }) => (
+              tick={(tickProps) => (
                 <PercentBarCategoryTick
-                  {...tickProps}
+                  x={Number(tickProps.x)}
+                  y={Number(tickProps.y)}
+                  payload={
+                    (tickProps.payload ?? {}) as {
+                      value?: string | number;
+                    }
+                  }
+                  index={tickProps.index ?? 0}
                   fontSize={percentBarLabelFont}
                   stagger={percentBarUseStagger}
                 />

--- a/components/projects/crew-progress-chart.tsx
+++ b/components/projects/crew-progress-chart.tsx
@@ -115,6 +115,37 @@ type PercentBarTooltipProps = {
   myName: string | null;
 };
 
+/** 달성률 막대 X축 — 인원 많을 때 폰트 축소 + 줄 지그재그로 겹침 완화 */
+function PercentBarCategoryTick(props: {
+  x: number;
+  y: number;
+  payload: { value?: string | number };
+  index: number;
+  fontSize: number;
+  stagger: boolean;
+}) {
+  const { x, y, payload, index, fontSize, stagger } = props;
+  const staggerDy =
+    stagger && index % 2 === 1 ? (fontSize <= 9 ? 12 : 13) : 0;
+  const label = payload.value ?? "";
+
+  return (
+    <g transform={`translate(${x},${y})`}>
+      <text
+        x={0}
+        y={0}
+        dy={14 + staggerDy}
+        textAnchor="end"
+        fill="var(--muted-foreground)"
+        fontSize={fontSize}
+        transform="rotate(-20)"
+      >
+        {label}
+      </text>
+    </g>
+  );
+}
+
 /** 달성률 막대 — dataKey 이름(percent)이 노출되지 않도록 전용 툴팁 */
 function PercentBarTooltip({
   active,
@@ -340,6 +371,29 @@ export function CrewProgressChart({
     })
     .sort((a, b) => b.percent - a.percent);
 
+  const percentBarCount = memberPercentData.length;
+  const percentBarLabelFont =
+    percentBarCount > 26 ? 8 : percentBarCount > 18 ? 9 : percentBarCount > 12 ? 10 : 11;
+  const percentBarUseStagger = percentBarCount >= 10;
+  const percentBarBottomMargin =
+    percentBarUseStagger && percentBarCount > 16
+      ? 56
+      : percentBarUseStagger
+        ? 48
+        : percentBarCount > 12
+          ? 36
+          : 28;
+  const percentBarXAxisHeight =
+    percentBarUseStagger && percentBarCount > 16
+      ? 58
+      : percentBarUseStagger
+        ? 50
+        : 42;
+  const percentBarChartHeight =
+    percentBarUseStagger || percentBarCount > 12
+      ? Math.min(292, 232 + percentBarXAxisHeight)
+      : 240;
+
   if (chartData.length === 0 || members.length === 0) {
     return (
       <div className="flex h-40 items-center justify-center rounded-2xl bg-muted">
@@ -359,7 +413,11 @@ export function CrewProgressChart({
         onValueChange={setMode}
       />
 
-      <ResponsiveContainer width="100%" height={240} className="outline-none">
+      <ResponsiveContainer
+        width="100%"
+        height={mode === "percent" ? percentBarChartHeight : 240}
+        className="outline-none"
+      >
         {mode === "mileage" ? (
           <LineChart data={chartData}>
             {mileageTicks.map((tick) => (
@@ -415,7 +473,10 @@ export function CrewProgressChart({
             ))}
           </LineChart>
         ) : (
-          <BarChart data={memberPercentData} margin={{ top: 4, right: 8, left: 0, bottom: 24 }}>
+          <BarChart
+            data={memberPercentData}
+            margin={{ top: 4, right: 8, left: 0, bottom: percentBarBottomMargin }}
+          >
             {[0, 20, 40, 60, 80, 100].map((tick) => (
               <ReferenceLine
                 key={tick}
@@ -426,11 +487,20 @@ export function CrewProgressChart({
             ))}
             <XAxis
               dataKey="name"
-              tick={{ fontSize: 11, fill: "var(--muted-foreground)" }}
               interval={0}
-              angle={-20}
-              textAnchor="end"
-              height={44}
+              height={percentBarXAxisHeight}
+              tick={(tickProps: {
+                x: number;
+                y: number;
+                payload: { value?: string | number };
+                index: number;
+              }) => (
+                <PercentBarCategoryTick
+                  {...tickProps}
+                  fontSize={percentBarLabelFont}
+                  stagger={percentBarUseStagger}
+                />
+              )}
             />
             <YAxis
               tick={{ fontSize: 11, fill: "var(--muted-foreground)" }}

--- a/components/projects/crew-progress-chart.tsx
+++ b/components/projects/crew-progress-chart.tsx
@@ -22,10 +22,12 @@ import { Skeleton } from "@/components/ui/skeleton";
 
 export type DailyPoint = Record<string, number | string> & { day: number };
 
+export type ChartMember = { id: string; name: string; goalKm: number };
+
 export type ChartInitialData = {
   mileageData: DailyPoint[];
   percentData: DailyPoint[];
-  members: { id: string; name: string }[];
+  members: ChartMember[];
   myGoalKm: number;
   myName: string | null;
   totalDays: number;
@@ -106,6 +108,39 @@ type MemberPercentBar = {
   goalKm: number;
 };
 
+type PercentBarTooltipProps = {
+  active?: boolean;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  payload?: any[];
+  myName: string | null;
+};
+
+/** 달성률 막대 — dataKey 이름(percent)이 노출되지 않도록 전용 툴팁 */
+function PercentBarTooltip({
+  active,
+  payload,
+  myName,
+}: PercentBarTooltipProps) {
+  if (!active || !payload?.length) return null;
+  const row = payload[0]?.payload as MemberPercentBar | undefined;
+  if (!row) return null;
+
+  const isMe = row.name === myName;
+  const goalText =
+    row.goalKm > 0 ? `${row.goalKm.toFixed(1)}km` : "-";
+
+  return (
+    <div className="rounded-md border bg-background p-2 text-xs shadow-md">
+      <p className={`mb-0.5 font-semibold ${isMe ? "" : "text-muted-foreground"}`}>
+        {row.name}
+      </p>
+      <p className={isMe ? "" : "text-muted-foreground"}>
+        {row.percent.toFixed(1)}% ({row.currentKm.toFixed(1)}km/{goalText})
+      </p>
+    </div>
+  );
+}
+
 export function CrewProgressChart({
   evtId,
   memId,
@@ -119,7 +154,7 @@ export function CrewProgressChart({
   const [percentData, setPercentData] = useState<DailyPoint[]>(
     initialData?.percentData ?? [],
   );
-  const [members, setMembers] = useState<{ id: string; name: string }[]>(
+  const [members, setMembers] = useState<ChartMember[]>(
     initialData?.members ?? [],
   );
   const [myGoalKm, setMyGoalKm] = useState<number>(
@@ -244,9 +279,10 @@ export function CrewProgressChart({
       pPoints.push(pPoint);
     }
 
-    const memberList = activeParticipants.map((p) => ({
+    const memberList: ChartMember[] = activeParticipants.map((p) => ({
       id: p.mem_id,
       name: (p.mem_mst as unknown as { mem_nm: string }).mem_nm,
+      goalKm: goalByMemId.get(p.mem_id) ?? Number(p.init_goal ?? 0),
     }));
 
     setMembers(memberList);
@@ -294,14 +330,12 @@ export function CrewProgressChart({
       const value = latest?.[member.name];
       const currentKm = typeof currentKmRaw === "number" ? currentKmRaw : 0;
       const percent = typeof value === "number" ? value : 0;
-      const goalKm =
-        percent > 0 ? Number((currentKm / (percent / 100)).toFixed(1)) : 0;
       return {
         memId: member.id,
         name: member.name,
         percent,
         currentKm: Number(currentKm.toFixed(1)),
-        goalKm,
+        goalKm: member.goalKm ?? 0,
       };
     })
     .sort((a, b) => b.percent - a.percent);
@@ -404,17 +438,7 @@ export function CrewProgressChart({
               width={36}
               domain={[0, 100]}
             />
-            <Tooltip
-              formatter={(value, _name, item) => {
-                const percent =
-                  typeof value === "number" ? value : Number(value ?? 0);
-                const row = item?.payload as MemberPercentBar | undefined;
-                if (!row) return `${percent.toFixed(1)}%`;
-                const goalText = row.goalKm > 0 ? `${row.goalKm.toFixed(1)}km` : "-";
-                return `${percent.toFixed(1)}% (${row.currentKm.toFixed(1)}km/${goalText})`;
-              }}
-              labelFormatter={(label) => `${label}`}
-            />
+            <Tooltip content={<PercentBarTooltip myName={myName} />} />
             <ReferenceLine
               y={100}
               stroke="var(--muted-foreground)"

--- a/components/projects/crew-progress-chart.tsx
+++ b/components/projects/crew-progress-chart.tsx
@@ -31,39 +31,28 @@ export type ChartInitialData = {
   totalDays: number;
 };
 
-const CHART_COLORS = [
-  "#EF4444",
-  "#F59E0B",
-  "#EAB308",
-  "#84CC16",
-  "#10B981",
-  "#06B6D4",
-  "#3B82F6",
-  "#6366F1",
-  "#8B5CF6",
-  "#A855F7",
-  "#D946EF",
-  "#EC4899",
-  "#F43F5E",
-  "#FB7185",
-  "#22C55E",
-  "#14B8A6",
-  "#0EA5E9",
-  "#60A5FA",
-  "#818CF8",
-  "#C084FC",
-];
-
-function hashString(value: string): number {
-  let hash = 0;
-  for (let i = 0; i < value.length; i++) {
-    hash = (hash * 31 + value.charCodeAt(i)) >>> 0;
+/** FNV-1a — mem_id(UUID 등) 문자열에서 인덱스 클러스터링을 줄임 */
+function fnv1a32(input: string): number {
+  let hash = 2166136261;
+  for (let i = 0; i < input.length; i++) {
+    hash ^= input.charCodeAt(i);
+    hash = Math.imul(hash, 16777619);
   }
-  return hash;
+  return hash >>> 0;
 }
 
+/**
+ * 멤버별 고정 색 (같은 mem_id → 항상 동일).
+ * 고정 HEX 팔레트 대신 색상환을 황금각(≈137.5°) 스텝으로 훑어 비슷한 파랑·보라만 연속되지 않게 함.
+ * 30명 규모에서도 채도·명도를 약간만 바꿔 구분도 유지.
+ */
 function colorByMemberId(memId: string): string {
-  return CHART_COLORS[hashString(memId) % CHART_COLORS.length];
+  const h = fnv1a32(memId);
+  const goldenDeg = 137.508;
+  const hue = ((h * goldenDeg) % 360 + 360) % 360;
+  const sat = 58 + (h % 14);
+  const light = 42 + ((h >>> 11) % 14);
+  return `hsl(${hue.toFixed(1)} ${sat}% ${light}%)`;
 }
 
 type ChartTooltipProps = TooltipContentProps<TooltipValueType, string | number> & {


### PR DESCRIPTION
요약
마일리지런 크루 진행 차트에서 선 색 구분, 달성률 툴팁·목표 표시, 인원 많을 때 가로축 이름 라벨 가독성을 개선했습니다.

변경 사항
마일리지(라인): mem_id 기준 색을 고정 HEX 팔레트 대신 FNV-1a + 황금각 HSL로 분산해 비슷한 파랑·보라만 몰리지 않게 함.
달성률(막대) 툴팁: Recharts 기본 percent : 라벨 제거, 이름 + 달성% (현재km/목표km) 형식 유지. 목표는 역산이 아니라 evt_mlg_goal_cfg / init_goal을 멤버에 붙여 표시.
달성률 X축: 인원 수에 따라 폰트 축소, 10명 이상 이름 지그재그(홀/짝 줄 간격), 하단 마진·축 높이·차트 높이 조정으로 겹침 완화.
테스트
프로젝트 탭에서 마일리지/달성률 전환, 툴팁·축 라벨·선 색 확인 권장.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **리팩토**
  * 팀 진행도 차트의 멤버 목표 데이터 처리를 개선했습니다.
  * 차트 색상 할당 및 도구 설명 렌더링 로직을 최적화했습니다.
  * 팀 멤버 수에 따른 차트 레이아웃 및 축 표시를 동적으로 조정하도록 개선했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->