### PR TITLE
feat(projects): 마일리지런 모바일 가독성 및 상호작용 개선

### DIFF
--- a/app/(main)/projects/page.tsx
+++ b/app/(main)/projects/page.tsx
@@ -88,8 +88,10 @@ export default async function ProjectsPage({
       <div className="flex flex-col gap-7 px-6 pb-24">
         <MonthTransitionProvider>
           {/* 이벤트명 + 월 네비게이터 */}
-          <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
-            <h2 className="text-xl font-bold break-keep">{event.evt_nm}</h2>
+          <div className="flex min-w-0 items-center justify-between gap-3">
+            <h2 className="min-w-0 flex-1 truncate whitespace-nowrap text-lg font-bold tracking-tight sm:text-xl">
+              {event.evt_nm}
+            </h2>
             <MonthNavigator
               currentMonth={selectedMonth}
               startMonth={event.stt_dt}
@@ -111,7 +113,7 @@ export default async function ProjectsPage({
           )}
 
           {/* 월별 동적 콘텐츠 — 전환 시 opacity 처리 */}
-          <TransitionOverlay className="flex flex-col gap-7">
+          <TransitionOverlay className="-mt-2 flex flex-col gap-7">
             <Suspense fallback={<Skeleton className="h-64 w-full rounded-2xl" />}>
               <CrewProgressChartServer
                 key={selectedMonth}
@@ -122,6 +124,11 @@ export default async function ProjectsPage({
                 evtEndMonth={event.end_dt}
               />
             </Suspense>
+            {isParticipant && member && (
+              <Suspense fallback={<Skeleton className="h-40 w-full rounded-2xl" />}>
+                <MyStatus evtId={event.evt_id} memId={member.id} month={selectedMonth} evtStartMonth={event.stt_dt} evtEndMonth={event.end_dt} />
+              </Suspense>
+            )}
             <Suspense fallback={null}>
               <RandomReview evtId={event.evt_id} />
             </Suspense>
@@ -132,9 +139,6 @@ export default async function ProjectsPage({
             {/* 참여자 전용 */}
             {isParticipant && member && (
               <>
-                <Suspense fallback={<Skeleton className="h-40 w-full rounded-2xl" />}>
-                  <MyStatus evtId={event.evt_id} memId={member.id} month={selectedMonth} evtStartMonth={event.stt_dt} evtEndMonth={event.end_dt} />
-                </Suspense>
                 <Suspense fallback={<Skeleton className="h-20 w-full rounded-2xl" />}>
                   <RefundStatus
                     evtId={event.evt_id}

--- a/app/globals.css
+++ b/app/globals.css
@@ -118,12 +118,16 @@
 
   /* Safari date input 정규화 */
   input[type="date"] {
-    -webkit-appearance: none;
-    appearance: none;
     min-height: auto;
     line-height: normal;
   }
   input[type="date"]::-webkit-date-and-time-value {
     text-align: left;
+  }
+
+  /* 특정 date input에서 기본 달력 아이콘 숨김 */
+  .date-no-icon::-webkit-calendar-picker-indicator {
+    display: none;
+    -webkit-appearance: none;
   }
 }

--- a/components/projects/activity-log-batch-form.tsx
+++ b/components/projects/activity-log-batch-form.tsx
@@ -218,7 +218,7 @@ export function ActivityLogBatchForm({ evtId, onSuccess }: ActivityLogBatchFormP
                   max={today}
                   value={d.act_dt}
                   onChange={(e) => updateDraft(d.id, { act_dt: e.target.value })}
-                  className="h-10 rounded-lg border text-sm"
+                  className="date-no-icon h-10 rounded-lg border pr-3 text-sm"
                 />
               </div>
 

--- a/components/projects/activity-log-form.tsx
+++ b/components/projects/activity-log-form.tsx
@@ -191,7 +191,7 @@ export function ActivityLogForm({
           id="act_dt"
           type="date"
           max={today}
-          className="h-12 rounded-xl border-[1.5px] text-[15px]"
+          className="date-no-icon h-12 rounded-xl border-[1.5px] pr-3 text-[15px]"
           {...register("act_dt")}
         />
         {errors.act_dt && (

--- a/components/projects/crew-monthly-stats.tsx
+++ b/components/projects/crew-monthly-stats.tsx
@@ -4,7 +4,6 @@ import {
   DEPOSIT_PER_MONTH,
   ENTRY_FEE_WITH_SINGLET,
 } from "@/lib/mileage";
-import { StatCard } from "@/components/common/stat-card";
 import {
   getEventParticipants,
   getEventGoalsCumulative,
@@ -111,21 +110,23 @@ export async function CrewMonthlyStats({
     totalRefundSum +
     participantCount * ENTRY_FEE_WITH_SINGLET;
 
+  const stats = [
+    { label: "달성/참가", value: `${achievedCount} / ${participantCount}` },
+    { label: "총 마일리지", value: `${totalMileage.toFixed(0)} km` },
+    { label: "회식비 풀", value: `₩${Math.floor(partyPool).toLocaleString()}` },
+    { label: "평균", value: `${avgMileage.toFixed(1)} km` },
+  ];
+
   return (
-    <div className="grid grid-cols-2 gap-3">
-      <StatCard
-        value={`${achievedCount} / ${participantCount}`}
-        label="달성인원 / 참가자수"
-      />
-      <StatCard value={`${totalMileage.toFixed(0)} km`} label="총 마일리지" />
-      <StatCard
-        value={`₩${Math.floor(partyPool).toLocaleString()}`}
-        label="총 회식비 풀"
-      />
-      <StatCard
-        value={`${avgMileage.toFixed(1)} km`}
-        label="평균 마일리지"
-      />
+    <div className="grid grid-cols-2 gap-x-4 gap-y-3 rounded-2xl bg-muted/35 px-4 py-3">
+      {stats.map((stat) => (
+        <div key={stat.label} className="space-y-0.5">
+          <p className="text-[11px] text-muted-foreground">{stat.label}</p>
+          <p className="text-2xl leading-tight font-bold text-foreground">
+            {stat.value}
+          </p>
+        </div>
+      ))}
     </div>
   );
 }

--- a/components/projects/crew-progress-chart.tsx
+++ b/components/projects/crew-progress-chart.tsx
@@ -396,11 +396,11 @@ export function CrewProgressChart({
       const isFutureInCurrentMonth =
         mode === "mileage" && isCurrentMonth && row.day > dayRef;
       for (const key of Object.keys(row)) {
-        if (key === "day" || selectedMemberIdSet.has(key)) {
-          filtered[key] = isFutureInCurrentMonth
-            ? Number.NaN
-            : (row[key] as number | string);
-        }
+        if (key === "day") continue;
+        if (!selectedMemberIdSet.has(key)) continue;
+        filtered[key] = isFutureInCurrentMonth
+          ? Number.NaN
+          : (row[key] as number | string);
       }
       return filtered;
     });
@@ -613,7 +613,7 @@ export function CrewProgressChart({
                         row.name === myName ? "font-semibold text-primary" : ""
                       }`}
                     >
-                      <div className="inline-flex items-center justify-center gap-1">
+                      <div className="flex w-full min-w-0 items-center justify-center gap-1">
                         <span className="inline-flex min-w-[20px] items-center justify-center text-center">
                           {row.rank <= 3 ? (
                             <span
@@ -632,7 +632,7 @@ export function CrewProgressChart({
                             row.rank
                           )}
                         </span>
-                        <span className="truncate text-[10px] leading-none">{row.name}</span>
+                        <span className="min-w-0 flex-1 truncate text-[10px] leading-none">{row.name}</span>
                       </div>
                     </td>
                     <td

--- a/components/projects/crew-progress-chart.tsx
+++ b/components/projects/crew-progress-chart.tsx
@@ -393,14 +393,18 @@ export function CrewProgressChart({
     const base = mode === "percent" ? percentData : mileageData;
     return base.map((row) => {
       const filtered: DailyPoint = { day: row.day };
+      const isFutureInCurrentMonth =
+        mode === "mileage" && isCurrentMonth && row.day > dayRef;
       for (const key of Object.keys(row)) {
         if (key === "day" || selectedMemberIdSet.has(key)) {
-          filtered[key] = row[key] as number | string;
+          filtered[key] = isFutureInCurrentMonth
+            ? Number.NaN
+            : (row[key] as number | string);
         }
       }
       return filtered;
     });
-  }, [mode, percentData, mileageData, selectedMemberIdSet]);
+  }, [mode, percentData, mileageData, selectedMemberIdSet, isCurrentMonth, dayRef]);
 
   const roleColorMap = useMemo(
     () => buildRoleColorMap(selectedMembers, top, bottom, near, memId),
@@ -449,8 +453,9 @@ export function CrewProgressChart({
   const hasBoostedPercent = memberPercentData.some((item) => item.boosted);
   const percentBarLabelFont =
     percentBarCount > 26 ? 8 : percentBarCount > 18 ? 9 : percentBarCount > 12 ? 10 : 11;
-  const percentBarBottomMargin = percentBarCount > 12 ? 36 : 28;
-  const percentBarXAxisHeight = percentBarCount > 12 ? 48 : 44;
+  // 차트 높이는 유지하고, X축 라벨 영역/하단 마진만 줄여 의미 없는 빈 공간을 압축한다.
+  const percentBarBottomMargin = percentBarCount > 12 ? 30 : 22;
+  const percentBarXAxisHeight = percentBarCount > 12 ? 40 : 36;
   const percentTicks = [0, 20, 40, 60, 80, 100];
   const sortedStatsRows = useMemo(() => {
     const sorted = [...statsRows];
@@ -534,72 +539,81 @@ export function CrewProgressChart({
       {mode === "stats" ? (
         <div className="overflow-hidden rounded-2xl border bg-card">
           <div className="max-h-[52vh] overflow-auto">
-            <table className="min-w-[540px] w-full border-collapse text-[13px] [font-variant-numeric:tabular-nums]">
+            <table className="min-w-[310px] w-full table-fixed border-collapse text-[11px] [font-variant-numeric:tabular-nums]">
+              <colgroup>
+                <col style={{ width: "60px" }} />
+                <col style={{ width: "50px" }} />
+                <col style={{ width: "50px" }} />
+                <col style={{ width: "50px" }} />
+                <col style={{ width: "40px" }} />
+              </colgroup>
               <thead className="sticky top-0 z-30 bg-[#F1F3F5]">
-                <tr className="border-b bg-[#F1F3F5] text-muted-foreground">
+                <tr className="border-b bg-[#F1F3F5] text-[10px] text-muted-foreground">
                   <th
                     aria-sort={getAriaSort("rank")}
-                    className="sticky left-0 z-40 w-[112px] min-w-[112px] max-w-[112px] bg-[#F1F3F5] px-2 py-2 text-center after:absolute after:right-0 after:top-0 after:h-full after:w-px after:bg-border"
+                    className="sticky left-0 z-40 w-[60px] min-w-[60px] max-w-[60px] bg-[#F1F3F5] px-1 py-1.5 text-center after:absolute after:right-0 after:top-0 after:h-full after:w-px after:bg-border"
                   >
                     <button
                       type="button"
-                      className={`inline-flex w-full items-center justify-center gap-1 text-center font-medium ${
+                      className={`inline-flex w-full items-center justify-center gap-0.5 text-center font-medium leading-none ${
                         statsSortKey === "rank" ? "text-foreground" : ""
                       }`}
                       onClick={() => toggleStatsSort("rank")}
                     >
                       <span>순위</span>
-                      <span className="inline-block w-2 text-center">{sortIndicator("rank")}</span>
+                      <span className="inline-block w-1.5 text-center text-[9px]">{sortIndicator("rank")}</span>
                     </button>
                   </th>
-                  <th aria-sort={getAriaSort("goalKm")} className="w-24 border-r bg-[#F1F3F5] px-2 py-2 text-center">
+                  <th aria-sort={getAriaSort("goalKm")} className="w-[50px] border-r bg-[#F1F3F5] px-1 py-1.5 text-center">
                     <button
                       type="button"
-                      className={`inline-flex w-full items-center justify-center gap-1 text-center font-medium ${
+                      className={`inline-flex w-full items-center justify-center gap-0.5 text-center font-medium leading-none ${
                         statsSortKey === "goalKm" ? "text-foreground" : ""
                       }`}
                       onClick={() => toggleStatsSort("goalKm")}
                     >
-                      <span>목표거리</span>
-                      <span className="inline-block w-2 text-center">{sortIndicator("goalKm")}</span>
+                      <span>목표<span className="text-[9px]">(km)</span></span>
+                      <span className="inline-block w-1.5 text-center text-[9px]">{sortIndicator("goalKm")}</span>
                     </button>
                   </th>
-                  <th aria-sort={getAriaSort("currentKm")} className="w-24 border-r bg-[#F1F3F5] px-2 py-2 text-center">
+                  <th aria-sort={getAriaSort("currentKm")} className="w-[50px] border-r bg-[#F1F3F5] px-1 py-1.5 text-center">
                     <button
                       type="button"
-                      className={`inline-flex w-full items-center justify-center gap-1 text-center font-medium ${
+                      className={`inline-flex w-full items-center justify-center gap-0.5 text-center font-medium leading-none ${
                         statsSortKey === "currentKm" ? "text-foreground" : ""
                       }`}
                       onClick={() => toggleStatsSort("currentKm")}
                     >
-                      <span>누적거리</span>
-                      <span className="inline-block w-2 text-center">{sortIndicator("currentKm")}</span>
+                      <span>누적<span className="text-[9px]">(km)</span></span>
+                      <span className="inline-block w-1.5 text-center text-[9px]">{sortIndicator("currentKm")}</span>
                     </button>
                   </th>
-                  <th aria-sort={getAriaSort("percent")} className="w-20 border-r bg-[#F1F3F5] px-2 py-2 text-center">
+                  <th aria-sort={getAriaSort("percent")} className="w-[50px] border-r bg-[#F1F3F5] px-1 py-1.5 text-center">
                     <button
                       type="button"
-                      className={`inline-flex w-full items-center justify-center gap-1 text-center font-medium ${
+                      className={`inline-flex w-full items-center justify-center gap-0.5 text-center font-medium leading-none ${
                         statsSortKey === "percent" ? "text-foreground" : ""
                       }`}
                       onClick={() => toggleStatsSort("percent")}
                     >
-                      <span>달성률</span>
-                      <span className="inline-block w-2 text-center">{sortIndicator("percent")}</span>
+                      <span>달성률<span className="text-[9px]">(%)</span></span>
+                      <span className="inline-block w-1.5 text-center text-[9px]">{sortIndicator("percent")}</span>
                     </button>
                   </th>
-                  <th className="w-24 bg-[#F1F3F5] px-2 py-2 text-center">추천거리(일)</th>
+                  <th className="w-[40px] bg-[#F1F3F5] px-1 py-1.5 text-center">
+                    추천<span className="text-[9px]">(km)</span>
+                  </th>
                 </tr>
               </thead>
               <tbody>
                 {sortedStatsRows.map((row) => (
                   <tr key={row.id} className="border-b last:border-b-0">
                     <td
-                      className={`sticky left-0 z-20 w-[112px] min-w-[112px] max-w-[112px] bg-[#F1F3F5] px-2 py-2 text-center after:absolute after:right-0 after:top-0 after:h-full after:w-px after:bg-border ${
+                      className={`sticky left-0 z-20 w-[60px] min-w-[60px] max-w-[60px] bg-[#F1F3F5] px-1 py-1 text-center after:absolute after:right-0 after:top-0 after:h-full after:w-px after:bg-border ${
                         row.name === myName ? "font-semibold text-primary" : ""
                       }`}
                     >
-                      <div className="inline-flex items-center justify-center gap-2">
+                      <div className="inline-flex items-center justify-center gap-1">
                         <span className="inline-flex min-w-[20px] items-center justify-center text-center">
                           {row.rank <= 3 ? (
                             <span
@@ -612,31 +626,31 @@ export function CrewProgressChart({
                               }
                               title={`${row.rank}위`}
                             >
-                              <Medal className="size-4" strokeWidth={2} />
+                              <Medal className="size-3.5" strokeWidth={2} />
                             </span>
                           ) : (
                             row.rank
                           )}
                         </span>
-                        <span className="truncate leading-none">{row.name}</span>
+                        <span className="truncate text-[10px] leading-none">{row.name}</span>
                       </div>
                     </td>
                     <td
-                      className={`border-r px-2 py-2.5 text-center whitespace-nowrap ${
+                      className={`border-r px-1 py-1.5 text-center whitespace-nowrap ${
                         statsSortKey === "goalKm" ? "bg-muted/25 font-medium" : ""
                       }`}
                     >
-                      {row.goalKm.toFixed(1)} km
+                      {row.goalKm.toFixed(1)}
                     </td>
                     <td
-                      className={`border-r px-2 py-2.5 text-center whitespace-nowrap ${
+                      className={`border-r px-1 py-1.5 text-center whitespace-nowrap ${
                         statsSortKey === "currentKm" ? "bg-muted/25 font-medium" : ""
                       }`}
                     >
-                      {row.currentKm.toFixed(1)} km
+                      {row.currentKm.toFixed(1)}
                     </td>
                     <td
-                      className={`border-r px-2 py-2.5 text-center whitespace-nowrap ${
+                      className={`border-r px-1 py-1.5 text-center whitespace-nowrap ${
                         statsSortKey === "percent" ? "font-semibold" : ""
                       } ${getPercentCellClass(row.percent)}`}
                     >
@@ -645,8 +659,8 @@ export function CrewProgressChart({
                         <span className="ml-1">🚀</span>
                       ) : null}
                     </td>
-                    <td className="px-2 py-2.5 text-center whitespace-nowrap">
-                      {row.dailyNeed === "done" ? "완료" : `${Number(row.dailyNeed).toFixed(1)} km`}
+                    <td className="px-1 py-1.5 text-center whitespace-nowrap">
+                      {row.dailyNeed === "done" ? "완료" : Number(row.dailyNeed).toFixed(1)}
                     </td>
                   </tr>
                 ))}
@@ -661,7 +675,25 @@ export function CrewProgressChart({
           className="outline-none"
         >
           {mode === "mileage" ? (
-            <LineChart data={selectedChartData}>
+            <LineChart
+              data={selectedChartData}
+              margin={{ top: 2, right: 8, left: 0, bottom: 6 }}
+            >
+            {isCurrentMonth && dayRef > 0 && (
+              <ReferenceLine
+                x={dayRef}
+                stroke="hsl(var(--primary))"
+                strokeOpacity={0.75}
+                strokeDasharray="4 4"
+                label={{
+                  value: "오늘",
+                  position: "top",
+                  fill: "hsl(var(--primary))",
+                  fontSize: 11,
+                  fontWeight: 600,
+                }}
+              />
+            )}
             {mileageTicks.map((tick) => (
               <ReferenceLine
                 key={tick}
@@ -671,10 +703,13 @@ export function CrewProgressChart({
               />
             ))}
             <XAxis
+              type="number"
               dataKey="day"
               tick={{ fontSize: 11, fill: "var(--muted-foreground)" }}
               domain={[1, totalDays]}
+              allowDataOverflow
               tickFormatter={(d: number) => `${d}일`}
+              height={24}
             />
             <YAxis
               tick={{ fontSize: 11, fill: "var(--muted-foreground)" }}

--- a/components/projects/crew-progress-chart.tsx
+++ b/components/projects/crew-progress-chart.tsx
@@ -542,10 +542,10 @@ export function CrewProgressChart({
             <table className="min-w-[310px] w-full table-fixed border-collapse text-[11px] [font-variant-numeric:tabular-nums]">
               <colgroup>
                 <col style={{ width: "60px" }} />
-                <col style={{ width: "50px" }} />
-                <col style={{ width: "50px" }} />
-                <col style={{ width: "50px" }} />
                 <col style={{ width: "40px" }} />
+                <col style={{ width: "50px" }} />
+                <col style={{ width: "55px" }} />
+                <col style={{ width: "50px" }} />
               </colgroup>
               <thead className="sticky top-0 z-30 bg-[#F1F3F5]">
                 <tr className="border-b bg-[#F1F3F5] text-[10px] text-muted-foreground">
@@ -564,7 +564,7 @@ export function CrewProgressChart({
                       <span className="inline-block w-1.5 text-center text-[9px]">{sortIndicator("rank")}</span>
                     </button>
                   </th>
-                  <th aria-sort={getAriaSort("goalKm")} className="w-[50px] border-r bg-[#F1F3F5] px-1 py-1.5 text-center">
+                  <th aria-sort={getAriaSort("goalKm")} className="w-[40px] border-r bg-[#F1F3F5] px-1 py-1.5 text-center">
                     <button
                       type="button"
                       className={`inline-flex w-full items-center justify-center gap-0.5 text-center font-medium leading-none ${
@@ -588,7 +588,7 @@ export function CrewProgressChart({
                       <span className="inline-block w-1.5 text-center text-[9px]">{sortIndicator("currentKm")}</span>
                     </button>
                   </th>
-                  <th aria-sort={getAriaSort("percent")} className="w-[50px] border-r bg-[#F1F3F5] px-1 py-1.5 text-center">
+                  <th aria-sort={getAriaSort("percent")} className="w-[55px] border-r bg-[#F1F3F5] px-1 py-1.5 text-center">
                     <button
                       type="button"
                       className={`inline-flex w-full items-center justify-center gap-0.5 text-center font-medium leading-none ${
@@ -600,7 +600,7 @@ export function CrewProgressChart({
                       <span className="inline-block w-1.5 text-center text-[9px]">{sortIndicator("percent")}</span>
                     </button>
                   </th>
-                  <th className="w-[40px] bg-[#F1F3F5] px-1 py-1.5 text-center">
+                  <th className="w-[50px] bg-[#F1F3F5] px-1 py-1.5 text-center">
                     추천<span className="text-[9px]">(km)</span>
                   </th>
                 </tr>
@@ -640,7 +640,7 @@ export function CrewProgressChart({
                         statsSortKey === "goalKm" ? "bg-muted/25 font-medium" : ""
                       }`}
                     >
-                      {row.goalKm.toFixed(1)}
+                      {row.goalKm.toFixed(0)}
                     </td>
                     <td
                       className={`border-r px-1 py-1.5 text-center whitespace-nowrap ${

--- a/components/projects/random-review-rotator.tsx
+++ b/components/projects/random-review-rotator.tsx
@@ -28,6 +28,7 @@ export function RandomReviewRotator({ lines }: RandomReviewRotatorProps) {
   const [index, setIndex] = useState(0);
   const [isAnimating, setIsAnimating] = useState(false);
   const [isPaused, setIsPaused] = useState(false);
+  const [tooltipLineId, setTooltipLineId] = useState<string | null>(null);
 
   useEffect(() => {
     setPicks(pickRandomFive(lines));
@@ -69,10 +70,16 @@ export function RandomReviewRotator({ lines }: RandomReviewRotatorProps) {
       onFocus={() => setIsPaused(true)}
       onBlur={() => setIsPaused(false)}
       onTouchStart={() => setIsPaused(true)}
-      onTouchEnd={() => setIsPaused(false)}
-      onTouchCancel={() => setIsPaused(false)}
+      onTouchEnd={() => {
+        setIsPaused(false);
+        setTooltipLineId(null);
+      }}
+      onTouchCancel={() => {
+        setIsPaused(false);
+        setTooltipLineId(null);
+      }}
     >
-      <div className="h-[44px] overflow-hidden">
+      <div className="h-[64px] overflow-hidden">
         <div
           className={
             isAnimating
@@ -84,11 +91,25 @@ export function RandomReviewRotator({ lines }: RandomReviewRotatorProps) {
           {[current, next].map((line, idx) => (
             <div
               key={`${line.id}-${idx}`}
-              className="flex h-[44px] flex-col justify-center"
+              className="flex h-[64px] flex-col justify-center"
               aria-hidden={idx === 1}
             >
-              <Caption className="line-clamp-1 text-foreground">"{line.quote}"</Caption>
-              <Caption className="line-clamp-1 text-muted-foreground">{line.meta}</Caption>
+              <div className="relative">
+                <Caption
+                  className="line-clamp-2 wrap-break-word leading-4 text-foreground"
+                  onTouchStart={() => setTooltipLineId(line.id)}
+                  onTouchEnd={() => setTooltipLineId(null)}
+                  onTouchCancel={() => setTooltipLineId(null)}
+                >
+                  "{line.quote}"
+                </Caption>
+                {tooltipLineId === line.id && (
+                  <div className="pointer-events-none absolute bottom-[calc(100%+6px)] left-0 z-20 max-w-[92%] rounded-lg border bg-popover px-2 py-1 text-xs leading-4 text-popover-foreground shadow-md">
+                    {line.quote}
+                  </div>
+                )}
+              </div>
+              <Caption className="mt-0.5 line-clamp-1 text-muted-foreground">{line.meta}</Caption>
             </div>
           ))}
         </div>

--- a/components/projects/random-review-rotator.tsx
+++ b/components/projects/random-review-rotator.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useMemo, useState } from "react";
+import { useEffect, useState } from "react";
 import { Caption } from "@/components/common/typography";
 
 export type ReviewLine = {
@@ -23,15 +23,17 @@ function pickRandomFive(lines: ReviewLine[]): ReviewLine[] {
 }
 
 export function RandomReviewRotator({ lines }: RandomReviewRotatorProps) {
-  const picks = useMemo(() => pickRandomFive(lines), [lines]);
+  // SSR/CSR 첫 렌더를 동일하게 맞추기 위해 초기값은 고정 순서로 자른다.
+  const [picks, setPicks] = useState<ReviewLine[]>(() => lines.slice(0, 5));
   const [index, setIndex] = useState(0);
   const [isAnimating, setIsAnimating] = useState(false);
   const [isPaused, setIsPaused] = useState(false);
 
   useEffect(() => {
+    setPicks(pickRandomFive(lines));
     setIndex(0);
     setIsAnimating(false);
-  }, [picks]);
+  }, [lines]);
 
   useEffect(() => {
     if (picks.length <= 1 || isPaused) return;

--- a/components/projects/random-review-rotator.tsx
+++ b/components/projects/random-review-rotator.tsx
@@ -28,7 +28,7 @@ export function RandomReviewRotator({ lines }: RandomReviewRotatorProps) {
   const [index, setIndex] = useState(0);
   const [isAnimating, setIsAnimating] = useState(false);
   const [isPaused, setIsPaused] = useState(false);
-  const [tooltipLineId, setTooltipLineId] = useState<string | null>(null);
+  const [tooltipText, setTooltipText] = useState<string | null>(null);
 
   useEffect(() => {
     setPicks(pickRandomFive(lines));
@@ -61,7 +61,7 @@ export function RandomReviewRotator({ lines }: RandomReviewRotatorProps) {
 
   return (
     <div
-      className="rounded-2xl bg-muted px-4 py-3"
+      className="relative rounded-2xl bg-muted px-4 py-3"
       role="status"
       aria-live="polite"
       aria-atomic="true"
@@ -72,13 +72,18 @@ export function RandomReviewRotator({ lines }: RandomReviewRotatorProps) {
       onTouchStart={() => setIsPaused(true)}
       onTouchEnd={() => {
         setIsPaused(false);
-        setTooltipLineId(null);
+        setTooltipText(null);
       }}
       onTouchCancel={() => {
         setIsPaused(false);
-        setTooltipLineId(null);
+        setTooltipText(null);
       }}
     >
+      {tooltipText && (
+        <div className="pointer-events-none absolute bottom-[calc(100%+6px)] left-4 right-4 z-20 rounded-lg border bg-popover px-2 py-1 text-xs leading-4 text-popover-foreground shadow-md">
+          {tooltipText}
+        </div>
+      )}
       <div className="h-[64px] overflow-hidden">
         <div
           className={
@@ -94,21 +99,14 @@ export function RandomReviewRotator({ lines }: RandomReviewRotatorProps) {
               className="flex h-[64px] flex-col justify-center"
               aria-hidden={idx === 1}
             >
-              <div className="relative">
-                <Caption
-                  className="line-clamp-2 wrap-break-word leading-4 text-foreground"
-                  onTouchStart={() => setTooltipLineId(line.id)}
-                  onTouchEnd={() => setTooltipLineId(null)}
-                  onTouchCancel={() => setTooltipLineId(null)}
-                >
-                  "{line.quote}"
-                </Caption>
-                {tooltipLineId === line.id && (
-                  <div className="pointer-events-none absolute bottom-[calc(100%+6px)] left-0 z-20 max-w-[92%] rounded-lg border bg-popover px-2 py-1 text-xs leading-4 text-popover-foreground shadow-md">
-                    {line.quote}
-                  </div>
-                )}
-              </div>
+              <Caption
+                className="line-clamp-2 wrap-break-word leading-4 text-foreground"
+                onTouchStart={() => setTooltipText(line.quote)}
+                onTouchEnd={() => setTooltipText(null)}
+                onTouchCancel={() => setTooltipText(null)}
+              >
+                "{line.quote}"
+              </Caption>
               <Caption className="mt-0.5 line-clamp-1 text-muted-foreground">{line.meta}</Caption>
             </div>
           ))}

--- a/components/projects/random-review.tsx
+++ b/components/projects/random-review.tsx
@@ -1,5 +1,5 @@
 import { createAdminClient } from "@/lib/supabase/admin";
-import { todayKST } from "@/lib/dayjs";
+import { formatKoreanShortDate, todayKST } from "@/lib/dayjs";
 import dayjs from "dayjs";
 import { type MileageSport } from "@/lib/mileage";
 import { RandomReviewRotator, type ReviewLine } from "@/components/projects/random-review-rotator";
@@ -44,10 +44,11 @@ export async function RandomReview({ evtId }: RandomReviewProps) {
       const dist = Number(item.dst_km);
       const safeDist = Number.isFinite(dist) ? dist : 0;
       const formattedDist = safeDist % 1 === 0 ? safeDist : safeDist.toFixed(1);
+      const actDate = formatKoreanShortDate(item.act_dt);
       return {
         id: item.act_id,
         quote,
-        meta: `${name} · ${sportEmoji} ${formattedDist}km`,
+        meta: `${name} · ${sportEmoji} ${formattedDist}km · ${actDate}`,
       };
     })
     .filter((line): line is ReviewLine => line !== null);

--- a/components/projects/refund-status.tsx
+++ b/components/projects/refund-status.tsx
@@ -6,7 +6,6 @@ import {
   DEPOSIT_PER_MONTH,
   ENTRY_FEE_WITH_SINGLET,
 } from "@/lib/mileage";
-import { StatCard } from "@/components/common/stat-card";
 import {
   getEventParticipants,
   getEventGoalsCumulative,
@@ -40,9 +39,15 @@ export async function RefundStatus({
   const participants = allParticipants;
   if (participants.length === 0) {
     return (
-      <div className="grid grid-cols-2 gap-3">
-        <StatCard value="₩0" label="환급 예정금" />
-        <StatCard value="₩0" label="회식비 상한" />
+      <div className="grid grid-cols-2 gap-x-4 gap-y-3 rounded-2xl bg-muted/35 px-4 py-3">
+        <div className="space-y-0.5">
+          <p className="text-[11px] text-muted-foreground">환급 예정</p>
+          <p className="text-2xl leading-tight font-bold text-foreground">₩0</p>
+        </div>
+        <div className="space-y-0.5">
+          <p className="text-[11px] text-muted-foreground">회식비 지원</p>
+          <p className="text-2xl leading-tight font-bold text-foreground">₩0</p>
+        </div>
       </div>
     );
   }
@@ -120,15 +125,19 @@ export async function RefundStatus({
       : 0;
 
   return (
-    <div className="grid grid-cols-2 gap-3">
-      <StatCard
-        value={`₩${Math.floor(myRefund).toLocaleString()}`}
-        label="환급 예정금"
-      />
-      <StatCard
-        value={`₩${myPartyBudget.toLocaleString()}`}
-        label="회식비 지원금(예상)"
-      />
+    <div className="grid grid-cols-2 gap-x-4 gap-y-3 rounded-2xl bg-muted/35 px-4 py-3">
+      <div className="space-y-0.5">
+        <p className="text-[11px] text-muted-foreground">환급 예정</p>
+        <p className="text-2xl leading-tight font-bold text-foreground">
+          {`₩${Math.floor(myRefund).toLocaleString()}`}
+        </p>
+      </div>
+      <div className="space-y-0.5">
+        <p className="text-[11px] text-muted-foreground">회식비 지원</p>
+        <p className="text-2xl leading-tight font-bold text-foreground">
+          {`₩${myPartyBudget.toLocaleString()}`}
+        </p>
+      </div>
     </div>
   );
 }


### PR DESCRIPTION
## Summary

- 프로젝트 화면 모바일 레이아웃을 재정렬해 핵심 정보 접근성을 개선했습니다.
  - 차트 직후 `내 상태` 노출
  - 상단 타이틀/월 네비 한 줄 정렬
  - 제목-탭 사이 여백 축소
- 크루 진행 차트의 시각적 정확성과 모바일 가독성을 개선했습니다.
  - 현재월 마일리지 라인: 오늘 이후 구간 미표시
  - `오늘` 기준 세로 가이드 라인 추가
  - 통계 표를 `table-fixed + colgroup` 기반으로 재구성하고 모바일 컬럼 폭을 세밀 조정
  - 목표값은 정수로 표기
- 통계/환급 영역 UI를 카드 중심에서 압축형 정보 레이아웃으로 정리했습니다.
- 한마디(랜덤 후기) 영역의 안정성과 정보 밀도를 개선했습니다.
  - hydration mismatch 원인 제거
  - 후기 텍스트 2줄 클램프 + 모바일 터치 시 전체 문구 툴팁
  - 메타 정보에 날짜 추가 (`이름 · 종목 · 거리 · 날짜`)
- 기록 입력 날짜 필드의 모바일 동작을 보완했습니다.
  - 날짜 아이콘 동작/가시성 관련 스타일 정리
  - 날짜 텍스트 겹침 완화(padding 조정)

## AS-IS

- 모바일에서 프로젝트 화면의 정보 밀도가 낮고, 핵심 정보 접근 순서가 분산되어 있었습니다.
- 크루 통계 표는 컬럼 폭/패딩이 커서 한 화면에 보이는 정보량이 제한되었습니다.
- 한마디 롤링은 서버/클라이언트 초기 렌더 차이로 hydration mismatch가 발생할 수 있었습니다.
- 일부 모바일 환경에서 날짜 입력 UI 가시성이 떨어졌습니다.

## TO-BE

- 모바일 기준 정보 우선순위를 재배치해 핵심 상태를 빠르게 확인할 수 있습니다.
- 통계 표가 고정 폭 기반으로 압축되어 작은 화면에서도 더 많은 데이터 확인이 가능합니다.
- 한마디 영역이 hydration-safe하게 동작하며, 긴 텍스트도 모바일에서 확인 가능합니다.
- 날짜 입력의 모바일 표시/조작 안정성이 개선되었습니다.

## Test Plan

- [ ] `/projects` 진입 시 타이틀/월네비가 한 줄로 유지되는지 확인
- [

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **신규 기능**
  * 리뷰에 터치 기반 툴팁 지원 추가
  * 리뷰 항목에 활동 날짜 표시 추가

* **버그 수정**
  * 차트에서 미래 날짜 데이터 표시 문제 개선

* **스타일**
  * UI 레이아웃 및 여백 최적화
  * 통계 테이블 디자인 개선 및 컴팩트화
  * 차트 마진 및 표시 영역 조정

<!-- end of auto-generated comment: release notes by coderabbit.ai -->