### PR TITLE
fix(projects): 일괄 기록 폼에서 iOS date input 셀 오버플로우 수정

### DIFF
--- a/components/projects/activity-log-batch-form.tsx
+++ b/components/projects/activity-log-batch-form.tsx
@@ -210,7 +210,7 @@ export function ActivityLogBatchForm({ evtId, onSuccess }: ActivityLogBatchFormP
 
             {isExpanded && (
               <>
-                <div className="grid grid-cols-2 gap-2">
+                <div className="grid grid-cols-2 gap-2 [&>*]:min-w-0">
               <div className="flex flex-col gap-1">
                 <Label className="text-xs">날짜</Label>
                 <Input


### PR DESCRIPTION
## 관련 이슈

관련 이슈 없음 (핫픽스)

## 요약

iOS Safari에서 마일리지 일괄 기록 입력 폼의 **날짜** 입력칸이 옆 **종목** 셀렉트 위로 밀려 겹쳐 보이는 시각 버그를 수정한다.

## AS-IS (변경 전)

`components/projects/activity-log-batch-form.tsx`의 입력 영역은 `grid grid-cols-2`로 4개 필드(날짜·종목·거리·상승고도)를 2열 배치한다.

- iOS Safari `<input type="date">`는 내부 datetime-edit 위젯과 picker indicator로 인해 **intrinsic min-content 폭이 큼**
- CSS Grid item은 기본 `min-width: auto`라서 자식의 intrinsic 폭만큼 셀이 확장됨
- 결과: 날짜 셀이 50% 너비를 넘어가 우측 **종목** 셀렉트 위로 겹침
- `globals.css`의 `.date-stable-xs`로 폰트를 12px까지 줄여놨음에도 iOS에서는 부족

## TO-BE (변경 후)

grid 컨테이너에 `[&>*]:min-w-0` 한 줄 추가.

- 모든 grid item이 `min-width: 0`을 적용받아 셀 너비를 강제로 유지
- `Input`의 `w-full`이 셀 너비 안으로 정상 압축되어 오버플로우 사라짐
- 레이아웃(2-col)은 그대로, 마크업 변경 없음

```diff
- <div className="grid grid-cols-2 gap-2">
+ <div className="grid grid-cols-2 gap-2 [&>*]:min-w-0">
```

## 주요 변경 사항

- `components/projects/activity-log-batch-form.tsx:213` — grid 컨테이너에 `[&>*]:min-w-0` 추가 (1줄)

## 영향 범위

- 변경 대상: 일괄 기록 입력 폼만 (단건 폼은 이미 모든 필드 세로 배치라 영향 없음)
- 동작 변경 없음, 순수 CSS 수정