### PR TITLE
fix(projects): 마일리지런 차트/오늘한마디/날짜입력 모바일 이슈 정리

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -130,4 +130,21 @@
     display: none;
     -webkit-appearance: none;
   }
+
+  /* 모바일 브라우저별 date input 크기 편차 축소 */
+  .date-stable {
+    font-size: 16px;
+    line-height: 1.25rem;
+    font-variant-numeric: tabular-nums;
+  }
+  .date-stable::-webkit-datetime-edit,
+  .date-stable::-webkit-datetime-edit-fields-wrapper,
+  .date-stable::-webkit-date-and-time-value {
+    padding: 0;
+    line-height: 1.25rem;
+  }
+  .date-stable::-webkit-calendar-picker-indicator {
+    margin: 0;
+    padding: 0;
+  }
 }

--- a/app/globals.css
+++ b/app/globals.css
@@ -125,12 +125,6 @@
     text-align: left;
   }
 
-  /* 특정 date input에서 기본 달력 아이콘 숨김 */
-  .date-no-icon::-webkit-calendar-picker-indicator {
-    display: none;
-    -webkit-appearance: none;
-  }
-
   /* 모바일 브라우저별 date input 크기 편차 축소 */
   .date-stable {
     font-size: 16px;

--- a/components/projects/activity-log-batch-form.tsx
+++ b/components/projects/activity-log-batch-form.tsx
@@ -218,7 +218,7 @@ export function ActivityLogBatchForm({ evtId, onSuccess }: ActivityLogBatchFormP
                   max={today}
                   value={d.act_dt}
                   onChange={(e) => updateDraft(d.id, { act_dt: e.target.value })}
-                  className="date-no-icon h-10 rounded-lg border pr-3 text-sm"
+                  className="date-stable h-10 rounded-lg border pr-3"
                 />
               </div>
 

--- a/components/projects/activity-log-form.tsx
+++ b/components/projects/activity-log-form.tsx
@@ -191,7 +191,7 @@ export function ActivityLogForm({
           id="act_dt"
           type="date"
           max={today}
-          className="date-no-icon h-12 rounded-xl border-[1.5px] pr-3 text-[15px]"
+          className="date-stable h-12 rounded-xl border-[1.5px] pr-3"
           {...register("act_dt")}
         />
         {errors.act_dt && (

--- a/components/projects/crew-progress-chart.tsx
+++ b/components/projects/crew-progress-chart.tsx
@@ -63,7 +63,12 @@ type ChartTooltipProps = TooltipContentProps<TooltipValueType, string | number> 
 function ChartTooltip({ active, payload, label, myName, mode }: ChartTooltipProps) {
   if (!active || !payload?.length) return null;
 
-  const sorted = [...payload].sort((a, b) => {
+  const finiteEntries = payload.filter((entry) =>
+    Number.isFinite(typeof entry.value === "number" ? entry.value : Number(entry.value)),
+  );
+  if (finiteEntries.length === 0) return null;
+
+  const sorted = [...finiteEntries].sort((a, b) => {
     const va = typeof a.value === "number" ? a.value : 0;
     const vb = typeof b.value === "number" ? b.value : 0;
     return vb - va;
@@ -729,12 +734,6 @@ export function CrewProgressChart({
                 stroke="var(--muted-foreground)"
                 strokeDasharray="6 4"
                 strokeWidth={1.5}
-                label={{
-                  value: `목표 ${myGoalKm}`,
-                  position: "right",
-                  fontSize: 10,
-                  fill: "var(--muted-foreground)",
-                }}
               />
             )}
             {selectedMembers.map((item) => (

--- a/components/projects/crew-progress-chart.tsx
+++ b/components/projects/crew-progress-chart.tsx
@@ -69,8 +69,8 @@ function ChartTooltip({ active, payload, label, myName, mode }: ChartTooltipProp
   if (finiteEntries.length === 0) return null;
 
   const sorted = [...finiteEntries].sort((a, b) => {
-    const va = typeof a.value === "number" ? a.value : 0;
-    const vb = typeof b.value === "number" ? b.value : 0;
+    const va = Number(a.value);
+    const vb = Number(b.value);
     return vb - va;
   });
 

--- a/components/projects/random-review-rotator.tsx
+++ b/components/projects/random-review-rotator.tsx
@@ -13,25 +13,32 @@ type RandomReviewRotatorProps = {
   lines: ReviewLine[];
 };
 
-function pickRandomFive(lines: ReviewLine[]): ReviewLine[] {
+function getPickCount(total: number): number {
+  if (total >= 100) return Math.max(10, Math.floor(total * 0.1));
+  return Math.min(10, total);
+}
+
+function pickRandomLines(lines: ReviewLine[]): ReviewLine[] {
   const shuffled = [...lines];
   for (let i = shuffled.length - 1; i > 0; i--) {
     const j = Math.floor(Math.random() * (i + 1));
     [shuffled[i], shuffled[j]] = [shuffled[j]!, shuffled[i]!];
   }
-  return shuffled.slice(0, 5);
+  return shuffled.slice(0, getPickCount(shuffled.length));
 }
 
 export function RandomReviewRotator({ lines }: RandomReviewRotatorProps) {
   // SSR/CSR 첫 렌더를 동일하게 맞추기 위해 초기값은 고정 순서로 자른다.
-  const [picks, setPicks] = useState<ReviewLine[]>(() => lines.slice(0, 5));
+  const [picks, setPicks] = useState<ReviewLine[]>(() =>
+    lines.slice(0, getPickCount(lines.length)),
+  );
   const [index, setIndex] = useState(0);
   const [isAnimating, setIsAnimating] = useState(false);
   const [isPaused, setIsPaused] = useState(false);
   const [tooltipText, setTooltipText] = useState<string | null>(null);
 
   useEffect(() => {
-    setPicks(pickRandomFive(lines));
+    setPicks(pickRandomLines(lines));
     setIndex(0);
     setIsAnimating(false);
   }, [lines]);
@@ -61,7 +68,7 @@ export function RandomReviewRotator({ lines }: RandomReviewRotatorProps) {
 
   return (
     <div
-      className="relative rounded-2xl bg-muted px-4 py-3"
+      className="relative rounded-2xl bg-muted px-4 py-3 select-none"
       role="status"
       aria-live="polite"
       aria-atomic="true"
@@ -77,6 +84,12 @@ export function RandomReviewRotator({ lines }: RandomReviewRotatorProps) {
       onTouchCancel={() => {
         setIsPaused(false);
         setTooltipText(null);
+      }}
+      onContextMenu={(event) => event.preventDefault()}
+      style={{
+        WebkitTouchCallout: "none",
+        WebkitUserSelect: "none",
+        userSelect: "none",
       }}
     >
       {tooltipText && (
@@ -101,7 +114,10 @@ export function RandomReviewRotator({ lines }: RandomReviewRotatorProps) {
             >
               <Caption
                 className="line-clamp-2 wrap-break-word leading-4 text-foreground"
-                onTouchStart={() => setTooltipText(line.quote)}
+                onTouchStart={(event) => {
+                  event.preventDefault();
+                  setTooltipText(line.quote);
+                }}
                 onTouchEnd={() => setTooltipText(null)}
                 onTouchCancel={() => setTooltipText(null)}
               >


### PR DESCRIPTION
## 배경
마일리지런 화면에서 모바일 사용성 관련 자잘한 이슈가 누적되어 있어, 차트 표시와 오늘한마디/입력 폼 동작을 함께 정리했습니다.

## AS-IS
- 진행 차트 우측 `목표` 라벨이 잘려 보이며 의미가 불명확함
- 현재일 이후 구간 툴팁에 `NaN km`가 노출됨
- 오늘한마디 노출 샘플이 고정 5건이라 데이터가 많아도 다양성이 낮음
- 오늘한마디 롱프레스 시 모바일 텍스트 선택/복사 UI가 떠서 툴팁이 끊김
- iOS/Android에서 `date` input 렌더링 편차로 날짜 필드 크기 체감이 다름
- 날짜 입력 기본 캘린더 아이콘을 숨긴 상태라 접근성이 떨어짐

## TO-BE
- 차트 목표선은 유지하고 우측 `목표` 텍스트 라벨은 제거
- 툴팁 렌더링 시 유효 숫자만 표시하여 미래 구간 `NaN` 노출 제거
- 오늘한마디 샘플 개수 로직 개선
  - 기본: 최대 10건
  - 최근 일주일 100건 이상: 전체의 10% (최소 10건)
- 오늘한마디 영역에서 텍스트 선택/컨텍스트 메뉴를 방지해 롱프레스 툴팁 유지
- `date-stable` 스타일 추가로 모바일 브라우저별 date input 높이/타이포 편차 축소
- `date-no-icon` 제거로 기본 캘린더 아이콘 복구

## 주요 변경 파일
- `components/projects/crew-progress-chart.tsx`
- `components/projects/random-review-rotator.tsx`
- `components/projects/activity-log-batch-form.tsx`
- `components/projects/activity-log-form.tsx`
- `app/globals.css`

## 테스트 체크리스트
- [ ] 마일리지 차트에서 목표선은 보이고, 우측 `목

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **버그 수정**
  * 모바일 브라우저 간 날짜 입력 필드의 렌더링 일관성 개선
  * 툴팁이 비숫자 데이터를 올바르게 처리하도록 수정
  * 차트 목표 레이블 정리

* **기능 개선**
  * 데이터 크기에 따라 동적으로 선택 항목 수 조정
  * 사용자 상호작용 제어 강화 (비선택 모드, 컨텍스트 메뉴 비활성화)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->