### PR TITLE
feat: Supabase auto-pause 방지 Vercel Cron 추가

### DIFF
--- a/app/api/cron/keep-alive/route.ts
+++ b/app/api/cron/keep-alive/route.ts
@@ -1,0 +1,18 @@
+import { NextResponse } from "next/server";
+import { createClient } from "@supabase/supabase-js";
+import { env } from "@/lib/env";
+
+export async function GET() {
+  const supabase = createClient(
+    env.NEXT_PUBLIC_SUPABASE_URL,
+    env.NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY
+  );
+
+  const { error } = await supabase.from("members").select("id").limit(1);
+
+  if (error) {
+    return NextResponse.json({ ok: false, error: error.message }, { status: 500 });
+  }
+
+  return NextResponse.json({ ok: true, timestamp: new Date().toISOString() });
+}

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,8 @@
+{
+  "crons": [
+    {
+      "path": "/api/cron/keep-alive",
+      "schedule": "0 0 */5 * *"
+    }
+  ]
+}


### PR DESCRIPTION
## 관련 이슈

관련 이슈 없음

## 요약

Supabase Free 플랜의 7일 비활성 자동 pause를 방지하기 위해 Vercel Cron Job을 추가합니다.

## AS-IS (변경 전)

- Supabase 프로덕션 프로젝트에 7일간 요청이 없으면 자동으로 pause 됨
- pause 후 resume 시 cold start로 인해 쿼리 타임아웃(`statement timeout`) 연쇄 발생
- 서비스 일시 중단 위험

## TO-BE (변경 후)

- Vercel Cron이 **5일마다** `/api/cron/keep-alive` 엔드포인트를 호출
- `members` 테이블에 간단한 `select` 쿼리를 실행하여 Supabase 활성 상태 유지
- 자동 pause 방지로 서비스 안정성 확보

## 주요 변경 사항

- `app/api/cron/keep-alive/route.ts` — Supabase ping API route 신규 생성
- `vercel.json` — Vercel Cron 스케줄 설정 (`0 0 */5 * *`)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 새로운 API 엔드포인트 추가
  * 정기 실행 작업 일정 설정 추가

<!-- end of auto-generated comment: release notes by coderabbit.ai -->