### PR TITLE
perf(titles): 재계산 sweep N×M 순차 쿼리 → bulk 처리로 타임아웃 해결

### DIFF
--- a/app/actions/admin/sweep-titles.ts
+++ b/app/actions/admin/sweep-titles.ts
@@ -3,7 +3,7 @@
 import { verifyAdmin } from "@/lib/queries/member";
 import { getRequestTeamContext } from "@/lib/queries/request-team";
 import { createAdminClient } from "@/lib/supabase/admin";
-import { evaluateAndGrantTitles } from "@/lib/titles/engine";
+import { sweepEvaluateAndGrant } from "@/lib/titles/engine";
 
 /**
  * 팀 전체 멤버를 대상으로 자동 칭호를 일괄 재평가한다.
@@ -17,14 +17,14 @@ export async function sweepAllTitles(): Promise<{
   ok: boolean;
   message: string | null;
   granted: number;
+  revoked: number;
 }> {
   const admin = await verifyAdmin();
-  if (!admin) return { ok: false, message: "권한이 없습니다.", granted: 0 };
+  if (!admin) return { ok: false, message: "권한이 없습니다.", granted: 0, revoked: 0 };
 
   const { teamId } = await getRequestTeamContext();
   const db = createAdminClient();
 
-  // 팀 소속 활성 멤버 전체 조회
   const { data: members, error } = await db
     .from("team_mem_rel")
     .select("team_mem_id")
@@ -33,29 +33,17 @@ export async function sweepAllTitles(): Promise<{
     .eq("del_yn", false)
     .eq("mem_st_cd", "active");
 
-  if (error) return { ok: false, message: "멤버 조회에 실패했습니다.", granted: 0 };
+  if (error) return { ok: false, message: "멤버 조회에 실패했습니다.", granted: 0, revoked: 0 };
   if (!members || members.length === 0) {
-    return { ok: true, message: "활성 멤버가 없습니다.", granted: 0 };
+    return { ok: true, message: "활성 멤버가 없습니다.", granted: 0, revoked: 0 };
   }
 
-  let totalGranted = 0;
-
-  for (const m of members) {
-    try {
-      const granted = await evaluateAndGrantTitles({
-        trigger: "manual_sweep",
-        teamId,
-        teamMemId: m.team_mem_id,
-      });
-      totalGranted += granted.length;
-    } catch (e) {
-      console.error(`[sweep-titles] team_mem_id=${m.team_mem_id} 평가 실패`, e);
-    }
-  }
+  const { granted, revoked } = await sweepEvaluateAndGrant(teamId, members.map((m) => m.team_mem_id));
 
   return {
     ok: true,
-    message: `${members.length}명 평가 완료. 총 ${totalGranted}개 칭호 신규 부여.`,
-    granted: totalGranted,
+    message: `${members.length}명 평가 완료. 신규 부여 ${granted}개, 자동 회수 ${revoked}개.`,
+    granted,
+    revoked,
   };
 }

--- a/lib/titles/engine.ts
+++ b/lib/titles/engine.ts
@@ -14,10 +14,12 @@
 
 import { createAdminClient } from "@/lib/supabase/admin";
 
-import { evaluateCondition } from "./evaluators";
+import { evaluateCondition, evaluateConditionFromSnapshot } from "./evaluators";
+import { loadMemberSnapshots } from "./snapshot";
 import { TRIGGER_COND_MAP } from "./types";
 
 import type { CondRule, TitleEvalContext } from "./types";
+import type { MemberSnapshot } from "./snapshot";
 
 type TtlMstRow = {
   ttl_id: string;
@@ -171,4 +173,129 @@ export async function evaluateAndGrantTitles(
   }
 
   return granted;
+}
+
+// ---------------------------------------------------------------------------
+// bulk sweep 전용 엔진 — sweepAllTitles() 에서만 호출
+// ---------------------------------------------------------------------------
+
+/**
+ * 팀 전체 멤버를 대상으로 auto 칭호를 일괄 재평가하고 부여/회수한다.
+ *
+ * DB 쿼리 수: 멤버·칭호 수에 무관하게 약 7번 고정.
+ *   - loadMemberSnapshots: 3번 (team_mem_rel, rec_race_hist, mem_ttl_rel)
+ *   - ttl_mst 조회: 1번
+ *   - bulk UPDATE (회수): 1번
+ *   - bulk UPSERT (부여): 1번
+ */
+export async function sweepEvaluateAndGrant(
+  teamId: string,
+  teamMemIds: string[],
+): Promise<{ granted: number; revoked: number }> {
+  if (teamMemIds.length === 0) return { granted: 0, revoked: 0 };
+
+  const db = createAdminClient();
+
+  // 1. 멤버 전체 스냅샷 로드
+  const snapshots = await loadMemberSnapshots(db, teamId, teamMemIds);
+  if (snapshots.size === 0) return { granted: 0, revoked: 0 };
+
+  // 2. 팀의 auto 칭호 전체 조회 (1번 — 멤버 수와 무관)
+  const { data: allTitles } = await db
+    .from("ttl_mst")
+    .select("ttl_id, ttl_nm, cond_rule_json")
+    .eq("team_id", teamId)
+    .eq("ttl_kind_enm", "auto")
+    .eq("use_yn", true)
+    .eq("vers", 0)
+    .eq("del_yn", false);
+
+  const titles = (allTitles as TtlMstRow[] ?? []).filter((t) => t.cond_rule_json != null);
+  if (titles.length === 0) return { granted: 0, revoked: 0 };
+
+  const autoTitleIds = new Set(titles.map((t) => t.ttl_id));
+  const allowedCondTypes = new Set(TRIGGER_COND_MAP["manual_sweep"]);
+  const snapshotsByMemId = new Map<string, MemberSnapshot>(
+    [...snapshots.values()].map((s) => [s.teamMemId, s]),
+  );
+
+  type GrantRow = {
+    team_id: string;
+    team_mem_id: string;
+    ttl_id: string;
+    grnt_rsn_txt: string;
+    is_prmy_yn: boolean;
+    vers: number;
+    del_yn: boolean;
+  };
+
+  const toRevoke: { mem_ttl_id: string }[] = [];
+  const toGrant: GrantRow[] = [];
+
+  // 3. 메모리 내 평가 — DB 쿼리 없음
+  for (const snapshot of snapshots.values()) {
+    const eligibleTitles = titles.filter((t) => {
+      const rule = t.cond_rule_json as CondRule;
+      return allowedCondTypes.has(rule.type);
+    });
+
+    // 3-1. 회수: 보유 중인 auto 칭호 조건 미충족 → 회수 대상 수집
+    for (const held of snapshot.heldRows) {
+      if (!autoTitleIds.has(held.ttl_id)) continue;
+      const title = eligibleTitles.find((t) => t.ttl_id === held.ttl_id);
+      if (!title) continue;
+
+      const passed = evaluateConditionFromSnapshot(
+        title.cond_rule_json as CondRule,
+        snapshot,
+        snapshotsByMemId,
+      );
+      if (!passed) {
+        toRevoke.push({ mem_ttl_id: held.mem_ttl_id });
+        snapshot.heldTitleIds.delete(held.ttl_id);
+      }
+    }
+
+    // 3-2. 부여: 미보유 칭호 조건 충족 → 부여 대상 수집
+    for (const title of eligibleTitles) {
+      if (snapshot.heldTitleIds.has(title.ttl_id)) continue;
+
+      const passed = evaluateConditionFromSnapshot(
+        title.cond_rule_json as CondRule,
+        snapshot,
+        snapshotsByMemId,
+      );
+      if (!passed) continue;
+
+      toGrant.push({
+        team_id: teamId,
+        team_mem_id: snapshot.teamMemId,
+        ttl_id: title.ttl_id,
+        grnt_rsn_txt: "자동수여 (trigger=manual_sweep)",
+        is_prmy_yn: false,
+        vers: 0,
+        del_yn: false,
+      });
+    }
+  }
+
+  // 4. bulk 회수
+  if (toRevoke.length > 0) {
+    await db
+      .from("mem_ttl_rel")
+      .update({ del_yn: true })
+      .in("mem_ttl_id", toRevoke.map((r) => r.mem_ttl_id))
+      .eq("del_yn", false);
+    console.info(`[sweep] 칭호 자동 회수 ${toRevoke.length}건`);
+  }
+
+  // 5. bulk 부여
+  if (toGrant.length > 0) {
+    await db
+      .from("mem_ttl_rel")
+      .upsert(toGrant, { onConflict: "team_mem_id,ttl_id,vers", ignoreDuplicates: true });
+    console.info(`[sweep] 칭호 신규 부여 ${toGrant.length}건`);
+  }
+
+  return { granted: toGrant.length, revoked: toRevoke.length };
 }

--- a/lib/titles/evaluators.ts
+++ b/lib/titles/evaluators.ts
@@ -38,6 +38,7 @@ import type {
   CondRacePbWithinSecOfTarget,
   CondHasTitleInCategories,
 } from "./types";
+import type { MemberSnapshot, RaceHistRow } from "./snapshot";
 import type { SupabaseClient } from "@supabase/supabase-js";
 
 type DB = SupabaseClient<Database>;
@@ -535,4 +536,114 @@ export async function evaluateCondition(
       rule satisfies never;
       return false;
   }
+}
+
+// ---------------------------------------------------------------------------
+// 공개 진입점 2 — bulk sweep 전용 (MemberSnapshot 메모리 평가, DB 쿼리 없음)
+// ---------------------------------------------------------------------------
+
+/**
+ * CondRule 하나를 스냅샷 데이터만으로 평가한다. (manual_sweep 전용)
+ * DB 왕복 없이 메모리 내에서만 연산한다.
+ *
+ * @param allSnapshots  race_pb_faster_than_member 처럼 타 멤버 데이터가 필요한 조건을 위해 전체 맵을 전달한다.
+ */
+export function evaluateConditionFromSnapshot(
+  rule: CondRule,
+  snapshot: MemberSnapshot,
+  allSnapshots: Map<string, MemberSnapshot>,
+): boolean {
+  switch (rule.type) {
+    case "race_pb_under_sec":
+      return evalRacePbUnderSecFromSnapshot(rule, snapshot.raceHist);
+
+    case "race_finish_count":
+      return evalRaceFinishCountFromSnapshot(rule, snapshot.raceHist);
+
+    case "mileage_run_complete":
+      return false; // TODO: 마일리지런 스냅샷 구현 전까지 false
+
+    case "attendance_count":
+      return snapshot.raceHist.length >= rule.count;
+
+    case "membership_days": {
+      if (!snapshot.joinDt) return false;
+      const diffDays = Math.floor(
+        (Date.now() - new Date(snapshot.joinDt).getTime()) / (1000 * 60 * 60 * 24),
+      );
+      return diffDays >= rule.days;
+    }
+
+    case "race_pb_faster_than_member":
+      return evalRacePbFasterThanMemberFromSnapshot(rule, snapshot, allSnapshots);
+
+    // 아래 조건들은 snapshot에 필요한 데이터가 없어 DB 조회 필요 — sweep 시 false 처리
+    case "joined_on_date":
+    case "race_finish_in_month_range":
+    case "race_finish_all_titles":
+    case "race_finish_all_of":
+    case "race_finish_total":
+    case "race_finish_in_year":
+    case "race_rank_by_gender":
+    case "race_rank_last":
+    case "race_pb_within_sec_of_target":
+    case "has_title_in_categories":
+      return false;
+
+    default:
+      rule satisfies never;
+      return false;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// snapshot 기반 내부 평가 함수 (메모리 전용)
+// ---------------------------------------------------------------------------
+
+function evalRacePbUnderSecFromSnapshot(
+  rule: CondRacePersonalBestUnderSec,
+  raceHist: RaceHistRow[],
+): boolean {
+  const candidates = raceHist.filter((r) => {
+    const typeMatch = r.comp_evt_type === rule.sport.toUpperCase();
+    const ctgrMatch = !rule.sport_ctgr || r.comp_sprt_cd === rule.sport_ctgr;
+    return typeMatch && ctgrMatch;
+  });
+  if (candidates.length === 0) return false;
+  const pb = Math.min(...candidates.map((r) => r.rec_time_sec));
+  return pb <= rule.sec;
+}
+
+function evalRaceFinishCountFromSnapshot(
+  rule: CondRaceFinishCount,
+  raceHist: RaceHistRow[],
+): boolean {
+  const count = raceHist.filter((r) => {
+    const typeMatch = !rule.sport || r.comp_evt_type === rule.sport.toUpperCase();
+    const ctgrMatch = !rule.sport_ctgr || r.comp_sprt_cd === rule.sport_ctgr;
+    return typeMatch && ctgrMatch;
+  }).length;
+  return count >= rule.count;
+}
+
+function evalRacePbFasterThanMemberFromSnapshot(
+  rule: CondRacePbFasterThanMember,
+  snapshot: MemberSnapshot,
+  allSnapshots: Map<string, MemberSnapshot>,
+): boolean {
+  if (snapshot.memId === rule.target_mem_id) return false;
+
+  const targetSnapshot = [...allSnapshots.values()].find((s) => s.memId === rule.target_mem_id);
+  const sport = rule.sport.toUpperCase();
+
+  const myPb = snapshot.raceHist
+    .filter((r) => r.comp_evt_type === sport)
+    .reduce<number | null>((min, r) => (min === null || r.rec_time_sec < min ? r.rec_time_sec : min), null);
+
+  const targetPb = (targetSnapshot?.raceHist ?? [])
+    .filter((r) => r.comp_evt_type === sport)
+    .reduce<number | null>((min, r) => (min === null || r.rec_time_sec < min ? r.rec_time_sec : min), null);
+
+  if (myPb === null || targetPb === null) return false;
+  return myPb < targetPb;
 }

--- a/lib/titles/snapshot.ts
+++ b/lib/titles/snapshot.ts
@@ -1,0 +1,138 @@
+/**
+ * 칭호 일괄 평가용 멤버 스냅샷
+ *
+ * sweepAllTitles() 에서 멤버 전체 데이터를 DB 쿼리 4번으로 한 번에 로드한다.
+ * evaluators.ts 의 bulk 전용 함수들은 DB 대신 이 스냅샷을 받아 메모리 내에서 평가한다.
+ *
+ * 단건 트리거(race_record, attendance 등)는 스냅샷을 사용하지 않으므로 이 파일과 무관하다.
+ */
+
+import type { SupabaseClient } from "@supabase/supabase-js";
+import type { Database } from "@/lib/supabase/database.types";
+
+type DB = SupabaseClient<Database>;
+
+// ---------------------------------------------------------------------------
+// 스냅샷 타입
+// ---------------------------------------------------------------------------
+
+export type RaceHistRow = {
+  mem_id: string;
+  rec_time_sec: number;
+  comp_evt_type: string;   // comp_evt_cfg.comp_evt_type (정규화 후)
+  comp_sprt_cd: string;    // comp_mst.comp_sprt_cd (정규화 후)
+};
+
+/** 멤버 한 명의 평가에 필요한 데이터 */
+export type MemberSnapshot = {
+  teamMemId: string;
+  memId: string;
+  joinDt: string | null;
+  raceHist: RaceHistRow[];
+  heldTitleIds: Set<string>;
+};
+
+export type HeldTitleRow = {
+  mem_ttl_id: string;
+  ttl_id: string;
+  vers: number;
+};
+
+export type MemberSnapshotWithHeld = MemberSnapshot & {
+  heldRows: HeldTitleRow[];
+};
+
+// ---------------------------------------------------------------------------
+// bulk 로더
+// ---------------------------------------------------------------------------
+
+/**
+ * 팀 전체 활성 멤버의 평가 데이터를 DB 쿼리 4번으로 한 번에 로드한다.
+ *
+ * @returns teamMemId → MemberSnapshotWithHeld 맵
+ */
+export async function loadMemberSnapshots(
+  db: DB,
+  teamId: string,
+  teamMemIds: string[],
+): Promise<Map<string, MemberSnapshotWithHeld>> {
+  if (teamMemIds.length === 0) return new Map();
+
+  // 1. team_mem_rel: team_mem_id → mem_id, join_dt 한 번에
+  const { data: relRows } = await db
+    .from("team_mem_rel")
+    .select("team_mem_id, mem_id, join_dt")
+    .eq("team_id", teamId)
+    .in("team_mem_id", teamMemIds)
+    .eq("vers", 0)
+    .eq("del_yn", false);
+
+  const relMap = new Map<string, { memId: string; joinDt: string | null }>();
+  for (const r of relRows ?? []) {
+    relMap.set(r.team_mem_id, { memId: r.mem_id, joinDt: r.join_dt ?? null });
+  }
+
+  const memIds = [...new Set([...relMap.values()].map((r) => r.memId))];
+  if (memIds.length === 0) return new Map();
+
+  // 2. rec_race_hist: 전체 멤버 기록 한 번에
+  const { data: histRows } = await db
+    .from("rec_race_hist")
+    .select("mem_id, rec_time_sec, comp_evt_cfg!inner(comp_evt_type), comp_mst!inner(comp_sprt_cd)")
+    .in("mem_id", memIds)
+    .eq("del_yn", false)
+    .eq("vers", 0);
+
+  const histMap = new Map<string, RaceHistRow[]>();
+  for (const row of histRows ?? []) {
+    const evtCfg = Array.isArray(row.comp_evt_cfg) ? row.comp_evt_cfg[0] : row.comp_evt_cfg;
+    const mst = Array.isArray(row.comp_mst) ? row.comp_mst[0] : row.comp_mst;
+    const evtType = (evtCfg as { comp_evt_type?: string } | null)?.comp_evt_type?.toUpperCase() ?? "";
+    const sprtCd = (mst as { comp_sprt_cd?: string } | null)?.comp_sprt_cd ?? "";
+
+    if (!histMap.has(row.mem_id)) histMap.set(row.mem_id, []);
+    histMap.get(row.mem_id)!.push({
+      mem_id: row.mem_id,
+      rec_time_sec: row.rec_time_sec,
+      comp_evt_type: evtType,
+      comp_sprt_cd: sprtCd,
+    });
+  }
+
+  // 3. mem_ttl_rel: 전체 멤버 보유 칭호 한 번에
+  const { data: heldRows } = await db
+    .from("mem_ttl_rel")
+    .select("team_mem_id, mem_ttl_id, ttl_id, vers")
+    .in("team_mem_id", teamMemIds)
+    .eq("vers", 0)
+    .eq("del_yn", false);
+
+  const heldMap = new Map<string, HeldTitleRow[]>();
+  for (const r of heldRows ?? []) {
+    if (!heldMap.has(r.team_mem_id)) heldMap.set(r.team_mem_id, []);
+    heldMap.get(r.team_mem_id)!.push({
+      mem_ttl_id: r.mem_ttl_id,
+      ttl_id: r.ttl_id,
+      vers: r.vers,
+    });
+  }
+
+  // 4. 조합
+  const result = new Map<string, MemberSnapshotWithHeld>();
+  for (const teamMemId of teamMemIds) {
+    const rel = relMap.get(teamMemId);
+    if (!rel) continue;
+
+    const held = heldMap.get(teamMemId) ?? [];
+    result.set(teamMemId, {
+      teamMemId,
+      memId: rel.memId,
+      joinDt: rel.joinDt,
+      raceHist: histMap.get(rel.memId) ?? [],
+      heldTitleIds: new Set(held.map((h) => h.ttl_id)),
+      heldRows: held,
+    });
+  }
+
+  return result;
+}


### PR DESCRIPTION
- MemberSnapshot 기반 멤버 전체 데이터 일괄 로드 (DB 쿼리 ~5000번 → ~7번 고정)
- sweepEvaluateAndGrant(): 메모리 내 평가 후 bulk upsert/update
- evaluateConditionFromSnapshot(): DB 없이 스냅샷만으로 조건 평가
- 단건 트리거(race_record 등)는 기존 evaluateAndGrantTitles() 그대로 유지