### PR TITLE
feat(titles): 山神 조건을 utmb_idx_rank 타입으로 교체

### DIFF
--- a/lib/titles/evaluators.ts
+++ b/lib/titles/evaluators.ts
@@ -37,6 +37,7 @@ import type {
   CondRaceRankLast,
   CondRacePbWithinSecOfTarget,
   CondHasTitleInCategories,
+  CondUtmbIdxRank,
 } from "./types";
 import type { MemberSnapshot, RaceHistRow } from "./snapshot";
 import type { SupabaseClient } from "@supabase/supabase-js";
@@ -473,6 +474,38 @@ export async function evalHasTitleInCategoriesInternal(
   return rule.categories.every((cat) => heldCategories.has(cat));
 }
 
+/** 팀 내 UTMB 인덱스 전체 N위인 경우 (예: 山神 — rank=1) */
+export async function evalUtmbIdxRankInternal(
+  rule: CondUtmbIdxRank,
+  memId: string,
+  teamId: string,
+  db: DB,
+): Promise<boolean> {
+  const { data: teamMembers } = await db
+    .from("team_mem_rel")
+    .select("mem_id")
+    .eq("team_id", teamId)
+    .eq("vers", 0)
+    .eq("del_yn", false);
+
+  if (!teamMembers?.length) return false;
+  const teamMemIds = teamMembers.map((r) => r.mem_id);
+
+  const { data } = await db
+    .from("mem_utmb_prf")
+    .select("mem_id, utmb_idx")
+    .in("mem_id", teamMemIds)
+    .eq("vers", 0)
+    .eq("del_yn", false);
+
+  if (!data?.length) return false;
+
+  const sorted = [...data].sort((a, b) => b.utmb_idx - a.utmb_idx);
+  const myRank = sorted.findIndex((r) => r.mem_id === memId) + 1;
+  if (myRank === 0) return false;
+  return myRank === rule.rank;
+}
+
 // ---------------------------------------------------------------------------
 // 공개 진입점 — engine.ts 에서 호출
 // ---------------------------------------------------------------------------
@@ -531,6 +564,9 @@ export async function evaluateCondition(
 
     case "has_title_in_categories":
       return evalHasTitleInCategoriesInternal(rule, ctx.teamMemId, ctx.teamId, db);
+
+    case "utmb_idx_rank":
+      return evalUtmbIdxRankInternal(rule, memId, ctx.teamId, db);
 
     default:
       rule satisfies never;
@@ -638,6 +674,16 @@ export function evaluateConditionFromSnapshot(
     case "has_title_in_categories": {
       const heldCtgrs = new Set([...snapshot.heldTitleMeta.values()].map((m) => m.ttl_ctgr_cd));
       return rule.categories.every((c: string) => heldCtgrs.has(c));
+    }
+
+    case "utmb_idx_rank": {
+      if (snapshot.utmbIdx === null) return false;
+      const sorted = [...allSnapshots.values()]
+        .filter((s) => s.utmbIdx !== null)
+        .sort((a, b) => b.utmbIdx! - a.utmbIdx!);
+      const myRank = sorted.findIndex((s) => s.memId === snapshot.memId) + 1;
+      if (myRank === 0) return false;
+      return myRank === rule.rank;
     }
 
     default:

--- a/lib/titles/snapshot.ts
+++ b/lib/titles/snapshot.ts
@@ -31,6 +31,7 @@ export type MemberSnapshot = {
   joinDt: string | null;
   gender: string;          // mem_mst.gdr_enm (race_rank_by_gender 조건용)
   raceHist: RaceHistRow[];
+  utmbIdx: number | null;  // mem_utmb_prf.utmb_idx (utmb_idx_rank 조건용)
   heldTitleIds: Set<string>;
   /** 보유 칭호 ID → { ttl_nm, ttl_ctgr_cd } 맵 (race_finish_all_titles, has_title_in_categories 조건용) */
   heldTitleMeta: Map<string, { ttl_nm: string; ttl_ctgr_cd: string }>;
@@ -116,7 +117,20 @@ export async function loadMemberSnapshots(
     });
   }
 
-  // 4. mem_ttl_rel: 전체 멤버 보유 칭호 한 번에
+  // 4. mem_utmb_prf: UTMB 인덱스 한 번에 (utmb_idx_rank 조건용)
+  const { data: utmbRows } = await db
+    .from("mem_utmb_prf")
+    .select("mem_id, utmb_idx")
+    .in("mem_id", memIds)
+    .eq("vers", 0)
+    .eq("del_yn", false);
+
+  const utmbIdxMap = new Map<string, number>();
+  for (const r of utmbRows ?? []) {
+    utmbIdxMap.set(r.mem_id, r.utmb_idx);
+  }
+
+  // 5. mem_ttl_rel: 전체 멤버 보유 칭호 한 번에
   const { data: heldRows } = await db
     .from("mem_ttl_rel")
     .select("team_mem_id, mem_ttl_id, ttl_id, vers")
@@ -134,7 +148,7 @@ export async function loadMemberSnapshots(
     });
   }
 
-  // 5. ttl_mst: 팀 칭호 메타 한 번에 (ttl_nm, ttl_ctgr_cd — race_finish_all_titles, has_title_in_categories 조건용)
+  // 6. ttl_mst: 팀 칭호 메타 한 번에 (ttl_nm, ttl_ctgr_cd — race_finish_all_titles, has_title_in_categories 조건용)
   const allHeldTtlIds = [...new Set([...(heldRows ?? []).map((r) => r.ttl_id)])];
   const titleMetaMap = new Map<string, { ttl_nm: string; ttl_ctgr_cd: string }>();
 
@@ -151,7 +165,7 @@ export async function loadMemberSnapshots(
     }
   }
 
-  // 6. 조합
+  // 7. 조합
   const result = new Map<string, MemberSnapshotWithHeld>();
   for (const teamMemId of teamMemIds) {
     const rel = relMap.get(teamMemId);
@@ -170,6 +184,7 @@ export async function loadMemberSnapshots(
       joinDt: rel.joinDt,
       gender: genderMap.get(rel.memId) ?? "",
       raceHist: histMap.get(rel.memId) ?? [],
+      utmbIdx: utmbIdxMap.get(rel.memId) ?? null,
       heldTitleIds: new Set(held.map((h) => h.ttl_id)),
       heldTitleMeta,
       heldRows: held,

--- a/lib/titles/types.ts
+++ b/lib/titles/types.ts
@@ -150,6 +150,12 @@ export type CondHasTitleInCategories = {
   categories: string[];
 };
 
+/** 팀 내 UTMB 인덱스 전체 1위인 경우 (예: 山神) */
+export type CondUtmbIdxRank = {
+  type: "utmb_idx_rank";
+  rank: number;
+};
+
 /** 모든 조건 유형의 유니온 — 새 조건 추가 시 여기에 타입을 추가한다 */
 export type CondRule =
   | CondRacePersonalBestUnderSec
@@ -167,7 +173,8 @@ export type CondRule =
   | CondRaceRankByGender
   | CondRaceRankLast
   | CondRacePbWithinSecOfTarget
-  | CondHasTitleInCategories;
+  | CondHasTitleInCategories
+  | CondUtmbIdxRank;
 
 // ---------------------------------------------------------------------------
 // TriggerKind — 트리거 종류
@@ -224,6 +231,7 @@ export const TRIGGER_COND_MAP = {
     "race_rank_last",
     "race_pb_within_sec_of_target",
     "has_title_in_categories",
+    "utmb_idx_rank",
   ],
 } satisfies Record<TriggerKind, CondRule["type"][]>;
 


### PR DESCRIPTION
- CondUtmbIdxRank 타입 추가 (mem_utmb_prf.utmb_idx 기준 팀 내 전체 순위)
- snapshot에 utmbIdx 필드 추가 및 mem_utmb_prf bulk 로드
- evaluators 단건/snapshot 평가 함수 추가
- DB ttl_mst 山神 cond_rule_json 업데이트 (trail_run PB → utmb_idx 1위)