### PR TITLE
fix(projects): 참여/로그인/기록입력 UX 문제 일괄 개선

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -194,4 +194,15 @@
     margin: 0;
     padding: 0;
   }
+
+  input[type="date"].date-stable-xs {
+    font-size: 12px !important;
+    line-height: 1rem !important;
+  }
+  input[type="date"].date-stable-xs::-webkit-datetime-edit,
+  input[type="date"].date-stable-xs::-webkit-datetime-edit-fields-wrapper,
+  input[type="date"].date-stable-xs::-webkit-date-and-time-value {
+    font-size: 12px !important;
+    line-height: 1rem !important;
+  }
 }

--- a/components/auth/dev-email-login.tsx
+++ b/components/auth/dev-email-login.tsx
@@ -44,6 +44,10 @@ export function DevEmailLogin({
 	const handleSubmit = async (e: React.FormEvent) => {
 		e.preventDefault();
 		setError(null);
+		if (!email.trim() || !password) {
+			setError("이메일과 비밀번호를 입력해 주세요.");
+			return;
+		}
 		setBusy(true);
 		try {
 			const supabase = createClient();
@@ -105,7 +109,7 @@ export function DevEmailLogin({
 					type="submit"
 					variant="secondary"
 					className="h-10 w-full"
-					disabled={busy || oauthBusy || !email.trim() || !password}
+					disabled={busy || oauthBusy}
 				>
 					{busy ? "로그인 중..." : "이메일로 로그인"}
 				</Button>

--- a/components/projects/activity-log-batch-form.tsx
+++ b/components/projects/activity-log-batch-form.tsx
@@ -218,7 +218,7 @@ export function ActivityLogBatchForm({ evtId, onSuccess }: ActivityLogBatchFormP
                   max={today}
                   value={d.act_dt}
                   onChange={(e) => updateDraft(d.id, { act_dt: e.target.value })}
-                  className="date-stable h-10 rounded-lg border pr-3"
+                  className="date-stable date-stable-xs h-10 rounded-lg border pr-3"
                 />
               </div>
 

--- a/components/projects/join-section.tsx
+++ b/components/projects/join-section.tsx
@@ -227,14 +227,6 @@ export function JoinSection({
         <AccountCopyButton />
       </div>
 
-      {/* 모임 계좌 안내 */}
-      <div className="rounded-xl bg-muted p-4 space-y-3 text-center">
-        <Caption className="text-foreground font-semibold block">
-          모임 계좌로 참가비를 입금하셔야 합니다
-        </Caption>
-        <AccountCopyButton />
-      </div>
-
       {/* 참여하기 버튼 */}
       <Button
         onClick={handleJoin}


### PR DESCRIPTION
관련 이슈: 관련 이슈 없음
요약
참여 신청 화면에서 모임 계좌 안내 중복 노출 제거
로컬 개발용 이메일 로그인 버튼 비활성 조건 완화 및 빈 입력 안내 추가
일괄 기록 입력 날짜 필드 폰트를 12px로 조정
AS-IS (변경 전)
참여 화면에서 계좌 안내/계좌번호가 중복 노출됨
개발용 이메일 로그인 버튼이 입력 전 비활성이라 동작 오해 가능
일괄 기록 입력의 날짜 폰트가 요구 사이즈보다 크게 표시됨
TO-BE (변경 후)
계좌 안내는 1회만 노출
이메일 로그인 버튼은 로딩/소셜 처리 중에만 비활성, 빈 값은 제출 시 에러 메시지 안내
일괄 기록 입력 날짜 입력 UI에 12px 전용 스타일 적용

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **버그 수정**
  * 이메일과 비밀번호 입력 검증이 강화되었습니다.
  * 참가비 입금 안내 섹션이 제거되었습니다.

* **스타일**
  * 날짜 입력 필드의 표시가 개선되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->