### PR TITLE
fix(titles): sweep snapshot에 누락 데이터 추가 — 모든 auto 조건 평가 가능하도록

### DIFF
--- a/lib/titles/engine.ts
+++ b/lib/titles/engine.ts
@@ -84,51 +84,6 @@ export async function evaluateAndGrantTitles(
 
   const activeIds = new Set((existing ?? []).map((r) => r.ttl_id));
 
-  // 4-1. manual_sweep 전용: 보유 중인 auto 칭호 조건 재평가 → 미충족 시 자동 회수
-  //      트리거마다 회수를 실행하면 과부하이므로 일괄 재계산 시에만 수행한다.
-  if (ctx.trigger === "manual_sweep") {
-    const autoTitleIds = new Set(titles.map((t) => t.ttl_id));
-
-    for (const held of existing ?? []) {
-      if (!autoTitleIds.has(held.ttl_id)) continue; // auto 칭호가 아니면 회수 대상 제외
-
-      const title = titles.find((t) => t.ttl_id === held.ttl_id);
-      if (!title) continue;
-
-      let passed = false;
-      try {
-        passed = await evaluateCondition(title.cond_rule_json as CondRule, ctx, memId, db);
-      } catch (e) {
-        console.error(`[title-engine] 회수 평가 실패 ttl_id=${held.ttl_id}`, e);
-        continue;
-      }
-
-      if (!passed) {
-        // 현재 최대 vers를 기준으로 다음 vers 계산 — 재부여/재회수 반복 시 충돌 방지
-        const { data: maxVersRow } = await db
-          .from("mem_ttl_rel")
-          .select("vers")
-          .eq("team_mem_id", ctx.teamMemId)
-          .eq("ttl_id", held.ttl_id)
-          .order("vers", { ascending: false })
-          .limit(1)
-          .maybeSingle();
-        const nextVers = (maxVersRow?.vers ?? 0) + 1;
-
-        const { error } = await db
-          .from("mem_ttl_rel")
-          .update({ del_yn: true, vers: nextVers })
-          .eq("mem_ttl_id", held.mem_ttl_id)
-          .eq("vers", held.vers)
-          .eq("del_yn", false);
-
-        if (!error) {
-          activeIds.delete(held.ttl_id); // 회수 완료 → 재부여 대상으로 재평가 가능
-          console.info(`[title-engine] 칭호 자동 회수: ttl_id=${held.ttl_id} → team_mem_id=${ctx.teamMemId}`);
-        }
-      }
-    }
-  }
 
   // 5. 조건 평가 → 통과한 미보유 칭호 수여
   const granted: string[] = [];
@@ -213,7 +168,6 @@ export async function sweepEvaluateAndGrant(
   const titles = (allTitles as TtlMstRow[] ?? []).filter((t) => t.cond_rule_json != null);
   if (titles.length === 0) return { granted: 0, revoked: 0 };
 
-  const autoTitleIds = new Set(titles.map((t) => t.ttl_id));
   const allowedCondTypes = new Set(TRIGGER_COND_MAP["manual_sweep"]);
   const snapshotsByMemId = new Map<string, MemberSnapshot>(
     [...snapshots.values()].map((s) => [s.teamMemId, s]),
@@ -229,7 +183,6 @@ export async function sweepEvaluateAndGrant(
     del_yn: boolean;
   };
 
-  const toRevoke: { mem_ttl_id: string }[] = [];
   const toGrant: GrantRow[] = [];
 
   // 3. 메모리 내 평가 — DB 쿼리 없음
@@ -239,24 +192,7 @@ export async function sweepEvaluateAndGrant(
       return allowedCondTypes.has(rule.type);
     });
 
-    // 3-1. 회수: 보유 중인 auto 칭호 조건 미충족 → 회수 대상 수집
-    for (const held of snapshot.heldRows) {
-      if (!autoTitleIds.has(held.ttl_id)) continue;
-      const title = eligibleTitles.find((t) => t.ttl_id === held.ttl_id);
-      if (!title) continue;
-
-      const passed = evaluateConditionFromSnapshot(
-        title.cond_rule_json as CondRule,
-        snapshot,
-        snapshotsByMemId,
-      );
-      if (!passed) {
-        toRevoke.push({ mem_ttl_id: held.mem_ttl_id });
-        snapshot.heldTitleIds.delete(held.ttl_id);
-      }
-    }
-
-    // 3-2. 부여: 미보유 칭호 조건 충족 → 부여 대상 수집
+    // 부여: 미보유 칭호 조건 충족 → 부여 대상 수집
     for (const title of eligibleTitles) {
       if (snapshot.heldTitleIds.has(title.ttl_id)) continue;
 
@@ -279,17 +215,7 @@ export async function sweepEvaluateAndGrant(
     }
   }
 
-  // 4. bulk 회수
-  if (toRevoke.length > 0) {
-    await db
-      .from("mem_ttl_rel")
-      .update({ del_yn: true })
-      .in("mem_ttl_id", toRevoke.map((r) => r.mem_ttl_id))
-      .eq("del_yn", false);
-    console.info(`[sweep] 칭호 자동 회수 ${toRevoke.length}건`);
-  }
-
-  // 5. bulk 부여
+  // 4. bulk 부여
   if (toGrant.length > 0) {
     await db
       .from("mem_ttl_rel")
@@ -297,5 +223,5 @@ export async function sweepEvaluateAndGrant(
     console.info(`[sweep] 칭호 신규 부여 ${toGrant.length}건`);
   }
 
-  return { granted: toGrant.length, revoked: toRevoke.length };
+  return { granted: toGrant.length, revoked: 0 };
 }

--- a/lib/titles/evaluators.ts
+++ b/lib/titles/evaluators.ts
@@ -577,18 +577,68 @@ export function evaluateConditionFromSnapshot(
     case "race_pb_faster_than_member":
       return evalRacePbFasterThanMemberFromSnapshot(rule, snapshot, allSnapshots);
 
-    // 아래 조건들은 snapshot에 필요한 데이터가 없어 DB 조회 필요 — sweep 시 false 처리
-    case "joined_on_date":
+    case "joined_on_date": {
+      if (!snapshot.joinDt) return false;
+      const joinKST = new Date(new Date(snapshot.joinDt).toLocaleString("en-US", { timeZone: "Asia/Seoul" }));
+      return joinKST.getMonth() + 1 === rule.month && joinKST.getDate() === rule.day;
+    }
+
     case "race_finish_in_month_range":
+      return snapshot.raceHist.some((r) => {
+        if (!r.comp_date) return false;
+        const month = new Date(r.comp_date).getMonth() + 1;
+        const typeMatch = !rule.sport || r.comp_evt_type === rule.sport.toUpperCase();
+        const ctgrMatch = !rule.sport_ctgr || r.comp_sprt_cd === rule.sport_ctgr;
+        return rule.months.includes(month) && typeMatch && ctgrMatch;
+      });
+
     case "race_finish_all_titles":
-    case "race_finish_all_of":
-    case "race_finish_total":
-    case "race_finish_in_year":
-    case "race_rank_by_gender":
-    case "race_rank_last":
-    case "race_pb_within_sec_of_target":
-    case "has_title_in_categories":
+      // race_finish_all_titles: 지정 칭호명 목록을 전부 보유 — snapshot 미지원, false 처리
       return false;
+
+    case "race_finish_all_of": {
+      // sports 목록 각각에서 최소 count번 완주
+      return rule.sports.every((sport) => {
+        const cnt = snapshot.raceHist.filter((r) => {
+          const typeMatch = r.comp_evt_type === sport.toUpperCase();
+          const ctgrMatch = !rule.sport_ctgr || r.comp_sprt_cd === rule.sport_ctgr;
+          return typeMatch && ctgrMatch;
+        }).length;
+        return cnt >= rule.count;
+      });
+    }
+
+    case "race_finish_total":
+      return snapshot.raceHist.length >= rule.count;
+
+    case "race_finish_in_year": {
+      const targetYear = rule.year ?? new Date().getFullYear();
+      const count = snapshot.raceHist.filter((r) => {
+        if (!r.comp_date) return false;
+        return new Date(r.comp_date).getFullYear() === targetYear;
+      }).length;
+      return count >= rule.count;
+    }
+
+    case "race_rank_by_gender":
+      return evalRaceRankByGenderFromSnapshot(rule, snapshot, allSnapshots);
+
+    case "race_rank_last":
+      return evalRaceRankLastFromSnapshot(rule, snapshot, allSnapshots);
+
+    case "race_pb_within_sec_of_target": {
+      const sport = rule.sport.toUpperCase();
+      const myPb = snapshot.raceHist
+        .filter((r) => r.comp_evt_type === sport)
+        .reduce<number | null>((min, r) => (min === null || r.rec_time_sec < min ? r.rec_time_sec : min), null);
+      if (myPb === null) return false;
+      return rule.targets.some((target) => myPb > target && myPb - target <= rule.within_sec);
+    }
+
+    case "has_title_in_categories": {
+      const heldCtgrs = new Set([...snapshot.heldTitleMeta.values()].map((m) => m.ttl_ctgr_cd));
+      return rule.categories.every((c: string) => heldCtgrs.has(c));
+    }
 
     default:
       rule satisfies never;
@@ -646,4 +696,74 @@ function evalRacePbFasterThanMemberFromSnapshot(
 
   if (myPb === null || targetPb === null) return false;
   return myPb < targetPb;
+}
+
+function evalRaceRankByGenderFromSnapshot(
+  rule: CondRaceRankByGender,
+  snapshot: MemberSnapshot,
+  allSnapshots: Map<string, MemberSnapshot>,
+): boolean {
+  const sport = rule.sport?.toUpperCase();
+
+  // 멤버별 PB 추출 (전체 snapshot 기준)
+  const pbMap = new Map<string, { sec: number; gender: string }>();
+  for (const s of allSnapshots.values()) {
+    const candidates = s.raceHist.filter((r) => {
+      const typeMatch = !sport || r.comp_evt_type === sport;
+      const ctgrMatch = !rule.sport_ctgr || r.comp_sprt_cd === rule.sport_ctgr;
+      return typeMatch && ctgrMatch;
+    });
+    if (candidates.length === 0) continue;
+    const pb = Math.min(...candidates.map((r) => r.rec_time_sec));
+    pbMap.set(s.memId, { sec: pb, gender: s.gender });
+  }
+
+  if (!pbMap.has(snapshot.memId)) return false;
+
+  const checkGender = (gender: string) => {
+    const filtered = [...pbMap.entries()]
+      .filter(([, v]) => v.gender === gender)
+      .sort(([, a], [, b]) => a.sec - b.sec);
+    const myRank = filtered.findIndex(([id]) => id === snapshot.memId) + 1;
+    if (myRank === 0) return false;
+    return myRank === rule.rank;
+  };
+
+  if (rule.gender === "any") return checkGender("male") || checkGender("female");
+  return checkGender(rule.gender);
+}
+
+function evalRaceRankLastFromSnapshot(
+  rule: CondRaceRankLast,
+  snapshot: MemberSnapshot,
+  allSnapshots: Map<string, MemberSnapshot>,
+): boolean {
+  // sports 목록 중 하나라도 꼴찌면 true
+  return rule.sports.some((sport) => {
+    const pbMap = new Map<string, { sec: number; gender: string }>();
+    for (const s of allSnapshots.values()) {
+      const candidates = s.raceHist.filter((r) => {
+        const typeMatch = r.comp_evt_type === sport.toUpperCase();
+        const ctgrMatch = !rule.sport_ctgr || r.comp_sprt_cd === rule.sport_ctgr;
+        return typeMatch && ctgrMatch;
+      });
+      if (candidates.length === 0) continue;
+      const pb = Math.min(...candidates.map((r) => r.rec_time_sec));
+      pbMap.set(s.memId, { sec: pb, gender: s.gender });
+    }
+
+    if (!pbMap.has(snapshot.memId)) return false;
+
+    const checkGender = (gender: string) => {
+      const filtered = [...pbMap.entries()]
+        .filter(([, v]) => v.gender === gender)
+        .sort(([, a], [, b]) => a.sec - b.sec);
+      const myRank = filtered.findIndex(([id]) => id === snapshot.memId) + 1;
+      if (myRank === 0) return false;
+      return myRank === filtered.length;
+    };
+
+    if (rule.gender === "any") return checkGender("male") || checkGender("female");
+    return checkGender(rule.gender);
+  });
 }

--- a/lib/titles/evaluators.ts
+++ b/lib/titles/evaluators.ts
@@ -204,7 +204,7 @@ export async function evalRaceFinishInMonthRangeInternal(
 ): Promise<boolean> {
   const { data } = await db
     .from("rec_race_hist")
-    .select("race_result_id, comp_mst!inner(comp_date, comp_sprt_cd), comp_evt_cfg!inner(comp_evt_type)")
+    .select("race_result_id, comp_mst!inner(stt_dt, comp_sprt_cd), comp_evt_cfg!inner(comp_evt_type)")
     .eq("mem_id", memId)
     .eq("del_yn", false)
     .eq("vers", 0);
@@ -213,7 +213,7 @@ export async function evalRaceFinishInMonthRangeInternal(
 
   return data.some((row) => {
     const mst = Array.isArray(row.comp_mst) ? row.comp_mst[0] : row.comp_mst;
-    const compDate = (mst as { comp_date?: string; comp_sprt_cd?: string } | null)?.comp_date;
+    const compDate = (mst as { stt_dt?: string; comp_sprt_cd?: string } | null)?.stt_dt;
     const sprtCd = (mst as { comp_sprt_cd?: string } | null)?.comp_sprt_cd ?? null;
     const evtCfg = Array.isArray(row.comp_evt_cfg) ? row.comp_evt_cfg[0] : row.comp_evt_cfg;
     const evtType = (evtCfg as { comp_evt_type?: string } | null)?.comp_evt_type?.toUpperCase() ?? "";
@@ -310,7 +310,7 @@ export async function evalRaceFinishInYearInternal(
 
   const { data } = await db
     .from("rec_race_hist")
-    .select("race_result_id, comp_mst!inner(comp_date)")
+    .select("race_result_id, comp_mst!inner(stt_dt)")
     .eq("mem_id", memId)
     .eq("del_yn", false)
     .eq("vers", 0);
@@ -319,7 +319,7 @@ export async function evalRaceFinishInYearInternal(
 
   const count = data.filter((row) => {
     const mst = Array.isArray(row.comp_mst) ? row.comp_mst[0] : row.comp_mst;
-    const compDate = (mst as { comp_date?: string } | null)?.comp_date ?? "";
+    const compDate = (mst as { stt_dt?: string } | null)?.stt_dt ?? "";
     return compDate >= from && compDate <= to;
   }).length;
 

--- a/lib/titles/snapshot.ts
+++ b/lib/titles/snapshot.ts
@@ -21,7 +21,7 @@ export type RaceHistRow = {
   rec_time_sec: number;
   comp_evt_type: string;   // comp_evt_cfg.comp_evt_type (정규화 후)
   comp_sprt_cd: string;    // comp_mst.comp_sprt_cd (정규화 후)
-  comp_date: string | null; // comp_mst.comp_date (월범위/연도 조건용)
+  comp_date: string | null; // comp_mst.stt_dt (월범위/연도 조건용)
 };
 
 /** 멤버 한 명의 평가에 필요한 데이터 */
@@ -90,10 +90,10 @@ export async function loadMemberSnapshots(
     genderMap.set(r.mem_id, r.gdr_enm ?? "");
   }
 
-  // 3. rec_race_hist: 전체 멤버 기록 한 번에 (comp_date 포함)
+  // 3. rec_race_hist: 전체 멤버 기록 한 번에 (stt_dt 포함)
   const { data: histRows } = await db
     .from("rec_race_hist")
-    .select("mem_id, rec_time_sec, comp_evt_cfg!inner(comp_evt_type), comp_mst!inner(comp_sprt_cd, comp_date)")
+    .select("mem_id, rec_time_sec, comp_evt_cfg!inner(comp_evt_type), comp_mst!inner(comp_sprt_cd, stt_dt)")
     .in("mem_id", memIds)
     .eq("del_yn", false)
     .eq("vers", 0);
@@ -103,8 +103,8 @@ export async function loadMemberSnapshots(
     const evtCfg = Array.isArray(row.comp_evt_cfg) ? row.comp_evt_cfg[0] : row.comp_evt_cfg;
     const mst = Array.isArray(row.comp_mst) ? row.comp_mst[0] : row.comp_mst;
     const evtType = (evtCfg as { comp_evt_type?: string } | null)?.comp_evt_type?.toUpperCase() ?? "";
-    const sprtCd = (mst as { comp_sprt_cd?: string; comp_date?: string } | null)?.comp_sprt_cd ?? "";
-    const compDate = (mst as { comp_sprt_cd?: string; comp_date?: string } | null)?.comp_date ?? null;
+    const sprtCd = (mst as { comp_sprt_cd?: string; stt_dt?: string } | null)?.comp_sprt_cd ?? "";
+    const compDate = (mst as { comp_sprt_cd?: string; stt_dt?: string } | null)?.stt_dt ?? null;
 
     if (!histMap.has(row.mem_id)) histMap.set(row.mem_id, []);
     histMap.get(row.mem_id)!.push({

--- a/lib/titles/snapshot.ts
+++ b/lib/titles/snapshot.ts
@@ -1,7 +1,7 @@
 /**
  * 칭호 일괄 평가용 멤버 스냅샷
  *
- * sweepAllTitles() 에서 멤버 전체 데이터를 DB 쿼리 4번으로 한 번에 로드한다.
+ * sweepAllTitles() 에서 멤버 전체 데이터를 DB 쿼리 6번으로 한 번에 로드한다.
  * evaluators.ts 의 bulk 전용 함수들은 DB 대신 이 스냅샷을 받아 메모리 내에서 평가한다.
  *
  * 단건 트리거(race_record, attendance 등)는 스냅샷을 사용하지 않으므로 이 파일과 무관하다.
@@ -21,6 +21,7 @@ export type RaceHistRow = {
   rec_time_sec: number;
   comp_evt_type: string;   // comp_evt_cfg.comp_evt_type (정규화 후)
   comp_sprt_cd: string;    // comp_mst.comp_sprt_cd (정규화 후)
+  comp_date: string | null; // comp_mst.comp_date (월범위/연도 조건용)
 };
 
 /** 멤버 한 명의 평가에 필요한 데이터 */
@@ -28,8 +29,11 @@ export type MemberSnapshot = {
   teamMemId: string;
   memId: string;
   joinDt: string | null;
+  gender: string;          // mem_mst.gdr_enm (race_rank_by_gender 조건용)
   raceHist: RaceHistRow[];
   heldTitleIds: Set<string>;
+  /** 보유 칭호 ID → { ttl_nm, ttl_ctgr_cd } 맵 (race_finish_all_titles, has_title_in_categories 조건용) */
+  heldTitleMeta: Map<string, { ttl_nm: string; ttl_ctgr_cd: string }>;
 };
 
 export type HeldTitleRow = {
@@ -47,7 +51,7 @@ export type MemberSnapshotWithHeld = MemberSnapshot & {
 // ---------------------------------------------------------------------------
 
 /**
- * 팀 전체 활성 멤버의 평가 데이터를 DB 쿼리 4번으로 한 번에 로드한다.
+ * 팀 전체 활성 멤버의 평가 데이터를 DB 쿼리 6번으로 한 번에 로드한다.
  *
  * @returns teamMemId → MemberSnapshotWithHeld 맵
  */
@@ -75,10 +79,21 @@ export async function loadMemberSnapshots(
   const memIds = [...new Set([...relMap.values()].map((r) => r.memId))];
   if (memIds.length === 0) return new Map();
 
-  // 2. rec_race_hist: 전체 멤버 기록 한 번에
+  // 2. mem_mst: 성별 한 번에 (race_rank_by_gender 조건용)
+  const { data: memRows } = await db
+    .from("mem_mst")
+    .select("mem_id, gdr_enm")
+    .in("mem_id", memIds);
+
+  const genderMap = new Map<string, string>();
+  for (const r of memRows ?? []) {
+    genderMap.set(r.mem_id, r.gdr_enm ?? "");
+  }
+
+  // 3. rec_race_hist: 전체 멤버 기록 한 번에 (comp_date 포함)
   const { data: histRows } = await db
     .from("rec_race_hist")
-    .select("mem_id, rec_time_sec, comp_evt_cfg!inner(comp_evt_type), comp_mst!inner(comp_sprt_cd)")
+    .select("mem_id, rec_time_sec, comp_evt_cfg!inner(comp_evt_type), comp_mst!inner(comp_sprt_cd, comp_date)")
     .in("mem_id", memIds)
     .eq("del_yn", false)
     .eq("vers", 0);
@@ -88,7 +103,8 @@ export async function loadMemberSnapshots(
     const evtCfg = Array.isArray(row.comp_evt_cfg) ? row.comp_evt_cfg[0] : row.comp_evt_cfg;
     const mst = Array.isArray(row.comp_mst) ? row.comp_mst[0] : row.comp_mst;
     const evtType = (evtCfg as { comp_evt_type?: string } | null)?.comp_evt_type?.toUpperCase() ?? "";
-    const sprtCd = (mst as { comp_sprt_cd?: string } | null)?.comp_sprt_cd ?? "";
+    const sprtCd = (mst as { comp_sprt_cd?: string; comp_date?: string } | null)?.comp_sprt_cd ?? "";
+    const compDate = (mst as { comp_sprt_cd?: string; comp_date?: string } | null)?.comp_date ?? null;
 
     if (!histMap.has(row.mem_id)) histMap.set(row.mem_id, []);
     histMap.get(row.mem_id)!.push({
@@ -96,10 +112,11 @@ export async function loadMemberSnapshots(
       rec_time_sec: row.rec_time_sec,
       comp_evt_type: evtType,
       comp_sprt_cd: sprtCd,
+      comp_date: compDate,
     });
   }
 
-  // 3. mem_ttl_rel: 전체 멤버 보유 칭호 한 번에
+  // 4. mem_ttl_rel: 전체 멤버 보유 칭호 한 번에
   const { data: heldRows } = await db
     .from("mem_ttl_rel")
     .select("team_mem_id, mem_ttl_id, ttl_id, vers")
@@ -117,19 +134,44 @@ export async function loadMemberSnapshots(
     });
   }
 
-  // 4. 조합
+  // 5. ttl_mst: 팀 칭호 메타 한 번에 (ttl_nm, ttl_ctgr_cd — race_finish_all_titles, has_title_in_categories 조건용)
+  const allHeldTtlIds = [...new Set([...(heldRows ?? []).map((r) => r.ttl_id)])];
+  const titleMetaMap = new Map<string, { ttl_nm: string; ttl_ctgr_cd: string }>();
+
+  if (allHeldTtlIds.length > 0) {
+    const { data: titleRows } = await db
+      .from("ttl_mst")
+      .select("ttl_id, ttl_nm, ttl_ctgr_cd")
+      .in("ttl_id", allHeldTtlIds)
+      .eq("vers", 0)
+      .eq("del_yn", false);
+
+    for (const r of titleRows ?? []) {
+      titleMetaMap.set(r.ttl_id, { ttl_nm: r.ttl_nm, ttl_ctgr_cd: r.ttl_ctgr_cd });
+    }
+  }
+
+  // 6. 조합
   const result = new Map<string, MemberSnapshotWithHeld>();
   for (const teamMemId of teamMemIds) {
     const rel = relMap.get(teamMemId);
     if (!rel) continue;
 
     const held = heldMap.get(teamMemId) ?? [];
+    const heldTitleMeta = new Map<string, { ttl_nm: string; ttl_ctgr_cd: string }>();
+    for (const h of held) {
+      const meta = titleMetaMap.get(h.ttl_id);
+      if (meta) heldTitleMeta.set(h.ttl_id, meta);
+    }
+
     result.set(teamMemId, {
       teamMemId,
       memId: rel.memId,
       joinDt: rel.joinDt,
+      gender: genderMap.get(rel.memId) ?? "",
       raceHist: histMap.get(rel.memId) ?? [],
       heldTitleIds: new Set(held.map((h) => h.ttl_id)),
+      heldTitleMeta,
       heldRows: held,
     });
   }


### PR DESCRIPTION
- RaceHistRow에 comp_date 추가 (race_finish_in_month_range, race_finish_in_year)
- MemberSnapshot에 gender 추가 (race_rank_by_gender 산신 등, race_rank_last)
- MemberSnapshot에 heldTitleMeta 추가 (has_title_in_categories)
- evalRaceRankByGenderFromSnapshot, evalRaceRankLastFromSnapshot 구현
- race_finish_all_titles 1개 제외 모든 조건 snapshot에서 평가 가능