### PR TITLE
fix(projects): 프로젝트 탭 차트 가독성/상호작용 후속 개선

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -175,17 +175,22 @@
 
   /* 모바일 브라우저별 date input 크기 편차 축소 */
   .date-stable {
-    font-size: 16px;
+    position: relative;
+    font-size: 14px;
     line-height: 1.25rem;
     font-variant-numeric: tabular-nums;
+    padding-right: 1.75rem;
   }
   .date-stable::-webkit-datetime-edit,
   .date-stable::-webkit-datetime-edit-fields-wrapper,
   .date-stable::-webkit-date-and-time-value {
+    font-size: 14px;
     padding: 0;
     line-height: 1.25rem;
   }
   .date-stable::-webkit-calendar-picker-indicator {
+    position: absolute;
+    right: 0.5rem;
     margin: 0;
     padding: 0;
   }

--- a/components/projects/crew-progress-chart.tsx
+++ b/components/projects/crew-progress-chart.tsx
@@ -718,7 +718,7 @@ export function CrewProgressChart({
             />
             <YAxis
               tick={{ fontSize: 11, fill: "var(--muted-foreground)" }}
-              tickFormatter={(v: number) => `${v}`}
+              tickFormatter={(v: number) => `${Math.round(v)}`}
               width={36}
               ticks={mileageTicks}
               domain={[0, mileageYAxisMax]}

--- a/components/projects/crew-progress-chart.tsx
+++ b/components/projects/crew-progress-chart.tsx
@@ -728,14 +728,6 @@ export function CrewProgressChart({
                 <ChartTooltip {...props} myName={myName} mode={mode} />
               )}
             />
-            {myGoalKm > 0 && (
-              <ReferenceLine
-                y={myGoalKm}
-                stroke="var(--muted-foreground)"
-                strokeDasharray="6 4"
-                strokeWidth={1.5}
-              />
-            )}
             {selectedMembers.map((item) => (
               <Line
                 key={item.member.id}
@@ -781,12 +773,6 @@ export function CrewProgressChart({
               domain={[0, 100]}
             />
             <Tooltip content={<PercentBarTooltip myName={myName} />} />
-            <ReferenceLine
-              y={100}
-              stroke="var(--muted-foreground)"
-              strokeDasharray="6 4"
-              strokeWidth={1.5}
-            />
             <Bar dataKey="barPercent" radius={[6, 6, 0, 0]}>
               {memberPercentData.map((item) => (
                 <Cell

--- a/components/projects/crew-progress-chart.tsx
+++ b/components/projects/crew-progress-chart.tsx
@@ -772,8 +772,8 @@ export function CrewProgressChart({
               ticks={percentTicks}
               domain={[0, 100]}
             />
-            <Tooltip content={<PercentBarTooltip myName={myName} />} />
-            <Bar dataKey="barPercent" radius={[6, 6, 0, 0]}>
+            <Tooltip cursor={false} content={<PercentBarTooltip myName={myName} />} />
+            <Bar dataKey="barPercent" radius={[6, 6, 0, 0]} activeBar={false}>
               {memberPercentData.map((item) => (
                 <Cell
                   key={item.memId}

--- a/lib/projects/crew-progress-chart.ts
+++ b/lib/projects/crew-progress-chart.ts
@@ -29,7 +29,7 @@ export const ROLE_COLORS = {
   me: "#0064DC",
   top: ["#B91414", "#FF4600", "#FF7300"] as const,
   bottom: ["#46AAC8", "#7864E6", "#8C32DC"] as const,
-  near: ["#E6C74A", "#AADC00", "#228B22", "#82D2B4"] as const,
+  near: ["#E6C74A", "#AADC00", "#228B22", "#82D2B4", "#785046"] as const,
 };
 
 export function round1(value: number): number {
@@ -176,12 +176,19 @@ export function buildRoleColorMap(
       colorMap.set(item.member.id, ROLE_COLORS.bottom[idx % ROLE_COLORS.bottom.length]!);
     }
   });
-  near.forEach((item, idx) => {
+  let nearAssignedCount = 0;
+  let nearColorIdx = 0;
+  near.forEach((item) => {
     if (item.member.id !== meId && !colorMap.has(item.member.id)) {
-      colorMap.set(item.member.id, ROLE_COLORS.near[idx % ROLE_COLORS.near.length]!);
+      colorMap.set(
+        item.member.id,
+        ROLE_COLORS.near[nearColorIdx % ROLE_COLORS.near.length]!,
+      );
+      nearColorIdx += 1;
+      nearAssignedCount += 1;
     }
   });
-  let fallbackIdx = 0;
+  let fallbackIdx = nearAssignedCount;
   for (const item of selected) {
     if (!colorMap.has(item.member.id)) {
       colorMap.set(item.member.id, ROLE_COLORS.near[fallbackIdx % ROLE_COLORS.near.length]!);


### PR DESCRIPTION
## 배경
프로젝트 탭(마일리지런) 차트에서 가독성과 터치 상호작용 관련 자잘한 불편이 있어 후속 개선을 진행했습니다.

## 변경 사항

- 마일리지 차트 Y축 눈금을 소수점 대신 반올림 정수로 표시
- 마일리지/달성률 차트의 진한 기준 점선 제거
- 달성률 차트에서 막대 선택 시 나타나던 활성 하이라이트(회색 cursor 배경/active bar 강조) 제거
- 크루 차트 색상 배정 로직 보정
  - near 색상 순환 시 실제 할당 순서 기준으로 인덱스를 증가
  - fallback 시작점을 near 할당 수와 맞춰 기본 near 팔레트가 먼저 소진되도록 조정
  - near 팔레트에 예비 갈색(`#785046`) 추가
- 날짜 입력 필드 가독성 조정
  - date input 폰트 크기/아이콘 정렬 관련 스타일 보정

## 커밋 목록
- `d6fc759` fix(projects): 마일리지 차트 Y축 눈금 정수 표기
- `d039ce2` fix(projects): 차트 기준선 제거 및 날짜 입력 가독성 조정
- `b7a528f` fix(projects): 크루 차트 near 색상 순환 로직 보정
- `67f50bc` fix(projects): 달성률 차트 활성 하이라이트 표시 제거

## 테스트 체크리스트
- [ ] 마일리지 차트 좌측 Y축 눈금이 정수로 표시된다
- [ ] 마일리지/달성률 차트에서 진한 기준 점선이 보이지 않는다
- [ ] 달성률 막대 터치/클릭 시 회색 활성 배경 없이 툴팁만 노출된다
- [ ] 크루 차트에서 near/fallback 색상 순환이 의도대로 동작한다
- [ ] 모바일(iOS/Android) 날짜 입력 표시가 기존 대비 가독성이 개선되었다