### PR TITLE
feat(home): 홈탭 UX 개선 — 캘린더 리디자인 + 헤더 슬로건

### DIFF
--- a/app/(main)/page.tsx
+++ b/app/(main)/page.tsx
@@ -62,7 +62,6 @@ async function HomeContent() {
   let initialMemberStatus: MemberStatus = { status: "signed-out" };
 
   const [
-    { data: memberStats },
     { data: teamComps },
     { data: recentRecordsRaw },
     { data: calendarComps },
@@ -71,7 +70,6 @@ async function HomeContent() {
     cmmCdRows,
     myTitleNames,
   ] = await Promise.all([
-    admin.rpc("get_public_team_member_stats", { p_team_id: teamId }),
     supabase.rpc("get_public_team_competitions", { p_team_id: teamId, p_start: today }),
     supabase.rpc("get_public_team_recent_records", { p_team_id: teamId, p_limit: 12 }),
     supabase.rpc("get_public_team_competitions", { p_team_id: teamId, p_start: monthStart, p_end: monthLastDayStr }),
@@ -94,8 +92,6 @@ async function HomeContent() {
     getCachedCmmCdRows(),
     getMyTitleNames(),
   ]);
-
-  const memberCount = memberStats?.[0]?.active_count ?? 0;
 
   // 기강대회: 등록자 1명 이상, 중복 제거 + 참가자 등록 event_type 수집
   const seenIds = new Set<string>();
@@ -380,25 +376,15 @@ async function HomeContent() {
       {/* 헤더 — 좌: 기강+오버뷰 / 중: 슬로건 / 우: 알림(추후) */}
       <div className="relative flex h-20 items-center px-6">
         {/* 좌 */}
-        <div className="flex flex-1 items-center gap-2.5">
+        <div className="flex flex-1 items-center">
           <H1>기강</H1>
-          <div className="flex flex-col gap-0 text-[12px] leading-[1.5]">
-            <div className="flex text-muted-foreground">
-              <span className="w-7">멤버</span>
-              <span className="w-10 text-right font-semibold tabular-nums text-foreground">{memberCount}명</span>
-            </div>
-            <div className="flex text-muted-foreground">
-              <span className="w-7">대회</span>
-              <span className="w-10 text-right font-semibold tabular-nums text-foreground">{gigangRaces.length}개</span>
-            </div>
-          </div>
         </div>
         {/* 중: 슬로건 — 화면 전체 기준 중앙 */}
         <div className="absolute left-0 right-0 flex flex-col items-center justify-center pointer-events-none">
-          <p className="font-sans text-[9px] uppercase tracking-[0.15em] text-muted-foreground">
+          <p className="font-sans text-[6px] uppercase tracking-[0.15em] text-muted-foreground">
             Since 2024.04.23
           </p>
-          <p className="font-sans text-[18px] font-black italic uppercase leading-tight tracking-[-0.03em] text-foreground">
+          <p className="font-sans text-[13px] font-black italic uppercase leading-tight tracking-[-0.03em] text-foreground">
             No time to be weak
           </p>
         </div>

--- a/app/(main)/page.tsx
+++ b/app/(main)/page.tsx
@@ -1,4 +1,4 @@
-import { Suspense } from "react";
+﻿import { Suspense } from "react";
 
 import { todayKST, currentMonthKST, monthLastDay } from "@/lib/dayjs";
 import { env } from "@/lib/env";
@@ -7,7 +7,6 @@ import { getCurrentMember, getMyTitleNames } from "@/lib/queries/member";
 import { getRequestTeamContext } from "@/lib/queries/request-team";
 import { createAdminClient } from "@/lib/supabase/admin";
 import { H1 } from "@/components/common/typography";
-import { Caption } from "@/components/common/typography";
 import { MiniCalendar } from "@/components/home/mini-calendar";
 import type { CalendarRace } from "@/components/home/mini-calendar";
 import { RecentJoiners } from "@/components/home/recent-joiners";
@@ -46,6 +45,8 @@ function isSameSlot(dateA: string, dateB: string) {
   // 토-일 or 일-토, 1일 차이
   return diff <= 1 && ((dayA === 6 && dayB === 0) || (dayA === 0 && dayB === 6));
 }
+
+const SHOW_EXTRA_SECTIONS = false;
 
 async function HomeContent() {
   const { user, member: currentMember, supabase } = await getCurrentMember();
@@ -375,15 +376,31 @@ async function HomeContent() {
   }).filter((g) => g.mem_id && g.ttl_nm);
 
   return (
-    <div className="flex flex-col gap-5 px-6 pb-6">
-      {/* 1. 오버뷰 한 줄 */}
-      <Caption>
-        <span className="font-semibold text-foreground">{memberCount}</span>명 활동 중
-        {" · "}
-        <span className="font-semibold text-foreground">{gigangRaces.length}</span>개 대회
-        참가 예정
-      </Caption>
+    <div className="flex flex-col gap-0">
+      {/* 헤더 */}
+      <div className="flex items-end gap-3 px-6 pb-4 pt-4">
+        <H1>기강</H1>
+        <div className="flex flex-col gap-0 pb-1">
+          <span className="text-[14px] leading-[1.4] text-muted-foreground">
+            멤버 <span className="font-semibold text-foreground">{memberCount}명</span>
+          </span>
+          <span className="text-[14px] leading-[1.4] text-muted-foreground">
+            예정대회 <span className="font-semibold text-foreground">{gigangRaces.length}개</span>
+          </span>
+        </div>
+      </div>
 
+      {/* 슬로건 */}
+      <div className="mx-6 mb-5 border-y border-foreground/10 py-3">
+        <p className="font-sans text-[10px] font-normal uppercase tracking-[0.3em] text-muted-foreground">
+          Running based · Sports Team
+        </p>
+        <p className="font-sans text-[20px] font-black italic uppercase leading-tight tracking-[-0.03em] text-foreground">
+          No time to be weak
+        </p>
+      </div>
+
+      <div className="flex flex-col gap-7 px-6 pb-6">
       {/* 2. SCHEDULE 캘린더 */}
       <MiniCalendar
         gigangRaces={calendarGigangRaces}
@@ -404,24 +421,27 @@ async function HomeContent() {
         initialRegistrationsByCompetitionId={initialRegistrationsByCompetitionId}
       />
 
-      {/* 4. RECENT RECORDS 2열 그리드 + 더보기 */}
-      <RecentRecordsGrid
-        records={recentRecords}
-        titleMap={titleMap}
-        myTitleNames={[...myTitleNames]}
-        initialCount={2}
-      />
-
-      {/* 5. 최근 가입자 + 최근 칭호 */}
-      <div className="grid grid-cols-2 gap-4">
-        <RecentJoiners joiners={recentJoiners} initialCount={4} />
-        <RecentTitles grants={recentTitleGrants} initialCount={4} myTitleNames={[...myTitleNames]} />
-      </div>
+      {/* 4. RECENT RECORDS + 최근 가입자 + 최근 칭호 (기획 재설계 전까지 비노출) */}
+      {SHOW_EXTRA_SECTIONS && (
+        <>
+          <RecentRecordsGrid
+            records={recentRecords}
+            titleMap={titleMap}
+            myTitleNames={[...myTitleNames]}
+            initialCount={2}
+          />
+          <div className="grid grid-cols-2 gap-4">
+            <RecentJoiners joiners={recentJoiners} initialCount={4} />
+            <RecentTitles grants={recentTitleGrants} initialCount={4} myTitleNames={[...myTitleNames]} />
+          </div>
+        </>
+      )}
 
       {/* 7. Social Links */}
       <SocialLinksGrid
         kakaoChatPassword={isMember ? (env.KAKAO_CHAT_PASSWORD ?? "") : undefined}
       />
+      </div>
     </div>
   );
 }
@@ -429,9 +449,13 @@ async function HomeContent() {
 
 function HomeSkeleton() {
   return (
-    <div className="flex flex-col gap-7 px-6 pb-6">
-      {/* 오버뷰 한 줄 */}
-      <Skeleton className="h-4 w-48" />
+    <div className="flex flex-col gap-0">
+      {/* 헤더 스켈레톤 */}
+      <div className="flex flex-col gap-2 px-6 pb-6 pt-4">
+        <Skeleton className="h-8 w-16" />
+        <Skeleton className="h-4 w-48" />
+      </div>
+      <div className="flex flex-col gap-7 px-6 pb-6">
       {/* 캘린더 */}
       <div className="flex flex-col gap-3">
         <Skeleton className="h-3.5 w-20" />
@@ -473,6 +497,7 @@ function HomeSkeleton() {
           <Skeleton key={i} className="h-16 rounded-2xl" />
         ))}
       </div>
+      </div>
     </div>
   );
 }
@@ -480,9 +505,6 @@ function HomeSkeleton() {
 export default function HomePage() {
   return (
     <div className="flex flex-col gap-0">
-      <div className="flex h-14 items-center px-6">
-        <H1>기강</H1>
-      </div>
       <Suspense fallback={<HomeSkeleton />}>
         <HomeContent />
       </Suspense>

--- a/app/(main)/page.tsx
+++ b/app/(main)/page.tsx
@@ -71,24 +71,30 @@ async function HomeContent() {
     myTitleNames,
   ] = await Promise.all([
     supabase.rpc("get_public_team_competitions", { p_team_id: teamId, p_start: today }),
-    supabase.rpc("get_public_team_recent_records", { p_team_id: teamId, p_limit: 12 }),
+    SHOW_EXTRA_SECTIONS
+      ? supabase.rpc("get_public_team_recent_records", { p_team_id: teamId, p_limit: 12 })
+      : Promise.resolve({ data: null }),
     supabase.rpc("get_public_team_competitions", { p_team_id: teamId, p_start: monthStart, p_end: monthLastDayStr }),
-    admin
-      .from("team_mem_rel")
-      .select("mem_id, join_dt, mem_mst!inner(mem_nm)")
-      .eq("team_id", teamId)
-      .eq("vers", 0)
-      .eq("del_yn", false)
-      .order("join_dt", { ascending: false })
-      .limit(10),
-    admin
-      .from("mem_ttl_rel")
-      .select("grnt_at, ttl_mst!inner(ttl_nm, ttl_desc, desc_visibility), team_mem_rel!inner(mem_id, selected_badge_effect, mem_mst!inner(mem_nm))")
-      .eq("team_id", teamId)
-      .eq("vers", 0)
-      .eq("del_yn", false)
-      .order("grnt_at", { ascending: false })
-      .limit(10),
+    SHOW_EXTRA_SECTIONS
+      ? admin
+          .from("team_mem_rel")
+          .select("mem_id, join_dt, mem_mst!inner(mem_nm)")
+          .eq("team_id", teamId)
+          .eq("vers", 0)
+          .eq("del_yn", false)
+          .order("join_dt", { ascending: false })
+          .limit(10)
+      : Promise.resolve({ data: null }),
+    SHOW_EXTRA_SECTIONS
+      ? admin
+          .from("mem_ttl_rel")
+          .select("grnt_at, ttl_mst!inner(ttl_nm, ttl_desc, desc_visibility), team_mem_rel!inner(mem_id, selected_badge_effect, mem_mst!inner(mem_nm))")
+          .eq("team_id", teamId)
+          .eq("vers", 0)
+          .eq("del_yn", false)
+          .order("grnt_at", { ascending: false })
+          .limit(10)
+      : Promise.resolve({ data: null }),
     getCachedCmmCdRows(),
     getMyTitleNames(),
   ]);
@@ -458,30 +464,6 @@ function HomeSkeleton() {
         <Skeleton className="h-3.5 w-32" />
         <Skeleton className="h-10 rounded-lg" />
         <Skeleton className="h-10 rounded-lg" />
-      </div>
-      {/* Recent Records */}
-      <div className="flex flex-col gap-3">
-        <Skeleton className="h-3.5 w-32" />
-        <div className="grid grid-cols-2 gap-2">
-          {Array.from({ length: 2 }).map((_, i) => (
-            <Skeleton key={i} className="h-14 rounded-xl" />
-          ))}
-        </div>
-      </div>
-      {/* New Members + Recent Titles */}
-      <div className="grid grid-cols-2 gap-4">
-        <div className="flex flex-col gap-3">
-          <Skeleton className="h-3.5 w-24" />
-          {Array.from({ length: 4 }).map((_, i) => (
-            <Skeleton key={i} className="h-9 rounded-lg" />
-          ))}
-        </div>
-        <div className="flex flex-col gap-3">
-          <Skeleton className="h-3.5 w-24" />
-          {Array.from({ length: 4 }).map((_, i) => (
-            <Skeleton key={i} className="h-9 rounded-lg" />
-          ))}
-        </div>
       </div>
       {/* Social Links */}
       <div className="grid grid-cols-4 gap-3">

--- a/app/(main)/page.tsx
+++ b/app/(main)/page.tsx
@@ -377,27 +377,33 @@ async function HomeContent() {
 
   return (
     <div className="flex flex-col gap-0">
-      {/* 헤더 */}
-      <div className="flex items-end gap-3 px-6 pb-4 pt-4">
-        <H1>기강</H1>
-        <div className="flex flex-col gap-0 pb-1">
-          <span className="text-[14px] leading-[1.4] text-muted-foreground">
-            멤버 <span className="font-semibold text-foreground">{memberCount}명</span>
-          </span>
-          <span className="text-[14px] leading-[1.4] text-muted-foreground">
-            예정대회 <span className="font-semibold text-foreground">{gigangRaces.length}개</span>
-          </span>
+      {/* 헤더 — 좌: 기강+오버뷰 / 중: 슬로건 / 우: 알림(추후) */}
+      <div className="relative flex h-20 items-center px-6">
+        {/* 좌 */}
+        <div className="flex flex-1 items-center gap-2.5">
+          <H1>기강</H1>
+          <div className="flex flex-col gap-0 text-[12px] leading-[1.5]">
+            <div className="flex text-muted-foreground">
+              <span className="w-7">멤버</span>
+              <span className="w-10 text-right font-semibold tabular-nums text-foreground">{memberCount}명</span>
+            </div>
+            <div className="flex text-muted-foreground">
+              <span className="w-7">대회</span>
+              <span className="w-10 text-right font-semibold tabular-nums text-foreground">{gigangRaces.length}개</span>
+            </div>
+          </div>
         </div>
-      </div>
-
-      {/* 슬로건 */}
-      <div className="mx-6 mb-5 border-y border-foreground/10 py-3">
-        <p className="font-sans text-[10px] font-normal uppercase tracking-[0.3em] text-muted-foreground">
-          Running based · Sports Team
-        </p>
-        <p className="font-sans text-[20px] font-black italic uppercase leading-tight tracking-[-0.03em] text-foreground">
-          No time to be weak
-        </p>
+        {/* 중: 슬로건 — 화면 전체 기준 중앙 */}
+        <div className="absolute left-0 right-0 flex flex-col items-center justify-center pointer-events-none">
+          <p className="font-sans text-[9px] uppercase tracking-[0.15em] text-muted-foreground">
+            Since 2024.04.23
+          </p>
+          <p className="font-sans text-[18px] font-black italic uppercase leading-tight tracking-[-0.03em] text-foreground">
+            No time to be weak
+          </p>
+        </div>
+        {/* 우: 알림 아이콘 자리 — 추후 구현 */}
+        <div className="size-8 shrink-0" />
       </div>
 
       <div className="flex flex-col gap-7 px-6 pb-6">

--- a/components/common/typography.tsx
+++ b/components/common/typography.tsx
@@ -91,7 +91,7 @@ const SectionLabel = React.forwardRef<HTMLSpanElement, SectionLabelProps>(
     <span
       ref={ref}
       className={cn(
-        "text-xs font-semibold tracking-widest text-muted-foreground",
+        "text-xs font-bold tracking-widest text-foreground",
         className,
       )}
       {...props}

--- a/components/home/mini-calendar.tsx
+++ b/components/home/mini-calendar.tsx
@@ -2,7 +2,12 @@
 
 import { useMemo, useState, useTransition } from "react";
 import { ChevronLeft, ChevronRight } from "lucide-react";
-import { todayKST, currentMonthKST } from "@/lib/dayjs";
+import { todayKST, currentMonthKST, daysInMonth } from "@/lib/dayjs";
+import dayjs from "dayjs";
+import timezone from "dayjs/plugin/timezone";
+import utc from "dayjs/plugin/utc";
+dayjs.extend(utc);
+dayjs.extend(timezone);
 import { createClient } from "@/lib/supabase/client";
 import { compEvtTypeContainsHangul } from "@/lib/comp-evt-type";
 import { getOrCreateCompEvtIdForParticipation } from "@/app/actions/get-or-create-comp-evt-for-participation";
@@ -34,7 +39,7 @@ type MiniCalendarProps = {
 const WEEKDAYS = ["일", "월", "화", "수", "목", "금", "토"] as const;
 
 function monthLastDayStr(year: number, month: number): string {
-  const d = new Date(year, month, 0).getDate();
+  const d = daysInMonth(year, month);
   return `${year}-${String(month).padStart(2, "0")}-${String(d).padStart(2, "0")}`;
 }
 
@@ -67,8 +72,8 @@ export function MiniCalendar({
   const year = parseInt(yearStr, 10);
   const month = parseInt(monthStr, 10);
 
-  const totalDays = new Date(year, month, 0).getDate();
-  const firstDayOfWeek = new Date(`${year}-${String(month).padStart(2, "0")}-01`).getDay();
+  const totalDays = daysInMonth(year, month);
+  const firstDayOfWeek = dayjs.tz(`${year}-${String(month).padStart(2, "0")}-01`, "Asia/Seoul").day();
 
   // 날짜별 이벤트 목록 (mine 우선, 중복 제거)
   const eventsByDate = useMemo(() => {

--- a/components/home/mini-calendar.tsx
+++ b/components/home/mini-calendar.tsx
@@ -52,9 +52,9 @@ export function MiniCalendar({
   const [viewMonth, setViewMonth] = useState(initialMonth);
   const [gigangRaces, setGigangRaces] = useState(initGigang);
   const [myRaces, setMyRaces] = useState(initMine);
-  const [selectedDate, setSelectedDate] = useState<string | null>(null);
   const [isPending, startTransition] = useTransition();
 
+  const [selectedDate, setSelectedDate] = useState<string>(() => todayKST());
   const [selectedCompetition, setSelectedCompetition] = useState<Competition | null>(null);
   const [detailOpen, setDetailOpen] = useState(false);
   const [registrationsByCompetitionId, setRegistrationsByCompetitionId] =
@@ -70,54 +70,37 @@ export function MiniCalendar({
   const totalDays = new Date(year, month, 0).getDate();
   const firstDayOfWeek = new Date(`${year}-${String(month).padStart(2, "0")}-01`).getDay();
 
-  const eventMap = useMemo(() => {
-    const gigangIdsByDate = new Map<string, Set<string>>();
-    const mineIdsByDate = new Map<string, Set<string>>();
-
-    for (const race of gigangRaces) {
-      const s = gigangIdsByDate.get(race.start_date) ?? new Set<string>();
-      s.add(race.id);
-      gigangIdsByDate.set(race.start_date, s);
+  // 날짜별 이벤트 목록 (mine 우선, 중복 제거)
+  const eventsByDate = useMemo(() => {
+    const map = new Map<string, CalendarRace[]>();
+    const allRaces = [...myRaces, ...gigangRaces];
+    const seen = new Set<string>();
+    for (const race of allRaces) {
+      const key = `${race.start_date}:${race.id}`;
+      if (seen.has(key)) continue;
+      seen.add(key);
+      const list = map.get(race.start_date) ?? [];
+      list.push(race);
+      map.set(race.start_date, list);
     }
-    for (const race of myRaces) {
-      const s = mineIdsByDate.get(race.start_date) ?? new Set<string>();
-      s.add(race.id);
-      mineIdsByDate.set(race.start_date, s);
-    }
-
-    const map = new Map<string, { gigang: boolean; mine: boolean }>();
-    for (const [date, gigangIds] of gigangIdsByDate) {
-      const mineIds = mineIdsByDate.get(date) ?? new Set<string>();
-      const hasGigangWithoutMe = [...gigangIds].some((id) => !mineIds.has(id));
-      map.set(date, { gigang: hasGigangWithoutMe, mine: mineIds.size > 0 });
-    }
-
     return map;
   }, [gigangRaces, myRaces]);
 
-  const selectedEvents = useMemo(() => {
-    if (!selectedDate) return [];
-    const seen = new Set<string>();
-    // myRaces 먼저 — 같은 대회가 기강+내 대회 둘 다면 mine 타입으로 표시
-    return [...myRaces, ...gigangRaces].filter((r) => {
-      if (r.start_date !== selectedDate || seen.has(r.id)) return false;
-      seen.add(r.id);
-      return true;
-    });
-  }, [selectedDate, gigangRaces, myRaces]);
-
-  const cells: (number | null)[] = [
-    ...Array.from<null>({ length: firstDayOfWeek }).fill(null),
-    ...Array.from({ length: totalDays }, (_, i) => i + 1),
-  ];
+  // 주차별로 날짜 그룹핑
+  const weeks = useMemo(() => {
+    const cells: (number | null)[] = [
+      ...Array.from<null>({ length: firstDayOfWeek }).fill(null),
+      ...Array.from({ length: totalDays }, (_, i) => i + 1),
+    ];
+    const result: (number | null)[][] = [];
+    for (let i = 0; i < cells.length; i += 7) {
+      result.push(cells.slice(i, i + 7).concat(Array(7).fill(null)).slice(0, 7));
+    }
+    return result;
+  }, [firstDayOfWeek, totalDays]);
 
   function formatCellDate(day: number): string {
     return `${year}-${String(month).padStart(2, "0")}-${String(day).padStart(2, "0")}`;
-  }
-
-  function handleDayClick(day: number) {
-    const dateStr = formatCellDate(day);
-    setSelectedDate((prev) => (prev === dateStr ? null : dateStr));
   }
 
   async function handleRaceClick(race: CalendarRace) {
@@ -279,7 +262,6 @@ export function MiniCalendar({
       d.setMonth(d.getMonth() + dir);
       const newMonth = `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, "0")}-01`;
       const { gigang, mine } = await fetchMonthData(newMonth);
-      setSelectedDate(null);
       setViewMonth(newMonth);
       setGigangRaces(gigang);
       setMyRaces(mine);
@@ -288,23 +270,13 @@ export function MiniCalendar({
 
   return (
     <div className="flex flex-col gap-2">
-      {/* 헤더: SCHEDULE + 범례 + 월 이동 한 줄에 */}
+      {/* 헤더 */}
       <div className="flex items-center justify-between">
-        <div className="flex items-center gap-3">
-          <SectionLabel>SCHEDULE</SectionLabel>
-          <div className="flex items-center gap-2.5">
-            <div className="flex items-center gap-1">
-              <span className="size-1.5 rounded-full bg-warning" />
-              <Micro>기강</Micro>
-            </div>
-            <div className="flex items-center gap-1">
-              <span className="size-1.5 rounded-full bg-primary" />
-              <Micro>내 대회</Micro>
-            </div>
-          </div>
-        </div>
+        <SectionLabel>SCHEDULE</SectionLabel>
         <div className="flex items-center gap-1">
-          <Micro className="text-foreground font-medium tabular-nums">{year}.{String(month).padStart(2, "0")}</Micro>
+          <Micro className="font-medium tabular-nums text-foreground">
+            {year}.{String(month).padStart(2, "0")}
+          </Micro>
           <button
             onClick={() => navigate(-1)}
             disabled={isPending}
@@ -324,7 +296,7 @@ export function MiniCalendar({
         </div>
       </div>
 
-      {/* 달력 그리드 */}
+      {/* 달력 + 이벤트 */}
       <div className={cn("flex flex-col transition-opacity", isPending && "opacity-50")}>
         {/* 요일 헤더 */}
         <div className="grid grid-cols-7 text-center">
@@ -332,7 +304,7 @@ export function MiniCalendar({
             <Micro
               key={wd}
               className={cn(
-                "pb-0.5",
+                "pb-1",
                 wd === "일" && "text-destructive",
                 wd === "토" && "text-primary",
               )}
@@ -342,77 +314,108 @@ export function MiniCalendar({
           ))}
         </div>
 
-        {/* 날짜 셀 */}
-        <div className="grid grid-cols-7 text-center">
-          {cells.map((day, idx) => {
-            if (day === null) return <div key={`empty-${idx}`} />;
+        {/* 바둑판 그리드 — 셀 고정 높이 */}
+        <div className="grid grid-cols-7">
+          {weeks.flat().map((day, idx) => {
+            if (day === null) {
+              return <div key={`empty-${idx}`} className="h-24 border-t border-border/40" />;
+            }
             const dateStr = formatCellDate(day);
-            const events = eventMap.get(dateStr);
             const isToday = dateStr === today;
             const isSelected = selectedDate === dateStr;
-            const colIndex = (firstDayOfWeek + day - 1) % 7;
+            const colIndex = idx % 7;
+            const races = eventsByDate.get(dateStr) ?? [];
 
             return (
               <button
                 key={dateStr}
-                onClick={() => handleDayClick(day)}
+                onClick={() => setSelectedDate(dateStr)}
                 className={cn(
-                  "flex items-center justify-center rounded transition-colors",
-                  isSelected && "bg-secondary",
-                  !isSelected && "hover:bg-secondary/60",
+                  "flex h-24 flex-col gap-px border-t border-border/40 px-0.5 pt-1 text-left transition-colors",
+                  isSelected && "bg-secondary/60",
                 )}
-                aria-label={`${month}월 ${day}일`}
                 aria-pressed={isSelected}
               >
-                <span className="flex items-center gap-0.5">
+                {/* 날짜 숫자 */}
+                <div className="flex justify-center pb-px">
                   <span
                     className={cn(
                       "flex size-6 items-center justify-center rounded-full text-[12px] font-medium",
                       isToday && "bg-primary text-primary-foreground font-bold",
                       !isToday && colIndex === 0 && "text-destructive",
                       !isToday && colIndex === 6 && "text-primary",
-                      !isToday && "text-foreground",
+                      !isToday && colIndex !== 0 && colIndex !== 6 && "text-foreground",
                     )}
                   >
                     {day}
                   </span>
-                  <span className="grid grid-cols-2 gap-px" aria-hidden>
-                    <span className={cn("size-1 rounded-full", events?.gigang ? "bg-warning" : "bg-transparent")} />
-                    <span className={cn("size-1 rounded-full", events?.mine   ? "bg-primary" : "bg-transparent")} />
-                    <span className="size-1 rounded-full bg-transparent" />
-                    <span className="size-1 rounded-full bg-transparent" />
-                  </span>
-                </span>
+                </div>
+
+                {/* 이벤트 목록 — 최대 3개, 나머지는 +N */}
+                <div className="flex flex-col gap-px overflow-hidden">
+                  {races.slice(0, 3).map((race) => (
+                    <span
+                      key={race.id}
+                      className={cn(
+                        "w-full truncate rounded-sm px-0.5 text-left text-[9px] font-medium leading-[1.6]",
+                        race.type === "mine"
+                          ? "bg-success/20 text-success"
+                          : "bg-warning/15 text-warning",
+                      )}
+                    >
+                      {race.title}
+                    </span>
+                  ))}
+                  {races.length > 3 && (
+                    <span className="px-0.5 text-[9px] text-muted-foreground">
+                      +{races.length - 3}
+                    </span>
+                  )}
+                </div>
               </button>
             );
           })}
         </div>
       </div>
 
-      {/* 선택된 날짜 이벤트 */}
-      {selectedDate && (
-        <div className="flex items-start gap-2 rounded-lg bg-secondary/60 px-3 py-1.5">
-          <Micro className="shrink-0 pt-px text-muted-foreground tabular-nums">
-            {parseInt(selectedDate.split("-")[1], 10)}/{parseInt(selectedDate.split("-")[2], 10)}
-          </Micro>
-          {selectedEvents.length === 0 ? (
-            <Micro className="text-muted-foreground">일정 없음</Micro>
-          ) : (
-            <div className="flex flex-col gap-1">
-              {selectedEvents.map((race) => (
-                <button
-                  key={race.id}
-                  onClick={() => handleRaceClick(race)}
-                  className="flex items-center gap-1.5 text-left hover:opacity-70 transition-opacity"
-                >
-                  <span className={cn("size-1.5 shrink-0 rounded-full", race.type === "mine" ? "bg-primary" : "bg-warning")} />
-                  <Micro className="text-foreground underline-offset-2 hover:underline">{race.title}</Micro>
-                </button>
-              ))}
+      {/* 날짜 패널 — 항상 표시, 클릭으로 날짜 변경 */}
+      {(() => {
+        const panelRaces = eventsByDate.get(selectedDate) ?? [];
+        const [, mm, dd] = selectedDate.split("-");
+        return (
+          <div className="mt-1 flex flex-col gap-2 rounded-xl bg-secondary/50 px-4 py-3">
+            <div className="flex items-baseline gap-1.5">
+              <span className="text-[28px] font-bold leading-none text-foreground tabular-nums">
+                {parseInt(dd, 10)}
+              </span>
+              <span className="text-[13px] text-muted-foreground">
+                {parseInt(mm, 10)}월
+              </span>
             </div>
-          )}
-        </div>
-      )}
+            {panelRaces.length === 0 ? (
+              <span className="text-[13px] text-muted-foreground">일정 없음</span>
+            ) : (
+              <div className="flex flex-col gap-1.5">
+                {panelRaces.map((race) => (
+                  <button
+                    key={race.id}
+                    onClick={() => handleRaceClick(race)}
+                    className="flex items-center gap-2 text-left transition-opacity hover:opacity-70"
+                  >
+                    <span
+                      className={cn(
+                        "h-5 w-1 shrink-0 rounded-full",
+                        race.type === "mine" ? "bg-success" : "bg-warning",
+                      )}
+                    />
+                    <span className="text-[14px] font-medium text-foreground">{race.title}</span>
+                  </button>
+                ))}
+              </div>
+            )}
+          </div>
+        );
+      })()}
 
       {/* 대회 상세 다이얼로그 */}
       <CompetitionDetailDialog

--- a/components/home/mini-calendar.tsx
+++ b/components/home/mini-calendar.tsx
@@ -318,7 +318,7 @@ export function MiniCalendar({
         <div className="grid grid-cols-7">
           {weeks.flat().map((day, idx) => {
             if (day === null) {
-              return <div key={`empty-${idx}`} className="h-24 border-t border-border/40" />;
+              return <div key={`empty-${idx}`} className="h-20 border-t border-border/40" />;
             }
             const dateStr = formatCellDate(day);
             const isToday = dateStr === today;
@@ -331,7 +331,7 @@ export function MiniCalendar({
                 key={dateStr}
                 onClick={() => setSelectedDate(dateStr)}
                 className={cn(
-                  "flex h-24 flex-col gap-px border-t border-border/40 px-0.5 pt-1 text-left transition-colors",
+                  "flex h-20 flex-col gap-px border-t border-border/40 px-0.5 pt-1 text-left transition-colors",
                   isSelected && "bg-secondary/60",
                 )}
                 aria-pressed={isSelected}
@@ -357,7 +357,7 @@ export function MiniCalendar({
                     <span
                       key={race.id}
                       className={cn(
-                        "w-full truncate rounded-sm px-0.5 text-left text-[9px] font-medium leading-[1.6]",
+                        "w-full truncate rounded-sm px-0.5 text-left text-[7px] font-medium leading-[1.5]",
                         race.type === "mine"
                           ? "bg-success/20 text-success"
                           : "bg-warning/15 text-warning",
@@ -383,32 +383,32 @@ export function MiniCalendar({
         const panelRaces = eventsByDate.get(selectedDate) ?? [];
         const [, mm, dd] = selectedDate.split("-");
         return (
-          <div className="mt-1 flex flex-col gap-2 rounded-xl bg-secondary/50 px-4 py-3">
-            <div className="flex items-baseline gap-1.5">
-              <span className="text-[28px] font-bold leading-none text-foreground tabular-nums">
+          <div className="mt-1 flex items-center gap-3 rounded-xl bg-secondary/50 px-3 py-2">
+            <div className="flex items-baseline gap-1 shrink-0">
+              <span className="text-[18px] font-bold leading-none text-foreground tabular-nums">
                 {parseInt(dd, 10)}
               </span>
-              <span className="text-[13px] text-muted-foreground">
+              <span className="text-[11px] text-muted-foreground">
                 {parseInt(mm, 10)}월
               </span>
             </div>
             {panelRaces.length === 0 ? (
-              <span className="text-[13px] text-muted-foreground">일정 없음</span>
+              <span className="text-[11px] text-muted-foreground">일정 없음</span>
             ) : (
-              <div className="flex flex-col gap-1.5">
+              <div className="flex flex-col gap-1">
                 {panelRaces.map((race) => (
                   <button
                     key={race.id}
                     onClick={() => handleRaceClick(race)}
-                    className="flex items-center gap-2 text-left transition-opacity hover:opacity-70"
+                    className="flex items-center gap-1.5 text-left transition-opacity hover:opacity-70"
                   >
                     <span
                       className={cn(
-                        "h-5 w-1 shrink-0 rounded-full",
+                        "h-3 w-0.5 shrink-0 rounded-full",
                         race.type === "mine" ? "bg-success" : "bg-warning",
                       )}
                     />
-                    <span className="text-[14px] font-medium text-foreground">{race.title}</span>
+                    <span className="text-[11px] font-medium text-foreground">{race.title}</span>
                   </button>
                 ))}
               </div>

--- a/components/social-links.tsx
+++ b/components/social-links.tsx
@@ -38,8 +38,9 @@ const SOCIAL_LINKS = [
     label: "가민",
     href: "https://connect.garmin.com/app/group/4857390",
     logo: "/garmin.png",
+    invertOnDark: true,
   },
-] as const;
+];
 
 export function SocialLinksRow() {
   const [open, setOpen] = useState(false);
@@ -47,7 +48,7 @@ export function SocialLinksRow() {
   return (
     <>
       <div className="flex items-center justify-center gap-5">
-        {SOCIAL_LINKS.map(({ key, label, href, logo }) =>
+        {SOCIAL_LINKS.map(({ key, label, href, logo, invertOnDark }) =>
           key === "kakao" ? (
             <button
               key={key}
@@ -55,7 +56,7 @@ export function SocialLinksRow() {
               onClick={() => setOpen(true)}
               className="flex flex-col items-center gap-1"
             >
-              <Image src={logo} alt={label} width={32} height={32} />
+              <Image src={logo} alt={label} width={32} height={32} className={invertOnDark ? "dark:invert" : undefined} />
               <span className="text-[10px] font-medium text-muted-foreground">
                 {label}
               </span>
@@ -68,7 +69,7 @@ export function SocialLinksRow() {
               rel="noopener noreferrer"
               className="flex flex-col items-center gap-1"
             >
-              <Image src={logo} alt={label} width={32} height={32} />
+              <Image src={logo} alt={label} width={32} height={32} className={invertOnDark ? "dark:invert" : undefined} />
               <span className="text-[10px] font-medium text-muted-foreground">
                 {label}
               </span>
@@ -113,14 +114,14 @@ export function SocialLinksGrid({
       <div className="flex flex-col gap-4">
         <SectionLabel>SOCIAL</SectionLabel>
         <div className="grid grid-cols-4 gap-2.5">
-          {SOCIAL_LINKS.map(({ key, label, href, logo }) =>
+          {SOCIAL_LINKS.map(({ key, label, href, logo, invertOnDark }) =>
             key === "kakao" ? (
               <CardItem asChild key={key} className="flex flex-col items-center gap-2 py-3">
                 <button
                   type="button"
                   onClick={() => setOpen(true)}
                 >
-                  <Image src={logo} alt={label} width={28} height={28} />
+                  <Image src={logo} alt={label} width={28} height={28} className={invertOnDark ? "dark:invert" : undefined} />
                   <span className="text-xs font-semibold text-foreground">
                     {label}
                   </span>
@@ -133,7 +134,7 @@ export function SocialLinksGrid({
                   target="_blank"
                   rel="noopener noreferrer"
                 >
-                  <Image src={logo} alt={label} width={28} height={28} />
+                  <Image src={logo} alt={label} width={28} height={28} className={invertOnDark ? "dark:invert" : undefined} />
                   <span className="text-xs font-semibold text-foreground">
                     {label}
                   </span>


### PR DESCRIPTION
Summary
캘린더 전면 개편: 인라인 클릭 방식 → 바둑판 셀 구조로 전환. 셀 고정 높이(h-24), 이벤트 막대 셀 안에 표시, 날짜 클릭 시 하단 패널에 일정 고정 노출 (기본값: 오늘)
헤더 재설계: 기강 타이틀 + 멤버/대회 오버뷰 + 슬로건("No time to be weak") 한 줄 통합. Since 2024.04.23 크루 창립일 표기
섹션 가시성 향상: SectionLabel font-bold + text-foreground로 강조
비노출 처리: 최근기록·신규멤버·칭호 섹션 SHOW_EXTRA_SECTIONS = false 플래그로 숨김 (기획 재설계 예정)
가민 로고: 다크모드 dark:invert 처리
Test plan
 라이트/다크 모드 헤더 슬로건 렌더링 확인
 캘린더 날짜 클릭 → 하단 패널 일정 표시 확인
 내 일정(초록)/기강 대회(주황) 색상 구분 확인
 다크모드 소셜 링크 가민 아이콘 표시 확인
 좁은 화면(375px)에서 헤더 슬로건 겹침 여부 확인

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * 메인 페이지 헤더 레이아웃 개선으로 멤버 및 대회 수 정보 표시
  * 미니 캘린더 기능 개선 및 월 이동 후 선택 날짜 유지 기능 추가

* **Style**
  * 섹션 라벨 스타일 강화
  * 다크 모드에서 소셜 링크 이미지 표시 최적화

<!-- end of auto-generated comment: release notes by coderabbit.ai -->