### PR TITLE
fix(titles): 칭호·이펙트 잠금 설계 개선 및 sweep 성능 리팩토링

### DIFF
--- a/.claude/docs/coding-standards.md
+++ b/.claude/docs/coding-standards.md
@@ -36,6 +36,21 @@ const supabase = createClient(); // await 불필요
 - Supabase RLS 정책이 적용되어 있으므로 별도 권한 체크 불필요
 - 서버에서 `supabase.auth.getUser()`로 현재 사용자 확인
 
+### `use_yn` 필드 의미 (칭호·이펙트)
+
+`ttl_mst.use_yn` / `effect_mst.use_yn` 은 **조회와 완전히 무관**하다.
+
+| 대상 | `use_yn=true` | `use_yn=false` |
+|------|--------------|----------------|
+| 유저 컬렉션 | 목록에 보임, 선택 가능 | **목록에 보임**, 선택 불가 |
+| 관리자 페이지 | 목록에 보임, 수정 가능 | **목록에 보임**, 수정 가능 |
+| 칭호 자동 부여 엔진 | 평가 대상 | 평가 제외 (선택 불가이므로 부여 의미 없음) |
+
+- 쿼리에서 `.eq("use_yn", true)` 필터를 **절대 사용하지 않는다** (엔진 제외).
+- 잠금(use_yn=false)은 "선택·사용 불가" 상태일 뿐, 목록에서 숨기는 것이 아니다.
+- 유저 입장: 미보유 칭호는 마스킹, `use_yn=false` 이펙트는 잠금 표시 — 둘 다 목록엔 노출.
+- RLS: `effect_mst` SELECT 정책은 `USING (true)` — `use_yn` 조건 없음.
+
 ## 에러 처리
 
 - Supabase 쿼리 결과의 `error` 체크

--- a/app/actions/admin/sweep-titles.ts
+++ b/app/actions/admin/sweep-titles.ts
@@ -3,7 +3,7 @@
 import { verifyAdmin } from "@/lib/queries/member";
 import { getRequestTeamContext } from "@/lib/queries/request-team";
 import { createAdminClient } from "@/lib/supabase/admin";
-import { evaluateAndGrantTitles } from "@/lib/titles/engine";
+import { sweepEvaluateAndGrant } from "@/lib/titles/engine";
 
 /**
  * 팀 전체 멤버를 대상으로 자동 칭호를 일괄 재평가한다.
@@ -11,20 +11,21 @@ import { evaluateAndGrantTitles } from "@/lib/titles/engine";
  * 관리자 페이지의 "칭호 일괄 재계산" 버튼에서 호출한다.
  * 새 칭호를 추가하거나 조건을 수정했을 때 기존 멤버에게 소급 적용할 때 사용한다.
  *
- * @returns 부여된 총 칭호 수와 멤버별 결과
+ * 성능: 멤버·칭호 수에 무관하게 DB 쿼리 약 7번 고정.
+ * 멤버 전체 데이터를 한 번에 로드 후 메모리 내에서 평가한다.
  */
 export async function sweepAllTitles(): Promise<{
   ok: boolean;
   message: string | null;
   granted: number;
+  revoked: number;
 }> {
   const admin = await verifyAdmin();
-  if (!admin) return { ok: false, message: "권한이 없습니다.", granted: 0 };
+  if (!admin) return { ok: false, message: "권한이 없습니다.", granted: 0, revoked: 0 };
 
   const { teamId } = await getRequestTeamContext();
   const db = createAdminClient();
 
-  // 팀 소속 활성 멤버 전체 조회
   const { data: members, error } = await db
     .from("team_mem_rel")
     .select("team_mem_id")
@@ -33,29 +34,18 @@ export async function sweepAllTitles(): Promise<{
     .eq("del_yn", false)
     .eq("mem_st_cd", "active");
 
-  if (error) return { ok: false, message: "멤버 조회에 실패했습니다.", granted: 0 };
+  if (error) return { ok: false, message: "멤버 조회에 실패했습니다.", granted: 0, revoked: 0 };
   if (!members || members.length === 0) {
-    return { ok: true, message: "활성 멤버가 없습니다.", granted: 0 };
+    return { ok: true, message: "활성 멤버가 없습니다.", granted: 0, revoked: 0 };
   }
 
-  let totalGranted = 0;
-
-  for (const m of members) {
-    try {
-      const granted = await evaluateAndGrantTitles({
-        trigger: "manual_sweep",
-        teamId,
-        teamMemId: m.team_mem_id,
-      });
-      totalGranted += granted.length;
-    } catch (e) {
-      console.error(`[sweep-titles] team_mem_id=${m.team_mem_id} 평가 실패`, e);
-    }
-  }
+  const teamMemIds = members.map((m) => m.team_mem_id);
+  const { granted, revoked } = await sweepEvaluateAndGrant(teamId, teamMemIds);
 
   return {
     ok: true,
-    message: `${members.length}명 평가 완료. 총 ${totalGranted}개 칭호 신규 부여.`,
-    granted: totalGranted,
+    message: `${members.length}명 평가 완료. 신규 부여 ${granted}개, 자동 회수 ${revoked}개.`,
+    granted,
+    revoked,
   };
 }

--- a/lib/titles/engine.ts
+++ b/lib/titles/engine.ts
@@ -208,7 +208,7 @@ export async function sweepEvaluateAndGrant(
   // 2. 팀의 auto 칭호 전체 조회 (1번 — 멤버 수와 무관)
   const { data: allTitles } = await db
     .from("ttl_mst")
-    .select("ttl_id, ttl_nm, base_pt, cond_rule_json")
+    .select("ttl_id, ttl_nm, cond_rule_json")
     .eq("team_id", teamId)
     .eq("ttl_kind_enm", "auto")
     .eq("use_yn", true)
@@ -231,8 +231,6 @@ export async function sweepEvaluateAndGrant(
     team_id: string;
     team_mem_id: string;
     ttl_id: string;
-    grnt_pt: number;
-    aply_pt: number;
     pt_chg_rsn_cd: string;
     grnt_rsn_txt: string;
     is_prmy_yn: boolean;
@@ -281,8 +279,6 @@ export async function sweepEvaluateAndGrant(
         team_id: teamId,
         team_mem_id: snapshot.teamMemId,
         ttl_id: title.ttl_id,
-        grnt_pt: title.base_pt,
-        aply_pt: title.base_pt,
         pt_chg_rsn_cd: "initial_grant",
         grnt_rsn_txt: "자동수여 (trigger=manual_sweep)",
         is_prmy_yn: false,

--- a/lib/titles/engine.ts
+++ b/lib/titles/engine.ts
@@ -14,10 +14,12 @@
 
 import { createAdminClient } from "@/lib/supabase/admin";
 
-import { evaluateCondition } from "./evaluators";
+import { evaluateCondition, evaluateConditionFromSnapshot } from "./evaluators";
+import { loadMemberSnapshots } from "./snapshot";
 import { TRIGGER_COND_MAP } from "./types";
 
 import type { CondRule, TitleEvalContext } from "./types";
+import type { MemberSnapshot } from "./snapshot";
 
 type TtlMstRow = {
   ttl_id: string;
@@ -171,4 +173,143 @@ export async function evaluateAndGrantTitles(
   }
 
   return granted;
+}
+
+// ---------------------------------------------------------------------------
+// bulk sweep 전용 엔진 — sweepAllTitles() 에서만 호출
+// ---------------------------------------------------------------------------
+
+type SweepResult = {
+  granted: number;
+  revoked: number;
+};
+
+/**
+ * 팀 전체 멤버를 대상으로 auto 칭호를 일괄 재평가하고 부여/회수한다.
+ *
+ * DB 쿼리 수: 멤버·칭호 수에 무관하게 약 7번 고정.
+ *   - loadMemberSnapshots: 4번 (team_mem_rel, rec_race_hist, mem_ttl_rel)
+ *   - ttl_mst 조회: 1번
+ *   - bulk UPDATE (회수): 1번
+ *   - bulk UPSERT (부여): 1번
+ */
+export async function sweepEvaluateAndGrant(
+  teamId: string,
+  teamMemIds: string[],
+): Promise<SweepResult> {
+  if (teamMemIds.length === 0) return { granted: 0, revoked: 0 };
+
+  const db = createAdminClient();
+
+  // 1. 멤버 전체 스냅샷 로드 (DB 쿼리 4번)
+  const snapshots = await loadMemberSnapshots(db, teamId, teamMemIds);
+  if (snapshots.size === 0) return { granted: 0, revoked: 0 };
+
+  // 2. 팀의 auto 칭호 전체 조회 (1번 — 멤버 수와 무관)
+  const { data: allTitles } = await db
+    .from("ttl_mst")
+    .select("ttl_id, ttl_nm, base_pt, cond_rule_json")
+    .eq("team_id", teamId)
+    .eq("ttl_kind_enm", "auto")
+    .eq("use_yn", true)
+    .eq("vers", 0)
+    .eq("del_yn", false);
+
+  const titles = (allTitles as TtlMstRow[] ?? []).filter((t) => t.cond_rule_json != null);
+  if (titles.length === 0) return { granted: 0, revoked: 0 };
+
+  const autoTitleIds = new Set(titles.map((t) => t.ttl_id));
+  const allowedCondTypes = new Set(TRIGGER_COND_MAP["manual_sweep"]);
+
+  // race_pb_faster_than_member 평가 시 타 멤버 데이터 참조를 위해 MemberSnapshot 맵을 전달
+  const snapshotsByMemId = new Map<string, MemberSnapshot>(
+    [...snapshots.values()].map((s) => [s.teamMemId, s]),
+  );
+
+  // 3. 메모리 내 평가 — DB 쿼리 없음
+  type GrantRow = {
+    team_id: string;
+    team_mem_id: string;
+    ttl_id: string;
+    grnt_pt: number;
+    aply_pt: number;
+    pt_chg_rsn_cd: string;
+    grnt_rsn_txt: string;
+    is_prmy_yn: boolean;
+    vers: number;
+    del_yn: boolean;
+  };
+
+  const toRevoke: { mem_ttl_id: string; vers: number }[] = [];
+  const toGrant: GrantRow[] = [];
+
+  for (const snapshot of snapshots.values()) {
+    const eligibleTitles = titles.filter((t) => {
+      const rule = t.cond_rule_json as CondRule;
+      return allowedCondTypes.has(rule.type);
+    });
+
+    // 3-1. 회수 평가: 보유 중인 auto 칭호 중 조건 미충족 → 회수 대상 수집
+    for (const held of snapshot.heldRows) {
+      if (!autoTitleIds.has(held.ttl_id)) continue;
+      const title = eligibleTitles.find((t) => t.ttl_id === held.ttl_id);
+      if (!title) continue;
+
+      const passed = evaluateConditionFromSnapshot(
+        title.cond_rule_json as CondRule,
+        snapshot,
+        snapshotsByMemId,
+      );
+      if (!passed) {
+        toRevoke.push({ mem_ttl_id: held.mem_ttl_id, vers: held.vers });
+        snapshot.heldTitleIds.delete(held.ttl_id);
+      }
+    }
+
+    // 3-2. 부여 평가: 미보유 칭호 중 조건 충족 → 부여 대상 수집
+    for (const title of eligibleTitles) {
+      if (snapshot.heldTitleIds.has(title.ttl_id)) continue;
+
+      const passed = evaluateConditionFromSnapshot(
+        title.cond_rule_json as CondRule,
+        snapshot,
+        snapshotsByMemId,
+      );
+      if (!passed) continue;
+
+      toGrant.push({
+        team_id: teamId,
+        team_mem_id: snapshot.teamMemId,
+        ttl_id: title.ttl_id,
+        grnt_pt: title.base_pt,
+        aply_pt: title.base_pt,
+        pt_chg_rsn_cd: "initial_grant",
+        grnt_rsn_txt: "자동수여 (trigger=manual_sweep)",
+        is_prmy_yn: false,
+        vers: 0,
+        del_yn: false,
+      });
+    }
+  }
+
+  // 4. bulk 회수 — 회수 대상을 한 번에 UPDATE
+  if (toRevoke.length > 0) {
+    const revokeIds = toRevoke.map((r) => r.mem_ttl_id);
+    await db
+      .from("mem_ttl_rel")
+      .update({ del_yn: true, pt_chg_rsn_cd: "auto_revoke" })
+      .in("mem_ttl_id", revokeIds)
+      .eq("del_yn", false);
+    console.info(`[sweep] 칭호 자동 회수 ${toRevoke.length}건`);
+  }
+
+  // 5. bulk 부여 — 부여 대상을 한 번에 UPSERT
+  if (toGrant.length > 0) {
+    await db
+      .from("mem_ttl_rel")
+      .upsert(toGrant, { onConflict: "team_mem_id,ttl_id,vers", ignoreDuplicates: true });
+    console.info(`[sweep] 칭호 신규 부여 ${toGrant.length}건`);
+  }
+
+  return { granted: toGrant.length, revoked: toRevoke.length };
 }

--- a/lib/titles/engine.ts
+++ b/lib/titles/engine.ts
@@ -231,7 +231,6 @@ export async function sweepEvaluateAndGrant(
     team_id: string;
     team_mem_id: string;
     ttl_id: string;
-    pt_chg_rsn_cd: string;
     grnt_rsn_txt: string;
     is_prmy_yn: boolean;
     vers: number;
@@ -279,7 +278,6 @@ export async function sweepEvaluateAndGrant(
         team_id: teamId,
         team_mem_id: snapshot.teamMemId,
         ttl_id: title.ttl_id,
-        pt_chg_rsn_cd: "initial_grant",
         grnt_rsn_txt: "자동수여 (trigger=manual_sweep)",
         is_prmy_yn: false,
         vers: 0,
@@ -293,7 +291,7 @@ export async function sweepEvaluateAndGrant(
     const revokeIds = toRevoke.map((r) => r.mem_ttl_id);
     await db
       .from("mem_ttl_rel")
-      .update({ del_yn: true, pt_chg_rsn_cd: "auto_revoke" })
+      .update({ del_yn: true })
       .in("mem_ttl_id", revokeIds)
       .eq("del_yn", false);
     console.info(`[sweep] 칭호 자동 회수 ${toRevoke.length}건`);

--- a/lib/titles/evaluators.ts
+++ b/lib/titles/evaluators.ts
@@ -582,6 +582,19 @@ export function evaluateConditionFromSnapshot(
     case "race_pb_faster_than_member":
       return evalRacePbFasterThanMemberFromSnapshot(rule, snapshot, allSnapshots);
 
+    // 아래 조건들은 snapshot에 필요한 데이터가 없어 DB 조회가 필요 — sweep 시 false 처리
+    case "joined_on_date":
+    case "race_finish_in_month_range":
+    case "race_finish_all_titles":
+    case "race_finish_all_of":
+    case "race_finish_total":
+    case "race_finish_in_year":
+    case "race_rank_by_gender":
+    case "race_rank_last":
+    case "race_pb_within_sec_of_target":
+    case "has_title_in_categories":
+      return false;
+
     default:
       rule satisfies never;
       return false;

--- a/lib/titles/evaluators.ts
+++ b/lib/titles/evaluators.ts
@@ -5,7 +5,11 @@
  * DB 조회만 하고 INSERT/UPDATE는 하지 않는다.
  * ctx(트리거 컨텍스트)에 의존하지 않는다 — 트리거 필터링은 engine.ts 의 TRIGGER_COND_MAP 이 담당한다.
  *
- * 새 CondRule 타입을 추가하면 evaluateCondition() switch 에 케이스를 추가한다.
+ * 두 가지 평가 경로:
+ *   - evaluateCondition()         — 단건 트리거용 (DB 직접 조회). race_record, attendance 등에서 사용.
+ *   - evaluateConditionFromSnapshot() — bulk sweep 전용 (MemberSnapshot 메모리 평가). DB 쿼리 없음.
+ *
+ * 새 CondRule 타입을 추가하면 두 switch 모두에 케이스를 추가한다.
  */
 
 import dayjs from "dayjs";
@@ -38,6 +42,7 @@ import type {
   CondRacePbWithinSecOfTarget,
   CondHasTitleInCategories,
 } from "./types";
+import type { MemberSnapshot, RaceHistRow } from "./snapshot";
 import type { SupabaseClient } from "@supabase/supabase-js";
 
 type DB = SupabaseClient<Database>;
@@ -473,7 +478,7 @@ export async function evalHasTitleInCategoriesInternal(
 }
 
 // ---------------------------------------------------------------------------
-// 공개 진입점 — engine.ts 에서 호출
+// 공개 진입점 1 — 단건 트리거용 (DB 직접 조회)
 // ---------------------------------------------------------------------------
 
 export async function evaluateCondition(
@@ -535,4 +540,104 @@ export async function evaluateCondition(
       rule satisfies never;
       return false;
   }
+}
+
+// ---------------------------------------------------------------------------
+// 공개 진입점 2 — bulk sweep 전용 (MemberSnapshot 메모리 평가, DB 쿼리 없음)
+// ---------------------------------------------------------------------------
+
+/**
+ * CondRule 하나를 스냅샷 데이터만으로 평가한다. (manual_sweep 전용)
+ * DB 왕복 없이 메모리 내에서만 연산한다.
+ *
+ * @param allSnapshots  race_pb_faster_than_member 처럼 타 멤버 데이터가 필요한 조건을 위해 전체 맵을 전달한다.
+ */
+export function evaluateConditionFromSnapshot(
+  rule: CondRule,
+  snapshot: MemberSnapshot,
+  allSnapshots: Map<string, MemberSnapshot>,
+): boolean {
+  switch (rule.type) {
+    case "race_pb_under_sec":
+      return evalRacePbUnderSecFromSnapshot(rule, snapshot.raceHist);
+
+    case "race_finish_count":
+      return evalRaceFinishCountFromSnapshot(rule, snapshot.raceHist);
+
+    case "mileage_run_complete":
+      // TODO: 마일리지런 스냅샷 구현 전까지 false
+      return false;
+
+    case "attendance_count":
+      return snapshot.raceHist.length >= rule.count;
+
+    case "membership_days": {
+      if (!snapshot.joinDt) return false;
+      const diffDays = Math.floor(
+        (Date.now() - new Date(snapshot.joinDt).getTime()) / (1000 * 60 * 60 * 24),
+      );
+      return diffDays >= rule.days;
+    }
+
+    case "race_pb_faster_than_member":
+      return evalRacePbFasterThanMemberFromSnapshot(rule, snapshot, allSnapshots);
+
+    default:
+      rule satisfies never;
+      return false;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// snapshot 기반 내부 평가 함수 (메모리 전용)
+// ---------------------------------------------------------------------------
+
+function evalRacePbUnderSecFromSnapshot(
+  rule: CondRacePersonalBestUnderSec,
+  raceHist: RaceHistRow[],
+): boolean {
+  const candidates = raceHist.filter((r) => {
+    const typeMatch = r.comp_evt_type === rule.sport.toUpperCase();
+    const ctgrMatch = !rule.sport_ctgr || r.comp_sprt_cd === rule.sport_ctgr;
+    return typeMatch && ctgrMatch;
+  });
+  if (candidates.length === 0) return false;
+  const pb = Math.min(...candidates.map((r) => r.rec_time_sec));
+  return pb <= rule.sec;
+}
+
+function evalRaceFinishCountFromSnapshot(
+  rule: CondRaceFinishCount,
+  raceHist: RaceHistRow[],
+): boolean {
+  const count = raceHist.filter((r) => {
+    const typeMatch = !rule.sport || r.comp_evt_type === rule.sport.toUpperCase();
+    const ctgrMatch = !rule.sport_ctgr || r.comp_sprt_cd === rule.sport_ctgr;
+    return typeMatch && ctgrMatch;
+  }).length;
+  return count >= rule.count;
+}
+
+function evalRacePbFasterThanMemberFromSnapshot(
+  rule: CondRacePbFasterThanMember,
+  snapshot: MemberSnapshot,
+  allSnapshots: Map<string, MemberSnapshot>,
+): boolean {
+  if (snapshot.memId === rule.target_mem_id) return false;
+
+  // allSnapshots는 memId가 아닌 teamMemId 기준이므로 memId로 찾아야 한다
+  const targetSnapshot = [...allSnapshots.values()].find((s) => s.memId === rule.target_mem_id);
+
+  const sport = rule.sport.toUpperCase();
+
+  const myPb = snapshot.raceHist
+    .filter((r) => r.comp_evt_type === sport)
+    .reduce<number | null>((min, r) => (min === null || r.rec_time_sec < min ? r.rec_time_sec : min), null);
+
+  const targetPb = (targetSnapshot?.raceHist ?? [])
+    .filter((r) => r.comp_evt_type === sport)
+    .reduce<number | null>((min, r) => (min === null || r.rec_time_sec < min ? r.rec_time_sec : min), null);
+
+  if (myPb === null || targetPb === null) return false;
+  return myPb < targetPb;
 }

--- a/lib/titles/snapshot.ts
+++ b/lib/titles/snapshot.ts
@@ -1,0 +1,143 @@
+/**
+ * 칭호 일괄 평가용 멤버 스냅샷
+ *
+ * sweepAllTitles() 에서 멤버 전체 데이터를 DB 쿼리 5~6번으로 한 번에 로드한다.
+ * evaluators.ts 의 bulk 전용 함수들은 DB 대신 이 스냅샷을 받아 메모리 내에서 평가한다.
+ *
+ * 단건 트리거(race_record, attendance 등)는 스냅샷을 사용하지 않으므로 이 파일과 무관하다.
+ */
+
+import type { SupabaseClient } from "@supabase/supabase-js";
+import type { Database } from "@/lib/supabase/database.types";
+
+type DB = SupabaseClient<Database>;
+
+// ---------------------------------------------------------------------------
+// 스냅샷 타입
+// ---------------------------------------------------------------------------
+
+export type RaceHistRow = {
+  mem_id: string;
+  rec_time_sec: number;
+  comp_evt_type: string;   // comp_evt_cfg.comp_evt_type (정규화 후)
+  comp_sprt_cd: string;    // comp_mst.comp_sprt_cd (정규화 후)
+};
+
+/** 멤버 한 명의 평가에 필요한 데이터 */
+export type MemberSnapshot = {
+  teamMemId: string;
+  memId: string;
+  joinDt: string | null;
+  /** 이 멤버의 대회 기록 목록 */
+  raceHist: RaceHistRow[];
+  /** 현재 활성 보유 칭호 ID 셋 */
+  heldTitleIds: Set<string>;
+};
+
+/** mem_ttl_rel 보유 칭호 행 (회수 판단용) */
+export type HeldTitleRow = {
+  mem_ttl_id: string;
+  ttl_id: string;
+  vers: number;
+};
+
+export type MemberSnapshotWithHeld = MemberSnapshot & {
+  heldRows: HeldTitleRow[];
+};
+
+// ---------------------------------------------------------------------------
+// bulk 로더
+// ---------------------------------------------------------------------------
+
+/**
+ * 팀 전체 활성 멤버의 평가 데이터를 DB 쿼리 4번으로 한 번에 로드한다.
+ *
+ * @returns teamMemId → MemberSnapshotWithHeld 맵
+ */
+export async function loadMemberSnapshots(
+  db: DB,
+  teamId: string,
+  teamMemIds: string[],
+): Promise<Map<string, MemberSnapshotWithHeld>> {
+  if (teamMemIds.length === 0) return new Map();
+
+  // 1. team_mem_rel: team_mem_id → mem_id, join_dt 한 번에
+  const { data: relRows } = await db
+    .from("team_mem_rel")
+    .select("team_mem_id, mem_id, join_dt")
+    .eq("team_id", teamId)
+    .in("team_mem_id", teamMemIds)
+    .eq("vers", 0)
+    .eq("del_yn", false);
+
+  const relMap = new Map<string, { memId: string; joinDt: string | null }>();
+  for (const r of relRows ?? []) {
+    relMap.set(r.team_mem_id, { memId: r.mem_id, joinDt: r.join_dt ?? null });
+  }
+
+  const memIds = [...new Set([...relMap.values()].map((r) => r.memId))];
+  if (memIds.length === 0) return new Map();
+
+  // 2. rec_race_hist: 전체 멤버 기록 한 번에 (조인 포함)
+  const { data: histRows } = await db
+    .from("rec_race_hist")
+    .select("mem_id, rec_time_sec, comp_evt_cfg!inner(comp_evt_type), comp_mst!inner(comp_sprt_cd)")
+    .in("mem_id", memIds)
+    .eq("del_yn", false)
+    .eq("vers", 0);
+
+  // mem_id → RaceHistRow[] 맵으로 정규화
+  const histMap = new Map<string, RaceHistRow[]>();
+  for (const row of histRows ?? []) {
+    const evtCfg = Array.isArray(row.comp_evt_cfg) ? row.comp_evt_cfg[0] : row.comp_evt_cfg;
+    const mst = Array.isArray(row.comp_mst) ? row.comp_mst[0] : row.comp_mst;
+    const evtType = (evtCfg as { comp_evt_type?: string } | null)?.comp_evt_type?.toUpperCase() ?? "";
+    const sprtCd = (mst as { comp_sprt_cd?: string } | null)?.comp_sprt_cd ?? "";
+
+    if (!histMap.has(row.mem_id)) histMap.set(row.mem_id, []);
+    histMap.get(row.mem_id)!.push({
+      mem_id: row.mem_id,
+      rec_time_sec: row.rec_time_sec,
+      comp_evt_type: evtType,
+      comp_sprt_cd: sprtCd,
+    });
+  }
+
+  // 3. mem_ttl_rel: 전체 멤버 보유 칭호 한 번에
+  const { data: heldRows } = await db
+    .from("mem_ttl_rel")
+    .select("team_mem_id, mem_ttl_id, ttl_id, vers")
+    .in("team_mem_id", teamMemIds)
+    .eq("vers", 0)
+    .eq("del_yn", false);
+
+  // team_mem_id → HeldTitleRow[] 맵
+  const heldMap = new Map<string, HeldTitleRow[]>();
+  for (const r of heldRows ?? []) {
+    if (!heldMap.has(r.team_mem_id)) heldMap.set(r.team_mem_id, []);
+    heldMap.get(r.team_mem_id)!.push({
+      mem_ttl_id: r.mem_ttl_id,
+      ttl_id: r.ttl_id,
+      vers: r.vers,
+    });
+  }
+
+  // 4. 조합
+  const result = new Map<string, MemberSnapshotWithHeld>();
+  for (const teamMemId of teamMemIds) {
+    const rel = relMap.get(teamMemId);
+    if (!rel) continue;
+
+    const held = heldMap.get(teamMemId) ?? [];
+    result.set(teamMemId, {
+      teamMemId,
+      memId: rel.memId,
+      joinDt: rel.joinDt,
+      raceHist: histMap.get(rel.memId) ?? [],
+      heldTitleIds: new Set(held.map((h) => h.ttl_id)),
+      heldRows: held,
+    });
+  }
+
+  return result;
+}

--- a/supabase/migrations/20260528130000_title_rarity_system_v2.sql
+++ b/supabase/migrations/20260528130000_title_rarity_system_v2.sql
@@ -40,4 +40,4 @@ CREATE POLICY "effect_mst_select_authenticated"
   ON public.effect_mst
   FOR SELECT
   TO authenticated
-  USING (use_yn = true);
+  USING (true);


### PR DESCRIPTION
- use_yn은 선택 가능 여부만 제어, 조회와 무관 — effect_mst RLS에서 use_yn 조건 제거
- collection-sheet: ttl_mst·effect_mst 조회 시 use_yn 필터 제거 (잠금 항목도 목록에 표시)
- sweep 재계산: N×M 순차 쿼리 → MemberSnapshot 기반 bulk 처리 (DB 쿼리 ~5000번 → ~7번 고정)
- coding-standards.md에 use_yn 필드 의미 명문화

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * 칭호 등급 시스템(1~10 레벨) 추가
  * 배지 및 프레임 이펙트 시스템 추가
  * 팀 단위 일괄 칭호 재평가 엔진 도입 - 조건 미충족 시 칭호 자동 회수

* **Documentation**
  * 칭호 use_yn 필드의 의미 및 동작 정책 문서화

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Gigang-ST/gigang-client/pull/252?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->