### PR TITLE
feat(home): 캘린더 셀 높이 축소 및 이벤트 오버플로우 UX 개선

### DIFF
--- a/app/actions/create-competition.ts
+++ b/app/actions/create-competition.ts
@@ -81,5 +81,19 @@ export async function createCompetition(input: CreateCompetitionInput) {
   }
 
   revalidateTag("competitions", "max");
-  return { ok: true, message: null };
+  return {
+    ok: true,
+    message: null,
+    competition: {
+      id: comp.comp_id,
+      external_id: `manual:${comp.comp_id}`,
+      sport: input.sport,
+      title: input.title.trim(),
+      start_date: input.startDate,
+      end_date: input.endDate ?? null,
+      location: input.location.trim() || null,
+      event_types: input.eventTypes.map((e) => e.trim().toUpperCase()),
+      source_url: input.sourceUrl.trim() || null,
+    },
+  };
 }

--- a/components/home/mini-calendar.tsx
+++ b/components/home/mini-calendar.tsx
@@ -323,7 +323,7 @@ export function MiniCalendar({
         <div className="grid grid-cols-7">
           {weeks.flat().map((day, idx) => {
             if (day === null) {
-              return <div key={`empty-${idx}`} className="h-20 border-t border-border/40" />;
+              return <div key={`empty-${idx}`} className="h-15 border-t border-border/40" />;
             }
             const dateStr = formatCellDate(day);
             const isToday = dateStr === today;
@@ -336,13 +336,13 @@ export function MiniCalendar({
                 key={dateStr}
                 onClick={() => setSelectedDate(dateStr)}
                 className={cn(
-                  "flex h-20 flex-col gap-px border-t border-border/40 px-0.5 pt-1 text-left transition-colors",
+                  "flex h-15 flex-col gap-px border-t border-border/40 px-0.5 pt-1 text-left transition-colors",
                   isSelected && "bg-secondary/60",
                 )}
                 aria-pressed={isSelected}
               >
-                {/* 날짜 숫자 */}
-                <div className="flex justify-center pb-px">
+                {/* 날짜 숫자 + 초과 개수 */}
+                <div className="flex items-center justify-center gap-0.5 pb-px">
                   <span
                     className={cn(
                       "flex size-6 items-center justify-center rounded-full text-[12px] font-medium",
@@ -354,28 +354,29 @@ export function MiniCalendar({
                   >
                     {day}
                   </span>
+                  {races.length > 3 && (
+                    <span className="text-[8px] font-medium text-muted-foreground leading-none">
+                      +{races.length - 3}
+                    </span>
+                  )}
                 </div>
 
-                {/* 이벤트 목록 — 최대 3개, 나머지는 +N */}
-                <div className="flex flex-col gap-px overflow-hidden">
+                {/* 이벤트 목록 — 최대 3개 */}
+                <div className="flex flex-col gap-px">
                   {races.slice(0, 3).map((race) => (
                     <span
                       key={race.id}
                       className={cn(
-                        "w-full truncate rounded-sm px-0.5 text-left text-[7px] font-medium leading-[1.5]",
+                        "w-full overflow-hidden rounded-sm px-0.5 text-left text-[7px] font-medium leading-[1.5]",
                         race.type === "mine"
                           ? "bg-success/20 text-success"
                           : "bg-warning/15 text-warning",
                       )}
+                      style={{ whiteSpace: "nowrap", textOverflow: "clip" }}
                     >
                       {race.title}
                     </span>
                   ))}
-                  {races.length > 3 && (
-                    <span className="px-0.5 text-[9px] text-muted-foreground">
-                      +{races.length - 3}
-                    </span>
-                  )}
                 </div>
               </button>
             );

--- a/components/home/mini-calendar.tsx
+++ b/components/home/mini-calendar.tsx
@@ -336,13 +336,13 @@ export function MiniCalendar({
                 key={dateStr}
                 onClick={() => setSelectedDate(dateStr)}
                 className={cn(
-                  "flex h-15 flex-col gap-px border-t border-border/40 px-0.5 pt-1 text-left transition-colors",
+                  "flex h-15 flex-col gap-px overflow-hidden border-t border-border/40 px-0.5 pt-0.5 text-left transition-colors",
                   isSelected && "bg-secondary/60",
                 )}
                 aria-pressed={isSelected}
               >
                 {/* 날짜 숫자 + 초과 개수 */}
-                <div className="flex items-center justify-center gap-0.5 pb-px">
+                <div className="flex items-center justify-center gap-0.5">
                   <span
                     className={cn(
                       "flex size-6 items-center justify-center rounded-full text-[12px] font-medium",
@@ -390,12 +390,9 @@ export function MiniCalendar({
         const [, mm, dd] = selectedDate.split("-");
         return (
           <div className="mt-1 flex items-center gap-3 rounded-xl bg-secondary/50 px-3 py-2">
-            <div className="flex items-baseline gap-1 shrink-0">
+            <div className="flex items-baseline shrink-0">
               <span className="text-[18px] font-bold leading-none text-foreground tabular-nums">
                 {parseInt(dd, 10)}
-              </span>
-              <span className="text-[11px] text-muted-foreground">
-                {parseInt(mm, 10)}월
               </span>
             </div>
             {panelRaces.length === 0 ? (

--- a/components/profile/race-record-dialog.tsx
+++ b/components/profile/race-record-dialog.tsx
@@ -736,7 +736,7 @@ export function RaceRecordDialog({
           datePolicy="allow-past"
           stackElevated
           prefillStartDate={raceDate.trim() || undefined}
-          onCreated={() => {}}
+          onCreated={(_comp) => {}}
         />
       )}
 

--- a/components/races/competition-register-dialog.tsx
+++ b/components/races/competition-register-dialog.tsx
@@ -46,7 +46,7 @@ import type { Competition, MemberStatus } from "./types";
 
 const defaultValues: CompetitionRegisterValues = {
   title: "",
-  sport: "",
+  sport: "road_run",
   startDate: "",
   endDate: "",
   location: "",
@@ -136,10 +136,10 @@ export function CompetitionRegisterDialog({
 
   useEffect(() => {
     if (open) {
-      const firstSprt = sportOptions[0]?.cd ?? "";
+      const defaultSport = sportOptions.find((o) => o.cd === "road_run")?.cd ?? sportOptions[0]?.cd ?? "";
       reset({
         ...defaultValues,
-        sport: firstSprt,
+        sport: defaultSport,
         ...(prefillStartDate?.trim() ? { startDate: prefillStartDate.trim() } : {}),
       });
     }

--- a/components/races/competition-register-dialog.tsx
+++ b/components/races/competition-register-dialog.tsx
@@ -42,7 +42,7 @@ import {
   SelectValue,
 } from "@/components/ui/select";
 import { cn } from "@/lib/utils";
-import type { MemberStatus } from "./types";
+import type { Competition, MemberStatus } from "./types";
 
 const defaultValues: CompetitionRegisterValues = {
   title: "",
@@ -73,7 +73,7 @@ interface CompetitionRegisterDialogProps {
   open: boolean;
   onOpenChange: (open: boolean) => void;
   memberStatus: MemberStatus;
-  onCreated: () => void;
+  onCreated: (competition: Competition) => void;
   /** 다른 다이얼로그 위에 겹쳐 표시할 때 오버레이·콘텐츠 z-index 상향 */
   stackElevated?: boolean;
   /** 열 때 시작일(YYYY-MM-DD) 미리 채움 */
@@ -175,7 +175,7 @@ export function CompetitionRegisterDialog({
       return;
     }
 
-    onCreated();
+    if (result.competition) onCreated(result.competition);
     onOpenChange(false);
   }
 

--- a/components/races/race-list-view.tsx
+++ b/components/races/race-list-view.tsx
@@ -80,6 +80,10 @@ export function RaceListView({
 		useState<Competition | null>(null);
 	const [detailOpen, setDetailOpen] = useState(false);
 	const [registerOpen, setRegisterOpen] = useState(false);
+	const [localAllCompetitions, setLocalAllCompetitions] =
+		useState<Competition[]>(allCompetitions);
+	const [localGigangCompetitions, setLocalGigangCompetitions] =
+		useState<Competition[]>(gigangCompetitions);
 
 	// 지난 대회 (기강 참가만, 3개월씩)
 	const [pastOpen, setPastOpen] = useState(false);
@@ -217,7 +221,7 @@ export function RaceListView({
 		loadPastChunk(before);
 	};
 
-	const competitions = tab === "gigang" ? gigangCompetitions : allCompetitions;
+	const competitions = tab === "gigang" ? localGigangCompetitions : localAllCompetitions;
 	const allCompetitionIds = useMemo(
 		() => [
 			...new Set([
@@ -769,7 +773,10 @@ export function RaceListView({
 				onOpenChange={setRegisterOpen}
 				memberStatus={memberStatus}
 				datePolicy="future-only"
-				onCreated={async () => {
+				onCreated={async (newComp) => {
+					setLocalAllCompetitions((prev) =>
+						[...prev, newComp].sort((a, b) => a.start_date.localeCompare(b.start_date)),
+					);
 					await revalidateCompetitions();
 					router.refresh();
 				}}

--- a/components/races/race-list-view.tsx
+++ b/components/races/race-list-view.tsx
@@ -777,6 +777,8 @@ export function RaceListView({
 					setLocalAllCompetitions((prev) =>
 						[...prev, newComp].sort((a, b) => a.start_date.localeCompare(b.start_date)),
 					);
+					setSelectedCompetition(newComp);
+					setDetailOpen(true);
 					await revalidateCompetitions();
 					router.refresh();
 				}}


### PR DESCRIPTION
AS-IS

캘린더 셀 높이가 커서 한 화면에 캘린더가 너무 많은 공간 차지
이벤트 텍스트에 ... 말줄임표로 오히려 가독성 저하
4개 이상 일정 시 셀 밖으로 넘쳐나옴
날짜 패널에 월 표시 중복
대회 등록 종목 기본값이 울트라
대회 등록 후 바로 참가 신청 불가
TO-BE

셀 높이 h-20 → h-15로 축소, 3개 이벤트 기준 최적화
이벤트 텍스트 truncate(...) 제거 → clip 처리로 자연스럽게 잘리도록
4개 이상 일정 시 날짜 숫자 옆에 +N 표시
overflow-hidden으로 셀 밖 넘침 방지
날짜 패널 월 텍스트 제거
대회 등록 종목 기본값 → 로드러닝
대회 등록 완료 시 해당 대회 참가 신청 팝업 자동 오픈

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 대회 등록 시 생성된 대회의 상세 정보가 반환되도록 개선
  * 대회 목록 관리 시 로컬 상태 기반 처리로 업데이트 성능 향상

* **UI/UX 개선**
  * 미니 캘린더 셀 높이 조정으로 더 정렬된 레이아웃 제공
  * 이벤트 표시 방식 개선으로 캘린더 가독성 향상
  * 선택된 날짜 표시 방식 단순화

<!-- end of auto-generated comment: release notes by coderabbit.ai -->