### PR TITLE
feat(home): 홈탭 UX 전면 개선

### DIFF
--- a/.claude/docs/home-redesign.md
+++ b/.claude/docs/home-redesign.md
@@ -1,0 +1,356 @@
+# 홈탭 개편 설계 문서
+
+> 브랜치: `feat/home-redesign`  
+> 기준 커밋: `6329181`  
+> 작성일: 2026-05-31
+
+---
+
+## 1. 개편 배경 및 목표
+
+### 문제
+- 적은 정보(활동 멤버 수, 예정 대회 수)가 큰 카드 2개를 차지 → 화면 낭비
+- 업커밍 레이스 카드가 너무 많은 공간을 점유
+- 최근 기록이 1열로 2개만 표시되고, "더 보기"가 /records 탭 리다이렉트
+- 홈 화면에 보여줄 정보가 전반적으로 부족
+
+### 목표
+- 기존 정보는 **최대한 압축**해서 공간 확보
+- 새로운 **월간 캘린더(SCHEDULE)** 섹션 추가로 일정 한눈에 파악
+- 최근 기록을 **2열 그리드**로 더 많이 보여주고 인라인 더보기
+- 향후 모임/훈련/대회접수 등 다양한 일정 타입 수용 가능한 확장 구조
+
+---
+
+## 2. 레이아웃 변경 전/후
+
+### Before
+```
+[헤더: 기강]
+[활동 멤버] [예정 대회]   ← CardItem 2개 (grid-cols-2, 큰 카드)
+[UPCOMING RACES]
+  [카드: 제목/날짜/위치/종목태그]
+  [카드: 제목/날짜/위치/종목태그]
+[RECENT RECORDS]
+  [카드: 이름 · 기록시간]
+  [카드: 이름 · 기록시간]
+  모두 보기 → /records
+[SOCIAL]
+```
+
+### After
+```
+[헤더: 기강]
+42명 활동 중 · 3개 대회 참가 예정  ← 한 줄 Caption 텍스트
+[SCHEDULE]
+  2026년 5월 (미니 캘린더 그리드)
+  범례: ● 기강 대회  ● 내 대회
+  [날짜 클릭 시 인라인 이벤트 목록]
+[UPCOMING RACES]         모두 보기
+  D-3  대회명             05/31
+  D-14 대회명             06/14
+[RECENT RECORDS]
+  [이름  1:23:45]  [이름  2:34:56]
+  [이름  3:45:67]  [이름  4:56:78]
+  더 보기 (8개) ↓
+[SOCIAL]
+```
+
+---
+
+## 3. 파일 구조
+
+```
+app/(main)/
+└── page.tsx                          ← 서버 컴포넌트 (데이터 패칭 + 레이아웃)
+
+components/home/
+├── mini-calendar.tsx                 ← 신규: 월간 캘린더 (Client)
+├── recent-records-grid.tsx           ← 신규: 기록 2열 그리드 + 더보기 (Client)
+├── upcoming-races.tsx                ← 수정: 압축 리스트 UI로 변경 (Client)
+└── upcoming-races.stories.tsx        ← 기존 (수정 불필요)
+```
+
+---
+
+## 4. 컴포넌트 상세 설계
+
+### 4-1. `app/(main)/page.tsx`
+
+#### 데이터 패칭 변경
+
+| 쿼리 | 변경 내용 |
+|------|----------|
+| `get_public_team_member_stats` | 유지 |
+| `get_public_team_competitions` (오늘~) | 유지 — 업커밍 카드용 |
+| `get_public_team_competitions` (이달 1일~) | **신규** — 캘린더용 `calendarComps` |
+| `comp_mst` count 쿼리 | **제거** — 더 이상 미사용 |
+| `get_public_team_recent_records` | `p_limit: 2` → `p_limit: 12` |
+| `getCachedCmmCdRows` | 유지 |
+
+#### 오버뷰 렌더링
+```tsx
+// Before: CardItem 2개 (grid-cols-2)
+// After:
+<Caption>
+  <span className="font-semibold text-foreground">{memberCount}</span>명 활동 중
+  {" · "}
+  <span className="font-semibold text-foreground">{gigangRaces.length}</span>개 대회 참가 예정
+</Caption>
+```
+
+#### 캘린더 데이터 가공
+
+```typescript
+// 이번 달 기강 대회 (등록자 1명 이상, 말일 이내)
+const calendarGigangRaces: CalendarRace[] = (calendarComps ?? [])
+  .filter(row => row.reg_count > 0 && row.stt_dt <= monthLastDayStr)
+  .map(row => ({ id, title, start_date, type: "gigang" }));
+
+// 이번 달 내 참가 대회 (로그인 시)
+const calendarMyRaces: CalendarRace[] = myRaces
+  .filter(r => r.start_date >= monthStart && r.start_date <= monthLastDayStr)
+  .map(r => ({ id, title, start_date, type: "mine" }));
+```
+
+#### 최종 렌더 순서
+1. 오버뷰 한 줄 텍스트
+2. `<MiniCalendar gigangRaces={...} myRaces={...} />`
+3. `<UpcomingRaces ... />`
+4. `<RecentRecordsGrid records={...} titleMap={...} initialCount={4} />`
+5. `<SocialLinksGrid ... />`
+
+---
+
+### 4-2. `components/home/mini-calendar.tsx`
+
+#### 타입 정의
+```typescript
+export type CalendarRace = {
+  id: string;
+  title: string;
+  start_date: string;       // "YYYY-MM-DD"
+  type: "gigang" | "mine";  // 향후 "meetup" | "info" 등 확장 예정
+};
+```
+
+#### Props
+```typescript
+type MiniCalendarProps = {
+  gigangRaces: CalendarRace[];  // 서버에서 전달 (이번 달 기강 대회)
+  myRaces: CalendarRace[];      // 서버에서 전달 (이번 달 내 참가 대회)
+};
+```
+
+#### 핵심 로직
+- `viewMonth` state로 표시 월 관리 (현재는 이번 달 고정, 이동 버튼 UI만 자리 잡힘)
+- `eventMap: Map<string, { gigang: boolean; mine: boolean }>` — 날짜별 이벤트 존재 여부
+- `selectedDate` state로 클릭된 날짜 관리
+- `selectedEvents` — 선택 날짜의 이벤트 목록 (gigang + mine 합산, 중복 제거)
+
+#### 달력 그리드 구성
+```
+cells = [null × firstDayOfWeek, 1, 2, ..., totalDays]
+grid-cols-7, 요일 헤더(일~토)
+```
+
+#### 도트 색상
+| 이벤트 타입 | 색상 토큰 |
+|------------|----------|
+| `gigang` (기강 대회) | `bg-warning` |
+| `mine` (내 참가 대회) | `bg-primary` |
+
+#### 날짜 클릭 동작
+- 이미 선택된 날짜 재클릭 → 선택 해제
+- 이벤트 없는 날짜 클릭 → "일정 없음" 표시
+- 이벤트 있는 날짜 → 제목 + 타입별 도트 인라인 표시
+
+#### 향후 확장 포인트
+```typescript
+// type 필드 확장만으로 새 이벤트 타입 수용 가능
+type: "gigang" | "mine" | "meetup" | "info"
+
+// Props 확장
+meetupEvents?: CalendarRace[];   // 모임/훈련 일정 (DB 테이블 추가 시)
+infoEvents?: CalendarRace[];     // 대회 접수 마감일 등
+
+// 도트 색상 추가
+// meetup → bg-success (초록)
+// info   → bg-info (파랑 계열)
+```
+
+---
+
+### 4-3. `components/home/upcoming-races.tsx`
+
+#### UI 변경
+```
+Before: CardItem (큰 카드, 제목/날짜/위치/종목 태그 포함)
+After:  한 줄 리스트 행 (divide-y)
+```
+
+#### 행 구성
+```
+[D-3 뱃지]  [대회명 truncate]        [MM/DD]
+```
+
+#### D-day 뱃지 색상 로직
+```typescript
+const ddayCls =
+  dday === "D-DAY" || dday.startsWith("D+")
+    ? "bg-destructive/10 text-destructive"   // 당일 또는 지남
+    : ddayNum <= 7
+      ? "bg-warning/15 text-warning"          // 7일 이내
+      : "bg-secondary text-muted-foreground"; // 여유 있음
+```
+
+#### 유지된 기능
+- 행 클릭 → `CompetitionDetailDialog` 오픈 (참가 신청/수정/취소)
+- `SectionHeader` + "모두 보기 → /races" 링크
+- `createRegistration` / `updateRegistration` / `deleteRegistration` 서버 액션
+
+---
+
+### 4-4. `components/home/recent-records-grid.tsx`
+
+#### 타입 정의
+```typescript
+export type RecentRecord = {
+  mem_id: string | null;
+  mem_nm: string | null;
+  race_nm: string | null;
+  evt_cd: string | null;
+  rec_time_sec: number | null;
+};
+
+export type RecordTitleInfo = {
+  ttl_nm: string;
+  ttl_desc: string | null;
+  desc_visibility: "always" | "others" | "held" | "never";
+  badge_effect: string;
+  frame_cd: string;
+};
+```
+
+#### Props
+```typescript
+type RecentRecordsGridProps = {
+  records: RecentRecord[];
+  titleMap: Record<string, RecordTitleInfo>;
+  initialCount?: number;   // 기본 4 (2열×2줄)
+};
+```
+
+#### 더보기 로직
+```typescript
+const [expanded, setExpanded] = useState(false);
+const visibleRecords = expanded ? records : records.slice(0, initialCount);
+// 서버에서 12개 미리 fetch, 클라이언트에서 4/전체 토글
+```
+
+#### 카드 셀 구성 (grid-cols-2)
+```
+[이름] [칭호배지]
+1:23:45               ← font-mono, text-base, font-bold
+MARATHON · 대회명     ← Caption, truncate
+```
+
+#### 프레임 효과
+- `getFrameCls(title?.frame_cd)` — 칭호 프레임 CSS 클래스 적용
+- 기존 `page.tsx`에서 인라인으로 처리하던 로직을 컴포넌트 내부로 이동
+
+---
+
+## 5. 데이터 흐름
+
+```
+page.tsx (서버)
+  │
+  ├─ admin.rpc("get_public_team_member_stats")
+  │     → memberCount
+  │
+  ├─ supabase.rpc("get_public_team_competitions", { p_start: today })
+  │     → gigangRaces (업커밍 카드용)
+  │     → upcomingCards (topGigang + myNext 결정)
+  │
+  ├─ supabase.rpc("get_public_team_competitions", { p_start: monthStart })
+  │     → calendarGigangRaces (캘린더용, 이번 달 필터)
+  │
+  ├─ supabase.rpc("get_public_team_recent_records", { p_limit: 12 })
+  │     → recentRecords
+  │
+  ├─ admin.from("mem_ttl_rel")
+  │     → titleMap (기록 멤버 칭호 정보)
+  │
+  └─ (로그인 시) comp_reg_rel 쿼리
+        → myRegistrations, myRaces
+        → calendarMyRaces (캘린더용)
+        → initialRegistrationsByCompetitionId (업커밍 카드용)
+
+Props 전달:
+  MiniCalendar       ← calendarGigangRaces, calendarMyRaces
+  UpcomingRaces      ← upcomingCards, initialRegistrationsByCompetitionId, initialMemberStatus
+  RecentRecordsGrid  ← recentRecords, titleMap
+  SocialLinksGrid    ← kakaoChatPassword (isMember 시)
+```
+
+---
+
+## 6. Skeleton 변경
+
+```
+Before:
+  [오버뷰 카드 2개]
+  [소셜 링크 4개]
+  [업커밍 카드 2개]
+
+After:
+  [한 줄 텍스트 스켈레톤]
+  [캘린더 블록]
+  [업커밍 리스트 2줄]
+  [기록 그리드 2×2]
+  [소셜 링크 4개]
+```
+
+---
+
+## 7. 미결 사항 및 다음 작업
+
+### 7-1. 칭호 관련 버그 수정 (이 브랜치에서 진행 예정)
+- [ ] 구체적인 버그 내용 파악 후 작성 예정
+
+### 7-2. 캘린더 월 이동 기능
+- 현재: 이번 달 고정, 이동 버튼 UI는 `opacity-0 pointer-events-none`으로 숨김
+- 필요: 이전/다음 달 클릭 시 해당 월 대회 데이터를 가져오는 서버 액션 또는 클라이언트 패칭 로직
+- 방안: `searchParams` 기반 URL 파라미터로 월 상태 관리 (RSC rerender) 또는 클라이언트에서 직접 RPC 호출
+
+### 7-3. 새 캘린더 이벤트 타입
+- `"meetup"` — 기강 모임/훈련 일정 (DB 테이블: `team_schedule` 등 신규 설계 필요)
+- `"info"` — 대회 접수 마감일 공지
+
+### 7-4. 홈 캘린더 서버 쿼리 최적화
+- 현재 `get_public_team_competitions`를 두 번 호출 (오늘 기준, 이달 1일 기준)
+- 이달 1일 기준 쿼리 결과로 업커밍도 처리 가능 → 쿼리 1회 절감 가능
+
+### 7-5. 접수 정보 알림 방식
+- 대회 접수 마감일을 어떤 데이터로 관리할지 결정 필요
+  - `comp_mst`에 `reg_deadline` 컬럼 추가 방안
+  - 별도 `team_schedule` 테이블 방안
+
+---
+
+## 8. 관련 파일 참조
+
+| 파일 | 역할 |
+|------|------|
+| `lib/dayjs.ts` | `todayKST`, `currentMonthKST`, `monthLastDay`, `formatDDay`, `secondsToTime` |
+| `lib/title-effects.ts` | `getFrameCls` — 칭호 프레임 CSS 클래스 |
+| `components/common/typography.tsx` | `H1`, `Caption`, `Micro`, `SectionLabel` |
+| `components/common/section-header.tsx` | `SectionHeader` (label + action 링크) |
+| `components/common/empty-state.tsx` | `EmptyState` |
+| `components/common/title-badge.tsx` | `TitleBadge` |
+| `components/races/competition-detail-dialog.tsx` | 대회 상세/참가 신청 다이얼로그 |
+| `components/social-links.tsx` | `SocialLinksGrid` |
+| `lib/queries/cmm-cd-cached.ts` | `getCachedCmmCdRows` |
+| `lib/queries/member.ts` | `getCurrentMember` |
+| `lib/queries/request-team.ts` | `getRequestTeamContext` |

--- a/.claude/docs/notice-update-notification.md
+++ b/.claude/docs/notice-update-notification.md
@@ -1,0 +1,304 @@
+# 공지사항 / 업데이트 / 알림 시스템 설계
+
+> 브랜치: `feat/notice-notification` (예정)  
+> 작성일: 2026-05-31
+
+---
+
+## 1. 개요 및 목표
+
+### 문제
+- 새 기능을 추가해도 멤버들이 모름 → 사용률 저조
+- 공지/운영 안내를 전달할 채널이 카카오톡뿐
+- 향후 모임일정·대회접수 등 다양한 이벤트 알림이 필요한데 인프라 없음
+
+### 목표
+- **공지사항**: 운영 안내, 기강 사용법 게시판
+- **업데이트**: 새 기능 릴리즈 노트 게시판
+- **알림함**: 인앱 알림 수신함 (종 모양 아이콘). 향후 PWA 푸시 확장 예정
+
+---
+
+## 2. 홈탭 노출 전략 (핵심 고민 해결)
+
+홈탭에 정보가 이미 가득하므로 **새 섹션을 추가하지 않는다.**  
+대신 기존 `PageHeader`의 우측에 아이콘 2개를 배치한다.
+
+```
+[기강]                    🔔  📋
+ ↑ H1                   알림  공지/업뎃
+```
+
+### 아이콘 역할
+| 아이콘 | 역할 | 클릭 시 |
+|--------|------|---------|
+| 🔔 Bell | 알림함 | `/notifications` 페이지로 이동 |
+| 📋 Megaphone (또는 Newspaper) | 공지/업데이트 | `/board` 페이지로 이동 |
+
+### 미읽음 뱃지
+- 알림: 미읽음 개수 빨간 뱃지 (최대 99+)
+- 공지/업데이트: 마지막 확인 시각 이후 새 글 있으면 파란 점 표시
+
+---
+
+## 3. 페이지 구조
+
+```
+app/
+├── (main)/
+│   └── page.tsx                    ← PageHeader에 아이콘 추가
+│
+└── (info)/
+    ├── notifications/
+    │   └── page.tsx                ← 알림함 (인앱 알림 목록)
+    │
+    └── board/
+        ├── page.tsx                ← 공지/업데이트 탭 목록
+        ├── [id]/
+        │   └── page.tsx            ← 게시글 상세
+        └── write/
+            └── page.tsx            ← 작성 (관리자 + 작성권한 멤버)
+```
+
+---
+
+## 4. DB 스키마
+
+### 4-1. `board_post` — 게시글
+
+```sql
+CREATE TABLE board_post (
+  post_id       uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  team_id       uuid NOT NULL REFERENCES team_mst(team_id),
+  post_type     text NOT NULL CHECK (post_type IN ('notice', 'update')),
+  title         text NOT NULL,
+  content       text NOT NULL,          -- Markdown
+  author_mem_id uuid REFERENCES mem_mst(mem_id),
+  is_pinned     boolean DEFAULT false,  -- 상단 고정
+  vers          integer DEFAULT 0,
+  del_yn        boolean DEFAULT false,
+  crt_at        timestamptz DEFAULT now(),
+  upd_at        timestamptz DEFAULT now()
+);
+```
+
+### 4-2. `notification` — 알림
+
+```sql
+CREATE TABLE notification (
+  noti_id       uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  team_id       uuid NOT NULL REFERENCES team_mst(team_id),
+  mem_id        uuid NOT NULL REFERENCES mem_mst(mem_id),
+  noti_type     text NOT NULL,          -- 아래 타입 목록 참조
+  title         text NOT NULL,
+  body          text,
+  ref_id        uuid,                   -- 연관 리소스 ID (post_id, comp_id 등)
+  ref_type      text,                   -- 'post' | 'competition' | 'title' | 'schedule' ...
+  is_read       boolean DEFAULT false,
+  vers          integer DEFAULT 0,
+  del_yn        boolean DEFAULT false,
+  crt_at        timestamptz DEFAULT now()
+);
+```
+
+### 알림 타입 (`noti_type`) 목록
+| 값 | 설명 | ref_type |
+|----|------|----------|
+| `notice_posted` | 공지 등록 | `post` |
+| `update_posted` | 업데이트 등록 | `post` |
+| `comp_registered` | 대회 등록됨 | `competition` |
+| `title_granted` | 칭호 획득 | `title` |
+| `schedule_posted` | 모임/일정 등록 (향후) | `schedule` |
+| `admin_custom` | 관리자 수동 알림 | - |
+
+### 4-3. `notification_pref` — 알림 수신 설정
+
+```sql
+CREATE TABLE notification_pref (
+  pref_id       uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  mem_id        uuid NOT NULL REFERENCES mem_mst(mem_id),
+  noti_type     text NOT NULL,
+  enabled       boolean DEFAULT true,
+  UNIQUE (mem_id, noti_type)
+);
+```
+
+---
+
+## 5. 컴포넌트 설계
+
+### 5-1. 홈탭 헤더 (`app/(main)/page.tsx`)
+
+```tsx
+// PageHeader에 action 슬롯 활용
+<div className="flex h-14 items-center justify-between px-6">
+  <H1>기강</H1>
+  <div className="flex items-center gap-2">
+    <BoardHeaderIcon />    {/* 공지/업데이트 아이콘 + 새글 dot */}
+    <NotificationBell />   {/* 종 아이콘 + 미읽음 뱃지 */}
+  </div>
+</div>
+```
+
+`NotificationBell`, `BoardHeaderIcon` — 클라이언트 컴포넌트.  
+미읽음 수는 Supabase realtime 또는 페이지 진입 시 fetch.
+
+### 5-2. 알림함 (`/notifications`)
+
+```
+[뒤로가기 헤더: 알림]          [모두 읽음]
+
+━━━ 오늘 ━━━
+🏆  SUB3 칭호를 획득했습니다          방금 전
+📢  5월 업데이트 안내                 1시간 전
+
+━━━ 이전 ━━━
+🏁  2026 서울마라톤이 등록됐습니다    3일 전
+```
+
+- 타입별 아이콘: 공지 📢, 업데이트 🆕, 대회 🏁, 칭호 🏆, 모임 👟, 관리자 📣
+- 클릭 시 `ref_type` + `ref_id`로 라우팅
+  - `post` → `/board/[ref_id]`
+  - `competition` → `/races` (대회 다이얼로그 오픈)
+  - `title` → `/profile`
+- 읽음 처리: 클릭 시 `is_read = true`
+
+### 5-3. 게시판 (`/board`)
+
+```
+[뒤로가기 헤더: 공지 / 업데이트]     [✏️ 작성] (권한자만)
+
+  [공지사항]  [업데이트]   ← SegmentControl
+
+  📌 [공지] 기강 앱 사용 가이드          05/30
+     [공지] 6월 운영 안내                05/28
+  ─────────────────────────────
+  🆕 [v1.4] 홈탭 개편 — 캘린더/기록     05/31
+     [v1.3] 칭호 시스템 도입             05/15
+```
+
+- 상단 고정(`is_pinned`) 게시글은 📌 아이콘
+- 업데이트 탭은 버전 태그 표시 (선택)
+- 무한스크롤 또는 페이지네이션 (초기엔 20개 고정)
+
+### 5-4. 게시글 상세 (`/board/[id]`)
+
+```
+[뒤로가기]
+
+제목
+작성자 · 05/31
+
+─────────────
+Markdown 렌더링 (react-markdown 또는 remark)
+─────────────
+```
+
+### 5-5. 알림 설정 (`/settings` 내 추가)
+
+설정 페이지에 `NOTIFICATIONS` 섹션 추가:
+
+```
+NOTIFICATIONS
+  공지사항          [ON/OFF]
+  업데이트          [ON/OFF]
+  대회 등록         [ON/OFF]
+  칭호 획득         [ON/OFF]
+  모임 일정 (예정)  [ON/OFF]
+```
+
+---
+
+## 6. 알림 생성 트리거
+
+알림은 **서버 액션 또는 DB 트리거**로 생성.  
+초기엔 서버 액션에서 명시적으로 생성, 향후 pg trigger로 이전 가능.
+
+| 이벤트 | 생성 시점 | 대상 |
+|--------|----------|------|
+| 게시글 등록 | `createPost` 서버 액션 | 팀 전체 멤버 |
+| 대회 등록 | `createCompetition` 서버 액션 | 팀 전체 멤버 |
+| 칭호 부여 | `grantTitle` 서버 액션 | 해당 멤버 1명 |
+| 관리자 직접 발송 | 관리자 페이지 | 선택한 대상 |
+
+`notification_pref`에서 `enabled = false`면 해당 타입 INSERT 스킵.
+
+---
+
+## 7. 파일 구조
+
+```
+app/
+└── (info)/
+    ├── notifications/
+    │   └── page.tsx
+    └── board/
+        ├── page.tsx
+        ├── [id]/page.tsx
+        └── write/page.tsx
+
+app/actions/
+├── create-post.ts
+├── delete-post.ts
+└── mark-notifications-read.ts
+
+components/
+├── common/
+│   ├── notification-bell.tsx      ← 헤더 알림 아이콘
+│   └── board-header-icon.tsx      ← 헤더 게시판 아이콘
+├── notifications/
+│   └── notification-item.tsx
+└── board/
+    ├── post-list.tsx
+    ├── post-card.tsx
+    └── post-detail.tsx
+
+supabase/migrations/
+└── YYYYMMDD_board_notification.sql
+```
+
+---
+
+## 8. RLS 정책
+
+| 테이블 | SELECT | INSERT | UPDATE | DELETE |
+|--------|--------|--------|--------|--------|
+| `board_post` | 팀 멤버 전체 | 관리자 + 작성권한 멤버 | 작성자 + 관리자 | 관리자 |
+| `notification` | 본인 것만 | 서버(service role) | 본인 것만 | - |
+| `notification_pref` | 본인 것만 | 본인 | 본인 | 본인 |
+
+작성권한 멤버는 `team_mem_rel`에 `can_post boolean` 컬럼 추가 또는  
+별도 `board_author_rel` 테이블로 관리.
+
+---
+
+## 9. 단계별 구현 순서
+
+### Phase 1 — 게시판 (공지/업데이트)
+1. DB 마이그레이션: `board_post` 테이블 + RLS
+2. 서버 액션: `createPost`, `deletePost`
+3. 게시판 목록/상세 페이지
+4. 관리자 작성 폼
+5. 홈탭 헤더에 📋 아이콘 + 새글 dot
+
+### Phase 2 — 인앱 알림
+1. DB 마이그레이션: `notification`, `notification_pref` + RLS
+2. 기존 서버 액션에 알림 생성 로직 추가 (칭호, 대회, 게시글)
+3. 알림함 페이지 (`/notifications`)
+4. 홈탭 헤더 🔔 아이콘 + 미읽음 뱃지
+5. 설정 페이지 알림 수신 ON/OFF
+
+### Phase 3 — 향후 확장
+- 모임/일정 이벤트 알림
+- PWA Web Push
+- 멤버 게시판 (자유게시판 확장)
+- 관리자 수동 알림 발송 UI
+
+---
+
+## 10. 미결 사항
+
+- Markdown 렌더링 라이브러리 선택 (`react-markdown` vs `@uiw/react-md-editor`)
+- 작성권한 멤버 관리 방식: `team_mem_rel` 컬럼 추가 vs 별도 테이블
+- 알림 보존 기간 정책 (예: 90일 후 자동 삭제)
+- 미읽음 수 실시간 업데이트: Supabase Realtime vs 폴링

--- a/app/(info)/admin/competitions/admin-competitions-client.tsx
+++ b/app/(info)/admin/competitions/admin-competitions-client.tsx
@@ -426,7 +426,7 @@ function CompetitionsContent({
           <Select
             value={form.sport}
             onValueChange={(v) =>
-              setForm({ ...form, sport: v, eventTypes: [] })
+              { setForm({ ...form, sport: v, eventTypes: [] }); setCustomEtInput(""); }
             }
           >
             <SelectTrigger className="h-12 rounded-xl border-[1.5px] text-[15px]">

--- a/app/(info)/admin/competitions/admin-competitions-client.tsx
+++ b/app/(info)/admin/competitions/admin-competitions-client.tsx
@@ -22,6 +22,7 @@ import {
   sprtCdDisplayName,
   type CachedCmmCdRow,
 } from "@/lib/queries/cmm-cd-cached";
+import { sanitizeAsciiUpperCompEvtTypeInput } from "@/lib/comp-evt-type";
 import { createClient } from "@/lib/supabase/client";
 import { cn } from "@/lib/utils";
 
@@ -121,6 +122,7 @@ function CompetitionsContent({
   const [registrations, setRegistrations] = useState<Registration[]>([]);
   const [regLoading, setRegLoading] = useState(false);
   const [saving, setSaving] = useState(false);
+  const [customEtInput, setCustomEtInput] = useState("");
 
   // 폼 상태
   const [form, setForm] = useState({
@@ -484,6 +486,7 @@ function CompetitionsContent({
           <label className="text-sm font-medium text-foreground">
             세부종목
           </label>
+          {/* 기본 목록 토글 */}
           <div className="flex flex-wrap gap-2">
             {formEventTypeCodes.map((et) => (
               <Button
@@ -501,6 +504,51 @@ function CompetitionsContent({
                 {et}
               </Button>
             ))}
+          </div>
+          {/* 직접 추가한 커스텀 코스 태그 */}
+          {form.eventTypes.filter(t => !formEventTypeCodes.includes(t)).length > 0 && (
+            <div className="flex flex-wrap gap-1.5">
+              {form.eventTypes.filter(t => !formEventTypeCodes.includes(t)).map(type => (
+                <button
+                  key={type}
+                  type="button"
+                  onClick={() => setForm({ ...form, eventTypes: form.eventTypes.filter(t2 => t2 !== type) })}
+                  className="flex items-center gap-1 rounded-full bg-primary px-2.5 py-0.5 text-[11px] font-medium text-primary-foreground"
+                >
+                  {type} ×
+                </button>
+              ))}
+            </div>
+          )}
+          {/* 직접 입력 */}
+          <div className="flex gap-1.5">
+            <Input
+              placeholder="직접 입력 (예: 12K, TRAIL100)"
+              value={customEtInput}
+              onChange={(e) => setCustomEtInput(sanitizeAsciiUpperCompEvtTypeInput(e.target.value))}
+              onKeyDown={(e) => {
+                if (e.key === "Enter") {
+                  e.preventDefault();
+                  const val = customEtInput.trim();
+                  if (!val || form.eventTypes.includes(val)) return;
+                  setForm({ ...form, eventTypes: [...form.eventTypes, val] });
+                  setCustomEtInput("");
+                }
+              }}
+              className="h-10 rounded-xl border-[1.5px] text-[13px]"
+            />
+            <Button
+              type="button"
+              variant="outline"
+              onClick={() => {
+                const val = customEtInput.trim();
+                if (!val || form.eventTypes.includes(val)) return;
+                setForm({ ...form, eventTypes: [...form.eventTypes, val] });
+                setCustomEtInput("");
+              }}
+            >
+              추가
+            </Button>
           </div>
         </div>
 

--- a/app/(main)/page.tsx
+++ b/app/(main)/page.tsx
@@ -80,7 +80,7 @@ async function HomeContent() {
       .eq("team_id", teamId)
       .eq("vers", 0)
       .eq("del_yn", false)
-      .order("crt_at", { ascending: false })
+      .order("join_dt", { ascending: false })
       .limit(10),
     admin
       .from("mem_ttl_rel")
@@ -447,8 +447,23 @@ function HomeSkeleton() {
       <div className="flex flex-col gap-3">
         <Skeleton className="h-3.5 w-32" />
         <div className="grid grid-cols-2 gap-2">
+          {Array.from({ length: 2 }).map((_, i) => (
+            <Skeleton key={i} className="h-14 rounded-xl" />
+          ))}
+        </div>
+      </div>
+      {/* New Members + Recent Titles */}
+      <div className="grid grid-cols-2 gap-4">
+        <div className="flex flex-col gap-3">
+          <Skeleton className="h-3.5 w-24" />
           {Array.from({ length: 4 }).map((_, i) => (
-            <Skeleton key={i} className="h-20 rounded-xl" />
+            <Skeleton key={i} className="h-9 rounded-lg" />
+          ))}
+        </div>
+        <div className="flex flex-col gap-3">
+          <Skeleton className="h-3.5 w-24" />
+          {Array.from({ length: 4 }).map((_, i) => (
+            <Skeleton key={i} className="h-9 rounded-lg" />
           ))}
         </div>
       </div>

--- a/app/(main)/page.tsx
+++ b/app/(main)/page.tsx
@@ -3,7 +3,7 @@ import { Suspense } from "react";
 import { todayKST, currentMonthKST, monthLastDay } from "@/lib/dayjs";
 import { env } from "@/lib/env";
 import { getCachedCmmCdRows } from "@/lib/queries/cmm-cd-cached";
-import { getCurrentMember } from "@/lib/queries/member";
+import { getCurrentMember, getMyTitleNames } from "@/lib/queries/member";
 import { getRequestTeamContext } from "@/lib/queries/request-team";
 import { createAdminClient } from "@/lib/supabase/admin";
 import { H1 } from "@/components/common/typography";
@@ -62,16 +62,14 @@ async function HomeContent() {
     { data: recentRecordsRaw },
     { data: calendarComps },
     cmmCdRows,
+    myTitleNames,
   ] = await Promise.all([
     admin.rpc("get_public_team_member_stats", { p_team_id: teamId }),
     supabase.rpc("get_public_team_competitions", { p_team_id: teamId, p_start: today }),
     supabase.rpc("get_public_team_recent_records", { p_team_id: teamId, p_limit: 12 }),
-    // 이번 달 전체 대회 (캘린더용) — 이달 1일부터 말일까지
-    supabase.rpc("get_public_team_competitions", {
-      p_team_id: teamId,
-      p_start: monthStart,
-    }),
+    supabase.rpc("get_public_team_competitions", { p_team_id: teamId, p_start: monthStart }),
     getCachedCmmCdRows(),
+    getMyTitleNames(),
   ]);
 
   const memberCount = memberStats?.[0]?.active_count ?? 0;
@@ -357,6 +355,7 @@ async function HomeContent() {
       <RecentRecordsGrid
         records={recentRecords}
         titleMap={titleMap}
+        myTitleNames={[...myTitleNames]}
         initialCount={4}
       />
 

--- a/app/(main)/page.tsx
+++ b/app/(main)/page.tsx
@@ -1,23 +1,20 @@
 import { Suspense } from "react";
 
-import Link from "next/link";
-
-import { secondsToTime, todayKST } from "@/lib/dayjs";
+import { todayKST, currentMonthKST, monthLastDay } from "@/lib/dayjs";
 import { env } from "@/lib/env";
 import { getCachedCmmCdRows } from "@/lib/queries/cmm-cd-cached";
 import { getCurrentMember } from "@/lib/queries/member";
 import { getRequestTeamContext } from "@/lib/queries/request-team";
 import { createAdminClient } from "@/lib/supabase/admin";
-import { getFrameCls } from "@/lib/title-effects";
-import { cn } from "@/lib/utils";
-
-import { TitleBadge } from "@/components/common/title-badge";
-import { SectionLabel } from "@/components/common/typography";
 import { H1 } from "@/components/common/typography";
+import { Caption } from "@/components/common/typography";
+import { MiniCalendar } from "@/components/home/mini-calendar";
+import type { CalendarRace } from "@/components/home/mini-calendar";
+import { RecentRecordsGrid } from "@/components/home/recent-records-grid";
+import type { RecentRecord, RecordTitleInfo } from "@/components/home/recent-records-grid";
 import { UpcomingRaces } from "@/components/home/upcoming-races";
 import type { CompetitionRegistration, MemberStatus } from "@/components/races/types";
 import { SocialLinksGrid } from "@/components/social-links";
-import { CardItem } from "@/components/ui/card";
 import { Skeleton } from "@/components/ui/skeleton";
 
 
@@ -51,25 +48,29 @@ async function HomeContent() {
   const admin = createAdminClient();
   const { teamId } = await getRequestTeamContext();
   const today = todayKST();
+  const monthStart = currentMonthKST();
+
+  // 이번 달 마지막 날 계산
+  const [yearStr, monthStr] = monthStart.split("-");
+  const monthLastDayStr = monthLastDay(parseInt(yearStr, 10), parseInt(monthStr, 10));
 
   let initialMemberStatus: MemberStatus = { status: "signed-out" };
 
   const [
     { data: memberStats },
     { data: teamComps },
-    { count: upcomingCount },
     { data: recentRecordsRaw },
+    { data: calendarComps },
     cmmCdRows,
   ] = await Promise.all([
     admin.rpc("get_public_team_member_stats", { p_team_id: teamId }),
     supabase.rpc("get_public_team_competitions", { p_team_id: teamId, p_start: today }),
-    supabase
-      .from("comp_mst")
-      .select("*", { count: "exact", head: true })
-      .eq("vers", 0)
-      .eq("del_yn", false)
-      .gte("stt_dt", today),
-    supabase.rpc("get_public_team_recent_records", { p_team_id: teamId, p_limit: 2 }),
+    supabase.rpc("get_public_team_recent_records", { p_team_id: teamId, p_limit: 12 }),
+    // 이번 달 전체 대회 (캘린더용) — 이달 1일부터 말일까지
+    supabase.rpc("get_public_team_competitions", {
+      p_team_id: teamId,
+      p_start: monthStart,
+    }),
     getCachedCmmCdRows(),
   ]);
 
@@ -107,19 +108,35 @@ async function HomeContent() {
   let topGigang: UpcomingRace | null = null;
   if (gigangRaces.length > 0) {
     const first = gigangRaces[0];
-    // 같은 슬롯(같은 날 or 같은 주말)에 있는 대회들 모으기
     const weekendGroup = gigangRaces.filter(
       (r) => isSameSlot(r.start_date, first.start_date),
     );
-    // 참여 인원 많은 순
     weekendGroup.sort((a, b) => (b.regCount ?? 0) - (a.regCount ?? 0));
     topGigang = weekendGroup[0];
   }
+
+  // 캘린더용 기강 대회 (이번 달)
+  const calendarGigangSeenIds = new Set<string>();
+  const calendarGigangRaces: CalendarRace[] = (calendarComps ?? [])
+    .filter((row) => (row.reg_count ?? 0) > 0 && row.stt_dt <= monthLastDayStr)
+    .filter((row) => {
+      if (calendarGigangSeenIds.has(row.comp_id)) return false;
+      calendarGigangSeenIds.add(row.comp_id);
+      return true;
+    })
+    .map((row) => ({
+      id: row.comp_id,
+      title: row.comp_nm,
+      start_date: row.stt_dt,
+      type: "gigang" as const,
+    }));
 
   // 내가 참가하는 대회 가져오기
   let myRaces: UpcomingRace[] = [];
   let myRegistrations: CompetitionRegistration[] = [];
   let isMember = false;
+  let calendarMyRaces: CalendarRace[] = [];
+
   if (user) {
     if (currentMember) {
       const member = currentMember;
@@ -143,15 +160,24 @@ async function HomeContent() {
         .eq("del_yn", false);
       myRegistrations = (myRegs ?? []).map((r) => ({
         id: r.comp_reg_id,
-        competition_id: (Array.isArray(r.team_comp_plan_rel) ? r.team_comp_plan_rel[0] : r.team_comp_plan_rel).comp_id,
+        competition_id: (
+          Array.isArray(r.team_comp_plan_rel)
+            ? r.team_comp_plan_rel[0]
+            : r.team_comp_plan_rel
+        ).comp_id,
         member_id: r.mem_id,
         role: r.prt_role_cd,
-        event_type: (Array.isArray(r.comp_evt_cfg) ? r.comp_evt_cfg[0] : r.comp_evt_cfg)?.comp_evt_type?.toUpperCase() ?? null,
+        event_type:
+          (
+            Array.isArray(r.comp_evt_cfg) ? r.comp_evt_cfg[0] : r.comp_evt_cfg
+          )?.comp_evt_type?.toUpperCase() ?? null,
         created_at: r.crt_at,
       })) as CompetitionRegistration[];
       myRaces = (myRegs ?? [])
         .map((r) => {
-          const plan = Array.isArray(r.team_comp_plan_rel) ? r.team_comp_plan_rel[0] : r.team_comp_plan_rel;
+          const plan = Array.isArray(r.team_comp_plan_rel)
+            ? r.team_comp_plan_rel[0]
+            : r.team_comp_plan_rel;
           const comp = Array.isArray(plan.comp_mst) ? plan.comp_mst[0] : plan.comp_mst;
           return {
             id: comp.comp_id,
@@ -159,25 +185,50 @@ async function HomeContent() {
             start_date: comp.stt_dt,
             location: comp.loc_nm,
             sport: comp.comp_sprt_cd,
-            event_types: (comp.comp_evt_cfg ?? []).map((e: { comp_evt_type: string | null }) => e.comp_evt_type?.toUpperCase()).filter(Boolean),
+            event_types: (comp.comp_evt_cfg ?? [])
+              .map((e: { comp_evt_type: string | null }) => e.comp_evt_type?.toUpperCase())
+              .filter(Boolean),
           } as UpcomingRace;
         })
         .filter((c) => c && c.start_date >= today)
         .sort((a, b) => a.start_date.localeCompare(b.start_date));
+
+      // 캘린더용 내 대회 (이번 달)
+      calendarMyRaces = myRaces
+        .filter((r) => r.start_date >= monthStart && r.start_date <= monthLastDayStr)
+        .map((r) => ({
+          id: r.id,
+          title: r.title,
+          start_date: r.start_date,
+          type: "mine" as const,
+        }));
+
       // 내 대회 각 competition에 대해 참가자들이 등록한 event_type 수집
       if (myRaces.length > 0) {
         const { data: regsByComp } = await supabase
           .from("comp_reg_rel")
           .select("team_comp_plan_rel!inner(comp_id), comp_evt_cfg(comp_evt_type)")
           .eq("team_comp_plan_rel.team_id", teamId)
-          .in("team_comp_plan_rel.comp_id", myRaces.map((r) => r.id));
+          .in(
+            "team_comp_plan_rel.comp_id",
+            myRaces.map((r) => r.id),
+          );
         const byCompId = new Map<string, Set<string>>();
         (regsByComp ?? []).forEach((row) => {
-          const compId = (Array.isArray(row.team_comp_plan_rel) ? row.team_comp_plan_rel[0] : row.team_comp_plan_rel)?.comp_id;
-          const evtCd = (Array.isArray(row.comp_evt_cfg) ? row.comp_evt_cfg[0] : row.comp_evt_cfg)?.comp_evt_type;
+          const compId = (
+            Array.isArray(row.team_comp_plan_rel)
+              ? row.team_comp_plan_rel[0]
+              : row.team_comp_plan_rel
+          )?.comp_id;
+          const evtCd = (
+            Array.isArray(row.comp_evt_cfg) ? row.comp_evt_cfg[0] : row.comp_evt_cfg
+          )?.comp_evt_type;
           if (!compId || !evtCd?.trim()) return;
           let set = byCompId.get(compId);
-          if (!set) { set = new Set(); byCompId.set(compId, set); }
+          if (!set) {
+            set = new Set();
+            byCompId.set(compId, set);
+          }
           set.add(evtCd.trim().toUpperCase());
         });
         myRaces = myRaces.map((r) => {
@@ -192,15 +243,13 @@ async function HomeContent() {
     }
   }
 
-  // 2개 카드 결정
+  // 업커밍 카드 결정 (기존 로직 유지)
   const upcomingCards: UpcomingRace[] = [];
 
-  // 카드 1: 기강대회 중 가장 가까운 것
   if (topGigang) {
     upcomingCards.push({ ...topGigang, label: "기강 대회" });
   }
 
-  // 카드 2: 내가 나가는 대회 (카드1과 다른 슬롯인 것)
   const isDifferentSlot = (r: UpcomingRace) =>
     !topGigang || !isSameSlot(r.start_date, topGigang.start_date);
 
@@ -208,13 +257,11 @@ async function HomeContent() {
   if (myNext) {
     upcomingCards.push({ ...myNext, label: "내 대회" });
   } else if (myRaces.length > 0 && !isDifferentSlot(myRaces[0])) {
-    // 내 대회가 기강1번과 같은 슬롯뿐 → 기강대회 다음 슬롯
     const nextGigang = gigangRaces.find((r) => isDifferentSlot(r));
     if (nextGigang) {
       upcomingCards.push({ ...nextGigang, label: "기강 대회" });
     }
   } else if (!currentMember) {
-    // 비로그인 또는 미가입: 기강대회 다음 슬롯
     const nextGigang = gigangRaces.find((r) => isDifferentSlot(r));
     if (nextGigang) {
       upcomingCards.push({ ...nextGigang, label: "기강 대회" });
@@ -228,15 +275,25 @@ async function HomeContent() {
     }
   });
 
-  const recentRecords = recentRecordsRaw ?? [];
+  const recentRecords: RecentRecord[] = (recentRecordsRaw ?? []).map((r) => ({
+    mem_id: r.mem_id ?? null,
+    mem_nm: r.mem_nm ?? null,
+    race_nm: r.race_nm ?? null,
+    evt_cd: r.evt_cd ?? null,
+    rec_time_sec: r.rec_time_sec ?? null,
+  }));
 
   // 최근 기록 멤버들의 칭호/프레임 조회
-  const recentMemberIds = recentRecords.map((r) => r.mem_id).filter((id): id is string => Boolean(id));
-  const memberTitleMap = new Map<string, { ttl_nm: string; ttl_desc: string | null; desc_visibility: "always" | "others" | "held" | "never"; badge_effect: string; frame_cd: string }>();
+  const recentMemberIds = recentRecords
+    .map((r) => r.mem_id)
+    .filter((id): id is string => Boolean(id));
+  const titleMap: Record<string, RecordTitleInfo> = {};
   if (recentMemberIds.length > 0) {
     const { data: titleData } = await admin
       .from("mem_ttl_rel")
-      .select("team_mem_rel!inner(mem_id, selected_badge_effect, selected_frame_cd), ttl_mst!inner(ttl_nm, ttl_desc, desc_visibility)")
+      .select(
+        "team_mem_rel!inner(mem_id, selected_badge_effect, selected_frame_cd), ttl_mst!inner(ttl_nm, ttl_desc, desc_visibility)",
+      )
       .in("team_mem_rel.mem_id", recentMemberIds)
       .eq("team_mem_rel.team_id", teamId)
       .eq("is_prmy_yn", true)
@@ -246,107 +303,68 @@ async function HomeContent() {
       const rel = Array.isArray(row.team_mem_rel) ? row.team_mem_rel[0] : row.team_mem_rel;
       const ttl = Array.isArray(row.ttl_mst) ? row.ttl_mst[0] : row.ttl_mst;
       if (rel?.mem_id && ttl?.ttl_nm) {
-        const r = rel as { mem_id: string; selected_badge_effect?: string | null; selected_frame_cd?: string | null };
-        const t = ttl as { ttl_nm: string; ttl_desc?: string | null; desc_visibility?: string };
-        memberTitleMap.set(r.mem_id, {
+        const r = rel as {
+          mem_id: string;
+          selected_badge_effect?: string | null;
+          selected_frame_cd?: string | null;
+        };
+        const t = ttl as {
+          ttl_nm: string;
+          ttl_desc?: string | null;
+          desc_visibility?: string;
+        };
+        titleMap[r.mem_id] = {
           ttl_nm: t.ttl_nm,
           ttl_desc: t.ttl_desc ?? null,
-          desc_visibility: (t.desc_visibility ?? "others") as "always" | "others" | "held" | "never",
+          desc_visibility: (t.desc_visibility ?? "others") as
+            | "always"
+            | "others"
+            | "held"
+            | "never",
           badge_effect: r.selected_badge_effect ?? "none",
           frame_cd: r.selected_frame_cd ?? "frame-none",
-        });
+        };
       }
     }
   }
 
   return (
     <div className="flex flex-col gap-7 px-6 pb-6">
-        {/* Team Overview */}
-        <div className="flex flex-col gap-4">
-          <SectionLabel>TEAM OVERVIEW</SectionLabel>
-          <div className="grid grid-cols-2 gap-3">
-            <CardItem className="flex flex-col gap-1">
-              <span className="text-2xl font-bold text-foreground">
-                {memberCount ?? 0}
-              </span>
-              <span className="text-xs text-muted-foreground">활동 멤버</span>
-            </CardItem>
-            <CardItem className="flex flex-col gap-1">
-              <span className="text-2xl font-bold text-foreground">
-                {upcomingCount ?? 0}
-              </span>
-              <span className="text-xs text-muted-foreground">
-                예정 대회 중 {gigangRaces.length}개 참가
-              </span>
-            </CardItem>
-          </div>
-        </div>
+      {/* 1. 오버뷰 한 줄 */}
+      <Caption>
+        <span className="font-semibold text-foreground">{memberCount}</span>명 활동 중
+        {" · "}
+        <span className="font-semibold text-foreground">{gigangRaces.length}</span>개 대회
+        참가 예정
+      </Caption>
 
-        {/* Upcoming Races */}
-        <UpcomingRaces
-          teamId={teamId}
-          cmmCdRows={cmmCdRows}
-          races={upcomingCards}
-          initialMemberStatus={initialMemberStatus}
-          initialRegistrationsByCompetitionId={initialRegistrationsByCompetitionId}
-        />
+      {/* 2. SCHEDULE 캘린더 */}
+      <MiniCalendar
+        gigangRaces={calendarGigangRaces}
+        myRaces={calendarMyRaces}
+      />
 
-        {/* Recent Records */}
-        <div className="flex flex-col gap-4">
-          <div className="flex items-center justify-between">
-            <SectionLabel>RECENT RECORDS</SectionLabel>
-            <Link
-              href="/records"
-              className="text-xs font-medium text-primary"
-            >
-              모두 보기
-            </Link>
-          </div>
-          {recentRecords.length === 0 ? (
-            <CardItem variant="dashed" className="py-8 text-center text-sm text-muted-foreground">
-              등록된 기록이 없습니다.
-            </CardItem>
-          ) : (
-            recentRecords.map((rec) => {
-              const title = rec.mem_id ? memberTitleMap.get(rec.mem_id) : undefined;
-              const frameCls = getFrameCls(title?.frame_cd);
-              return (
-                <CardItem
-                  key={`${rec.mem_id}-${rec.race_nm}`}
-                  className={cn("flex items-center justify-between", frameCls)}
-                >
-                  <div className="flex flex-col gap-0.5">
-                    <div className="flex items-center gap-1.5">
-                      <span className="text-[15px] font-semibold text-foreground">
-                        {rec.mem_nm ?? "멤버"}
-                      </span>
-                      {title && (
-                        <TitleBadge
-                          name={title.ttl_nm}
-                          effect={title.badge_effect}
-                          size="xs"
-                          tooltip={{ desc: title.ttl_desc, visibility: title.desc_visibility as "always" | "others" | "held" | "never", isHeld: true, isOwner: false }}
-                        />
-                      )}
-                    </div>
-                    <span className="text-xs text-muted-foreground">
-                      {(rec.evt_cd ?? "UNKNOWN").toUpperCase()} · {rec.race_nm}
-                    </span>
-                  </div>
-                  <span className="font-mono text-lg font-bold text-foreground">
-                    {secondsToTime(rec.rec_time_sec ?? 0)}
-                  </span>
-                </CardItem>
-              );
-            })
-          )}
-        </div>
+      {/* 3. UPCOMING RACES 압축 리스트 */}
+      <UpcomingRaces
+        teamId={teamId}
+        cmmCdRows={cmmCdRows}
+        races={upcomingCards}
+        initialMemberStatus={initialMemberStatus}
+        initialRegistrationsByCompetitionId={initialRegistrationsByCompetitionId}
+      />
 
-        {/* Social Links */}
-        <SocialLinksGrid
-          kakaoChatPassword={isMember ? (env.KAKAO_CHAT_PASSWORD ?? "") : undefined}
-        />
-      </div>
+      {/* 4. RECENT RECORDS 2열 그리드 + 더보기 */}
+      <RecentRecordsGrid
+        records={recentRecords}
+        titleMap={titleMap}
+        initialCount={4}
+      />
+
+      {/* 5. Social Links */}
+      <SocialLinksGrid
+        kakaoChatPassword={isMember ? (env.KAKAO_CHAT_PASSWORD ?? "") : undefined}
+      />
+    </div>
   );
 }
 
@@ -354,12 +372,26 @@ async function HomeContent() {
 function HomeSkeleton() {
   return (
     <div className="flex flex-col gap-7 px-6 pb-6">
-      {/* Team Overview */}
-      <div className="flex flex-col gap-4">
-        <Skeleton className="h-3.5 w-28" />
-        <div className="grid grid-cols-2 gap-3">
-          <Skeleton className="h-20 rounded-2xl" />
-          <Skeleton className="h-20 rounded-2xl" />
+      {/* 오버뷰 한 줄 */}
+      <Skeleton className="h-4 w-48" />
+      {/* 캘린더 */}
+      <div className="flex flex-col gap-3">
+        <Skeleton className="h-3.5 w-20" />
+        <Skeleton className="h-64 rounded-xl" />
+      </div>
+      {/* Upcoming */}
+      <div className="flex flex-col gap-3">
+        <Skeleton className="h-3.5 w-32" />
+        <Skeleton className="h-10 rounded-lg" />
+        <Skeleton className="h-10 rounded-lg" />
+      </div>
+      {/* Recent Records */}
+      <div className="flex flex-col gap-3">
+        <Skeleton className="h-3.5 w-32" />
+        <div className="grid grid-cols-2 gap-2">
+          {Array.from({ length: 4 }).map((_, i) => (
+            <Skeleton key={i} className="h-20 rounded-xl" />
+          ))}
         </div>
       </div>
       {/* Social Links */}
@@ -367,12 +399,6 @@ function HomeSkeleton() {
         {Array.from({ length: 4 }).map((_, i) => (
           <Skeleton key={i} className="h-16 rounded-2xl" />
         ))}
-      </div>
-      {/* Upcoming Races */}
-      <div className="flex flex-col gap-4">
-        <Skeleton className="h-3.5 w-32" />
-        <Skeleton className="h-28 rounded-2xl" />
-        <Skeleton className="h-28 rounded-2xl" />
       </div>
     </div>
   );

--- a/app/(main)/page.tsx
+++ b/app/(main)/page.tsx
@@ -10,8 +10,12 @@ import { H1 } from "@/components/common/typography";
 import { Caption } from "@/components/common/typography";
 import { MiniCalendar } from "@/components/home/mini-calendar";
 import type { CalendarRace } from "@/components/home/mini-calendar";
+import { RecentJoiners } from "@/components/home/recent-joiners";
+import type { RecentJoiner } from "@/components/home/recent-joiners";
 import { RecentRecordsGrid } from "@/components/home/recent-records-grid";
 import type { RecentRecord, RecordTitleInfo } from "@/components/home/recent-records-grid";
+import { RecentTitles } from "@/components/home/recent-titles";
+import type { RecentTitleGrant } from "@/components/home/recent-titles";
 import { UpcomingRaces } from "@/components/home/upcoming-races";
 import type { CompetitionRegistration, MemberStatus } from "@/components/races/types";
 import { SocialLinksGrid } from "@/components/social-links";
@@ -61,13 +65,31 @@ async function HomeContent() {
     { data: teamComps },
     { data: recentRecordsRaw },
     { data: calendarComps },
+    { data: recentJoinersRaw },
+    { data: recentTitleGrantsRaw },
     cmmCdRows,
     myTitleNames,
   ] = await Promise.all([
     admin.rpc("get_public_team_member_stats", { p_team_id: teamId }),
     supabase.rpc("get_public_team_competitions", { p_team_id: teamId, p_start: today }),
     supabase.rpc("get_public_team_recent_records", { p_team_id: teamId, p_limit: 12 }),
-    supabase.rpc("get_public_team_competitions", { p_team_id: teamId, p_start: monthStart }),
+    supabase.rpc("get_public_team_competitions", { p_team_id: teamId, p_start: monthStart, p_end: monthLastDayStr }),
+    admin
+      .from("team_mem_rel")
+      .select("mem_id, join_dt, mem_mst!inner(mem_nm)")
+      .eq("team_id", teamId)
+      .eq("vers", 0)
+      .eq("del_yn", false)
+      .order("crt_at", { ascending: false })
+      .limit(10),
+    admin
+      .from("mem_ttl_rel")
+      .select("grnt_at, ttl_mst!inner(ttl_nm, ttl_desc, desc_visibility), team_mem_rel!inner(mem_id, selected_badge_effect, mem_mst!inner(mem_nm))")
+      .eq("team_id", teamId)
+      .eq("vers", 0)
+      .eq("del_yn", false)
+      .order("grnt_at", { ascending: false })
+      .limit(10),
     getCachedCmmCdRows(),
     getMyTitleNames(),
   ]);
@@ -191,15 +213,15 @@ async function HomeContent() {
         .filter((c) => c && c.start_date >= today)
         .sort((a, b) => a.start_date.localeCompare(b.start_date));
 
-      // 캘린더용 내 대회 (이번 달)
-      calendarMyRaces = myRaces
-        .filter((r) => r.start_date >= monthStart && r.start_date <= monthLastDayStr)
-        .map((r) => ({
-          id: r.id,
-          title: r.title,
-          start_date: r.start_date,
-          type: "mine" as const,
-        }));
+      // 캘린더용 내 대회 (이번 달) — today 필터 없이 myRegs 원본에서 직접 추출
+      calendarMyRaces = (myRegs ?? [])
+        .flatMap((r) => {
+          const plan = Array.isArray(r.team_comp_plan_rel) ? r.team_comp_plan_rel[0] : r.team_comp_plan_rel;
+          const comp = Array.isArray(plan.comp_mst) ? plan.comp_mst[0] : plan.comp_mst;
+          if (!comp) return [];
+          const race: CalendarRace = { id: comp.comp_id, title: comp.comp_nm, start_date: comp.stt_dt, type: "mine" };
+          return race.start_date >= monthStart && race.start_date <= monthLastDayStr ? [race] : [];
+        });
 
       // 내 대회 각 competition에 대해 참가자들이 등록한 event_type 수집
       if (myRaces.length > 0) {
@@ -268,9 +290,7 @@ async function HomeContent() {
 
   const initialRegistrationsByCompetitionId: Record<string, CompetitionRegistration> = {};
   myRegistrations.forEach((reg) => {
-    if (upcomingCards.some((card) => card.id === reg.competition_id)) {
-      initialRegistrationsByCompetitionId[reg.competition_id] = reg;
-    }
+    initialRegistrationsByCompetitionId[reg.competition_id] = reg;
   });
 
   const recentRecords: RecentRecord[] = (recentRecordsRaw ?? []).map((r) => ({
@@ -326,8 +346,36 @@ async function HomeContent() {
     }
   }
 
+  // 최근 가입자 가공
+  const recentJoiners: RecentJoiner[] = (recentJoinersRaw ?? []).map((row) => {
+    const mem = Array.isArray(row.mem_mst) ? row.mem_mst[0] : row.mem_mst;
+    return {
+      mem_id: row.mem_id as string,
+      mem_nm: (mem as { mem_nm: string })?.mem_nm ?? "멤버",
+      join_dt: row.join_dt as string,
+    };
+  });
+
+  // 최근 칭호 획득 가공
+  const recentTitleGrants: RecentTitleGrant[] = (recentTitleGrantsRaw ?? []).map((row) => {
+    const rel = Array.isArray(row.team_mem_rel) ? row.team_mem_rel[0] : row.team_mem_rel;
+    const ttl = Array.isArray(row.ttl_mst) ? row.ttl_mst[0] : row.ttl_mst;
+    const memInfo = rel as { mem_id: string; selected_badge_effect?: string | null; mem_mst: { mem_nm: string } | { mem_nm: string }[] } | null;
+    const memMst = memInfo ? (Array.isArray(memInfo.mem_mst) ? memInfo.mem_mst[0] : memInfo.mem_mst) : null;
+    const ttlInfo = ttl as { ttl_nm: string; ttl_desc?: string | null; desc_visibility?: string } | null;
+    return {
+      mem_id: memInfo?.mem_id ?? "",
+      mem_nm: (memMst as { mem_nm: string } | null)?.mem_nm ?? "멤버",
+      ttl_nm: ttlInfo?.ttl_nm ?? "",
+      ttl_desc: ttlInfo?.ttl_desc ?? null,
+      desc_visibility: (ttlInfo?.desc_visibility ?? "others") as "always" | "others" | "held" | "never",
+      badge_effect: memInfo?.selected_badge_effect ?? "none",
+      grnt_at: row.grnt_at as string,
+    };
+  }).filter((g) => g.mem_id && g.ttl_nm);
+
   return (
-    <div className="flex flex-col gap-7 px-6 pb-6">
+    <div className="flex flex-col gap-5 px-6 pb-6">
       {/* 1. 오버뷰 한 줄 */}
       <Caption>
         <span className="font-semibold text-foreground">{memberCount}</span>명 활동 중
@@ -340,6 +388,11 @@ async function HomeContent() {
       <MiniCalendar
         gigangRaces={calendarGigangRaces}
         myRaces={calendarMyRaces}
+        teamId={teamId}
+        memberId={currentMember?.id}
+        cmmCdRows={cmmCdRows}
+        initialMemberStatus={initialMemberStatus}
+        initialRegistrationsByCompetitionId={initialRegistrationsByCompetitionId}
       />
 
       {/* 3. UPCOMING RACES 압축 리스트 */}
@@ -356,10 +409,16 @@ async function HomeContent() {
         records={recentRecords}
         titleMap={titleMap}
         myTitleNames={[...myTitleNames]}
-        initialCount={4}
+        initialCount={2}
       />
 
-      {/* 5. Social Links */}
+      {/* 5. 최근 가입자 + 최근 칭호 */}
+      <div className="grid grid-cols-2 gap-4">
+        <RecentJoiners joiners={recentJoiners} initialCount={4} />
+        <RecentTitles grants={recentTitleGrants} initialCount={4} myTitleNames={[...myTitleNames]} />
+      </div>
+
+      {/* 7. Social Links */}
       <SocialLinksGrid
         kakaoChatPassword={isMember ? (env.KAKAO_CHAT_PASSWORD ?? "") : undefined}
       />

--- a/app/(main)/records/page.tsx
+++ b/app/(main)/records/page.tsx
@@ -3,6 +3,7 @@ import { Suspense } from "react";
 import { unstable_cache } from "next/cache";
 
 import { secondsToTime } from "@/lib/dayjs";
+import { getMyTitleNames } from "@/lib/queries/member";
 import { getRequestTeamContext } from "@/lib/queries/request-team";
 import { createAdminClient } from "@/lib/supabase/admin";
 
@@ -27,9 +28,12 @@ const TRIATHLON_EVENTS = [
 
 async function RecordsContent() {
   const { teamId } = await getRequestTeamContext();
-  const serializedData = await getCachedRecordsData(teamId);
+  const [serializedData, myTitleNames] = await Promise.all([
+    getCachedRecordsData(teamId),
+    getMyTitleNames(),
+  ]);
 
-  return <RecordsClient data={serializedData} />;
+  return <RecordsClient data={serializedData} myTitleNames={[...myTitleNames]} />;
 }
 
 function getCachedRecordsData(teamId: string) {

--- a/app/(main)/records/page.tsx
+++ b/app/(main)/records/page.tsx
@@ -222,7 +222,7 @@ function getCachedRecordsData(teamId: string) {
         memberTitles,
       };
     },
-    [`records-team-${teamId}`],
+    [`records-team-v2-${teamId}`],
     { revalidate: 60 * 60 * 24, tags: ["records", `records:${teamId}`] },
   )();
 }

--- a/app/(main)/records/records-client.tsx
+++ b/app/(main)/records/records-client.tsx
@@ -17,7 +17,8 @@ import { Input } from "@/components/ui/input";
 /* ------------------------------------------------------------------ */
 
 type DescVisibility = "always" | "others" | "held" | "never";
-type MemberTitle = { ttl_nm: string; ttl_desc: string | null; desc_visibility: DescVisibility; badge_effect: string; frame_cd: string; isHeld: boolean };
+type MemberTitleBase = { ttl_nm: string; ttl_desc: string | null; desc_visibility: DescVisibility; badge_effect: string; frame_cd: string };
+type MemberTitle = MemberTitleBase & { isHeld: boolean };
 
 type RankingEntry = {
   rank: number;
@@ -63,7 +64,7 @@ type RecordsData = {
   marathon: { events: MarathonEvent[] };
   trail: { entries: TrailEntry[] };
   triathlon: { events: TriathlonEvent[] };
-  memberTitles: Record<string, MemberTitle>;
+  memberTitles: Record<string, MemberTitleBase>;
 };
 
 /* ------------------------------------------------------------------ */

--- a/app/(main)/records/records-client.tsx
+++ b/app/(main)/records/records-client.tsx
@@ -17,7 +17,7 @@ import { Input } from "@/components/ui/input";
 /* ------------------------------------------------------------------ */
 
 type DescVisibility = "always" | "others" | "held" | "never";
-type MemberTitle = { ttl_nm: string; ttl_desc: string | null; desc_visibility: DescVisibility; badge_effect: string; frame_cd: string };
+type MemberTitle = { ttl_nm: string; ttl_desc: string | null; desc_visibility: DescVisibility; badge_effect: string; frame_cd: string; isHeld: boolean };
 
 type RankingEntry = {
   rank: number;
@@ -170,7 +170,7 @@ function MarathonHalfCard({
             {entry.name}
           </span>
           {title && (
-            <TitleBadge name={title.ttl_nm} effect={title.badge_effect} size="xs" tooltip={{ desc: title.ttl_desc, visibility: title.desc_visibility as "always" | "others" | "held" | "never", isHeld: true, isOwner: false }} />
+            <TitleBadge name={title.ttl_nm} effect={title.badge_effect} size="xs" tooltip={{ desc: title.ttl_desc, visibility: title.desc_visibility as "always" | "others" | "held" | "never", isHeld: title.isHeld, isOwner: false }} />
           )}
         </div>
       </div>
@@ -315,7 +315,7 @@ function TrailContent({
                     name={title.ttl_nm}
                     effect={title.badge_effect}
                     size="xs"
-                    tooltip={{ desc: title.ttl_desc, visibility: title.desc_visibility as "always" | "others" | "held" | "never", isHeld: true, isOwner: false }}
+                    tooltip={{ desc: title.ttl_desc, visibility: title.desc_visibility as "always" | "others" | "held" | "never", isHeld: title.isHeld, isOwner: false }}
                   />
                 )}
               </div>
@@ -394,7 +394,7 @@ function TriathlonContent({
                           name={title.ttl_nm}
                           effect={title.badge_effect}
                           size="xs"
-                          tooltip={{ desc: title.ttl_desc, visibility: title.desc_visibility, isHeld: true, isOwner: false }}
+                          tooltip={{ desc: title.ttl_desc, visibility: title.desc_visibility, isHeld: title.isHeld, isOwner: false }}
                         />
                       )}
                     </div>
@@ -424,7 +424,16 @@ function TriathlonContent({
 /*  메인 컴포넌트                                                       */
 /* ------------------------------------------------------------------ */
 
-export function RecordsClient({ data }: { data: RecordsData }) {
+export function RecordsClient({ data, myTitleNames = [] }: { data: RecordsData; myTitleNames?: string[] }) {
+  const myTitleNameSet = new Set(myTitleNames);
+
+  // memberTitles에 isHeld 주입
+  const memberTitles: Record<string, MemberTitle> = Object.fromEntries(
+    Object.entries(data.memberTitles).map(([memId, t]) => [
+      memId,
+      { ...t, isHeld: myTitleNameSet.has(t.ttl_nm) },
+    ])
+  );
   const [selectedCategory, setSelectedCategory] =
     useState<CategoryKey>("marathon");
   const [query, setQuery] = useState("");
@@ -487,13 +496,13 @@ export function RecordsClient({ data }: { data: RecordsData }) {
 
       {/* 카테고리별 콘텐츠 */}
       {selectedCategory === "marathon" && (
-        <MarathonContent events={filteredMarathon.events} memberTitles={data.memberTitles} />
+        <MarathonContent events={filteredMarathon.events} memberTitles={memberTitles} />
       )}
       {selectedCategory === "trail" && (
-        <TrailContent entries={filteredTrail.entries} memberTitles={data.memberTitles} />
+        <TrailContent entries={filteredTrail.entries} memberTitles={memberTitles} />
       )}
       {selectedCategory === "triathlon" && (
-        <TriathlonContent events={filteredTriathlon.events} memberTitles={data.memberTitles} />
+        <TriathlonContent events={filteredTriathlon.events} memberTitles={memberTitles} />
       )}
     </div>
   );

--- a/components/common/title-badge.tsx
+++ b/components/common/title-badge.tsx
@@ -1,9 +1,52 @@
 "use client";
 
 import { useEffect, useRef, useState } from "react";
+import { createPortal } from "react-dom";
+import { usePathname } from "next/navigation";
 import { Check, Lock } from "lucide-react";
 import { cn } from "@/lib/utils";
-import { Caption } from "@/components/common/typography";
+
+function TooltipBubble({ anchorRef, text }: { anchorRef: React.RefObject<HTMLButtonElement | null>; text: string }) {
+  const [pos, setPos] = useState<{ top: number; left: number } | null>(null);
+  const bubbleRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    const anchor = anchorRef.current;
+    const bubble = bubbleRef.current;
+    if (!anchor || !bubble || pos !== null) return;
+
+    const aRect = anchor.getBoundingClientRect();
+    const bRect = bubble.getBoundingClientRect();
+    const vw = window.innerWidth;
+    const MARGIN = 8;
+
+    let left = aRect.left + aRect.width / 2 - bRect.width / 2;
+    const top = aRect.top - bRect.height - 6;
+
+    if (left + bRect.width + MARGIN > vw) left = vw - bRect.width - MARGIN;
+    if (left < MARGIN) left = MARGIN;
+
+    setPos({ top, left });
+  });
+
+  if (typeof document === "undefined") return null;
+  return createPortal(
+    <div
+      ref={bubbleRef}
+      style={pos ? { position: "fixed", top: pos.top, left: pos.left } : { position: "fixed", visibility: "hidden" }}
+      className={cn(
+        "z-[9999] max-w-[200px] break-words rounded-md px-2.5 py-1.5",
+        "bg-zinc-800 text-[11px] leading-relaxed text-zinc-100",
+        "dark:bg-zinc-700 dark:text-zinc-50",
+        "pointer-events-none select-none",
+        "animate-in fade-in-0 zoom-in-95 duration-150",
+      )}
+    >
+      {text}
+    </div>,
+    document.body,
+  );
+}
 
 // ---------------------------------------------------------------------------
 // 이펙트 CSS 맵
@@ -141,34 +184,49 @@ export function TitleBadge({
   masked?: boolean;
   onClick?: () => void;
 }) {
-  const [clickOpen, setClickOpen] = useState(false);
-  const [hoverOpen, setHoverOpen] = useState(false);
-  const tooltipOpen = clickOpen || hoverOpen;
-  const clickTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const [tipOpen, setTipOpen] = useState(false);
+  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const btnRef = useRef<HTMLButtonElement>(null);
+  const pathname = usePathname();
 
+  // 타이머 클린업
   useEffect(() => {
-    return () => {
-      if (clickTimerRef.current) clearTimeout(clickTimerRef.current);
-    };
+    return () => { if (timerRef.current) clearTimeout(timerRef.current); };
   }, []);
+
+  // 탭 이동 시 닫기
+  useEffect(() => { setTipOpen(false); }, [pathname]);
+
+  // 스크롤 시 닫기
+  useEffect(() => {
+    if (!tipOpen) return;
+    const close = () => setTipOpen(false);
+    window.addEventListener("scroll", close, { passive: true, capture: true });
+    return () => window.removeEventListener("scroll", close, { capture: true });
+  }, [tipOpen]);
 
   const effectKey = effect ?? "none";
   const cls = BADGE_CSS[effectKey] ?? "";
   const border = BADGE_BORDER[effectKey] ?? "border-zinc-700 text-zinc-300";
 
-  const descVisible = tooltip
+  // 말풍선 텍스트: visibility 조건 통과하면 desc, 아니면 "???"
+  // 말풍선 표시 여부는 tooltip prop 존재 여부로만 결정
+  const descText = tooltip
     ? resolveDescVisible(tooltip.visibility, tooltip.isHeld, tooltip.isOwner)
-    : false;
-  const descText = descVisible ? tooltip?.desc : null;
+      ? (tooltip.desc ?? "???")
+      : "???"
+    : null;
 
   const isInteractive = !!tooltip || !!onClick;
 
+  function openTip() {
+    if (timerRef.current) clearTimeout(timerRef.current);
+    setTipOpen(true);
+    timerRef.current = setTimeout(() => setTipOpen(false), 3000);
+  }
+
   function handleClick() {
-    if (tooltip) {
-      if (clickTimerRef.current) clearTimeout(clickTimerRef.current);
-      setClickOpen(true);
-      clickTimerRef.current = setTimeout(() => setClickOpen(false), 5000);
-    }
+    if (tooltip && !masked) openTip();
     onClick?.();
   }
 
@@ -196,42 +254,31 @@ export function TitleBadge({
     </>
   );
 
+  const badgeCls = cn(
+    "inline-flex shrink-0 items-center rounded-full border bg-zinc-900 dark:bg-transparent font-medium leading-none",
+    SIZE_CLASS[size],
+    collectionStyle ?? border,
+    className,
+  );
+
   if (!isInteractive) {
-    return (
-      <span
-        className={cn(
-          "inline-flex shrink-0 items-center rounded-full border bg-zinc-900 dark:bg-transparent font-medium leading-none",
-          SIZE_CLASS[size],
-          collectionStyle ?? border,
-          className,
-        )}
-      >
-        {inner}
-      </span>
-    );
+    return <span className={badgeCls}>{inner}</span>;
   }
 
   return (
-    <div className="relative inline-flex">
+    <div className="relative inline-flex overflow-visible">
       <button
+        ref={btnRef}
         onClick={handleClick}
-        onMouseEnter={() => tooltip && setHoverOpen(true)}
-        onMouseLeave={() => setHoverOpen(false)}
         disabled={masked}
-        className={cn(
-          "inline-flex shrink-0 items-center gap-1.5 rounded-full border bg-zinc-900 dark:bg-transparent font-medium leading-none",
-          SIZE_CLASS[size],
-          collectionStyle ?? border,
-          className,
-        )}
+        className={badgeCls}
       >
         {inner}
       </button>
 
-      {tooltip && tooltipOpen && !masked && (
-        <span className="ml-1.5 max-w-[180px] truncate text-[10px] text-muted-foreground">
-          {descText ?? "???"}
-        </span>
+      {/* 말풍선 툴팁 — 배지 위에 떠서 3초 후 자동 소멸 */}
+      {tooltip && tipOpen && !masked && (
+        <TooltipBubble anchorRef={btnRef} text={descText ?? "???"} />
       )}
     </div>
   );

--- a/components/common/title-badge.tsx
+++ b/components/common/title-badge.tsx
@@ -130,7 +130,7 @@ function resolveDescVisible(
 ): boolean {
   switch (visibility) {
     case "always": return true;
-    case "others": return isHeld || !isOwner;
+    case "others": return true;
     case "held":   return isHeld;
     case "never":  return false;
   }
@@ -166,6 +166,8 @@ export function TitleBadge({
   selected,
   masked,
   onClick,
+  tooltipOpen,
+  onTooltipOpen,
 }: {
   name: string;
   effect: string | null;
@@ -183,8 +185,13 @@ export function TitleBadge({
   /** 미보유 마스킹 (칭호명 blur + 자물쇠) */
   masked?: boolean;
   onClick?: () => void;
+  /** 외부에서 툴팁 열림 상태를 제어할 때 사용 (컬렉션 등 여러 배지가 공존하는 경우) */
+  tooltipOpen?: boolean;
+  onTooltipOpen?: () => void;
 }) {
-  const [tipOpen, setTipOpen] = useState(false);
+  const [tipOpenInternal, setTipOpenInternal] = useState(false);
+  const tipOpen = tooltipOpen !== undefined ? tooltipOpen : tipOpenInternal;
+  const setTipOpen = tooltipOpen !== undefined ? () => {} : setTipOpenInternal;
   const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const btnRef = useRef<HTMLButtonElement>(null);
   const pathname = usePathname();
@@ -220,9 +227,13 @@ export function TitleBadge({
   const isInteractive = !!tooltip || !!onClick;
 
   function openTip() {
-    if (timerRef.current) clearTimeout(timerRef.current);
-    setTipOpen(true);
-    timerRef.current = setTimeout(() => setTipOpen(false), 3000);
+    if (tooltipOpen !== undefined) {
+      onTooltipOpen?.();
+    } else {
+      if (timerRef.current) clearTimeout(timerRef.current);
+      setTipOpenInternal(true);
+      timerRef.current = setTimeout(() => setTipOpenInternal(false), 3000);
+    }
   }
 
   function handleClick() {

--- a/components/home/mini-calendar.tsx
+++ b/components/home/mini-calendar.tsx
@@ -1,0 +1,226 @@
+"use client";
+
+import { useMemo, useState } from "react";
+import { ChevronLeft, ChevronRight } from "lucide-react";
+import { todayKST, currentMonthKST } from "@/lib/dayjs";
+import { Caption, Micro, SectionLabel } from "@/components/common/typography";
+import { SectionHeader } from "@/components/common/section-header";
+import { cn } from "@/lib/utils";
+
+export type CalendarRace = {
+  id: string;
+  title: string;
+  start_date: string;
+  /** "gigang" = 기강 팀 참가자 1명 이상, "mine" = 내가 참가 */
+  type: "gigang" | "mine";
+};
+
+type MiniCalendarProps = {
+  /** 서버에서 전달하는 이번 달 기강 대회 목록 */
+  gigangRaces: CalendarRace[];
+  /** 서버에서 전달하는 내 참가 대회 목록 */
+  myRaces: CalendarRace[];
+};
+
+const WEEKDAYS = ["일", "월", "화", "수", "목", "금", "토"] as const;
+
+export function MiniCalendar({ gigangRaces, myRaces }: MiniCalendarProps) {
+  // 초기 달 = 이번 달 (YYYY-MM-01 문자열)
+  const initialMonth = currentMonthKST();
+  const [viewMonth] = useState(initialMonth); // 이번 달만 표시 (확장 예정)
+  const [selectedDate, setSelectedDate] = useState<string | null>(null);
+
+  const today = todayKST();
+
+  // viewMonth("YYYY-MM-01")에서 year, month 파싱
+  const [yearStr, monthStr] = viewMonth.split("-");
+  const year = parseInt(yearStr, 10);
+  const month = parseInt(monthStr, 10); // 1-indexed
+
+  // 해당 월의 총 일수
+  const totalDays = new Date(year, month, 0).getDate();
+  // 1일의 요일 (0=일, 6=토)
+  const firstDayOfWeek = new Date(`${year}-${String(month).padStart(2, "0")}-01`).getDay();
+
+  // 날짜별 이벤트 맵 구성
+  const eventMap = useMemo(() => {
+    const map = new Map<string, { gigang: boolean; mine: boolean }>();
+
+    for (const race of gigangRaces) {
+      const key = race.start_date;
+      const existing = map.get(key) ?? { gigang: false, mine: false };
+      map.set(key, { ...existing, gigang: true });
+    }
+    for (const race of myRaces) {
+      const key = race.start_date;
+      const existing = map.get(key) ?? { gigang: false, mine: false };
+      map.set(key, { ...existing, mine: true });
+    }
+
+    return map;
+  }, [gigangRaces, myRaces]);
+
+  // 선택된 날짜의 이벤트
+  const selectedEvents = useMemo(() => {
+    if (!selectedDate) return [];
+    const result: CalendarRace[] = [];
+
+    // 중복 제거: gigangRaces와 myRaces 합쳐서 날짜 일치하는 것
+    const seen = new Set<string>();
+    for (const race of [...gigangRaces, ...myRaces]) {
+      if (race.start_date === selectedDate && !seen.has(race.id)) {
+        seen.add(race.id);
+        result.push(race);
+      }
+    }
+    return result;
+  }, [selectedDate, gigangRaces, myRaces]);
+
+  // 달력 셀 배열 (앞 빈칸 + 날짜)
+  const cells: (number | null)[] = [
+    ...Array.from<null>({ length: firstDayOfWeek }).fill(null),
+    ...Array.from({ length: totalDays }, (_, i) => i + 1),
+  ];
+
+  function formatCellDate(day: number): string {
+    return `${year}-${String(month).padStart(2, "0")}-${String(day).padStart(2, "0")}`;
+  }
+
+  function handleDayClick(day: number) {
+    const dateStr = formatCellDate(day);
+    setSelectedDate((prev) => (prev === dateStr ? null : dateStr));
+  }
+
+  const monthLabel = `${year}년 ${month}월`;
+
+  return (
+    <div className="flex flex-col gap-4">
+      <SectionHeader label="SCHEDULE" />
+
+      {/* 캘린더 */}
+      <div className="flex flex-col gap-2">
+        {/* 월 헤더 */}
+        <div className="flex items-center justify-between px-1">
+          <Caption className="text-foreground font-medium">{monthLabel}</Caption>
+          {/* 이동 버튼 자리 — 추후 확장 예정 */}
+          <div className="flex gap-1 opacity-0 pointer-events-none" aria-hidden>
+            <button className="size-6 flex items-center justify-center rounded" disabled>
+              <ChevronLeft className="size-4" />
+            </button>
+            <button className="size-6 flex items-center justify-center rounded" disabled>
+              <ChevronRight className="size-4" />
+            </button>
+          </div>
+        </div>
+
+        {/* 요일 헤더 */}
+        <div className="grid grid-cols-7 text-center">
+          {WEEKDAYS.map((wd) => (
+            <Micro
+              key={wd}
+              className={cn(
+                "py-1",
+                wd === "일" && "text-destructive",
+                wd === "토" && "text-primary",
+              )}
+            >
+              {wd}
+            </Micro>
+          ))}
+        </div>
+
+        {/* 날짜 셀 */}
+        <div className="grid grid-cols-7 text-center">
+          {cells.map((day, idx) => {
+            if (day === null) {
+              return <div key={`empty-${idx}`} />;
+            }
+            const dateStr = formatCellDate(day);
+            const events = eventMap.get(dateStr);
+            const isToday = dateStr === today;
+            const isSelected = selectedDate === dateStr;
+            const colIndex = (firstDayOfWeek + day - 1) % 7;
+
+            return (
+              <button
+                key={dateStr}
+                onClick={() => handleDayClick(day)}
+                className={cn(
+                  "relative flex flex-col items-center gap-0.5 py-1.5 rounded-lg transition-colors",
+                  isSelected && "bg-secondary",
+                  !isSelected && "hover:bg-secondary/60",
+                )}
+                aria-label={`${month}월 ${day}일`}
+                aria-pressed={isSelected}
+              >
+                {/* 날짜 숫자 */}
+                <span
+                  className={cn(
+                    "flex size-7 items-center justify-center rounded-full text-[13px] font-medium",
+                    isToday && "bg-primary text-primary-foreground font-bold",
+                    !isToday && colIndex === 0 && "text-destructive",
+                    !isToday && colIndex === 6 && "text-primary",
+                    !isToday && !isSelected && "text-foreground",
+                  )}
+                >
+                  {day}
+                </span>
+
+                {/* 이벤트 도트 */}
+                {events && (
+                  <div className="flex gap-0.5">
+                    {events.gigang && (
+                      <span className="size-1.5 rounded-full bg-warning" aria-hidden />
+                    )}
+                    {events.mine && (
+                      <span className="size-1.5 rounded-full bg-primary" aria-hidden />
+                    )}
+                  </div>
+                )}
+                {/* 도트 없을 때 간격 유지 */}
+                {!events && <span className="size-1.5" />}
+              </button>
+            );
+          })}
+        </div>
+      </div>
+
+      {/* 범례 */}
+      <div className="flex items-center gap-4 px-1">
+        <div className="flex items-center gap-1.5">
+          <span className="size-2 rounded-full bg-warning" />
+          <Micro>기강 대회</Micro>
+        </div>
+        <div className="flex items-center gap-1.5">
+          <span className="size-2 rounded-full bg-primary" />
+          <Micro>내 대회</Micro>
+        </div>
+      </div>
+
+      {/* 선택된 날짜 이벤트 목록 */}
+      {selectedDate && (
+        <div className="flex flex-col gap-2 rounded-xl bg-secondary/60 px-3 py-3">
+          <Caption className="font-medium text-foreground">
+            {parseInt(selectedDate.split("-")[1], 10)}월{" "}
+            {parseInt(selectedDate.split("-")[2], 10)}일
+          </Caption>
+          {selectedEvents.length === 0 ? (
+            <Caption>일정 없음</Caption>
+          ) : (
+            selectedEvents.map((race) => (
+              <div key={race.id} className="flex items-center gap-2">
+                <span
+                  className={cn(
+                    "size-2 shrink-0 rounded-full",
+                    race.type === "mine" ? "bg-primary" : "bg-warning",
+                  )}
+                />
+                <Caption className="text-foreground">{race.title}</Caption>
+              </div>
+            ))
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/components/home/mini-calendar.tsx
+++ b/components/home/mini-calendar.tsx
@@ -1,82 +1,111 @@
 "use client";
 
-import { useMemo, useState } from "react";
+import { useMemo, useState, useTransition } from "react";
 import { ChevronLeft, ChevronRight } from "lucide-react";
 import { todayKST, currentMonthKST } from "@/lib/dayjs";
-import { Caption, Micro, SectionLabel } from "@/components/common/typography";
-import { SectionHeader } from "@/components/common/section-header";
+import { createClient } from "@/lib/supabase/client";
+import { compEvtTypeContainsHangul } from "@/lib/comp-evt-type";
+import { getOrCreateCompEvtIdForParticipation } from "@/app/actions/get-or-create-comp-evt-for-participation";
+import { revalidateCompetitions } from "@/app/actions/revalidate-competitions";
+import { ensureTeamCompPlanRel } from "@/lib/queries/ensure-team-comp-plan-rel";
+import { Micro, SectionLabel } from "@/components/common/typography";
+import { CompetitionDetailDialog } from "@/components/races/competition-detail-dialog";
 import { cn } from "@/lib/utils";
+import type { Competition, CompetitionRegistration, MemberStatus } from "@/components/races/types";
+import type { CachedCmmCdRow } from "@/lib/queries/cmm-cd-cached";
 
 export type CalendarRace = {
   id: string;
   title: string;
   start_date: string;
-  /** "gigang" = 기강 팀 참가자 1명 이상, "mine" = 내가 참가 */
   type: "gigang" | "mine";
 };
 
 type MiniCalendarProps = {
-  /** 서버에서 전달하는 이번 달 기강 대회 목록 */
   gigangRaces: CalendarRace[];
-  /** 서버에서 전달하는 내 참가 대회 목록 */
   myRaces: CalendarRace[];
+  teamId: string;
+  memberId?: string;
+  cmmCdRows: CachedCmmCdRow[];
+  initialMemberStatus: MemberStatus;
+  initialRegistrationsByCompetitionId: Record<string, CompetitionRegistration>;
 };
 
 const WEEKDAYS = ["일", "월", "화", "수", "목", "금", "토"] as const;
 
-export function MiniCalendar({ gigangRaces, myRaces }: MiniCalendarProps) {
-  // 초기 달 = 이번 달 (YYYY-MM-01 문자열)
+function monthLastDayStr(year: number, month: number): string {
+  const d = new Date(year, month, 0).getDate();
+  return `${year}-${String(month).padStart(2, "0")}-${String(d).padStart(2, "0")}`;
+}
+
+export function MiniCalendar({
+  gigangRaces: initGigang,
+  myRaces: initMine,
+  teamId,
+  memberId,
+  cmmCdRows,
+  initialMemberStatus,
+  initialRegistrationsByCompetitionId,
+}: MiniCalendarProps) {
+  const supabase = useMemo(() => createClient(), []);
   const initialMonth = currentMonthKST();
-  const [viewMonth] = useState(initialMonth); // 이번 달만 표시 (확장 예정)
+  const [viewMonth, setViewMonth] = useState(initialMonth);
+  const [gigangRaces, setGigangRaces] = useState(initGigang);
+  const [myRaces, setMyRaces] = useState(initMine);
   const [selectedDate, setSelectedDate] = useState<string | null>(null);
+  const [isPending, startTransition] = useTransition();
+
+  const [selectedCompetition, setSelectedCompetition] = useState<Competition | null>(null);
+  const [detailOpen, setDetailOpen] = useState(false);
+  const [registrationsByCompetitionId, setRegistrationsByCompetitionId] =
+    useState<Record<string, CompetitionRegistration>>(initialRegistrationsByCompetitionId);
+
+  const memberStatus = initialMemberStatus;
 
   const today = todayKST();
-
-  // viewMonth("YYYY-MM-01")에서 year, month 파싱
   const [yearStr, monthStr] = viewMonth.split("-");
   const year = parseInt(yearStr, 10);
-  const month = parseInt(monthStr, 10); // 1-indexed
+  const month = parseInt(monthStr, 10);
 
-  // 해당 월의 총 일수
   const totalDays = new Date(year, month, 0).getDate();
-  // 1일의 요일 (0=일, 6=토)
   const firstDayOfWeek = new Date(`${year}-${String(month).padStart(2, "0")}-01`).getDay();
 
-  // 날짜별 이벤트 맵 구성
   const eventMap = useMemo(() => {
-    const map = new Map<string, { gigang: boolean; mine: boolean }>();
+    const gigangIdsByDate = new Map<string, Set<string>>();
+    const mineIdsByDate = new Map<string, Set<string>>();
 
     for (const race of gigangRaces) {
-      const key = race.start_date;
-      const existing = map.get(key) ?? { gigang: false, mine: false };
-      map.set(key, { ...existing, gigang: true });
+      const s = gigangIdsByDate.get(race.start_date) ?? new Set<string>();
+      s.add(race.id);
+      gigangIdsByDate.set(race.start_date, s);
     }
     for (const race of myRaces) {
-      const key = race.start_date;
-      const existing = map.get(key) ?? { gigang: false, mine: false };
-      map.set(key, { ...existing, mine: true });
+      const s = mineIdsByDate.get(race.start_date) ?? new Set<string>();
+      s.add(race.id);
+      mineIdsByDate.set(race.start_date, s);
+    }
+
+    const map = new Map<string, { gigang: boolean; mine: boolean }>();
+    for (const [date, gigangIds] of gigangIdsByDate) {
+      const mineIds = mineIdsByDate.get(date) ?? new Set<string>();
+      const hasGigangWithoutMe = [...gigangIds].some((id) => !mineIds.has(id));
+      map.set(date, { gigang: hasGigangWithoutMe, mine: mineIds.size > 0 });
     }
 
     return map;
   }, [gigangRaces, myRaces]);
 
-  // 선택된 날짜의 이벤트
   const selectedEvents = useMemo(() => {
     if (!selectedDate) return [];
-    const result: CalendarRace[] = [];
-
-    // 중복 제거: gigangRaces와 myRaces 합쳐서 날짜 일치하는 것
     const seen = new Set<string>();
-    for (const race of [...gigangRaces, ...myRaces]) {
-      if (race.start_date === selectedDate && !seen.has(race.id)) {
-        seen.add(race.id);
-        result.push(race);
-      }
-    }
-    return result;
+    // myRaces 먼저 — 같은 대회가 기강+내 대회 둘 다면 mine 타입으로 표시
+    return [...myRaces, ...gigangRaces].filter((r) => {
+      if (r.start_date !== selectedDate || seen.has(r.id)) return false;
+      seen.add(r.id);
+      return true;
+    });
   }, [selectedDate, gigangRaces, myRaces]);
 
-  // 달력 셀 배열 (앞 빈칸 + 날짜)
   const cells: (number | null)[] = [
     ...Array.from<null>({ length: firstDayOfWeek }).fill(null),
     ...Array.from({ length: totalDays }, (_, i) => i + 1),
@@ -91,35 +120,219 @@ export function MiniCalendar({ gigangRaces, myRaces }: MiniCalendarProps) {
     setSelectedDate((prev) => (prev === dateStr ? null : dateStr));
   }
 
-  const monthLabel = `${year}년 ${month}월`;
+  async function handleRaceClick(race: CalendarRace) {
+    const { data } = await supabase
+      .from("comp_mst")
+      .select("comp_id, comp_nm, comp_sprt_cd, stt_dt, end_dt, loc_nm, src_url, comp_evt_cfg(comp_evt_type)")
+      .eq("comp_id", race.id)
+      .single();
+
+    const comp: Competition = data
+      ? {
+          id: data.comp_id,
+          external_id: "",
+          sport: data.comp_sprt_cd ?? null,
+          title: data.comp_nm,
+          start_date: data.stt_dt,
+          end_date: data.end_dt ?? null,
+          location: data.loc_nm ?? null,
+          event_types: (data.comp_evt_cfg as { comp_evt_type: string | null }[])
+            .map((e) => e.comp_evt_type?.toUpperCase())
+            .filter((e): e is string => Boolean(e)),
+          source_url: data.src_url ?? null,
+        }
+      : {
+          id: race.id,
+          external_id: "",
+          sport: null,
+          title: race.title,
+          start_date: race.start_date,
+          end_date: null,
+          location: null,
+          event_types: null,
+          source_url: null,
+        };
+
+    setSelectedCompetition(comp);
+    setDetailOpen(true);
+  }
+
+  const createRegistration = async (
+    competitionId: string,
+    payload: { role: "participant" | "cheering" | "volunteer"; eventType: string },
+  ) => {
+    if (memberStatus.status !== "ready") return { ok: false as const, message: "로그인이 필요합니다." };
+    const eventType = payload.role === "participant" ? payload.eventType.trim().toUpperCase() : null;
+    if (payload.role === "participant" && eventType && compEvtTypeContainsHangul(eventType))
+      return { ok: false as const, message: "종목은 한글을 사용할 수 없습니다. 영문·숫자로 입력해 주세요." };
+
+    const ensured = await ensureTeamCompPlanRel(supabase, teamId, competitionId);
+    if (!ensured.ok) return { ok: false as const, message: "신청에 실패했습니다." };
+
+    let compEvtId: string | null = null;
+    if (payload.role === "participant") {
+      if (!eventType) return { ok: false as const, message: "참가 종목을 선택해 주세요." };
+      const resolved = await getOrCreateCompEvtIdForParticipation(competitionId, eventType);
+      if (!resolved.ok) return { ok: false as const, message: resolved.message };
+      compEvtId = resolved.compEvtId;
+    }
+
+    const { data, error } = await supabase
+      .from("comp_reg_rel")
+      .insert({ team_comp_id: ensured.teamCompId, mem_id: memberStatus.memberId, prt_role_cd: payload.role, comp_evt_id: compEvtId, vers: 0, del_yn: false })
+      .select("comp_reg_id, mem_id, prt_role_cd, crt_at")
+      .single();
+    if (error) return { ok: false as const, message: "신청에 실패했습니다." };
+    setRegistrationsByCompetitionId((prev) => ({
+      ...prev,
+      [competitionId]: { id: data.comp_reg_id, competition_id: competitionId, member_id: data.mem_id, role: data.prt_role_cd as "participant" | "cheering" | "volunteer", event_type: eventType, created_at: data.crt_at },
+    }));
+    return { ok: true as const, message: "참가 신청 완료" };
+  };
+
+  const updateRegistration = async (
+    registrationId: string,
+    competitionId: string,
+    payload: { role: "participant" | "cheering" | "volunteer"; eventType: string },
+  ) => {
+    if (memberStatus.status !== "ready") return { ok: false as const, message: "로그인이 필요합니다." };
+    const eventType = payload.role === "participant" ? payload.eventType.trim().toUpperCase() : null;
+    if (payload.role === "participant" && eventType && compEvtTypeContainsHangul(eventType))
+      return { ok: false as const, message: "종목은 한글을 사용할 수 없습니다. 영문·숫자로 입력해 주세요." };
+
+    let compEvtId: string | null = null;
+    if (payload.role === "participant") {
+      if (!eventType) return { ok: false as const, message: "참가 종목을 선택해 주세요." };
+      const resolved = await getOrCreateCompEvtIdForParticipation(competitionId, eventType);
+      if (!resolved.ok) return { ok: false as const, message: resolved.message };
+      compEvtId = resolved.compEvtId;
+    }
+
+    const { data, error } = await supabase
+      .from("comp_reg_rel")
+      .update({ prt_role_cd: payload.role, comp_evt_id: compEvtId })
+      .eq("comp_reg_id", registrationId)
+      .select("comp_reg_id, mem_id, prt_role_cd, crt_at")
+      .single();
+    if (error) return { ok: false as const, message: "수정에 실패했습니다." };
+    setRegistrationsByCompetitionId((prev) => ({
+      ...prev,
+      [competitionId]: { id: data.comp_reg_id, competition_id: competitionId, member_id: data.mem_id, role: data.prt_role_cd as "participant" | "cheering" | "volunteer", event_type: eventType, created_at: data.crt_at },
+    }));
+    return { ok: true as const, message: "업데이트 완료" };
+  };
+
+  const deleteRegistration = async (registrationId: string, competitionId: string) => {
+    const { error } = await supabase.from("comp_reg_rel").delete().eq("comp_reg_id", registrationId);
+    if (error) return { ok: false as const, message: "취소에 실패했습니다." };
+    setRegistrationsByCompetitionId((prev) => {
+      const next = { ...prev };
+      delete next[competitionId];
+      return next;
+    });
+    return { ok: true as const, message: "취소 완료" };
+  };
+
+  async function fetchMonthData(newMonth: string) {
+    const [yStr, mStr] = newMonth.split("-");
+    const y = parseInt(yStr, 10);
+    const m = parseInt(mStr, 10);
+    const lastDay = monthLastDayStr(y, m);
+
+    const { data: teamComps } = await supabase.rpc("get_public_team_competitions", {
+      p_team_id: teamId,
+      p_start: newMonth,
+      p_end: lastDay,
+    });
+
+    const seenIds = new Set<string>();
+    const newGigang: CalendarRace[] = (teamComps ?? [])
+      .filter((row) => (row.reg_count ?? 0) > 0)
+      .filter((row) => { if (seenIds.has(row.comp_id)) return false; seenIds.add(row.comp_id); return true; })
+      .map((row) => ({ id: row.comp_id, title: row.comp_nm, start_date: row.stt_dt, type: "gigang" as const }));
+
+    let newMine: CalendarRace[] = [];
+    if (memberId) {
+      const { data: myRegs } = await supabase
+        .from("comp_reg_rel")
+        .select("team_comp_plan_rel!inner(comp_id, comp_mst!inner(comp_id, comp_nm, stt_dt))")
+        .eq("mem_id", memberId)
+        .eq("team_comp_plan_rel.team_id", teamId)
+        .eq("vers", 0)
+        .eq("del_yn", false);
+
+      newMine = (myRegs ?? []).flatMap((r) => {
+        const plan = Array.isArray(r.team_comp_plan_rel) ? r.team_comp_plan_rel[0] : r.team_comp_plan_rel;
+        const comp = Array.isArray(plan?.comp_mst) ? plan.comp_mst[0] : plan?.comp_mst;
+        if (!comp) return [];
+        const race: CalendarRace = { id: comp.comp_id, title: comp.comp_nm, start_date: comp.stt_dt, type: "mine" };
+        return race.start_date >= newMonth && race.start_date <= lastDay ? [race] : [];
+      });
+    }
+
+    return { gigang: newGigang, mine: newMine };
+  }
+
+  function navigate(dir: -1 | 1) {
+    startTransition(async () => {
+      const d = new Date(`${viewMonth}`);
+      d.setMonth(d.getMonth() + dir);
+      const newMonth = `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, "0")}-01`;
+      const { gigang, mine } = await fetchMonthData(newMonth);
+      setSelectedDate(null);
+      setViewMonth(newMonth);
+      setGigangRaces(gigang);
+      setMyRaces(mine);
+    });
+  }
 
   return (
-    <div className="flex flex-col gap-4">
-      <SectionHeader label="SCHEDULE" />
-
-      {/* 캘린더 */}
-      <div className="flex flex-col gap-2">
-        {/* 월 헤더 */}
-        <div className="flex items-center justify-between px-1">
-          <Caption className="text-foreground font-medium">{monthLabel}</Caption>
-          {/* 이동 버튼 자리 — 추후 확장 예정 */}
-          <div className="flex gap-1 opacity-0 pointer-events-none" aria-hidden>
-            <button className="size-6 flex items-center justify-center rounded" disabled>
-              <ChevronLeft className="size-4" />
-            </button>
-            <button className="size-6 flex items-center justify-center rounded" disabled>
-              <ChevronRight className="size-4" />
-            </button>
+    <div className="flex flex-col gap-2">
+      {/* 헤더: SCHEDULE + 범례 + 월 이동 한 줄에 */}
+      <div className="flex items-center justify-between">
+        <div className="flex items-center gap-3">
+          <SectionLabel>SCHEDULE</SectionLabel>
+          <div className="flex items-center gap-2.5">
+            <div className="flex items-center gap-1">
+              <span className="size-1.5 rounded-full bg-warning" />
+              <Micro>기강</Micro>
+            </div>
+            <div className="flex items-center gap-1">
+              <span className="size-1.5 rounded-full bg-primary" />
+              <Micro>내 대회</Micro>
+            </div>
           </div>
         </div>
+        <div className="flex items-center gap-1">
+          <Micro className="text-foreground font-medium tabular-nums">{year}.{String(month).padStart(2, "0")}</Micro>
+          <button
+            onClick={() => navigate(-1)}
+            disabled={isPending}
+            className="flex size-5 items-center justify-center rounded text-muted-foreground transition-colors hover:bg-secondary hover:text-foreground disabled:opacity-40"
+            aria-label="이전 달"
+          >
+            <ChevronLeft className="size-3.5" />
+          </button>
+          <button
+            onClick={() => navigate(1)}
+            disabled={isPending}
+            className="flex size-5 items-center justify-center rounded text-muted-foreground transition-colors hover:bg-secondary hover:text-foreground disabled:opacity-40"
+            aria-label="다음 달"
+          >
+            <ChevronRight className="size-3.5" />
+          </button>
+        </div>
+      </div>
 
+      {/* 달력 그리드 */}
+      <div className={cn("flex flex-col transition-opacity", isPending && "opacity-50")}>
         {/* 요일 헤더 */}
         <div className="grid grid-cols-7 text-center">
           {WEEKDAYS.map((wd) => (
             <Micro
               key={wd}
               className={cn(
-                "py-1",
+                "pb-0.5",
                 wd === "일" && "text-destructive",
                 wd === "토" && "text-primary",
               )}
@@ -132,9 +345,7 @@ export function MiniCalendar({ gigangRaces, myRaces }: MiniCalendarProps) {
         {/* 날짜 셀 */}
         <div className="grid grid-cols-7 text-center">
           {cells.map((day, idx) => {
-            if (day === null) {
-              return <div key={`empty-${idx}`} />;
-            }
+            if (day === null) return <div key={`empty-${idx}`} />;
             const dateStr = formatCellDate(day);
             const events = eventMap.get(dateStr);
             const isToday = dateStr === today;
@@ -146,81 +357,80 @@ export function MiniCalendar({ gigangRaces, myRaces }: MiniCalendarProps) {
                 key={dateStr}
                 onClick={() => handleDayClick(day)}
                 className={cn(
-                  "relative flex flex-col items-center gap-0.5 py-1.5 rounded-lg transition-colors",
+                  "flex items-center justify-center rounded transition-colors",
                   isSelected && "bg-secondary",
                   !isSelected && "hover:bg-secondary/60",
                 )}
                 aria-label={`${month}월 ${day}일`}
                 aria-pressed={isSelected}
               >
-                {/* 날짜 숫자 */}
-                <span
-                  className={cn(
-                    "flex size-7 items-center justify-center rounded-full text-[13px] font-medium",
-                    isToday && "bg-primary text-primary-foreground font-bold",
-                    !isToday && colIndex === 0 && "text-destructive",
-                    !isToday && colIndex === 6 && "text-primary",
-                    !isToday && !isSelected && "text-foreground",
-                  )}
-                >
-                  {day}
+                <span className="flex items-center gap-0.5">
+                  <span
+                    className={cn(
+                      "flex size-6 items-center justify-center rounded-full text-[12px] font-medium",
+                      isToday && "bg-primary text-primary-foreground font-bold",
+                      !isToday && colIndex === 0 && "text-destructive",
+                      !isToday && colIndex === 6 && "text-primary",
+                      !isToday && "text-foreground",
+                    )}
+                  >
+                    {day}
+                  </span>
+                  <span className="grid grid-cols-2 gap-px" aria-hidden>
+                    <span className={cn("size-1 rounded-full", events?.gigang ? "bg-warning" : "bg-transparent")} />
+                    <span className={cn("size-1 rounded-full", events?.mine   ? "bg-primary" : "bg-transparent")} />
+                    <span className="size-1 rounded-full bg-transparent" />
+                    <span className="size-1 rounded-full bg-transparent" />
+                  </span>
                 </span>
-
-                {/* 이벤트 도트 */}
-                {events && (
-                  <div className="flex gap-0.5">
-                    {events.gigang && (
-                      <span className="size-1.5 rounded-full bg-warning" aria-hidden />
-                    )}
-                    {events.mine && (
-                      <span className="size-1.5 rounded-full bg-primary" aria-hidden />
-                    )}
-                  </div>
-                )}
-                {/* 도트 없을 때 간격 유지 */}
-                {!events && <span className="size-1.5" />}
               </button>
             );
           })}
         </div>
       </div>
 
-      {/* 범례 */}
-      <div className="flex items-center gap-4 px-1">
-        <div className="flex items-center gap-1.5">
-          <span className="size-2 rounded-full bg-warning" />
-          <Micro>기강 대회</Micro>
-        </div>
-        <div className="flex items-center gap-1.5">
-          <span className="size-2 rounded-full bg-primary" />
-          <Micro>내 대회</Micro>
-        </div>
-      </div>
-
-      {/* 선택된 날짜 이벤트 목록 */}
+      {/* 선택된 날짜 이벤트 */}
       {selectedDate && (
-        <div className="flex flex-col gap-2 rounded-xl bg-secondary/60 px-3 py-3">
-          <Caption className="font-medium text-foreground">
-            {parseInt(selectedDate.split("-")[1], 10)}월{" "}
-            {parseInt(selectedDate.split("-")[2], 10)}일
-          </Caption>
+        <div className="flex items-start gap-2 rounded-lg bg-secondary/60 px-3 py-1.5">
+          <Micro className="shrink-0 pt-px text-muted-foreground tabular-nums">
+            {parseInt(selectedDate.split("-")[1], 10)}/{parseInt(selectedDate.split("-")[2], 10)}
+          </Micro>
           {selectedEvents.length === 0 ? (
-            <Caption>일정 없음</Caption>
+            <Micro className="text-muted-foreground">일정 없음</Micro>
           ) : (
-            selectedEvents.map((race) => (
-              <div key={race.id} className="flex items-center gap-2">
-                <span
-                  className={cn(
-                    "size-2 shrink-0 rounded-full",
-                    race.type === "mine" ? "bg-primary" : "bg-warning",
-                  )}
-                />
-                <Caption className="text-foreground">{race.title}</Caption>
-              </div>
-            ))
+            <div className="flex flex-col gap-1">
+              {selectedEvents.map((race) => (
+                <button
+                  key={race.id}
+                  onClick={() => handleRaceClick(race)}
+                  className="flex items-center gap-1.5 text-left hover:opacity-70 transition-opacity"
+                >
+                  <span className={cn("size-1.5 shrink-0 rounded-full", race.type === "mine" ? "bg-primary" : "bg-warning")} />
+                  <Micro className="text-foreground underline-offset-2 hover:underline">{race.title}</Micro>
+                </button>
+              ))}
+            </div>
           )}
         </div>
       )}
+
+      {/* 대회 상세 다이얼로그 */}
+      <CompetitionDetailDialog
+        cmmCdRows={cmmCdRows}
+        teamId={teamId}
+        competition={selectedCompetition}
+        registration={selectedCompetition ? registrationsByCompetitionId[selectedCompetition.id] : undefined}
+        memberStatus={memberStatus}
+        open={detailOpen}
+        onOpenChange={setDetailOpen}
+        onCreate={createRegistration}
+        onUpdate={updateRegistration}
+        onDelete={deleteRegistration}
+        onCompetitionUpdated={async () => {
+          await revalidateCompetitions();
+          window.location.reload();
+        }}
+      />
     </div>
   );
 }

--- a/components/home/recent-joiners.tsx
+++ b/components/home/recent-joiners.tsx
@@ -1,0 +1,62 @@
+"use client";
+
+import { useState } from "react";
+import { SectionHeader } from "@/components/common/section-header";
+import { EmptyState } from "@/components/common/empty-state";
+
+export type RecentJoiner = {
+  mem_id: string;
+  mem_nm: string;
+  join_dt: string; // "YYYY-MM-DD"
+};
+
+type RecentJoinersProps = {
+  joiners: RecentJoiner[];
+  initialCount?: number;
+};
+
+export function RecentJoiners({ joiners, initialCount = 4 }: RecentJoinersProps) {
+  const [expanded, setExpanded] = useState(false);
+  const visible = expanded ? joiners : joiners.slice(0, initialCount);
+  const hasMore = joiners.length > initialCount;
+
+  return (
+    <div className="flex min-w-0 flex-col gap-3">
+      <div className="flex items-center justify-between">
+        <SectionHeader label="NEW MEMBERS" />
+        {hasMore && (
+          <button
+            onClick={() => setExpanded((p) => !p)}
+            className="text-[11px] text-muted-foreground transition-colors hover:text-foreground"
+          >
+            {expanded ? "접기" : "더 보기"}
+          </button>
+        )}
+      </div>
+
+      {joiners.length === 0 ? (
+        <EmptyState variant="inline" message="최근 가입자가 없습니다." />
+      ) : (
+        <div className="flex flex-col divide-y divide-border">
+          {visible.map((j) => {
+            const [, mm, dd] = j.join_dt.split("-");
+            return (
+              <div key={j.mem_id} className="flex min-h-9 items-center justify-between gap-1">
+                <div className="flex min-w-0 items-center gap-1.5">
+                  <span className="text-[11px]">🎉</span>
+                  <span className="truncate text-[12px] font-medium text-foreground">{j.mem_nm}</span>
+                  <span className="shrink-0 rounded px-1 py-px text-[9px] font-bold tracking-wide bg-primary/15 text-primary">
+                    NEW
+                  </span>
+                </div>
+                <span className="shrink-0 font-mono text-[10px] text-muted-foreground tabular-nums">
+                  {mm}/{dd}
+                </span>
+              </div>
+            );
+          })}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/components/home/recent-joiners.tsx
+++ b/components/home/recent-joiners.tsx
@@ -41,15 +41,13 @@ export function RecentJoiners({ joiners, initialCount = 4 }: RecentJoinersProps)
           {visible.map((j) => {
             const [, mm, dd] = j.join_dt.split("-");
             return (
-              <div key={j.mem_id} className="flex min-h-9 items-center justify-between gap-1">
-                <div className="flex min-w-0 items-center gap-1.5">
-                  <span className="text-[11px]">🎉</span>
-                  <span className="truncate text-[12px] font-medium text-foreground">{j.mem_nm}</span>
-                  <span className="shrink-0 rounded px-1 py-px text-[9px] font-bold tracking-wide bg-primary/15 text-primary">
-                    NEW
-                  </span>
-                </div>
-                <span className="shrink-0 font-mono text-[10px] text-muted-foreground tabular-nums">
+              <div key={j.mem_id} className="flex min-h-9 items-center gap-1.5">
+                <span className="text-[11px]">🎉</span>
+                <span className="min-w-0 flex-1 truncate text-[12px] font-medium text-foreground">{j.mem_nm}</span>
+                <span className="shrink-0 rounded px-1 py-px text-[9px] font-bold tracking-wide bg-primary/15 text-primary">
+                  NEW
+                </span>
+                <span className="w-8 shrink-0 text-right font-mono text-[10px] text-muted-foreground tabular-nums">
                   {mm}/{dd}
                 </span>
               </div>

--- a/components/home/recent-records-grid.tsx
+++ b/components/home/recent-records-grid.tsx
@@ -67,7 +67,7 @@ export function RecentRecordsGrid({
               const frameCls = getFrameCls(title?.frame_cd);
               return (
                 <div
-                  key={`${rec.mem_id ?? "unknown"}-${rec.race_nm ?? idx}`}
+                  key={`${rec.mem_id ?? "unknown"}-${rec.race_nm ?? ""}-${rec.evt_cd ?? idx}`}
                   className={cn(
                     "flex flex-col gap-0.5 rounded-xl border border-border bg-card p-2",
                     frameCls,

--- a/components/home/recent-records-grid.tsx
+++ b/components/home/recent-records-grid.tsx
@@ -29,6 +29,7 @@ export type RecordTitleInfo = {
 type RecentRecordsGridProps = {
   records: RecentRecord[];
   titleMap: Record<string, RecordTitleInfo>;
+  myTitleNames?: string[];
   /** 처음 표시할 개수 (기본 4) */
   initialCount?: number;
 };
@@ -36,8 +37,10 @@ type RecentRecordsGridProps = {
 export function RecentRecordsGrid({
   records,
   titleMap,
+  myTitleNames = [],
   initialCount = 4,
 }: RecentRecordsGridProps) {
+  const myTitleNameSet = new Set(myTitleNames);
   const [expanded, setExpanded] = useState(false);
 
   const visibleRecords = expanded ? records : records.slice(0, initialCount);
@@ -76,7 +79,7 @@ export function RecentRecordsGrid({
                         tooltip={{
                           desc: title.ttl_desc,
                           visibility: title.desc_visibility,
-                          isHeld: true,
+                          isHeld: myTitleNameSet.has(title.ttl_nm),
                           isOwner: false,
                         }}
                       />

--- a/components/home/recent-records-grid.tsx
+++ b/components/home/recent-records-grid.tsx
@@ -1,0 +1,114 @@
+"use client";
+
+import { useState } from "react";
+import { secondsToTime } from "@/lib/dayjs";
+import { getFrameCls } from "@/lib/title-effects";
+import { cn } from "@/lib/utils";
+import { TitleBadge } from "@/components/common/title-badge";
+import { Body, Caption, Micro } from "@/components/common/typography";
+import { SectionHeader } from "@/components/common/section-header";
+import { EmptyState } from "@/components/common/empty-state";
+import { Button } from "@/components/ui/button";
+
+export type RecentRecord = {
+  mem_id: string | null;
+  mem_nm: string | null;
+  race_nm: string | null;
+  evt_cd: string | null;
+  rec_time_sec: number | null;
+};
+
+export type RecordTitleInfo = {
+  ttl_nm: string;
+  ttl_desc: string | null;
+  desc_visibility: "always" | "others" | "held" | "never";
+  badge_effect: string;
+  frame_cd: string;
+};
+
+type RecentRecordsGridProps = {
+  records: RecentRecord[];
+  titleMap: Record<string, RecordTitleInfo>;
+  /** 처음 표시할 개수 (기본 4) */
+  initialCount?: number;
+};
+
+export function RecentRecordsGrid({
+  records,
+  titleMap,
+  initialCount = 4,
+}: RecentRecordsGridProps) {
+  const [expanded, setExpanded] = useState(false);
+
+  const visibleRecords = expanded ? records : records.slice(0, initialCount);
+  const hasMore = records.length > initialCount;
+
+  return (
+    <div className="flex flex-col gap-4">
+      <SectionHeader label="RECENT RECORDS" />
+
+      {records.length === 0 ? (
+        <EmptyState variant="card" message="등록된 기록이 없습니다." />
+      ) : (
+        <>
+          <div className="grid grid-cols-2 gap-2">
+            {visibleRecords.map((rec, idx) => {
+              const title = rec.mem_id ? titleMap[rec.mem_id] : undefined;
+              const frameCls = getFrameCls(title?.frame_cd);
+              return (
+                <div
+                  key={`${rec.mem_id ?? "unknown"}-${rec.race_nm ?? idx}`}
+                  className={cn(
+                    "flex flex-col gap-1 rounded-xl border border-border bg-card p-3",
+                    frameCls,
+                  )}
+                >
+                  {/* 이름 + 칭호 */}
+                  <div className="flex items-center gap-1 overflow-hidden">
+                    <Body className="shrink-0 font-semibold leading-none">
+                      {rec.mem_nm ?? "멤버"}
+                    </Body>
+                    {title && (
+                      <TitleBadge
+                        name={title.ttl_nm}
+                        effect={title.badge_effect}
+                        size="xs"
+                        tooltip={{
+                          desc: title.ttl_desc,
+                          visibility: title.desc_visibility,
+                          isHeld: true,
+                          isOwner: false,
+                        }}
+                      />
+                    )}
+                  </div>
+
+                  {/* 기록 시간 */}
+                  <span className="font-mono text-base font-bold leading-none text-foreground">
+                    {secondsToTime(rec.rec_time_sec ?? 0)}
+                  </span>
+
+                  {/* 종목 · 대회명 */}
+                  <Caption className="truncate leading-tight">
+                    {(rec.evt_cd ?? "UNKNOWN").toUpperCase()} · {rec.race_nm}
+                  </Caption>
+                </div>
+              );
+            })}
+          </div>
+
+          {hasMore && (
+            <Button
+              variant="ghost"
+              size="sm"
+              className="w-full text-muted-foreground"
+              onClick={() => setExpanded((prev) => !prev)}
+            >
+              {expanded ? "접기" : `더 보기 (${records.length - initialCount}개)`}
+            </Button>
+          )}
+        </>
+      )}
+    </div>
+  );
+}

--- a/components/home/recent-records-grid.tsx
+++ b/components/home/recent-records-grid.tsx
@@ -5,10 +5,8 @@ import { secondsToTime } from "@/lib/dayjs";
 import { getFrameCls } from "@/lib/title-effects";
 import { cn } from "@/lib/utils";
 import { TitleBadge } from "@/components/common/title-badge";
-import { Body, Caption, Micro } from "@/components/common/typography";
 import { SectionHeader } from "@/components/common/section-header";
 import { EmptyState } from "@/components/common/empty-state";
-import { Button } from "@/components/ui/button";
 
 export type RecentRecord = {
   mem_id: string | null;
@@ -47,30 +45,39 @@ export function RecentRecordsGrid({
   const hasMore = records.length > initialCount;
 
   return (
-    <div className="flex flex-col gap-4">
-      <SectionHeader label="RECENT RECORDS" />
+    <div className="flex flex-col gap-3">
+      <div className="flex items-center justify-between">
+        <SectionHeader label="RECENT RECORDS" />
+        {hasMore && (
+          <button
+            onClick={() => setExpanded((prev) => !prev)}
+            className="text-[11px] text-muted-foreground hover:text-foreground transition-colors"
+          >
+            {expanded ? "접기" : "더 보기"}
+          </button>
+        )}
+      </div>
 
       {records.length === 0 ? (
         <EmptyState variant="card" message="등록된 기록이 없습니다." />
       ) : (
-        <>
-          <div className="grid grid-cols-2 gap-2">
-            {visibleRecords.map((rec, idx) => {
+        <div className="grid grid-cols-2 gap-2">
+          {visibleRecords.map((rec, idx) => {
               const title = rec.mem_id ? titleMap[rec.mem_id] : undefined;
               const frameCls = getFrameCls(title?.frame_cd);
               return (
                 <div
                   key={`${rec.mem_id ?? "unknown"}-${rec.race_nm ?? idx}`}
                   className={cn(
-                    "flex flex-col gap-1 rounded-xl border border-border bg-card p-3",
+                    "flex flex-col gap-0.5 rounded-xl border border-border bg-card p-2",
                     frameCls,
                   )}
                 >
-                  {/* 이름 + 칭호 */}
-                  <div className="flex items-center gap-1 overflow-visible">
-                    <Body className="shrink-0 font-semibold leading-none">
+                  {/* 줄 1: 이름 + 칭호 */}
+                  <div className="flex min-w-0 items-center gap-1">
+                    <span className="truncate text-[12px] font-semibold text-foreground">
                       {rec.mem_nm ?? "멤버"}
-                    </Body>
+                    </span>
                     {title && (
                       <TitleBadge
                         name={title.ttl_nm}
@@ -85,32 +92,19 @@ export function RecentRecordsGrid({
                       />
                     )}
                   </div>
-
-                  {/* 기록 시간 */}
-                  <span className="font-mono text-base font-bold leading-none text-foreground">
-                    {secondsToTime(rec.rec_time_sec ?? 0)}
-                  </span>
-
-                  {/* 종목 · 대회명 */}
-                  <Caption className="truncate leading-tight">
-                    {(rec.evt_cd ?? "UNKNOWN").toUpperCase()} · {rec.race_nm}
-                  </Caption>
+                  {/* 줄 2: 대회명 + 기록 */}
+                  <div className="flex min-w-0 items-center gap-1">
+                    <span className="min-w-0 flex-1 truncate text-[10px] text-muted-foreground">
+                      {rec.race_nm ?? "-"}
+                    </span>
+                    <span className="shrink-0 font-mono text-[11px] font-bold text-foreground">
+                      {secondsToTime(rec.rec_time_sec ?? 0)}
+                    </span>
+                  </div>
                 </div>
               );
             })}
           </div>
-
-          {hasMore && (
-            <Button
-              variant="ghost"
-              size="sm"
-              className="w-full text-muted-foreground"
-              onClick={() => setExpanded((prev) => !prev)}
-            >
-              {expanded ? "접기" : `더 보기 (${records.length - initialCount}개)`}
-            </Button>
-          )}
-        </>
       )}
     </div>
   );

--- a/components/home/recent-records-grid.tsx
+++ b/components/home/recent-records-grid.tsx
@@ -64,7 +64,7 @@ export function RecentRecordsGrid({
                   )}
                 >
                   {/* 이름 + 칭호 */}
-                  <div className="flex items-center gap-1 overflow-hidden">
+                  <div className="flex items-center gap-1 overflow-visible">
                     <Body className="shrink-0 font-semibold leading-none">
                       {rec.mem_nm ?? "멤버"}
                     </Body>

--- a/components/home/recent-titles.tsx
+++ b/components/home/recent-titles.tsx
@@ -48,22 +48,20 @@ export function RecentTitles({ grants, initialCount = 4, myTitleNames = [] }: Re
           const mm = String(date.getMonth() + 1).padStart(2, "0");
           const dd = String(date.getDate()).padStart(2, "0");
           return (
-            <div key={`${g.mem_id}-${g.ttl_nm}-${idx}`} className="flex min-h-9 items-center justify-between gap-1">
-              <div className="flex min-w-0 items-center gap-1.5">
-                <span className="shrink-0 truncate text-[12px] font-medium text-foreground">{g.mem_nm}</span>
-                <TitleBadge
-                  name={g.ttl_nm}
-                  effect={g.badge_effect}
-                  size="xs"
-                  tooltip={{
-                    desc: g.ttl_desc,
-                    visibility: g.desc_visibility,
-                    isHeld: myTitleNameSet.has(g.ttl_nm),
-                    isOwner: false,
-                  }}
-                />
-              </div>
-              <span className="shrink-0 font-mono text-[10px] text-muted-foreground tabular-nums">{mm}/{dd}</span>
+            <div key={`${g.mem_id}-${g.ttl_nm}-${idx}`} className="flex min-h-9 items-center gap-1.5">
+              <span className="min-w-0 flex-1 truncate text-[12px] font-medium text-foreground">{g.mem_nm}</span>
+              <TitleBadge
+                name={g.ttl_nm}
+                effect={g.badge_effect}
+                size="xs"
+                tooltip={{
+                  desc: g.ttl_desc,
+                  visibility: g.desc_visibility,
+                  isHeld: myTitleNameSet.has(g.ttl_nm),
+                  isOwner: false,
+                }}
+              />
+              <span className="w-8 shrink-0 text-right font-mono text-[10px] text-muted-foreground tabular-nums">{mm}/{dd}</span>
             </div>
           );
         })}

--- a/components/home/recent-titles.tsx
+++ b/components/home/recent-titles.tsx
@@ -1,0 +1,73 @@
+"use client";
+
+import { useState } from "react";
+import { SectionHeader } from "@/components/common/section-header";
+import { TitleBadge } from "@/components/common/title-badge";
+
+export type RecentTitleGrant = {
+  mem_id: string;
+  mem_nm: string;
+  ttl_nm: string;
+  ttl_desc: string | null;
+  desc_visibility: "always" | "others" | "held" | "never";
+  badge_effect: string;
+  grnt_at: string;
+};
+
+type RecentTitlesProps = {
+  grants: RecentTitleGrant[];
+  initialCount?: number;
+  myTitleNames?: string[];
+};
+
+export function RecentTitles({ grants, initialCount = 4, myTitleNames = [] }: RecentTitlesProps) {
+  const [expanded, setExpanded] = useState(false);
+  const myTitleNameSet = new Set(myTitleNames);
+  const visible = expanded ? grants : grants.slice(0, initialCount);
+  const hasMore = grants.length > initialCount;
+
+  if (grants.length === 0) return null;
+
+  return (
+    <div className="flex min-w-0 flex-col gap-3">
+      <div className="flex items-center justify-between">
+        <SectionHeader label="RECENT TITLES" />
+        {hasMore && (
+          <button
+            onClick={() => setExpanded((p) => !p)}
+            className="text-[11px] text-muted-foreground transition-colors hover:text-foreground"
+          >
+            {expanded ? "접기" : "더 보기"}
+          </button>
+        )}
+      </div>
+
+      <div className="flex flex-col divide-y divide-border">
+        {visible.map((g, idx) => {
+          const date = new Date(g.grnt_at);
+          const mm = String(date.getMonth() + 1).padStart(2, "0");
+          const dd = String(date.getDate()).padStart(2, "0");
+          return (
+            <div key={`${g.mem_id}-${g.ttl_nm}-${idx}`} className="flex min-h-9 items-center justify-between gap-1">
+              <div className="flex min-w-0 items-center gap-1.5">
+                <span className="shrink-0 truncate text-[12px] font-medium text-foreground">{g.mem_nm}</span>
+                <TitleBadge
+                  name={g.ttl_nm}
+                  effect={g.badge_effect}
+                  size="xs"
+                  tooltip={{
+                    desc: g.ttl_desc,
+                    visibility: g.desc_visibility,
+                    isHeld: myTitleNameSet.has(g.ttl_nm),
+                    isOwner: false,
+                  }}
+                />
+              </div>
+              <span className="shrink-0 font-mono text-[10px] text-muted-foreground tabular-nums">{mm}/{dd}</span>
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+}

--- a/components/home/recent-titles.tsx
+++ b/components/home/recent-titles.tsx
@@ -1,8 +1,15 @@
 "use client";
 
 import { useState } from "react";
+import dayjs from "dayjs";
+import utc from "dayjs/plugin/utc";
+import timezone from "dayjs/plugin/timezone";
 import { SectionHeader } from "@/components/common/section-header";
+import { EmptyState } from "@/components/common/empty-state";
 import { TitleBadge } from "@/components/common/title-badge";
+
+dayjs.extend(utc);
+dayjs.extend(timezone);
 
 export type RecentTitleGrant = {
   mem_id: string;
@@ -26,7 +33,12 @@ export function RecentTitles({ grants, initialCount = 4, myTitleNames = [] }: Re
   const visible = expanded ? grants : grants.slice(0, initialCount);
   const hasMore = grants.length > initialCount;
 
-  if (grants.length === 0) return null;
+  if (grants.length === 0) return (
+    <div className="flex min-w-0 flex-col gap-3">
+      <SectionHeader label="RECENT TITLES" />
+      <EmptyState variant="inline" message="최근 획득 칭호가 없습니다." />
+    </div>
+  );
 
   return (
     <div className="flex min-w-0 flex-col gap-3">
@@ -44,9 +56,9 @@ export function RecentTitles({ grants, initialCount = 4, myTitleNames = [] }: Re
 
       <div className="flex flex-col divide-y divide-border">
         {visible.map((g, idx) => {
-          const date = new Date(g.grnt_at);
-          const mm = String(date.getMonth() + 1).padStart(2, "0");
-          const dd = String(date.getDate()).padStart(2, "0");
+          const kst = dayjs(g.grnt_at).tz("Asia/Seoul");
+          const mm = String(kst.month() + 1).padStart(2, "0");
+          const dd = String(kst.date()).padStart(2, "0");
           return (
             <div key={`${g.mem_id}-${g.ttl_nm}-${idx}`} className="flex min-h-9 items-center gap-1.5">
               <span className="min-w-0 flex-1 truncate text-[12px] font-medium text-foreground">{g.mem_nm}</span>

--- a/components/home/upcoming-races.tsx
+++ b/components/home/upcoming-races.tsx
@@ -208,27 +208,29 @@ export function UpcomingRaces({
                 onClick={() => handleRowClick(race)}
                 className="flex w-full items-center gap-3 py-2 text-left transition-colors hover:bg-muted/40 first:pt-0.5 last:pb-0.5"
               >
-                {/* D-day 뱃지 */}
+                {/* D-day 뱃지 — 너비 고정 */}
                 <span
                   className={cn(
-                    "shrink-0 rounded-md px-2 py-0.5 font-mono text-[11px] font-bold",
+                    "w-14 shrink-0 rounded-md px-2 py-0.5 text-center font-mono text-[11px] font-bold",
                     ddayCls,
                   )}
                 >
                   {dday}
                 </span>
 
-                {/* 대회명 + 라벨 */}
-                <div className="flex flex-1 items-center gap-1.5 min-w-0">
-                  <Caption className="truncate text-foreground font-medium">
-                    {race.title}
-                  </Caption>
+                {/* 라벨 — 너비 고정 */}
+                <span className="w-14 shrink-0 text-center">
                   {race.label && (
-                    <span className="shrink-0 rounded px-1 py-px text-[10px] font-medium bg-secondary text-muted-foreground">
+                    <span className="rounded px-1 py-px text-[10px] font-medium bg-secondary text-muted-foreground">
                       {race.label}
                     </span>
                   )}
-                </div>
+                </span>
+
+                {/* 대회명 */}
+                <Caption className="flex-1 truncate text-foreground font-medium">
+                  {race.title}
+                </Caption>
 
                 {/* 날짜 */}
                 <Micro className="shrink-0 tabular-nums">

--- a/components/home/upcoming-races.tsx
+++ b/components/home/upcoming-races.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import { useState, useMemo } from "react";
-import { Calendar, MapPin } from "lucide-react";
 import Link from "next/link";
 import { compEvtTypeContainsHangul } from "@/lib/comp-evt-type";
 import { createClient } from "@/lib/supabase/client";
@@ -9,11 +8,13 @@ import { getOrCreateCompEvtIdForParticipation } from "@/app/actions/get-or-creat
 import { revalidateCompetitions } from "@/app/actions/revalidate-competitions";
 import { CompetitionDetailDialog } from "@/components/races/competition-detail-dialog";
 import { formatDDay } from "@/lib/dayjs";
-import { CardItem } from "@/components/ui/card";
+import { Micro, Caption } from "@/components/common/typography";
+import { SectionHeader } from "@/components/common/section-header";
+import { EmptyState } from "@/components/common/empty-state";
 import type { Competition, CompetitionRegistration, MemberStatus } from "@/components/races/types";
-import { SectionLabel } from "@/components/common/typography";
 import type { CachedCmmCdRow } from "@/lib/queries/cmm-cd-cached";
 import { ensureTeamCompPlanRel } from "@/lib/queries/ensure-team-comp-plan-rel";
+import { cn } from "@/lib/utils";
 
 type UpcomingRace = {
   id: string;
@@ -49,7 +50,10 @@ export function UpcomingRaces({
   const [registrationsByCompetitionId, setRegistrationsByCompetitionId] =
     useState<Record<string, CompetitionRegistration>>(initialRegistrationsByCompetitionId);
 
-  const createRegistration = async (competitionId: string, payload: { role: "participant" | "cheering" | "volunteer"; eventType: string }) => {
+  const createRegistration = async (
+    competitionId: string,
+    payload: { role: "participant" | "cheering" | "volunteer"; eventType: string },
+  ) => {
     if (memberStatus.status !== "ready") return { ok: false as const, message: "로그인이 필요합니다." };
     const eventType = payload.role === "participant" ? payload.eventType.trim().toUpperCase() : null;
     if (payload.role === "participant" && eventType && compEvtTypeContainsHangul(eventType)) {
@@ -64,25 +68,45 @@ export function UpcomingRaces({
       if (!eventType) {
         return { ok: false as const, message: "참가 종목을 선택해 주세요." };
       }
-      const resolved = await getOrCreateCompEvtIdForParticipation(
-        competitionId,
-        eventType,
-      );
+      const resolved = await getOrCreateCompEvtIdForParticipation(competitionId, eventType);
       if (!resolved.ok) {
         return { ok: false as const, message: resolved.message };
       }
       compEvtId = resolved.compEvtId;
     }
 
-    const { data, error } = await supabase.from("comp_reg_rel")
-      .insert({ team_comp_id: plan.team_comp_id, mem_id: memberStatus.memberId, prt_role_cd: payload.role, comp_evt_id: compEvtId, vers: 0, del_yn: false })
-      .select("comp_reg_id, mem_id, prt_role_cd, crt_at").single();
+    const { data, error } = await supabase
+      .from("comp_reg_rel")
+      .insert({
+        team_comp_id: plan.team_comp_id,
+        mem_id: memberStatus.memberId,
+        prt_role_cd: payload.role,
+        comp_evt_id: compEvtId,
+        vers: 0,
+        del_yn: false,
+      })
+      .select("comp_reg_id, mem_id, prt_role_cd, crt_at")
+      .single();
     if (error) return { ok: false as const, message: "신청에 실패했습니다." };
-    setRegistrationsByCompetitionId(prev => ({ ...prev, [competitionId]: { id: data.comp_reg_id, competition_id: competitionId, member_id: data.mem_id, role: data.prt_role_cd as "participant" | "cheering" | "volunteer", event_type: eventType, created_at: data.crt_at } }));
+    setRegistrationsByCompetitionId((prev) => ({
+      ...prev,
+      [competitionId]: {
+        id: data.comp_reg_id,
+        competition_id: competitionId,
+        member_id: data.mem_id,
+        role: data.prt_role_cd as "participant" | "cheering" | "volunteer",
+        event_type: eventType,
+        created_at: data.crt_at,
+      },
+    }));
     return { ok: true as const, message: "참가 신청 완료" };
   };
 
-  const updateRegistration = async (registrationId: string, competitionId: string, payload: { role: "participant" | "cheering" | "volunteer"; eventType: string }) => {
+  const updateRegistration = async (
+    registrationId: string,
+    competitionId: string,
+    payload: { role: "participant" | "cheering" | "volunteer"; eventType: string },
+  ) => {
     if (memberStatus.status !== "ready") return { ok: false as const, message: "로그인이 필요합니다." };
     const eventType = payload.role === "participant" ? payload.eventType.trim().toUpperCase() : null;
     if (payload.role === "participant" && eventType && compEvtTypeContainsHangul(eventType)) {
@@ -94,33 +118,49 @@ export function UpcomingRaces({
       if (!eventType) {
         return { ok: false as const, message: "참가 종목을 선택해 주세요." };
       }
-      const resolved = await getOrCreateCompEvtIdForParticipation(
-        competitionId,
-        eventType,
-      );
+      const resolved = await getOrCreateCompEvtIdForParticipation(competitionId, eventType);
       if (!resolved.ok) {
         return { ok: false as const, message: resolved.message };
       }
       compEvtId = resolved.compEvtId;
     }
 
-    const { data, error } = await supabase.from("comp_reg_rel")
-      .update({ prt_role_cd: payload.role, comp_evt_id: compEvtId }).eq("comp_reg_id", registrationId)
-      .select("comp_reg_id, mem_id, prt_role_cd, crt_at").single();
+    const { data, error } = await supabase
+      .from("comp_reg_rel")
+      .update({ prt_role_cd: payload.role, comp_evt_id: compEvtId })
+      .eq("comp_reg_id", registrationId)
+      .select("comp_reg_id, mem_id, prt_role_cd, crt_at")
+      .single();
     if (error) return { ok: false as const, message: "수정에 실패했습니다." };
-    setRegistrationsByCompetitionId(prev => ({ ...prev, [competitionId]: { id: data.comp_reg_id, competition_id: competitionId, member_id: data.mem_id, role: data.prt_role_cd as "participant" | "cheering" | "volunteer", event_type: eventType, created_at: data.crt_at } }));
+    setRegistrationsByCompetitionId((prev) => ({
+      ...prev,
+      [competitionId]: {
+        id: data.comp_reg_id,
+        competition_id: competitionId,
+        member_id: data.mem_id,
+        role: data.prt_role_cd as "participant" | "cheering" | "volunteer",
+        event_type: eventType,
+        created_at: data.crt_at,
+      },
+    }));
     return { ok: true as const, message: "업데이트 완료" };
   };
 
   const deleteRegistration = async (registrationId: string, competitionId: string) => {
-    const { error } = await supabase.from("comp_reg_rel").delete().eq("comp_reg_id", registrationId);
+    const { error } = await supabase
+      .from("comp_reg_rel")
+      .delete()
+      .eq("comp_reg_id", registrationId);
     if (error) return { ok: false as const, message: "취소에 실패했습니다." };
-    setRegistrationsByCompetitionId(prev => { const next = { ...prev }; delete next[competitionId]; return next; });
+    setRegistrationsByCompetitionId((prev) => {
+      const next = { ...prev };
+      delete next[competitionId];
+      return next;
+    });
     return { ok: true as const, message: "취소 완료" };
   };
 
-  function handleCardClick(race: UpcomingRace) {
-    // UpcomingRace → Competition 변환 (필수 필드 채우기)
+  function handleRowClick(race: UpcomingRace) {
     const displayEventTypes = race.registered_event_types?.length
       ? race.registered_event_types
       : race.event_types;
@@ -140,83 +180,78 @@ export function UpcomingRaces({
   }
 
   return (
-    <div className="flex flex-col gap-4">
-      <div className="flex items-center justify-between">
-        <SectionLabel>UPCOMING RACES</SectionLabel>
-        <Link href="/races" className="text-xs font-medium text-primary">
-          모두 보기
-        </Link>
-      </div>
+    <div className="flex flex-col gap-3">
+      <SectionHeader
+        label="UPCOMING RACES"
+        action={{ label: "모두 보기", href: "/races" }}
+      />
+
       {races.length === 0 ? (
-        <CardItem variant="dashed" className="py-8 text-center text-sm text-muted-foreground">
-          예정된 대회가 없습니다
-        </CardItem>
+        <EmptyState variant="inline" message="예정된 대회가 없습니다" />
       ) : (
-        races.map((race) => {
-          const eventTypes = race.registered_event_types ?? race.event_types;
-          return (
-            <CardItem asChild key={race.id}>
+        <div className="flex flex-col divide-y divide-border">
+          {races.map((race) => {
+            const dday = formatDDay(race.start_date);
+            // D-day 뱃지 색상: D-DAY 또는 D+는 destructive, D-7 이하는 warning, 나머지 muted
+            const ddayNum = dday.startsWith("D-") && dday !== "D-DAY"
+              ? parseInt(dday.slice(2), 10)
+              : null;
+            const ddayCls = dday === "D-DAY" || dday.startsWith("D+")
+              ? "bg-destructive/10 text-destructive"
+              : ddayNum !== null && ddayNum <= 7
+                ? "bg-warning/15 text-warning"
+                : "bg-secondary text-muted-foreground";
+
+            return (
               <button
-                onClick={() => handleCardClick(race)}
-                className="flex w-full flex-col gap-3 text-left transition-colors hover:bg-muted/50"
+                key={race.id}
+                onClick={() => handleRowClick(race)}
+                className="flex w-full items-center gap-3 py-2.5 text-left transition-colors hover:bg-muted/40 first:pt-1 last:pb-1"
               >
-              <div className="flex items-start justify-between">
-                <div className="flex flex-col gap-1">
-                  {race.label && (
-                    <span className="text-[11px] font-semibold text-primary">
-                      {race.label}
-                    </span>
+                {/* D-day 뱃지 */}
+                <span
+                  className={cn(
+                    "shrink-0 rounded-md px-2 py-0.5 font-mono text-[11px] font-bold",
+                    ddayCls,
                   )}
-                  <span className="text-[15px] font-semibold text-foreground">
-                    {race.title}
-                  </span>
-                </div>
-                <span className="shrink-0 rounded-full bg-destructive/10 px-2.5 py-1 text-[11px] font-bold text-destructive">
-                  {formatDDay(race.start_date)}
+                >
+                  {dday}
                 </span>
-              </div>
-              <div className="flex flex-wrap items-center gap-x-3 gap-y-1 text-xs text-muted-foreground">
-                <span className="flex items-center gap-1">
-                  <Calendar className="size-3" />
-                  {race.start_date}
-                </span>
-                {race.location && (
-                  <span className="flex items-center gap-1">
-                    <MapPin className="size-3" />
-                    {race.location}
-                  </span>
-                )}
-              </div>
-              {eventTypes && eventTypes.length > 0 && (
-                <div className="flex flex-wrap gap-1.5">
-                  {eventTypes.map((et: string) => (
-                    <span
-                      key={et}
-                      className="rounded-full bg-secondary px-2.5 py-0.5 text-[11px] font-bold text-secondary-foreground"
-                    >
-                      {et}
-                    </span>
-                  ))}
-                </div>
-              )}
+
+                {/* 대회명 */}
+                <Caption className="flex-1 truncate text-foreground font-medium">
+                  {race.title}
+                </Caption>
+
+                {/* 날짜 */}
+                <Micro className="shrink-0 tabular-nums">
+                  {race.start_date.slice(5).replace("-", "/")}
+                </Micro>
               </button>
-            </CardItem>
-          );
-        })
+            );
+          })}
+        </div>
       )}
 
       <CompetitionDetailDialog
         cmmCdRows={cmmCdRows}
         teamId={teamId}
         competition={selectedCompetition}
-        registration={selectedCompetition ? registrationsByCompetitionId[selectedCompetition.id] : undefined}
+        registration={
+          selectedCompetition
+            ? registrationsByCompetitionId[selectedCompetition.id]
+            : undefined
+        }
         memberStatus={memberStatus}
         open={detailOpen}
         onOpenChange={setDetailOpen}
         onCreate={createRegistration}
         onUpdate={updateRegistration}
         onDelete={deleteRegistration}
-        onCompetitionUpdated={async () => { await revalidateCompetitions(); window.location.reload(); }}
+        onCompetitionUpdated={async () => {
+          await revalidateCompetitions();
+          window.location.reload();
+        }}
       />
     </div>
   );

--- a/components/home/upcoming-races.tsx
+++ b/components/home/upcoming-races.tsx
@@ -206,7 +206,7 @@ export function UpcomingRaces({
               <button
                 key={race.id}
                 onClick={() => handleRowClick(race)}
-                className="flex w-full items-center gap-3 py-2.5 text-left transition-colors hover:bg-muted/40 first:pt-1 last:pb-1"
+                className="flex w-full items-center gap-3 py-2 text-left transition-colors hover:bg-muted/40 first:pt-0.5 last:pb-0.5"
               >
                 {/* D-day 뱃지 */}
                 <span
@@ -218,10 +218,17 @@ export function UpcomingRaces({
                   {dday}
                 </span>
 
-                {/* 대회명 */}
-                <Caption className="flex-1 truncate text-foreground font-medium">
-                  {race.title}
-                </Caption>
+                {/* 대회명 + 라벨 */}
+                <div className="flex flex-1 items-center gap-1.5 min-w-0">
+                  <Caption className="truncate text-foreground font-medium">
+                    {race.title}
+                  </Caption>
+                  {race.label && (
+                    <span className="shrink-0 rounded px-1 py-px text-[10px] font-medium bg-secondary text-muted-foreground">
+                      {race.label}
+                    </span>
+                  )}
+                </div>
 
                 {/* 날짜 */}
                 <Micro className="shrink-0 tabular-nums">

--- a/components/profile/collection-sheet.tsx
+++ b/components/profile/collection-sheet.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useState, useTransition } from "react";
+import { useEffect, useRef, useState, useTransition } from "react";
 
 import { Check, X } from "lucide-react";
 
@@ -158,8 +158,16 @@ export function CollectionSheet({
   const [selectedBadge, setSelectedBadge] = useState<string | null>(currentBadgeEffect);
   const [selectedFrame, setSelectedFrame] = useState<string | null>(currentFrameCd);
   const [previewTtlId, setPreviewTtlId] = useState<string | null>(null);
+  const [openTooltipTtlId, setOpenTooltipTtlId] = useState<string | null>(null);
+  const tooltipTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   const [isPending, startTransition] = useTransition();
+
+  function openTooltip(ttlId: string) {
+    if (tooltipTimerRef.current) clearTimeout(tooltipTimerRef.current);
+    setOpenTooltipTtlId(ttlId);
+    tooltipTimerRef.current = setTimeout(() => setOpenTooltipTtlId(null), 3000);
+  }
 
   // 시트 재오픈 시 선택 상태를 현재 저장값으로 리셋
   useEffect(() => {
@@ -169,7 +177,12 @@ export function CollectionSheet({
       setSelectedFrame(currentFrameCd);
       setPreviewTtlId(null);
     }
+    // 시트 닫힐 때 툴팁 초기화
+    if (!open) setOpenTooltipTtlId(null);
   }, [open, currentPrimaryTtlId, currentBadgeEffect, currentFrameCd]);
+
+  // 탭 변경 시 툴팁 닫기
+  useEffect(() => { setOpenTooltipTtlId(null); }, [tab]);
 
   // 뱃지 미리보기는 저장될 selectedTtlId 기준
   const selectedTitle = allTitles.find((t) => t.ttl_id === selectedTtlId);
@@ -346,10 +359,11 @@ export function CollectionSheet({
                     <div className="flex flex-wrap gap-2">
                       {regularTitles.map((t) => {
                         const owned = ownedTitleIds.has(t.ttl_id);
-                        const masked = !owned || !t.use_yn;
+                        const masked = t.desc_visibility !== "always" && (!owned || !t.use_yn);
                         const blocked = owned && t.use_yn && isBlockedByHigher(t);
                         const selectable = owned && t.use_yn && !blocked;
                         const isSelected = selectedTtlId === t.ttl_id;
+                        const dimmed = !masked && !owned; // always라 마스킹은 없지만 미보유
                         return (
                           <TitleBadge
                             key={t.ttl_id}
@@ -363,7 +377,9 @@ export function CollectionSheet({
                               isHeld: owned,
                               isOwner: true,
                             }}
-                            className={cn(blocked && "opacity-50")}
+                            tooltipOpen={openTooltipTtlId === t.ttl_id}
+                            onTooltipOpen={() => openTooltip(t.ttl_id)}
+                            className={cn((blocked || dimmed) && "opacity-50")}
                             onClick={() => {
                               if (selectable) {
                                 setSelectedTtlId(isSelected ? null : t.ttl_id);
@@ -401,6 +417,8 @@ export function CollectionSheet({
                                   isHeld: true,
                                   isOwner: true,
                                 }}
+                                tooltipOpen={openTooltipTtlId === t.ttl_id}
+                                onTooltipOpen={() => openTooltip(t.ttl_id)}
                                 onClick={() => setSelectedTtlId(isSelected ? null : t.ttl_id)}
                               />
                             );

--- a/components/projects/random-review-rotator.tsx
+++ b/components/projects/random-review-rotator.tsx
@@ -18,6 +18,7 @@ export type ReviewLine = {
   descVisibility: "always" | "others" | "held" | "never";
   badgeEffect: string | null;
   frameCd: string | null;
+  isHeld: boolean;
 };
 
 type RandomReviewRotatorProps = {
@@ -146,7 +147,7 @@ export function RandomReviewRotator({ lines }: RandomReviewRotatorProps) {
                     name={line.ttlNm}
                     effect={line.badgeEffect}
                     size="xs"
-                    tooltip={{ desc: line.ttlDesc, visibility: line.descVisibility as "always" | "others" | "held" | "never", isHeld: true, isOwner: false }}
+                    tooltip={{ desc: line.ttlDesc, visibility: line.descVisibility as "always" | "others" | "held" | "never", isHeld: line.isHeld, isOwner: false }}
                   />
                 )}
                 <span>{line.metaSuffix}</span>

--- a/components/projects/random-review.tsx
+++ b/components/projects/random-review.tsx
@@ -2,6 +2,7 @@ import dayjs from "dayjs";
 
 import { formatKoreanShortDate, todayKST } from "@/lib/dayjs";
 import { type MileageSport } from "@/lib/mileage";
+import { getMyTitleNames } from "@/lib/queries/member";
 import { createAdminClient } from "@/lib/supabase/admin";
 
 import { RandomReviewRotator, type ReviewLine } from "@/components/projects/random-review-rotator";
@@ -21,7 +22,8 @@ export async function RandomReview({ evtId }: RandomReviewProps) {
   const today = todayKST();
   const sevenDaysAgo = dayjs(today).subtract(7, "day").format("YYYY-MM-DD");
 
-  const { data: reviews } = await supabase
+  const [{ data: reviews }, myTitleNames] = await Promise.all([
+    supabase
     .from("evt_mlg_act_hist")
     .select(
       "act_id, review, act_dt, sprt_enm, dst_km, evt_team_prt_rel!inner(evt_id, mem_mst!inner(mem_id, mem_nm))",
@@ -31,9 +33,12 @@ export async function RandomReview({ evtId }: RandomReviewProps) {
     .neq("review", "")
     .gte("act_dt", sevenDaysAgo)
     .lte("act_dt", today)
-    .order("act_dt", { ascending: false });
+      .order("act_dt", { ascending: false }),
+    getMyTitleNames(),
+  ]);
 
   if (!reviews || reviews.length === 0) return null;
+  const myTitleNameSet = new Set(myTitleNames);
 
   // 멤버 ID 목록 추출
   const memIds: string[] = [];
@@ -95,6 +100,7 @@ export async function RandomReview({ evtId }: RandomReviewProps) {
         descVisibility: titleInfo?.desc_visibility ?? "others",
         badgeEffect: titleInfo?.badge_effect ?? null,
         frameCd: titleInfo?.frame_cd ?? null,
+        isHeld: titleInfo ? myTitleNameSet.has(titleInfo.ttl_nm) : false,
       };
     })
     .filter((line): line is ReviewLine => line !== null);

--- a/components/races/competition-register-dialog.tsx
+++ b/components/races/competition-register-dialog.tsx
@@ -147,31 +147,10 @@ export function CompetitionRegisterDialog({
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [open, prefillStartDate, reset]);
 
-  const otherSelected = selectedEventTypes.includes(COMP_EVT_TYPE_OTHER);
-
-  const selectedCourseCount = useMemo(() => {
-    const pre = selectedEventTypes.filter((t) => t !== COMP_EVT_TYPE_OTHER).length;
-    const other =
-      otherSelected && sanitizeAsciiUpperCompEvtTypeInput(customEventType).trim()
-        ? 1
-        : 0;
-    return pre + other;
-  }, [selectedEventTypes, otherSelected, customEventType]);
+  const selectedCourseCount = selectedEventTypes.filter((t) => t !== COMP_EVT_TYPE_OTHER).length;
 
   const toggleEventType = (type: string) => {
     const current = selectedEventTypes;
-    if (type === COMP_EVT_TYPE_OTHER) {
-      if (current.includes(COMP_EVT_TYPE_OTHER)) {
-        setValue(
-          "selectedEventTypes",
-          current.filter((t) => t !== COMP_EVT_TYPE_OTHER),
-        );
-        setValue("customEventType", "");
-      } else {
-        setValue("selectedEventTypes", [...current, COMP_EVT_TYPE_OTHER]);
-      }
-      return;
-    }
     setValue(
       "selectedEventTypes",
       current.includes(type) ? current.filter((t) => t !== type) : [...current, type],

--- a/components/races/competition-register-dialog.tsx
+++ b/components/races/competition-register-dialog.tsx
@@ -56,16 +56,9 @@ const defaultValues: CompetitionRegisterValues = {
 };
 
 function resolveSubmittedEventTypes(data: CompetitionRegisterValues): string[] {
-  const base = data.selectedEventTypes.filter((t) => t !== COMP_EVT_TYPE_OTHER);
-  const otherOn = data.selectedEventTypes.includes(COMP_EVT_TYPE_OTHER);
-  const custom = otherOn
-    ? sanitizeAsciiUpperCompEvtTypeInput(data.customEventType).trim()
-    : "";
-  const merged = [...base];
-  if (custom) merged.push(custom);
   const seen = new Set<string>();
   const out: string[] = [];
-  for (const raw of merged) {
+  for (const raw of data.selectedEventTypes.filter(t => t !== COMP_EVT_TYPE_OTHER)) {
     const k = normalizeCompEvtTypeKey(String(raw));
     if (!k || seen.has(k)) continue;
     seen.add(k);
@@ -325,55 +318,74 @@ export function CompetitionRegisterDialog({
                 참가 코스 *
                 {selectedCourseCount > 0 ? ` (${selectedCourseCount}개 선택)` : ""}
               </Label>
-              {eventChipList.length > 0 ? (
-                <div className="flex flex-col gap-2">
+              <div className="flex flex-col gap-2">
+                {/* 기본 목록 토글 */}
+                {eventChipList.filter(t => t !== COMP_EVT_TYPE_OTHER).length > 0 && (
                   <div className="flex flex-wrap gap-1.5">
-                    {eventChipList.map((type) => (
+                    {eventChipList.filter(t => t !== COMP_EVT_TYPE_OTHER).map((type) => (
                       <Button
                         key={type}
                         type="button"
                         size="xs"
                         onClick={() => toggleEventType(type)}
-                        variant={
-                          type === COMP_EVT_TYPE_OTHER
-                            ? selectedEventTypes.includes(COMP_EVT_TYPE_OTHER)
-                              ? "default"
-                              : "outline"
-                            : selectedEventTypes.includes(type)
-                              ? "default"
-                              : "outline"
-                        }
+                        variant={selectedEventTypes.includes(type) ? "default" : "outline"}
                         className={cn(
                           "rounded-full",
-                          type !== COMP_EVT_TYPE_OTHER &&
-                            !selectedEventTypes.includes(type) &&
-                            "text-muted-foreground hover:border-primary/50",
-                          type === COMP_EVT_TYPE_OTHER &&
-                            !selectedEventTypes.includes(COMP_EVT_TYPE_OTHER) &&
-                            "text-muted-foreground hover:border-primary/50",
+                          !selectedEventTypes.includes(type) && "text-muted-foreground hover:border-primary/50",
                         )}
                       >
-                        {type === COMP_EVT_TYPE_OTHER ? "기타 (직접 입력)" : type}
+                        {type}
                       </Button>
                     ))}
                   </div>
-                  {otherSelected && (
-                    <Input
-                      placeholder="예: 12K, HALF (영문·숫자만)"
-                      value={customEventType}
-                      onChange={(e) =>
-                        setValue(
-                          "customEventType",
-                          sanitizeAsciiUpperCompEvtTypeInput(e.target.value),
-                          { shouldValidate: true },
-                        )
+                )}
+                {/* 직접 추가한 커스텀 코스 태그 */}
+                {selectedEventTypes.filter(t => t !== COMP_EVT_TYPE_OTHER && !eventChipList.includes(t)).length > 0 && (
+                  <div className="flex flex-wrap gap-1.5">
+                    {selectedEventTypes.filter(t => t !== COMP_EVT_TYPE_OTHER && !eventChipList.includes(t)).map(type => (
+                      <button
+                        key={type}
+                        type="button"
+                        onClick={() => setValue("selectedEventTypes", selectedEventTypes.filter(t2 => t2 !== type), { shouldValidate: true })}
+                        className="flex items-center gap-1 rounded-full bg-primary px-2.5 py-0.5 text-[11px] font-medium text-primary-foreground"
+                      >
+                        {type} ×
+                      </button>
+                    ))}
+                  </div>
+                )}
+                {/* 직접 입력 */}
+                <div className="flex gap-1.5">
+                  <Input
+                    placeholder="직접 입력 (예: 12K, HALF, 영문·숫자만)"
+                    value={customEventType}
+                    onChange={(e) => setValue("customEventType", sanitizeAsciiUpperCompEvtTypeInput(e.target.value))}
+                    onKeyDown={(e) => {
+                      if (e.key === "Enter") {
+                        e.preventDefault();
+                        const val = customEventType.trim();
+                        if (!val || selectedEventTypes.includes(val)) return;
+                        setValue("selectedEventTypes", [...selectedEventTypes, val], { shouldValidate: true });
+                        setValue("customEventType", "");
                       }
-                    />
-                  )}
+                    }}
+                  />
+                  <Button
+                    type="button"
+                    variant="outline"
+                    size="sm"
+                    className="shrink-0"
+                    onClick={() => {
+                      const val = customEventType.trim();
+                      if (!val || selectedEventTypes.includes(val)) return;
+                      setValue("selectedEventTypes", [...selectedEventTypes, val], { shouldValidate: true });
+                      setValue("customEventType", "");
+                    }}
+                  >
+                    추가
+                  </Button>
                 </div>
-              ) : (
-                <p className="text-xs text-muted-foreground">종목을 먼저 선택해 주세요.</p>
-              )}
+              </div>
               {errors.selectedEventTypes && (
                 <p className="text-xs text-destructive">{errors.selectedEventTypes.message}</p>
               )}

--- a/lib/queries/member.ts
+++ b/lib/queries/member.ts
@@ -40,6 +40,49 @@ export const getCurrentMember = cache(async () => {
 });
 
 /**
+ * 현재 로그인한 유저가 보유한 칭호 ID Set을 반환한다.
+ * 비로그인 또는 미가입이면 빈 Set 반환.
+ */
+/**
+ * 현재 로그인한 유저가 보유한 칭호 ID Set을 반환한다.
+ * 비로그인 또는 미가입이면 빈 Set 반환.
+ */
+export async function getMyTitleIds(): Promise<Set<string>> {
+  const { member, supabase } = await getCurrentMember();
+  if (!member) return new Set();
+  const { data } = await supabase
+    .from("mem_ttl_rel")
+    .select("ttl_id")
+    .eq("mem_id", member.id)
+    .eq("vers", 0)
+    .eq("del_yn", false);
+  return new Set((data ?? []).map((r) => r.ttl_id));
+}
+
+/**
+ * 현재 로그인한 유저가 보유한 칭호명 Set을 반환한다.
+ * 비로그인 또는 미가입이면 빈 Set 반환.
+ */
+export async function getMyTitleNames(): Promise<Set<string>> {
+  const { member, supabase } = await getCurrentMember();
+  if (!member) return new Set();
+  const { teamId } = await getRequestTeamContext();
+  const { data } = await supabase
+    .from("mem_ttl_rel")
+    .select("ttl_mst!inner(ttl_nm), team_mem_rel!inner(mem_id)")
+    .eq("team_mem_rel.mem_id", member.id)
+    .eq("team_id", teamId)
+    .eq("vers", 0)
+    .eq("del_yn", false);
+  return new Set(
+    (data ?? []).map((r) => {
+      const t = Array.isArray(r.ttl_mst) ? r.ttl_mst[0] : r.ttl_mst;
+      return (t as { ttl_nm: string }).ttl_nm;
+    }).filter(Boolean)
+  );
+}
+
+/**
  * 현재 로그인한 유저가 요청 Host 기준 팀의 owner 또는 admin 인지 확인한다.
  */
 export async function verifyAdmin() {

--- a/lib/validations/competition.ts
+++ b/lib/validations/competition.ts
@@ -32,21 +32,9 @@ function buildCompetitionRegisterSchema(datePolicy: CompetitionRegisterDatePolic
     path: ["endDate"],
   })
   .refine(
-    (data) => {
-      const base = data.selectedEventTypes.filter((t) => t !== COMP_EVT_TYPE_OTHER);
-      const otherOn = data.selectedEventTypes.includes(COMP_EVT_TYPE_OTHER);
-      const custom = sanitizeAsciiUpperCompEvtTypeInput(data.customEventType).trim();
-      if (otherOn && compEvtTypeContainsHangul(data.customEventType)) return false;
-      if (otherOn && !custom) return false;
-      if (!otherOn && base.length === 0) return false;
-      if (otherOn && custom) {
-        const ck = normalizeCompEvtTypeKey(custom);
-        if (base.some((t) => normalizeCompEvtTypeKey(t) === ck)) return false;
-      }
-      return true;
-    },
+    (data) => data.selectedEventTypes.filter(t => t !== COMP_EVT_TYPE_OTHER).length > 0,
     {
-      message: "참가 코스를 1개 이상 선택하거나, 기타 입력을 완료해 주세요.",
+      message: "참가 코스를 1개 이상 선택해 주세요.",
       path: ["selectedEventTypes"],
     },
   );


### PR DESCRIPTION
AS-IS
업커밍레이스: 대회명만 표시, 기강/내 대회 구분 없음
캘린더: 세로 공간 낭비, 월 이동 불가, dot이 날짜 아래 별도 행 차지, 내 대회 dot 색상 오류
Recent Records: 카드 크기 큼, 더 보기 버튼이 하단 full-width 차지
홈 화면에 신규 가입자/칭호 획득 정보 없음
대회 등록 시 기타 코스 1개만 입력 가능
TO-BE
업커밍레이스

D-DAY | 구분라벨 | 대회명 순서로 변경, 각 컬럼 고정 너비(w-14)로 대회명 시작 위치 정렬
기강 대회 / 내 대회 라벨 표시
캘린더

날짜 셀 세로 압축, dot을 날짜 오른쪽 2×2 그리드로 배치 (향후 모임/정보 슬롯 확장 예정)
월 이동 버튼 추가 — 이동 시 Supabase에서 해당 월 데이터 클라이언트 패칭 (p_start/p_end 범위 쿼리)
내가 참여한 기강 대회는 파랑 dot 우선 표시 (기강+내 대회 중복 시 mine 타입 우선)
날짜 클릭 시 이벤트 목록에서 대회 클릭 → CompetitionDetailDialog 오픈 (참가 신청/수정/취소)
SCHEDULE + 범례 + 월 이동을 한 줄로 압축
Recent Records

랭킹탭 MarathonHalfCard와 동일한 스타일 (이름+기록 2줄, p-2)
기본 2개(1행) 표시, 더 보기 버튼을 헤더 우상단으로 이동
New Members 섹션 신규

최근 가입자 🎉 이모지 + NEW 뱃지, 더 보기
Recent Titles 섹션 신규

최근 칭호 획득 이력, 칭호 배지 툴팁 (기존 칭호 시스템과 동일 로직)
New Members와 좌우 반반 배치(grid-cols-2), min-h-9로 행 높이 통일
대회 등록/수정 폼

기타 코스 직접 입력을 태그 방식으로 변경 — Enter 또는 추가 버튼으로 여러 개 추가, 태그 클릭으로 제거
관리자 대회 수정 폼(admin-competitions-client) 동일하게 적용
Zod 스키마 검증 로직 단순화

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 홈 화면에 월간 캘린더 추가로 대회 일정 조회 가능
  * 대회 등록 시 세부종목을 직접 입력할 수 있는 기능 추가
  * 홈 화면에 최근 칭호, 최근 가입자 정보 표시

* **기능 개선**
  * 업커밍 레이스 화면을 리스트 형식으로 개선
  * 타이틀 배지 툴팁 위치 및 표시 방식 개선
  * 기록 페이지의 칭호 표시 로직 최적화

<!-- end of auto-generated comment: release notes by coderabbit.ai -->