### PR TITLE
fix(records): UTMB 갱신 시 트레일러닝 랭킹 캐시 무효화

### DIFF
--- a/app/(main)/profile/page.tsx
+++ b/app/(main)/profile/page.tsx
@@ -79,7 +79,6 @@ async function ProfileContent() {
 
         {/* Personal Best */}
         <PersonalBestGrid
-          memberId={member.id}
           bestRecords={bestRecords}
           utmbData={utmbProfile?.utmb_prf_url && utmbProfile?.utmb_idx != null ? { utmb_profile_url: utmbProfile.utmb_prf_url, utmb_index: utmbProfile.utmb_idx, recent_race_name: utmbProfile.rct_race_nm, recent_race_record: utmbProfile.rct_race_rec } : null}
         />

--- a/app/actions/admin/refresh-utmb-indexes.ts
+++ b/app/actions/admin/refresh-utmb-indexes.ts
@@ -1,5 +1,7 @@
 "use server";
 
+import { revalidateTag } from "next/cache";
+
 import { createAdminClient } from "@/lib/supabase/admin";
 import { verifyAdmin } from "@/lib/queries/member";
 import { getRequestTeamContext } from "@/lib/queries/request-team";
@@ -137,6 +139,10 @@ export async function refreshUtmbIndexes(): Promise<RefreshResult> {
     },
     { updated: 0, unchanged: 0, failed: 0 },
   );
+
+  if (summary.updated > 0) {
+    revalidateTag(`records:${teamId}`, "max");
+  }
 
   return { rows, summary };
 }

--- a/app/actions/save-utmb-profile.ts
+++ b/app/actions/save-utmb-profile.ts
@@ -1,0 +1,60 @@
+"use server";
+
+import { revalidateTag } from "next/cache";
+
+import { getCurrentMember } from "@/lib/queries/member";
+import { getRequestTeamContext } from "@/lib/queries/request-team";
+
+type SaveUtmbProfileInput = {
+  profileUrl: string;
+  utmbIndex: number;
+  recentRaceName: string | null;
+  recentRaceRecord: string | null;
+};
+
+export async function saveUtmbProfile(input: SaveUtmbProfileInput) {
+  const { member, supabase } = await getCurrentMember();
+  if (!member) return { ok: false as const, message: "로그인이 필요합니다." };
+
+  const { teamId } = await getRequestTeamContext();
+
+  const { error } = await supabase.from("mem_utmb_prf").upsert(
+    {
+      mem_id: member.id,
+      utmb_prf_url: input.profileUrl,
+      utmb_idx: input.utmbIndex,
+      rct_race_nm: input.recentRaceName,
+      rct_race_rec: input.recentRaceRecord,
+      vers: 0,
+      del_yn: false,
+    },
+    { onConflict: "mem_id,vers" },
+  );
+
+  if (error) {
+    return { ok: false as const, message: error.message };
+  }
+
+  revalidateTag(`records:${teamId}`, "max");
+  return { ok: true as const, message: null };
+}
+
+export async function deleteUtmbProfile() {
+  const { member, supabase } = await getCurrentMember();
+  if (!member) return { ok: false as const, message: "로그인이 필요합니다." };
+
+  const { teamId } = await getRequestTeamContext();
+
+  const { error } = await supabase
+    .from("mem_utmb_prf")
+    .delete()
+    .eq("mem_id", member.id)
+    .eq("vers", 0);
+
+  if (error) {
+    return { ok: false as const, message: error.message };
+  }
+
+  revalidateTag(`records:${teamId}`, "max");
+  return { ok: true as const, message: null };
+}

--- a/components/profile/personal-best-grid.stories.tsx
+++ b/components/profile/personal-best-grid.stories.tsx
@@ -27,7 +27,6 @@ export const WithAllRecords: Story = {
   args: {
     bestRecords: mockBestRecords,
     utmbData: mockUtmb,
-    memberId: "member-001",
   },
   render: (args) => (
     <div className="w-[375px] p-4">
@@ -40,7 +39,6 @@ export const NoRecords: Story = {
   args: {
     bestRecords: {},
     utmbData: null,
-    memberId: "member-001",
   },
   render: (args) => (
     <div className="w-[375px] p-4">
@@ -55,7 +53,6 @@ export const PartialRecords: Story = {
       FULL: { record_time_sec: 13200, race_name: "2024 동아 마라톤" },
     },
     utmbData: null,
-    memberId: "member-001",
   },
   render: (args) => (
     <div className="w-[375px] p-4">

--- a/components/profile/personal-best-grid.tsx
+++ b/components/profile/personal-best-grid.tsx
@@ -2,6 +2,10 @@
 
 import { useState } from "react";
 import { fetchUtmbIndex } from "@/app/actions/utmb";
+import {
+	deleteUtmbProfile,
+	saveUtmbProfile,
+} from "@/app/actions/save-utmb-profile";
 import { Button } from "@/components/ui/button";
 import {
 	Dialog,
@@ -12,7 +16,6 @@ import {
 } from "@/components/ui/dialog";
 import { Input } from "@/components/ui/input";
 import { secondsToTime } from "@/lib/dayjs";
-import { createClient } from "@/lib/supabase/client";
 
 type BestRecord = {
 	record_time_sec: number;
@@ -29,12 +32,11 @@ type UtmbData = {
 type Props = {
 	bestRecords: Record<string, BestRecord>;
 	utmbData: UtmbData;
-	memberId: string;
 };
 
 const PB_EVENTS = ["FULL", "HALF", "10K"] as const;
 
-export function PersonalBestGrid({ bestRecords, utmbData, memberId }: Props) {
+export function PersonalBestGrid({ bestRecords, utmbData }: Props) {
 	const [utmb, setUtmb] = useState(utmbData);
 	const [utmbOpen, setUtmbOpen] = useState(false);
 
@@ -115,30 +117,25 @@ export function PersonalBestGrid({ bestRecords, utmbData, memberId }: Props) {
 		const fullUrl = utmbUrl.trim().startsWith("http")
 			? utmbUrl.trim()
 			: `https://utmb.world/en/runner/${utmbUrl.trim()}`;
-		const supabase = createClient();
-		const { error } = await supabase.from("mem_utmb_prf").upsert(
-			{
-				mem_id: memberId,
-				utmb_prf_url: fullUrl,
-				utmb_idx: utmbIndex,
-				rct_race_nm: recentRaceName.trim() || null,
-				rct_race_rec: recentRaceRecord.trim() || null,
-				vers: 0,
-				del_yn: false,
-			},
-			{ onConflict: "mem_id,vers" },
-		);
+		const trimmedRaceName = recentRaceName.trim() || null;
+		const trimmedRaceRecord = recentRaceRecord.trim() || null;
+		const result = await saveUtmbProfile({
+			profileUrl: fullUrl,
+			utmbIndex,
+			recentRaceName: trimmedRaceName,
+			recentRaceRecord: trimmedRaceRecord,
+		});
 		setSaving(false);
-		if (error) {
-			setMessage(error.message);
+		if (!result.ok) {
+			setMessage(result.message);
 			setIsError(true);
 			return;
 		}
 		setUtmb({
 			utmb_profile_url: fullUrl,
 			utmb_index: utmbIndex,
-			recent_race_name: recentRaceName.trim() || null,
-			recent_race_record: recentRaceRecord.trim() || null,
+			recent_race_name: trimmedRaceName,
+			recent_race_record: trimmedRaceRecord,
 		});
 		setUtmbOpen(false);
 	};
@@ -146,15 +143,10 @@ export function PersonalBestGrid({ bestRecords, utmbData, memberId }: Props) {
 	const handleDelete = async () => {
 		if (!window.confirm("UTMB Index 정보를 삭제하시겠습니까?")) return;
 		setSaving(true);
-		const supabase = createClient();
-		const { error } = await supabase
-			.from("mem_utmb_prf")
-			.delete()
-			.eq("mem_id", memberId)
-			.eq("vers", 0);
+		const result = await deleteUtmbProfile();
 		setSaving(false);
-		if (error) {
-			setMessage(error.message);
+		if (!result.ok) {
+			setMessage(result.message);
 			setIsError(true);
 			return;
 		}


### PR DESCRIPTION
## 관련 이슈

관련 이슈 없음

## 요약

랭킹 페이지(`/records`)는 `unstable_cache`로 24시간 캐시되며 `records:${teamId}` 태그가 무효화돼야만 갱신된다. UTMB 인덱스를 변경하는 두 경로(개인 프로필 저장/삭제, 관리자 일괄 갱신) 모두에서 해당 태그가 누락돼, DB는 갱신되어도 트레일러닝 랭킹이 24시간 동안 stale 상태로 남는 문제를 수정한다.

## AS-IS (변경 전)

- `app/(main)/records/page.tsx`의 `getCachedRecordsData`는 `unstable_cache`로 24시간 캐시되며 태그는 `["records", "records:${teamId}"]`
- 마라톤/철인3종 기록은 `app/actions/save-race-record.ts`에서 저장/수정/삭제 후 `revalidateTag` 를 호출하므로 즉시 반영
- 그러나 UTMB 갱신 두 경로는 캐시 태그를 무효화하지 않음:
  - 개인 프로필(`components/profile/personal-best-grid.tsx`)에서 `createClient()`로 **클라이언트가 직접** `mem_utmb_prf` 를 upsert/delete — 서버 액션이 아니라 `revalidateTag` 호출 자리 자체가 없음
  - 관리자 일괄 갱신(`app/actions/admin/refresh-utmb-indexes.ts`, #230) 은 서버 액션이지만 마지막 `return` 까지 `revalidateTag` 호출이 없음
- 결과: UTMB 인덱스가 갱신돼도 랭킹의 트레일러닝 탭은 24시간 동안 이전 데이터 그대로 노출

## TO-BE (변경 후)

- 개인 프로필 UTMB 저장/삭제를 새 서버 액션으로 이관 (`app/actions/save-utmb-profile.ts`)
  - `saveUtmbProfile` / `deleteUtmbProfile` — `getCurrentMember()` 로 본인 검증 후 작업
  - 작업 성공 시 `revalidateTag(\`records:${teamId}\`, \"max\")` 호출
  - 클라이언트 컴포넌트는 직접 `supabase` 호출 대신 서버 액션 호출, 더 이상 필요 없는 `memberId` prop 도 제거
- 관리자 일괄 갱신(`refreshUtmbIndexes`)에 `revalidateTag` 추가
  - `summary.updated > 0` 일 때만(불필요한 무효화 방지) `records:${teamId}` 태그 무효화
- 부수 효과: 클라이언트 직접 write를 서버 액션으로 옮기면서 `mem_id` 를 입력값이 아닌 세션 사용자로 강제 — 보안 측면도 함께 개선

## 변경 흐름 (Mermaid)

```mermaid
flowchart LR
    subgraph BEFORE["AS-IS"]
        A1[프로필 다이얼로그<br/>handleSave/Delete] -->|클라이언트 supabase 직접 write| A2[(mem_utmb_prf)]
        A3[관리자 일괄 갱신<br/>refreshUtmbIndexes] --> A2
        A2 -. 캐시 태그 무효화 없음 .-> A4[/records 페이지<br/>24시간 stale/]
    end

    subgraph AFTER["TO-BE"]
        B1[프로필 다이얼로그] -->|saveUtmbProfile<br/>deleteUtmbProfile<br/>서버 액션| B2[mem_utmb_prf 쓰기<br/>+ revalidateTag]
        B3[관리자 일괄 갱신<br/>refreshUtmbIndexes] -->|updated > 0| B2
        B2 --> B4[records:teamId<br/>태그 무효화]
        B4 --> B5[/records 페이지<br/>다음 요청 시 재조회/]
    end
```

## 주요 변경 사항

- `app/actions/save-utmb-profile.ts` — 신규 서버 액션 (`saveUtmbProfile`, `deleteUtmbProfile`)
- `app/actions/admin/refresh-utmb-indexes.ts` — 갱신된 행이 있을 때 `revalidateTag` 호출
- `components/profile/personal-best-grid.tsx` — 클라이언트 supabase 직접 호출 제거, 서버 액션 사용, `memberId` prop 제거
- `components/profile/personal-best-grid.stories.tsx`, `app/(main)/profile/page.tsx` — `memberId` prop 사용 제거

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **버그 수정**
  * UTMB 인덱스 새로고침 후 캐시 무효화 개선으로 데이터 일관성 강화

* **개선 사항**
  * UTMB 프로필 데이터 저장 및 삭제 기능이 더욱 안전하게 처리됨
  * 개인 최고 기록 그리드 컴포넌트 최적화로 성능 향상

<!-- end of auto-generated comment: release notes by coderabbit.ai -->