### PR TITLE
fix(projects): join-section 중복 컴포넌트 정의 제거

### DIFF
--- a/components/projects/join-section.tsx
+++ b/components/projects/join-section.tsx
@@ -55,43 +55,6 @@ function AccountCopyButton() {
   );
 }
 
-const MEETING_ACCOUNT = {
-  bank: "카카오뱅크",
-  number: "3333096788223",
-  displayNumber: "3333-09-6788223",
-};
-
-function AccountCopyButton() {
-  const [copied, setCopied] = useState(false);
-
-  async function handleCopy() {
-    try {
-      await navigator.clipboard.writeText(MEETING_ACCOUNT.number);
-      setCopied(true);
-      setTimeout(() => setCopied(false), 1500);
-    } catch {
-      alert("복사에 실패했습니다.");
-    }
-  }
-
-  return (
-    <button
-      type="button"
-      onClick={handleCopy}
-      className="flex w-full items-center justify-center gap-2 rounded-lg border border-border bg-background px-3 py-2.5 text-sm font-medium text-foreground transition-colors hover:bg-accent"
-    >
-      <span>
-        {MEETING_ACCOUNT.bank} {MEETING_ACCOUNT.displayNumber}
-      </span>
-      {copied ? (
-        <Check className="size-4 text-green-600" />
-      ) : (
-        <Copy className="size-4 text-muted-foreground" />
-      )}
-    </button>
-  );
-}
-
 type JoinSectionProps = {
 	evtId: string;
 	evtStartMonth: string; // "2026-05-01"


### PR DESCRIPTION
## 관련 이슈

관련 이슈 없음

## 요약

`components/projects/join-section.tsx`에 `MEETING_ACCOUNT` 상수와 `AccountCopyButton` 컴포넌트가 동일하게 두 번 정의되어 있던 것을 제거합니다.

## AS-IS (변경 전)

- `MEETING_ACCOUNT` 상수와 `AccountCopyButton` 컴포넌트가 파일 내에 중복으로 두 번 선언되어 있었음
- 첫 번째 선언은 불필요한 중복으로, 동일한 내용이 아래에 또 정의됨

## TO-BE (변경 후)

- 중복된 첫 번째 `MEETING_ACCOUNT` + `AccountCopyButton` 선언 제거
- 파일 하단의 단일 정의만 유지