### PR TITLE
fix(projects): iOS Safari 기록입력 날짜 input overflow 수정

### DIFF
--- a/components/projects/activity-log-batch-form.tsx
+++ b/components/projects/activity-log-batch-form.tsx
@@ -210,67 +210,83 @@ export function ActivityLogBatchForm({ evtId, onSuccess }: ActivityLogBatchFormP
 
             {isExpanded && (
               <>
-                <div className="grid grid-cols-2 gap-2">
-              <div className="flex flex-col gap-1">
-                <Label className="text-xs">날짜</Label>
-                <Input
-                  type="date"
-                  max={today}
-                  value={d.act_dt}
-                  onChange={(e) => updateDraft(d.id, { act_dt: e.target.value })}
-                  className="date-stable date-stable-xs h-10 rounded-lg border pr-3"
-                />
+                <div className="flex flex-col gap-2">
+              <div className="grid grid-cols-2 gap-2">
+                <div className="flex flex-col gap-1">
+                  <Label className="text-xs">날짜</Label>
+                  <Input
+                    type="text"
+                    readOnly
+                    value={d.act_dt}
+                    onClick={(e) => {
+                      const hidden = (e.target as HTMLElement).nextElementSibling as HTMLInputElement;
+                      hidden?.showPicker?.();
+                      hidden?.focus();
+                    }}
+                    className="h-10 cursor-pointer rounded-lg border text-sm"
+                  />
+                  <input
+                    type="date"
+                    max={today}
+                    value={d.act_dt}
+                    onChange={(e) => updateDraft(d.id, { act_dt: e.target.value })}
+                    className="sr-only"
+                    tabIndex={-1}
+                  />
+                </div>
+
+                <div className="flex flex-col gap-1">
+                  <Label className="text-xs">종목</Label>
+                  <Select
+                    value={d.sprt_enm}
+                    onValueChange={(value) =>
+                      updateDraft(d.id, { sprt_enm: value as MileageSport })
+                    }
+                  >
+                    <SelectTrigger className="h-10 rounded-lg border text-sm">
+                      <SelectValue />
+                    </SelectTrigger>
+                    <SelectContent>
+                      {(Object.entries(MILEAGE_SPORT_LABELS) as [MileageSport, string][]).map(
+                        ([value, label]) => (
+                          <SelectItem key={value} value={value}>
+                            {label}
+                          </SelectItem>
+                        ),
+                      )}
+                    </SelectContent>
+                  </Select>
+                </div>
               </div>
 
-              <div className="flex flex-col gap-1">
-                <Label className="text-xs">종목</Label>
-                <Select
-                  value={d.sprt_enm}
-                  onValueChange={(value) =>
-                    updateDraft(d.id, { sprt_enm: value as MileageSport })
-                  }
-                >
-                  <SelectTrigger className="h-10 rounded-lg border text-sm">
-                    <SelectValue />
-                  </SelectTrigger>
-                  <SelectContent>
-                    {(Object.entries(MILEAGE_SPORT_LABELS) as [MileageSport, string][]).map(
-                      ([value, label]) => (
-                        <SelectItem key={value} value={value}>
-                          {label}
-                        </SelectItem>
-                      ),
-                    )}
-                  </SelectContent>
-                </Select>
-              </div>
+              <div className="grid grid-cols-2 gap-2">
+                <div className="flex flex-col gap-1">
+                  <Label className="text-xs">거리 (km)</Label>
+                  <Input
+                    type="number"
+                    step="0.1"
+                    min="0.1"
+                    placeholder="예: 10.5"
+                    value={d.distance_km}
+                    onChange={(e) => updateDraft(d.id, { distance_km: e.target.value })}
+                    className="h-10 rounded-lg border text-sm"
+                  />
+                </div>
 
-              <div className="flex flex-col gap-1">
-                <Label className="text-xs">거리 (km)</Label>
-                <Input
-                  type="number"
-                  step="0.1"
-                  min="0.1"
-                  placeholder="예: 10.5"
-                  value={d.distance_km}
-                  onChange={(e) => updateDraft(d.id, { distance_km: e.target.value })}
-                  className="h-10 rounded-lg border text-sm"
-                />
-              </div>
-
-              <div className="flex flex-col gap-1">
-                <Label className="text-xs">
-                  상승고도 (m{d.sprt_enm === "SWIMMING" ? ", 수영 제외" : ""})
-                </Label>
-                <Input
-                  type="number"
-                  step="1"
-                  min="0"
-                  value={d.sprt_enm === "SWIMMING" ? "0" : d.elevation_m}
-                  disabled={d.sprt_enm === "SWIMMING"}
-                  onChange={(e) => updateDraft(d.id, { elevation_m: e.target.value })}
-                  className="h-10 rounded-lg border text-sm"
-                />
+                <div className="flex flex-col gap-1">
+                  <Label className="text-xs">
+                    상승고도 (m{d.sprt_enm === "SWIMMING" ? ", 수영 제외" : ""})
+                  </Label>
+                  <Input
+                    type="number"
+                    step="1"
+                    min="0"
+                    value={d.sprt_enm === "SWIMMING" ? "0" : d.elevation_m}
+                    disabled={d.sprt_enm === "SWIMMING"}
+                    onChange={(e) => updateDraft(d.id, { elevation_m: e.target.value })}
+                    className="h-10 rounded-lg border text-sm"
+                  />
+                </div>
               </div>
                 </div>
 


### PR DESCRIPTION
## 관련 이슈

관련 이슈 없음

## 요약

iOS Safari에서 기록입력 Sheet의 날짜 `input[type="date"]`가 `grid-cols-2` 셀을 넘쳐 레이아웃이 깨지는 문제를 수정합니다.

## AS-IS (변경 전)

- 날짜 입력에 `input[type="date"]`를 직접 사용
- iOS Safari는 `input[type="date"]`를 `display: inline-flex`로 렌더링하여 `width: 100%`를 무시함
- 한국어 로케일 날짜 포맷(`2026. 4. 27.`)이 기본 영문(`04/27/2026`)보다 넓어 grid 셀 50% 너비를 초과
- 날짜 input이 종목 Select 영역으로 넘침 (overflow)

## TO-BE (변경 후)

- 날짜 표시를 `type="text"` (readOnly)로 분리 → iOS Safari 레이아웃 문제 완전 우회
- 숨겨진 `type="date"` input의 `showPicker()`로 네이티브 날짜 선택 UI 유지
- 4개 필드를 하나의 `grid-cols-2`에서 날짜/종목, 거리/상승고도 두 개의 `grid-cols-2`로 분리하여 레이아웃 안정성 확보

## 주요 변경 사항

- `components/projects/activity-log-batch-form.tsx`: 날짜 input을 text + hidden date 패턴으로 변경, grid 레이아웃 구조 분리

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **UI 개선**
  * 활동 기록 폼의 날짜 입력 인터페이스가 개선되었습니다. 더 직관적인 상호작용 방식으로 사용 경험이 향상되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->