### PR TITLE
style(projects): 통계 표 가독성/대비 최종 보정

### DIFF
--- a/components/projects/crew-progress-chart.tsx
+++ b/components/projects/crew-progress-chart.tsx
@@ -523,14 +523,14 @@ export function CrewProgressChart({
       )}
 
       {mode === "stats" ? (
-        <div className="rounded-2xl border bg-card">
+        <div className="overflow-hidden rounded-2xl border bg-card">
           <div className="max-h-[52vh] overflow-auto">
             <table className="min-w-[540px] w-full border-collapse text-[13px] [font-variant-numeric:tabular-nums]">
-              <thead className="sticky top-0 z-30 bg-card">
-                <tr className="border-b bg-card text-muted-foreground">
+              <thead className="sticky top-0 z-30 bg-[#DEE1E4]">
+                <tr className="border-b bg-[#DEE1E4] text-muted-foreground">
                   <th
                     aria-sort={getAriaSort("rank")}
-                    className="sticky left-0 z-40 w-[128px] min-w-[128px] max-w-[128px] bg-card px-2 py-2 text-center after:absolute after:right-0 after:top-0 after:h-full after:w-px after:bg-border"
+                    className="sticky left-0 z-40 w-[112px] min-w-[112px] max-w-[112px] bg-[#DEE1E4] px-2 py-2 text-center after:absolute after:right-0 after:top-0 after:h-full after:w-px after:bg-border"
                   >
                     <button
                       type="button"
@@ -543,7 +543,7 @@ export function CrewProgressChart({
                       <span className="inline-block w-2 text-center">{sortIndicator("rank")}</span>
                     </button>
                   </th>
-                  <th aria-sort={getAriaSort("goalKm")} className="w-24 border-r bg-card px-2 py-2 text-center">
+                  <th aria-sort={getAriaSort("goalKm")} className="w-24 border-r bg-[#DEE1E4] px-2 py-2 text-center">
                     <button
                       type="button"
                       className={`inline-flex w-full items-center justify-center gap-1 text-center font-medium ${
@@ -555,7 +555,7 @@ export function CrewProgressChart({
                       <span className="inline-block w-2 text-center">{sortIndicator("goalKm")}</span>
                     </button>
                   </th>
-                  <th aria-sort={getAriaSort("currentKm")} className="w-24 border-r bg-card px-2 py-2 text-center">
+                  <th aria-sort={getAriaSort("currentKm")} className="w-24 border-r bg-[#DEE1E4] px-2 py-2 text-center">
                     <button
                       type="button"
                       className={`inline-flex w-full items-center justify-center gap-1 text-center font-medium ${
@@ -567,7 +567,7 @@ export function CrewProgressChart({
                       <span className="inline-block w-2 text-center">{sortIndicator("currentKm")}</span>
                     </button>
                   </th>
-                  <th aria-sort={getAriaSort("percent")} className="w-20 border-r bg-card px-2 py-2 text-center">
+                  <th aria-sort={getAriaSort("percent")} className="w-20 border-r bg-[#DEE1E4] px-2 py-2 text-center">
                     <button
                       type="button"
                       className={`inline-flex w-full items-center justify-center gap-1 text-center font-medium ${
@@ -579,18 +579,18 @@ export function CrewProgressChart({
                       <span className="inline-block w-2 text-center">{sortIndicator("percent")}</span>
                     </button>
                   </th>
-                  <th className="w-24 bg-card px-2 py-2 text-center">추천거리(일)</th>
+                  <th className="w-24 bg-[#DEE1E4] px-2 py-2 text-center">추천거리(일)</th>
                 </tr>
               </thead>
               <tbody>
                 {sortedStatsRows.map((row) => (
                   <tr key={row.id} className="border-b last:border-b-0">
                     <td
-                      className={`sticky left-0 z-20 w-[128px] min-w-[128px] max-w-[128px] bg-card px-2 py-2 text-left after:absolute after:right-0 after:top-0 after:h-full after:w-px after:bg-border ${
+                      className={`sticky left-0 z-20 w-[112px] min-w-[112px] max-w-[112px] bg-[#DEE1E4] px-2 py-2 text-center after:absolute after:right-0 after:top-0 after:h-full after:w-px after:bg-border ${
                         row.name === myName ? "font-semibold text-primary" : ""
                       }`}
                     >
-                      <div className="inline-flex items-center gap-2">
+                      <div className="inline-flex items-center justify-center gap-2">
                         <span className="inline-flex min-w-[20px] items-center justify-center text-center">
                           {row.rank <= 3 ? (
                             <span


### PR DESCRIPTION
## 요약
- 전체 통계 표의 순위+이름 고정 컬럼을 사용자 피드백 기준으로 최종 보정했습니다.
- 헤더/순위 열 색상 대비를 조정하고, 컬럼 폭/정렬/표시 요소를 모바일 가독성 중심으로 다듬었습니다.

## 변경 사항
- `components/projects/crew-progress-chart.tsx`
  - 달성률 컬럼 색상 5구간을 지정 HEX로 반영
    - 0~20: `#EF9A9A`
    - 21~40: `#FFCC80`
    - 41~60: `#FFF59D`
    - 61~80: `#C5E1A5`
    - 81~100: `#A5D6A7`
  - 120% 초과 표기를 `🚀` 이모지만 남기도록 단순화
  - 헤더/순위 열 배경을 `#DEE1E4` 톤으로 맞춰 구분감 강화
  - 라운드 컨테이너와 표 경계가 어색하게 보이던 부분을 `overflow-hidden`으로 정리
  - 순위+이름 병합 고정 컬럼 폭 축소 (`128px` → `112px`)
  - 병합 컬럼 내용 가운데 정렬 보정

## 테스트
- [ ] 전체 통계 탭에서 헤더와 순위열 구분이 충분한지 확인
- [ ] 병합된 순위+이름 컬럼 폭/정렬이 모바일에서 자연스러운지 확인
- [ ] 달성률 색상 구간이 의도한 HEX로 보이는지 확인
- [ ] 120% 이상 항목이 `🚀`만 표시되는지 확인