### PR TITLE
feat(records): 랭킹 전체 멤버 표시 및 이름 검색 기능 추가

### DIFF
--- a/app/(main)/records/page.tsx
+++ b/app/(main)/records/page.tsx
@@ -109,12 +109,10 @@ function getCachedRecordsData(teamId: string) {
           male: rows
             .filter((r) => r.gender === "male")
             .sort((a, b) => a.sortKey - b.sortKey)
-            .slice(0, 10)
             .map(toEntry),
           female: rows
             .filter((r) => r.gender === "female")
             .sort((a, b) => a.sortKey - b.sortKey)
-            .slice(0, 10)
             .map(toEntry),
         };
       });
@@ -122,7 +120,6 @@ function getCachedRecordsData(teamId: string) {
       // --- 트레일러닝 ---
       const trailEntries = utmbMembers
         .sort((a, b) => b.index - a.index)
-        .slice(0, 10)
         .map((r, i) => ({
           rank: i + 1,
           name: r.name,
@@ -151,8 +148,7 @@ function getCachedRecordsData(teamId: string) {
           // 올림픽 통영/기타: 같은 DB event_type에서 race_name으로 분리
           rows = olympicRows
             .filter((r) => evt.filter(r.raceName))
-            .sort((a, b) => a.sortKey - b.sortKey)
-            .slice(0, 10);
+            .sort((a, b) => a.sortKey - b.sortKey);
         } else {
           rows = (pbData ?? [])
             .filter((r) => r.event_type === evt.eventType)
@@ -165,8 +161,7 @@ function getCachedRecordsData(teamId: string) {
                 sortKey: r.record_time_sec,
               };
             })
-            .sort((a, b) => a.sortKey - b.sortKey)
-            .slice(0, 10);
+            .sort((a, b) => a.sortKey - b.sortKey);
         }
 
         return {

--- a/app/(main)/records/records-client.tsx
+++ b/app/(main)/records/records-client.tsx
@@ -1,9 +1,10 @@
 "use client";
 
 import { useState } from "react";
-import { Medal } from "lucide-react";
+import { Medal, Search } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
 
 /* ------------------------------------------------------------------ */
 /*  타입 정의                                                          */
@@ -218,16 +219,16 @@ function MarathonContent({ events }: { events: MarathonEvent[] }) {
           </div>
         ) : (
           Array.from({ length: maxRows }).map((_, i) => {
-            const rank = i + 1;
             const male = currentEvent?.male[i];
             const female = currentEvent?.female[i];
+            const rank = male?.rank ?? female?.rank ?? i + 1;
             return (
               <div
                 key={rank}
                 className="flex items-center gap-3 border-b border-border py-3 last:border-b-0 last:rounded-b-lg"
               >
-                <MarathonCell entry={male} rank={rank} />
-                <MarathonCell entry={female} rank={rank} />
+                <MarathonCell entry={male} rank={male?.rank ?? rank} />
+                <MarathonCell entry={female} rank={female?.rank ?? rank} />
               </div>
             );
           })
@@ -361,6 +362,30 @@ function TriathlonContent({ events }: { events: TriathlonEvent[] }) {
 export function RecordsClient({ data }: { data: RecordsData }) {
   const [selectedCategory, setSelectedCategory] =
     useState<CategoryKey>("marathon");
+  const [query, setQuery] = useState("");
+
+  const q = query.trim().toLowerCase();
+
+  const filteredMarathon = {
+    events: data.marathon.events.map((evt) => ({
+      ...evt,
+      male: evt.male.filter((e) => e.name.toLowerCase().includes(q)),
+      female: evt.female.filter((e) => e.name.toLowerCase().includes(q)),
+    })),
+  };
+
+  const filteredTrail = {
+    entries: data.trail.entries.filter((e) =>
+      e.name.toLowerCase().includes(q),
+    ),
+  };
+
+  const filteredTriathlon = {
+    events: data.triathlon.events.map((evt) => ({
+      ...evt,
+      entries: evt.entries.filter((e) => e.name.toLowerCase().includes(q)),
+    })),
+  };
 
   return (
     <div className="flex flex-col gap-4">
@@ -384,15 +409,26 @@ export function RecordsClient({ data }: { data: RecordsData }) {
         ))}
       </div>
 
+      {/* 검색창 */}
+      <div className="relative px-6">
+        <Search className="absolute left-9 top-1/2 size-4 -translate-y-1/2 text-muted-foreground" />
+        <Input
+          value={query}
+          onChange={(e) => setQuery(e.target.value)}
+          placeholder="이름으로 검색"
+          className="pl-9"
+        />
+      </div>
+
       {/* 카테고리별 콘텐츠 */}
       {selectedCategory === "marathon" && (
-        <MarathonContent events={data.marathon.events} />
+        <MarathonContent events={filteredMarathon.events} />
       )}
       {selectedCategory === "trail" && (
-        <TrailContent entries={data.trail.entries} />
+        <TrailContent entries={filteredTrail.entries} />
       )}
       {selectedCategory === "triathlon" && (
-        <TriathlonContent events={data.triathlon.events} />
+        <TriathlonContent events={filteredTriathlon.events} />
       )}
     </div>
   );


### PR DESCRIPTION
## 관련 이슈

관련 이슈 없음

## 요약

기강의 전당(랭킹) 페이지에서 상위 10명만 표시하던 것을 전체 멤버로 확장하고, 이름으로 빠르게 찾을 수 있는 검색 기능을 추가합니다.

## AS-IS (변경 전)

- 마라톤(남/여), 트레일러닝, 철인3종 모두 상위 10명까지만 표시 (`.slice(0, 10)`)
- 검색 기능 없음 — 멤버가 많아질수록 본인 순위 확인이 불편

## TO-BE (변경 후)

- 모든 카테고리에서 기록이 있는 **전체 멤버** 표시
- 카테고리 탭 아래 **이름 검색창** 추가 — 검색 시 해당 멤버만 필터링
- 검색 후에도 **원래 순위(rank) 유지** — 3등인 멤버는 검색 결과에서도 3등으로 표시
- 검색은 클라이언트 사이드 필터링으로 처리 — 서버 캐시(24h) 영향 없음

## 주요 변경 파일

- `app/(main)/records/page.tsx` — `.slice(0, 10)` 제거 (마라톤 남/여, 트레일, 철인3종)
- `app/(main)/records/records-client.tsx` — 검색 상태 및 필터링 로직 추가, 마라톤 rank를 인덱스 기반 → `entry.rank` 기반으로 수정