### PR TITLE
feat(projects): 크루 진행 차트 3개 탭 가독성/통계 UX 개선

### DIFF
--- a/components/projects/crew-progress-chart.tsx
+++ b/components/projects/crew-progress-chart.tsx
@@ -506,8 +506,7 @@ export function CrewProgressChart({
       {mode === "stats" ? (
         <div className="rounded-2xl border bg-card">
           <div className="max-h-[52vh] overflow-auto">
-            <div className="min-w-[620px] overflow-x-auto">
-              <table className="w-full border-collapse text-xs [font-variant-numeric:tabular-nums]">
+              <table className="min-w-[620px] w-full border-collapse text-xs [font-variant-numeric:tabular-nums]">
                 <thead className="sticky top-0 z-30 bg-muted/60 backdrop-blur-sm">
                   <tr className="border-b text-muted-foreground">
                     <th className="sticky left-0 z-30 w-[56px] border-r bg-muted/70 px-2 py-2 text-center">순위</th>
@@ -590,7 +589,6 @@ export function CrewProgressChart({
                   ))}
                 </tbody>
               </table>
-            </div>
           </div>
         </div>
       ) : (

--- a/components/projects/crew-progress-chart.tsx
+++ b/components/projects/crew-progress-chart.tsx
@@ -566,7 +566,7 @@ export function CrewProgressChart({
                 <tbody>
                   {sortedStatsRows.map((row) => (
                     <tr key={row.id} className="border-b last:border-b-0">
-                      <td className="sticky left-0 z-20 border-r bg-card px-2 py-2 text-center">
+                      <td className="sticky left-0 z-20 border-r bg-muted/50 px-2 py-2 text-center">
                         {row.rank <= 3 ? (
                           <span className={`inline-flex items-center ${rankAccentClass(row.rank)}`} title={`${row.rank}위`}>
                             <Medal className="size-4" strokeWidth={2} />
@@ -575,7 +575,7 @@ export function CrewProgressChart({
                           row.rank
                         )}
                       </td>
-                      <td className={`sticky left-[56px] z-20 border-r bg-card px-2 py-2 ${row.name === myName ? "font-semibold text-primary" : ""}`}>
+                      <td className={`sticky left-[56px] z-20 border-r bg-muted/35 px-2 py-2 ${row.name === myName ? "font-semibold text-primary" : ""}`}>
                       {row.name}
                       </td>
                       <td className="border-r px-2 py-2 text-right">{row.goalKm.toFixed(1)} km</td>

--- a/components/projects/crew-progress-chart.tsx
+++ b/components/projects/crew-progress-chart.tsx
@@ -456,6 +456,21 @@ export function CrewProgressChart({
     });
     return sorted;
   }, [statsRows, statsSortKey, statsSortDir]);
+  const toggleStatsSort = useCallback((key: StatsSortKey) => {
+    setStatsSortKey((prevKey) => {
+      if (prevKey === key) {
+        setStatsSortDir((prev) => (prev === "desc" ? "asc" : "desc"));
+        return prevKey;
+      }
+      setStatsSortDir("desc");
+      return key;
+    });
+  }, []);
+  const sortIndicator = useCallback(
+    (key: StatsSortKey) =>
+      statsSortKey === key ? (statsSortDir === "desc" ? "▼" : "▲") : "",
+    [statsSortDir, statsSortKey],
+  );
 
   if (loading) {
     return <Skeleton className="h-64 w-full rounded-2xl" />;
@@ -515,48 +530,27 @@ export function CrewProgressChart({
                       <button
                         type="button"
                         className="w-full text-right font-medium"
-                        onClick={() => {
-                          if (statsSortKey === "goalKm") {
-                            setStatsSortDir((prev) => (prev === "desc" ? "asc" : "desc"));
-                          } else {
-                            setStatsSortKey("goalKm");
-                            setStatsSortDir("desc");
-                          }
-                        }}
+                        onClick={() => toggleStatsSort("goalKm")}
                       >
-                        목표거리 {statsSortKey === "goalKm" ? (statsSortDir === "desc" ? "▼" : "▲") : ""}
+                        목표거리 {sortIndicator("goalKm")}
                       </button>
                     </th>
                     <th className="w-[90px] border-r px-2 py-2 text-right">
                       <button
                         type="button"
                         className="w-full text-right font-medium"
-                        onClick={() => {
-                          if (statsSortKey === "currentKm") {
-                            setStatsSortDir((prev) => (prev === "desc" ? "asc" : "desc"));
-                          } else {
-                            setStatsSortKey("currentKm");
-                            setStatsSortDir("desc");
-                          }
-                        }}
+                        onClick={() => toggleStatsSort("currentKm")}
                       >
-                        누적거리 {statsSortKey === "currentKm" ? (statsSortDir === "desc" ? "▼" : "▲") : ""}
+                        누적거리 {sortIndicator("currentKm")}
                       </button>
                     </th>
                     <th className="w-[84px] border-r px-2 py-2 text-right">
                       <button
                         type="button"
                         className="w-full text-right font-medium"
-                        onClick={() => {
-                          if (statsSortKey === "percent") {
-                            setStatsSortDir((prev) => (prev === "desc" ? "asc" : "desc"));
-                          } else {
-                            setStatsSortKey("percent");
-                            setStatsSortDir("desc");
-                          }
-                        }}
+                        onClick={() => toggleStatsSort("percent")}
                       >
-                        달성률 {statsSortKey === "percent" ? (statsSortDir === "desc" ? "▼" : "▲") : ""}
+                        달성률 {sortIndicator("percent")}
                       </button>
                     </th>
                     <th className="w-[90px] px-2 py-2 text-right">추천거리(일)</th>

--- a/components/projects/crew-progress-chart.tsx
+++ b/components/projects/crew-progress-chart.tsx
@@ -8,6 +8,7 @@ import {
   useRef,
   useTransition,
 } from "react";
+import { Medal } from "lucide-react";
 import {
   LineChart,
   Line,
@@ -100,9 +101,14 @@ type MemberPercentBar = {
   memId: string;
   name: string;
   percent: number;
+  displayPercent: number;
+  overGoal: boolean;
   currentKm: number;
   goalKm: number;
 };
+
+type StatsSortKey = "currentKm" | "goalKm" | "percent";
+type StatsSortDir = "asc" | "desc";
 
 type PercentBarTooltipProps = {
   active?: boolean;
@@ -137,6 +143,21 @@ function PercentBarTooltip({
   );
 }
 
+function rankAccentClass(rank: number): string {
+  if (rank === 1) return "text-amber-500";
+  if (rank === 2) return "text-slate-400";
+  if (rank === 3) return "text-amber-700";
+  return "text-muted-foreground";
+}
+
+function getPercentCellStyle(percent: number): { backgroundColor: string } {
+  const clamped = Math.max(0, percent);
+  if (clamped < 25) return { backgroundColor: "rgba(185, 20, 20, 0.12)" };
+  if (clamped < 50) return { backgroundColor: "rgba(255, 115, 0, 0.14)" };
+  if (clamped <= 100) return { backgroundColor: "rgba(34, 139, 34, 0.14)" };
+  return { backgroundColor: "rgba(34, 139, 34, 0.22)" };
+}
+
 export function CrewProgressChart({
   evtId,
   memId,
@@ -144,6 +165,8 @@ export function CrewProgressChart({
   initialData,
 }: CrewProgressChartProps) {
   const [mode, setMode] = useState<"mileage" | "percent" | "stats">("mileage");
+  const [statsSortKey, setStatsSortKey] = useState<StatsSortKey>("currentKm");
+  const [statsSortDir, setStatsSortDir] = useState<StatsSortDir>("desc");
   const [mileageData, setMileageData] = useState<DailyPoint[]>(
     initialData?.mileageData ?? [],
   );
@@ -281,7 +304,7 @@ export function CrewProgressChart({
           goalByMemId.get(p.mem_id) ?? Number(p.init_goal ?? 0);
         pPoint[p.mem_id] =
           goal > 0
-            ? Number(Math.min((val / goal) * 100, 100).toFixed(1))
+            ? Number(((val / goal) * 100).toFixed(1))
             : 0;
       }
 
@@ -380,7 +403,7 @@ export function CrewProgressChart({
 
   const mileageMax = selectedMembers.reduce((max, item) => {
     const memberMax = mileageData.reduce((m, row) => {
-      const value = row[item.member.name];
+      const value = row[item.member.id];
       return typeof value === "number" ? Math.max(m, value) : m;
     }, 0);
     return Math.max(max, memberMax);
@@ -403,6 +426,8 @@ export function CrewProgressChart({
         memId: member.member.id,
         name: member.member.name,
         percent,
+        displayPercent: Number(Math.min(percent, 100).toFixed(1)),
+        overGoal: percent > 100,
         currentKm: Number(currentKm.toFixed(1)),
         goalKm: member.member.goalKm ?? 0,
       };
@@ -415,10 +440,22 @@ export function CrewProgressChart({
   );
 
   const percentBarCount = memberPercentData.length;
+  const hasPercentOverGoal = memberPercentData.some((item) => item.overGoal);
   const percentBarLabelFont =
     percentBarCount > 26 ? 8 : percentBarCount > 18 ? 9 : percentBarCount > 12 ? 10 : 11;
   const percentBarBottomMargin = percentBarCount > 12 ? 36 : 28;
   const percentBarXAxisHeight = percentBarCount > 12 ? 48 : 44;
+  const percentTicks = [0, 20, 40, 60, 80, 100];
+  const sortedStatsRows = useMemo(() => {
+    const sorted = [...statsRows];
+    sorted.sort((a, b) => {
+      const lhs = a[statsSortKey];
+      const rhs = b[statsSortKey];
+      const delta = lhs - rhs;
+      return statsSortDir === "asc" ? delta : -delta;
+    });
+    return sorted;
+  }, [statsRows, statsSortKey, statsSortDir]);
 
   if (loading) {
     return <Skeleton className="h-64 w-full rounded-2xl" />;
@@ -469,34 +506,89 @@ export function CrewProgressChart({
       {mode === "stats" ? (
         <div className="rounded-2xl border bg-card">
           <div className="max-h-[52vh] overflow-auto">
-            <div className="min-w-[540px] overflow-x-auto">
+            <div className="min-w-[620px] overflow-x-auto">
               <table className="w-full border-collapse text-xs [font-variant-numeric:tabular-nums]">
-              <thead className="sticky top-0 bg-card">
-                <tr className="border-b text-muted-foreground">
-                  <th className="px-3 py-2 text-left">순위</th>
-                  <th className="px-3 py-2 text-left">이름</th>
-                  <th className="px-3 py-2 text-right">목표거리</th>
-                  <th className="px-3 py-2 text-right">누적거리</th>
-                  <th className="px-3 py-2 text-right">달성률</th>
-                  <th className="px-3 py-2 text-right">추천거리(일)</th>
-                </tr>
-              </thead>
-              <tbody>
-                {statsRows.map((row) => (
-                  <tr key={row.id} className="border-b last:border-b-0">
-                    <td className="px-3 py-2">{row.rank}</td>
-                    <td className={`px-3 py-2 ${row.name === myName ? "font-semibold text-primary" : ""}`}>
-                      {row.name}
-                    </td>
-                    <td className="px-3 py-2 text-right">{row.goalKm.toFixed(1)} km</td>
-                    <td className="px-3 py-2 text-right">{row.currentKm.toFixed(1)} km</td>
-                    <td className="px-3 py-2 text-right">{row.percent.toFixed(1)}%</td>
-                    <td className="px-3 py-2 text-right">
-                      {row.dailyNeed === "done" ? "완료" : `${Number(row.dailyNeed).toFixed(1)} km`}
-                    </td>
+                <thead className="sticky top-0 z-30 bg-muted/60 backdrop-blur-sm">
+                  <tr className="border-b text-muted-foreground">
+                    <th className="sticky left-0 z-30 w-[56px] border-r bg-muted/70 px-2 py-2 text-center">순위</th>
+                    <th className="sticky left-[56px] z-30 w-[88px] border-r bg-muted/70 px-2 py-2 text-left">이름</th>
+                    <th className="w-[84px] border-r px-2 py-2 text-right">
+                      <button
+                        type="button"
+                        className="w-full text-right font-medium"
+                        onClick={() => {
+                          if (statsSortKey === "goalKm") {
+                            setStatsSortDir((prev) => (prev === "desc" ? "asc" : "desc"));
+                          } else {
+                            setStatsSortKey("goalKm");
+                            setStatsSortDir("desc");
+                          }
+                        }}
+                      >
+                        목표거리 {statsSortKey === "goalKm" ? (statsSortDir === "desc" ? "▼" : "▲") : ""}
+                      </button>
+                    </th>
+                    <th className="w-[90px] border-r px-2 py-2 text-right">
+                      <button
+                        type="button"
+                        className="w-full text-right font-medium"
+                        onClick={() => {
+                          if (statsSortKey === "currentKm") {
+                            setStatsSortDir((prev) => (prev === "desc" ? "asc" : "desc"));
+                          } else {
+                            setStatsSortKey("currentKm");
+                            setStatsSortDir("desc");
+                          }
+                        }}
+                      >
+                        누적거리 {statsSortKey === "currentKm" ? (statsSortDir === "desc" ? "▼" : "▲") : ""}
+                      </button>
+                    </th>
+                    <th className="w-[84px] border-r px-2 py-2 text-right">
+                      <button
+                        type="button"
+                        className="w-full text-right font-medium"
+                        onClick={() => {
+                          if (statsSortKey === "percent") {
+                            setStatsSortDir((prev) => (prev === "desc" ? "asc" : "desc"));
+                          } else {
+                            setStatsSortKey("percent");
+                            setStatsSortDir("desc");
+                          }
+                        }}
+                      >
+                        달성률 {statsSortKey === "percent" ? (statsSortDir === "desc" ? "▼" : "▲") : ""}
+                      </button>
+                    </th>
+                    <th className="w-[90px] px-2 py-2 text-right">추천거리(일)</th>
                   </tr>
-                ))}
-              </tbody>
+                </thead>
+                <tbody>
+                  {sortedStatsRows.map((row) => (
+                    <tr key={row.id} className="border-b last:border-b-0">
+                      <td className="sticky left-0 z-20 border-r bg-card px-2 py-2 text-center">
+                        {row.rank <= 3 ? (
+                          <span className={`inline-flex items-center ${rankAccentClass(row.rank)}`} title={`${row.rank}위`}>
+                            <Medal className="size-4" strokeWidth={2} />
+                          </span>
+                        ) : (
+                          row.rank
+                        )}
+                      </td>
+                      <td className={`sticky left-[56px] z-20 border-r bg-card px-2 py-2 ${row.name === myName ? "font-semibold text-primary" : ""}`}>
+                      {row.name}
+                      </td>
+                      <td className="border-r px-2 py-2 text-right">{row.goalKm.toFixed(1)} km</td>
+                      <td className="border-r px-2 py-2 text-right">{row.currentKm.toFixed(1)} km</td>
+                      <td className="border-r px-2 py-2 text-right" style={getPercentCellStyle(row.percent)}>
+                        {row.percent.toFixed(1)}%
+                      </td>
+                      <td className="px-2 py-2 text-right">
+                        {row.dailyNeed === "done" ? "완료" : `${Number(row.dailyNeed).toFixed(1)} km`}
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
               </table>
             </div>
           </div>
@@ -567,7 +659,7 @@ export function CrewProgressChart({
               data={memberPercentData}
               margin={{ top: 4, right: 8, left: 0, bottom: percentBarBottomMargin }}
             >
-            {[0, 20, 40, 60, 80, 100].map((tick) => (
+            {percentTicks.map((tick) => (
               <ReferenceLine
                 key={tick}
                 y={tick}
@@ -590,6 +682,7 @@ export function CrewProgressChart({
               tick={{ fontSize: 11, fill: "var(--muted-foreground)" }}
               tickFormatter={(v: number) => `${v}%`}
               width={36}
+              ticks={percentTicks}
               domain={[0, 100]}
             />
             <Tooltip content={<PercentBarTooltip myName={myName} />} />
@@ -599,13 +692,13 @@ export function CrewProgressChart({
               strokeDasharray="6 4"
               strokeWidth={1.5}
               label={{
-                value: "100%",
+                value: hasPercentOverGoal ? "100%+ 🚀" : "100%",
                 position: "right",
                 fontSize: 10,
                 fill: "var(--muted-foreground)",
               }}
             />
-            <Bar dataKey="percent" radius={[6, 6, 0, 0]}>
+            <Bar dataKey="displayPercent" radius={[6, 6, 0, 0]}>
               {memberPercentData.map((item) => (
                 <Cell
                   key={item.memId}

--- a/lib/projects/crew-progress-chart.ts
+++ b/lib/projects/crew-progress-chart.ts
@@ -1,4 +1,4 @@
-import { calcDailyNeeded, calcMonthRefundRate } from "@/lib/mileage";
+import { calcDailyNeeded } from "@/lib/mileage";
 
 export type CrewChartMember = {
   id: string;
@@ -202,7 +202,7 @@ export function buildStatsRows(
     name: item.member.name,
     goalKm: item.member.goalKm,
     currentKm: item.currentKm,
-    percent: round1(calcMonthRefundRate(item.currentKm, item.member.goalKm) * 100),
+    percent: round1(item.member.goalKm > 0 ? (item.currentKm / item.member.goalKm) * 100 : 0),
     dailyNeed: calcDailyNeeded(item.currentKm, item.member.goalKm, dayRef, totalDays),
   }));
 }

--- a/lib/projects/crew-progress-chart.ts
+++ b/lib/projects/crew-progress-chart.ts
@@ -28,8 +28,8 @@ export type StatsRow = {
 export const ROLE_COLORS = {
   me: "#0064DC",
   top: ["#B91414", "#FF4600", "#FF7300"] as const,
-  bottom: ["#7864E6", "#8C32DC", "#46AAC8"] as const,
-  near: ["#FFD200", "#AADC00", "#32B450", "#82D2B4"] as const,
+  bottom: ["#46AAC8", "#7864E6", "#8C32DC"] as const,
+  near: ["#E6C74A", "#AADC00", "#228B22", "#82D2B4"] as const,
 };
 
 export function round1(value: number): number {


### PR DESCRIPTION
## 관련 이슈
관련 이슈 없음

## 요약
- 크루 진행 차트의 마일리지/달성률/전체 통계 3개 탭을 가독성과 해석 일관성 중심으로 개선했습니다.
- 달성률 100% 초과 데이터를 툴팁/통계에서는 그대로 노출하고, 그래프 축은 100% 기준을 유지하도록 조정했습니다.

## AS-IS (변경 전)
- 마일리지 탭 Y축 계산이 실제 데이터 키와 어긋나 눈금/보조선이 직관적이지 않았습니다.
- 달성률 탭은 눈금과 보조선 기준이 사용자 관점에서 일치하지 않고, 달성률이 100%에서 상한 처리되어 초과 달성 정보가 손실됐습니다.
- 전체 통계 탭은 모바일 가로 스크롤에서 핵심 컬럼 고정이 없고, 컬럼 정렬/가독성 보조 장치가 부족했습니다.

## TO-BE (변경 후)
- 마일리지 탭의 축 계산을 실제 멤버 id 키 기반으로 정정해 눈금과 보조선의 일관성을 확보했습니다.
- 달성률 탭은 0/20/40/60/80/100 기준으로 눈금과 보조선을 맞추고, 100% 초과 달성률은 툴팁에 그대로 표시합니다(그래프 막대 표시는 100%로 클램프).
- 전체 통계 탭에 `순위`/`이름` sticky 컬럼, 헤더 음영, 세로 구분선, 컬럼 폭 최적화, 클릭 정렬(목표/누적/달성률), 1~3위 메달 아이콘, 달성률 구간별 배경 강조를 적용했습니다.

## 주요 변경 사항
- `components/projects/crew-progress-chart.tsx`
  - 마일리지 Y축 최대값 계산 로직 보정 (`name` -> `id` 키)
  - 달성률 데이터에서 실제값(`percent`)과 그래프 표시값(`displayPercent`) 분리
  - 100% 초과 시 라벨을 `100%+ 🚀`로 표시
  - 전체 통계 탭 sticky 컬럼/정렬 UI/메달 아이콘/달성률 셀 강조 추가
- `lib/projects/crew-progress-chart.ts`
  - 통계 달성률 계산에서 100% 상한 제거
  - 색상 팔레트(near/bottom) 가독성 개선 반영

## 테스트 계획
- [ ] 마일리지 탭에서 Y축 눈금/보조선이 데이터 증가와 함께 자연스럽게 맞는지 확인
- [ ] 달성률 탭에서 100% 초과 사용자(예: 305%)가 툴팁에는 실제값으로 보이고, 막대 높이는 100% 기준으로 유지되는지 확인
- [ ] 달성률 탭 Y축 눈금과 보조선이 동일 기준(0/20/40/60/80/100)으로 보이는지 확인
- [ ] 전체 통계 탭에서 모바일 가로 스크롤 시 `순위`/`이름` 컬럼이 sticky로 유지되는지 확인
- [ ] 전체 통계 탭에서 목표/누적/달성률 헤더 클릭 시 정렬만 바뀌고 `순위` 값은 고정 유지되는지 확인
- [ ] 1~3위 메달 아이콘 및 달성률 구간별 셀 배경 강조가 의도대로 보이는지 확인

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 전체 통계 테이블을 목표 거리, 현재 거리, 달성률로 정렬할 수 있습니다.
  * 상위 3명에게 메달 아이콘이 표시됩니다.
  * 테이블 헤더가 고정되어 스크롤 시 열 정보가 항상 표시됩니다.

* **버그 수정**
  * 거리 계산 로직을 수정했습니다.
  * 달성률 계산 정확도를 개선했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->