### PR TITLE
fix(projects): 마일리지 기록 등록 완료 토스트 안내 추가

### DIFF
--- a/components/projects/activity-log-batch-form.tsx
+++ b/components/projects/activity-log-batch-form.tsx
@@ -45,7 +45,7 @@ type ActivityDraft = {
 
 type ActivityLogBatchFormProps = {
   evtId: string;
-  onSuccess: () => void;
+  onSuccess: (savedCount: number) => void;
 };
 
 function isMultiplierActive(mult: EventMultiplier, actDt: string): boolean {
@@ -153,7 +153,7 @@ export function ActivityLogBatchForm({ evtId, onSuccess }: ActivityLogBatchFormP
         alert(result.message ?? "오류가 발생했습니다.");
         return;
       }
-      onSuccess();
+      onSuccess(payload.length);
     } catch {
       alert("오류가 발생했습니다. 다시 시도해 주세요.");
     } finally {

--- a/components/projects/activity-log-fab.tsx
+++ b/components/projects/activity-log-fab.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { useRouter } from "next/navigation";
 import { Plus } from "lucide-react";
 import { Button } from "@/components/ui/button";
@@ -19,16 +19,46 @@ type ActivityLogFabProps = {
 
 export function ActivityLogFab({ evtId, memId: _memId }: ActivityLogFabProps) {
   const [open, setOpen] = useState(false);
+  const [showSuccessNotice, setShowSuccessNotice] = useState(false);
+  const [savedCount, setSavedCount] = useState(0);
+  const successTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const router = useRouter();
 
-  const handleSuccess = () => {
+  const handleSuccess = (count: number) => {
     setOpen(false);
     router.refresh();
     window.dispatchEvent(new Event("mileage:refresh"));
+    setSavedCount(count);
+    setShowSuccessNotice(true);
+
+    if (successTimerRef.current) {
+      clearTimeout(successTimerRef.current);
+    }
+    successTimerRef.current = setTimeout(() => {
+      setShowSuccessNotice(false);
+      successTimerRef.current = null;
+    }, 3500);
   };
+
+  useEffect(() => {
+    return () => {
+      if (successTimerRef.current) {
+        clearTimeout(successTimerRef.current);
+      }
+    };
+  }, []);
 
   return (
     <>
+      {showSuccessNotice && (
+        <div className="fixed bottom-40 left-1/2 z-50 w-[calc(100%-3rem)] max-w-md -translate-x-1/2 rounded-xl border border-primary/25 bg-background/95 px-4 py-3 shadow-lg backdrop-blur-sm">
+          <p className="text-sm font-semibold text-primary">[ {savedCount}건 등록완료 ]</p>
+          <p className="mt-1 text-sm text-foreground">
+          동기부여를 위해 러닝기록을 단톡방에 올려주세요!
+          </p>
+        </div>
+      )}
+
       <Button
         size="icon"
         className="fixed bottom-24 right-6 z-50 size-14 rounded-full shadow-lg"

--- a/components/projects/crew-progress-chart.tsx
+++ b/components/projects/crew-progress-chart.tsx
@@ -411,6 +411,21 @@ export function CrewProgressChart({
     });
   }, [mode, percentData, mileageData, selectedMemberIdSet, isCurrentMonth, dayRef]);
 
+  const validPointCountByMember = useMemo(() => {
+    const counts = new Map<string, number>();
+    for (const item of selectedMembers) {
+      let count = 0;
+      for (const row of selectedChartData) {
+        const value = row[item.member.id];
+        if (typeof value === "number" && Number.isFinite(value)) {
+          count += 1;
+        }
+      }
+      counts.set(item.member.id, count);
+    }
+    return counts;
+  }, [selectedMembers, selectedChartData]);
+
   const roleColorMap = useMemo(
     () => buildRoleColorMap(selectedMembers, top, bottom, near, memId),
     [selectedMembers, top, bottom, near, memId],
@@ -735,7 +750,15 @@ export function CrewProgressChart({
                 dataKey={item.member.id}
                 name={item.member.name}
                 stroke={roleColorMap.get(item.member.id) ?? ROLE_COLORS.near[0]}
-                dot={false}
+                dot={
+                  (validPointCountByMember.get(item.member.id) ?? 0) <= 1
+                    ? {
+                        r: item.member.name === myName ? 4 : 3,
+                        strokeWidth: 0,
+                        fill: roleColorMap.get(item.member.id) ?? ROLE_COLORS.near[0],
+                      }
+                    : false
+                }
                 strokeWidth={item.member.name === myName ? 3 : 1.5}
                 opacity={item.member.name === myName ? 1 : 0.82}
               />

--- a/components/projects/crew-progress-chart.tsx
+++ b/components/projects/crew-progress-chart.tsx
@@ -411,20 +411,7 @@ export function CrewProgressChart({
     });
   }, [mode, percentData, mileageData, selectedMemberIdSet, isCurrentMonth, dayRef]);
 
-  const validPointCountByMember = useMemo(() => {
-    const counts = new Map<string, number>();
-    for (const item of selectedMembers) {
-      let count = 0;
-      for (const row of selectedChartData) {
-        const value = row[item.member.id];
-        if (typeof value === "number" && Number.isFinite(value)) {
-          count += 1;
-        }
-      }
-      counts.set(item.member.id, count);
-    }
-    return counts;
-  }, [selectedMembers, selectedChartData]);
+  const showSingleDayDot = isCurrentMonth && dayRef <= 1;
 
   const roleColorMap = useMemo(
     () => buildRoleColorMap(selectedMembers, top, bottom, near, memId),
@@ -751,7 +738,7 @@ export function CrewProgressChart({
                 name={item.member.name}
                 stroke={roleColorMap.get(item.member.id) ?? ROLE_COLORS.near[0]}
                 dot={
-                  (validPointCountByMember.get(item.member.id) ?? 0) <= 1
+                  showSingleDayDot
                     ? {
                         r: item.member.name === myName ? 4 : 3,
                         strokeWidth: 0,

--- a/components/projects/my-status.tsx
+++ b/components/projects/my-status.tsx
@@ -124,7 +124,7 @@ export async function MyStatus({
             <Caption>월 종료</Caption>
           ) : (
             <Caption>
-              일일 필요{" "}
+              잔여 일평균{" "}
               <span className="font-semibold text-foreground">
                 {(dailyNeeded as number).toFixed(1)} km
               </span>


### PR DESCRIPTION
## Summary
- 마일리지 기록 저장 성공 시 하단 FAB 영역에서 자동으로 사라지는 완료 안내 토스트를 노출합니다.
- 토스트 제목에 저장 건수를 반영해 `[ N건 등록완료 ]` 형식으로 표시합니다.
- 다건 저장 폼의 성공 콜백에 저장 건수(`savedCount`)를 전달해 토스트 문구와 실제 저장 결과를 일치시켰습니다.

## Test plan
- [ ] 마일리지 기록 1건 저장 후 `[ 1건 등록완료 ]` 토스트가 노출되고 약 3.5초 뒤 자동으로 사라지는지 확인
- [ ] 마일리지 기록 2건 이상 일괄 저장 후 `[ N건 등록완료 ]` 건수가 정확한지 확인
- [ ] 저장 실패 시 토스트가 뜨지 않고 기존 에러(alert)만 동작하는지 확인

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 활동 로그 배치 제출 후 성공 안내 배너가 임시로 표시됩니다.

* **개선사항**
  * 차트 시각화가 개선되어 데이터 포인트에 따라 끝점 표시가 최적화됩니다.
  * 상태 화면의 UI 텍스트 레이블이 업데이트되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->