### PR TITLE
feat(profile): 시간 입력 필드 자동 콜론 삽입 기능 추가

### DIFF
--- a/components/profile/race-record-dialog.tsx
+++ b/components/profile/race-record-dialog.tsx
@@ -42,6 +42,15 @@ interface Competition {
   registrationCompEvtId?: string | null;
 }
 
+/* ---------- 시간 입력 자동 포맷 ---------- */
+
+function formatTimeInput(raw: string): string {
+  const digits = raw.replace(/\D/g, "").slice(0, 6);
+  if (digits.length <= 2) return digits;
+  if (digits.length <= 4) return `${digits.slice(0, 2)}:${digits.slice(2)}`;
+  return `${digits.slice(0, 2)}:${digits.slice(2, 4)}:${digits.slice(4)}`;
+}
+
 /* ---------- 컴포넌트 ---------- */
 
 export function RaceRecordDialog({
@@ -609,32 +618,36 @@ export function RaceRecordDialog({
                   <label className="text-sm font-medium">대회 총 시간</label>
                   <Input
                     placeholder="HH:MM:SS"
+                    inputMode="numeric"
                     value={totalTime}
-                    onChange={(e) => setTotalTime(e.target.value)}
+                    onChange={(e) => setTotalTime(formatTimeInput(e.target.value))}
                   />
                 </div>
                 <div className="flex flex-col gap-1.5">
                   <label className="text-sm font-medium">수영</label>
                   <Input
                     placeholder="HH:MM:SS"
+                    inputMode="numeric"
                     value={swimTime}
-                    onChange={(e) => setSwimTime(e.target.value)}
+                    onChange={(e) => setSwimTime(formatTimeInput(e.target.value))}
                   />
                 </div>
                 <div className="flex flex-col gap-1.5">
                   <label className="text-sm font-medium">자전거</label>
                   <Input
                     placeholder="HH:MM:SS"
+                    inputMode="numeric"
                     value={bikeTime}
-                    onChange={(e) => setBikeTime(e.target.value)}
+                    onChange={(e) => setBikeTime(formatTimeInput(e.target.value))}
                   />
                 </div>
                 <div className="flex flex-col gap-1.5">
                   <label className="text-sm font-medium">러닝</label>
                   <Input
                     placeholder="HH:MM:SS"
+                    inputMode="numeric"
                     value={runTime}
-                    onChange={(e) => setRunTime(e.target.value)}
+                    onChange={(e) => setRunTime(formatTimeInput(e.target.value))}
                   />
                 </div>
                 <div className="flex flex-col gap-1.5">
@@ -659,8 +672,9 @@ export function RaceRecordDialog({
                 <label className="text-sm font-medium">완주 시간</label>
                 <Input
                   placeholder="HH:MM:SS"
+                  inputMode="numeric"
                   value={totalTime}
-                  onChange={(e) => setTotalTime(e.target.value)}
+                  onChange={(e) => setTotalTime(formatTimeInput(e.target.value))}
                 />
               </div>
             )}


### PR DESCRIPTION
## 관련 이슈

관련 이슈 없음

## 요약

기록 입력 모달의 시간 필드에서 숫자만 입력하면 콜론(`:`)이 자동으로 삽입되도록 개선했습니다.

## AS-IS (변경 전)

- `HH:MM:SS` 형식의 시간을 직접 타이핑해야 함
- 콜론을 수동으로 입력해야 하며 실수하기 쉬움
- 모바일에서 텍스트 키패드가 뜨는 불편함

## TO-BE (변경 후)

- 숫자만 입력하면 자동으로 콜론이 삽입됨
  - `12` → `12`
  - `1234` → `12:34`
  - `123456` → `12:34:56`
- 백스페이스로 지우면 숫자가 줄면서 콜론도 자동으로 사라짐
- `inputMode="numeric"` 추가로 모바일에서 숫자 키패드 표시
- 적용 대상: 완주 시간 / 트라이애슬론 총 시간·수영·자전거·러닝 전 필드 (`components/profile/race-record-dialog.tsx`)