### PR TITLE
fix(projects): stabilize review slot reset transition behavior

### DIFF
--- a/components/projects/random-review-rotator.tsx
+++ b/components/projects/random-review-rotator.tsx
@@ -70,13 +70,21 @@ export function RandomReviewRotator({ lines }: RandomReviewRotatorProps) {
       onTouchEnd={() => setIsPaused(false)}
       onTouchCancel={() => setIsPaused(false)}
     >
-      <div className="overflow-hidden">
+      <div className="h-[44px] overflow-hidden">
         <div
-          className="transition-transform duration-500 ease-in-out motion-reduce:transition-none"
+          className={
+            isAnimating
+              ? "transition-transform duration-500 ease-in-out motion-reduce:transition-none"
+              : "transition-none motion-reduce:transition-none"
+          }
           style={{ transform: isAnimating ? "translateY(-50%)" : "translateY(0%)" }}
         >
           {[current, next].map((line, idx) => (
-            <div key={`${line.id}-${idx}`} className="flex min-h-[44px] flex-col justify-center">
+            <div
+              key={`${line.id}-${idx}`}
+              className="flex h-[44px] flex-col justify-center"
+              aria-hidden={idx === 1}
+            >
               <Caption className="line-clamp-1 text-foreground">"{line.quote}"</Caption>
               <Caption className="line-clamp-1 text-muted-foreground">{line.meta}</Caption>
             </div>


### PR DESCRIPTION
## 요약
- 롤링 한마디 슬롯 전환이 pause/resume 구간에서 반쯤 밀린 상태로 멈출 수 있는 문제를 보완했습니다.
- 전환 리셋/재개 시 애니메이션 상태를 안정적으로 초기화해 깜빡임/중간 정지 현상을 줄였습니다.

## 변경 사항
- `components/projects/random-review-rotator.tsx`
  - 슬롯 높이 고정 및 overflow 처리 보강
  - 전환/리셋 시 transition 적용 조건 분리
  - 다음 슬라이드 접근성 노출 최소화(`aria-hidden`)
  - pause/cleanup 시 애니메이션 상태 초기화로 half-shift 상태 방지

## 테스트
- [ ] 한마디가 3~5회 이상 자연스럽게 롤링되는지 확인
- [ ] hover/focus/touch로 일시정지 후 재개 시 위치가 틀어지지 않는지 확인
- [ ] 전환 중 pause 했을 때 반쯤 밀린 상태로 멈추지 않는지 확인