### PR TITLE
fix(titles): 칭호 시스템 버그 수정 및 마일리지런 칭호 전면 개선

### DIFF
--- a/.claude/docs/utmb-history-design.md
+++ b/.claude/docs/utmb-history-design.md
@@ -1,0 +1,215 @@
+# UTMB 대회 히스토리 연동 설계
+
+> 작성일: 2026-06-01  
+> 상태: 설계 완료 (미구현)  
+> 목적: UTMB 프로필에서 트레일런 대회 히스토리 전체를 가져와 칭호 조건 평가에 활용
+
+---
+
+## 배경 및 목적
+
+현재는 대회 기록을 수동으로 `rec_race_hist`에 등록해야 칭호 조건 평가에 반영된다.  
+트레일런 대회는 UTMB가 공식 집계하므로, UTMB 프로필에서 히스토리를 자동으로 가져오면 수동 등록 없이 칭호를 부여할 수 있다.
+
+**원칙:**
+- 트레일런(`trail_run`) 종목은 `rec_race_hist` 수동 등록을 칭호 조건에 사용하지 않는다.
+- 대신 `mem_utmb_race_hist` (새 테이블)에서 가져온 UTMB 히스토리를 사용한다.
+- 로드런/울트라/철인3종/사이클 등 다른 종목은 기존 `rec_race_hist` 그대로 유지.
+
+---
+
+## 1. UTMB 페이지 데이터 구조 파악
+
+### 현재 파싱 중인 필드 (`app/actions/utmb.ts`)
+
+| 출처 | 필드 | 저장 위치 |
+|------|------|-----------|
+| `<meta name="description">` | UTMB Index 수치 | `mem_utmb_prf.utmb_idx` |
+| `<meta name="title">` | 이름 | (저장 안 함) |
+| `__NEXT_DATA__.props.pageProps.results.results[].race` | 최근 대회명 | `mem_utmb_prf.rct_race_nm` |
+| `__NEXT_DATA__.props.pageProps.results.results[].dateIso` | 날짜 | (정렬에만 사용) |
+| `__NEXT_DATA__.props.pageProps.results.results[].time` | 기록 | `mem_utmb_prf.rct_race_rec` |
+| `__NEXT_DATA__.props.pageProps.results.results[].isDnf` | DNF 여부 | `mem_utmb_prf.rct_race_rec` ("DNF") |
+
+### UTMB 페이지에 표시되는 추가 필드 (파싱 가능 추정)
+
+실제 프로필 페이지(https://utmb.world/runner/7965644.hojung.kang)에서 확인된 컬럼:
+
+| 필드명(추정) | 설명 | 예시 값 |
+|-------------|------|---------|
+| `race` | 대회명 | "OXFAM TRAILWALKER 25K" |
+| `dateIso` | 날짜(ISO) | "2026-05-16" |
+| `distance` | 거리(km) | 26.3 |
+| `elevation` | 누적 고도(m+) | 1063 |
+| `time` | 완주 기록(HH:MM:SS) | "06:08:05" |
+| `rankOverall` | 전체 순위 | 17 |
+| `rankOverallTotal` | 전체 참가자 수 | 276 |
+| `rankGender` | 성별 순위 | 5 |
+| `rankGenderTotal` | 성별 참가자 수 | 120 |
+| `isDnf` | DNF 여부 | false |
+| `utmbScore` / `points` | UTMB Index 기여 점수 | 636 (최고점) |
+
+> **주의**: `__NEXT_DATA__` JSON의 실제 키 이름은 구현 시점에 브라우저 소스 보기로 직접 확인 필요.  
+> 현재 코드에서 `latest.race`, `latest.isDnf`, `latest.time`, `latest.dateIso` 접근하는 것으로 봐서 이 4개는 확실하고, 나머지는 실제 파싱 시 검증 필요.
+
+---
+
+## 2. DB 설계
+
+### 신규 테이블: `mem_utmb_race_hist`
+
+```sql
+create table mem_utmb_race_hist (
+  utmb_race_id  uuid primary key default gen_random_uuid(),
+  mem_id        uuid not null references mem_mst(mem_id),
+  race_nm       text not null,           -- 대회명
+  race_dt       date not null,           -- 대회 날짜
+  dist_km       numeric(6,2),            -- 거리(km)
+  elev_m        integer,                 -- 누적 고도(m+)
+  fin_time      text,                    -- 완주 기록 (HH:MM:SS, DNF이면 null)
+  fin_time_sec  integer,                 -- 완주 기록(초, 칭호 조건 계산용)
+  is_dnf        boolean not null default false,
+  rank_overall  integer,                 -- 전체 순위
+  rank_gender   integer,                 -- 성별 순위
+  utmb_score    integer,                 -- UTMB Index 기여 점수
+  synced_at     timestamptz not null default now(),
+  vers          integer not null default 0,
+  del_yn        boolean not null default false
+);
+
+create index on mem_utmb_race_hist(mem_id, race_dt desc);
+```
+
+### 기존 테이블 변경 없음
+
+`mem_utmb_prf`는 그대로 유지. `rct_race_nm`, `rct_race_rec`은 프로필 표시용으로 계속 사용.
+
+---
+
+## 3. 데이터 수집 흐름
+
+### 트리거 시점
+
+| 시점 | 설명 |
+|------|------|
+| 프로필 최초 등록 | `saveUtmbProfile()` 호출 시 히스토리도 함께 저장 |
+| 수동 새로고침 | 관리자 페이지 "UTMB 새로고침" 버튼 → 현재 `refresh-utmb-indexes.ts` 확장 |
+| 주기적 배치 | (선택) 월 1회 cron으로 자동 동기화 |
+
+### 수집 로직 (`fetchUtmbIndex` 확장)
+
+```typescript
+// app/actions/utmb.ts 수정안
+type UtmbRaceResult = {
+  raceName: string;
+  dateIso: string;
+  distanceKm: number | null;
+  elevationM: number | null;
+  finTime: string | null;      // "HH:MM:SS" or null
+  finTimeSec: number | null;   // 칭호 계산용
+  isDnf: boolean;
+  rankOverall: number | null;
+  rankGender: number | null;
+  utmbScore: number | null;
+};
+
+type UtmbResult =
+  | {
+      ok: true;
+      index: number;
+      name: string;
+      recentRaceName: string | null;
+      recentRaceRecord: string | null;
+      raceHistory: UtmbRaceResult[];   // 신규
+    }
+  | { ok: false; error: string };
+```
+
+`__NEXT_DATA__`에서 `results` 배열 전체를 순회하며 위 타입으로 매핑.  
+`finTime`(HH:MM:SS)을 초로 변환하는 유틸 필요 (`lib/time.ts` 등).
+
+---
+
+## 4. 칭호 조건 연동 설계
+
+### evaluator 변경 원칙
+
+트레일런(`sport_ctgr = "trail_run"`) 조건을 평가할 때:
+- `rec_race_hist` 대신 `mem_utmb_race_hist` 조회
+- 또는 두 소스를 합쳐서(union) 평가
+
+가장 단순한 접근: **evaluator에서 trail_run일 때 소스를 분기**
+
+```typescript
+// evaluators.ts 개념 코드
+async function evalRaceFinishCountInternal(rule, memId, db) {
+  if (rule.sport_ctgr === "trail_run") {
+    // UTMB 히스토리에서 조회
+    const { count } = await db
+      .from("mem_utmb_race_hist")
+      .select("*", { count: "exact", head: true })
+      .eq("mem_id", memId)
+      .eq("is_dnf", false)
+      .eq("del_yn", false);
+    return (count ?? 0) >= rule.count;
+  }
+  // 기존 rec_race_hist 로직
+  ...
+}
+```
+
+영향받는 CondRule 타입:
+| CondRule | 변경 필요 여부 | 비고 |
+|----------|--------------|------|
+| `race_finish_count` | O | `sport_ctgr=trail_run`이면 UTMB 소스 |
+| `race_pb_under_sec` | O | `fin_time_sec` 컬럼으로 PB 계산 |
+| `race_finish_in_month_range` | O | `race_dt`의 월로 필터 |
+| `race_finish_all_of` | O | trail_run 포함 시 |
+| `race_finish_total` | △ | trail_run을 포함할지 정책 결정 필요 |
+| `race_finish_in_year` | △ | 동일 |
+| `race_rank_by_gender` | O | UTMB 히스토리의 `rank_gender` 활용 가능 |
+| `race_pb_faster_than_member` | O | trail_run PB 비교 시 |
+
+### MemberSnapshot 확장
+
+`snapshot.ts`의 `MemberSnapshot` 타입에 `utmbRaceHist` 필드 추가:
+
+```typescript
+type UtmbRaceHistRow = {
+  race_nm: string;
+  race_dt: string;
+  dist_km: number | null;
+  fin_time_sec: number | null;
+  is_dnf: boolean;
+  rank_overall: number | null;
+  rank_gender: number | null;
+};
+
+type MemberSnapshot = {
+  // ... 기존 필드
+  utmbRaceHist: UtmbRaceHistRow[];  // 신규
+};
+```
+
+---
+
+## 5. 구현 순서 (추후 착수 시)
+
+1. **데이터 파악** — 실제 UTMB 프로필 HTML 소스에서 `__NEXT_DATA__` 키 이름 확인
+2. **DB 마이그레이션** — `mem_utmb_race_hist` 테이블 생성
+3. **`fetchUtmbIndex` 확장** — `raceHistory` 배열 파싱 추가
+4. **`saveUtmbProfile` 확장** — 히스토리 upsert 로직 추가
+5. **`refresh-utmb-indexes.ts` 확장** — 배치 갱신에 히스토리 동기화 포함
+6. **evaluators.ts 수정** — trail_run 조건 소스 분기
+7. **snapshot.ts 수정** — `utmbRaceHist` 필드 추가 및 bulk sweep 연동
+8. **기존 칭호 조건 검토** — trail_run 관련 조건 재정의 필요 여부 확인
+
+---
+
+## 6. 미결 사항 (구현 전 결정 필요)
+
+- [ ] `race_finish_total`, `race_finish_in_year`에 UTMB 히스토리를 포함할지 (트레일런 이중 카운팅 방지)
+- [ ] 수동 등록된 `rec_race_hist` 트레일런 기록은 칭호 평가에서 완전히 제외할지, 병존할지
+- [ ] UTMB에 등록되지 않은 소규모 트레일런 대회 처리 방침
+- [ ] `dist_km` / `elev_m` 기반 새 칭호 조건 추가 여부 (예: "100km 이상 완주")
+- [ ] 동기화 주기 및 방식 (사용자가 직접 갱신 vs 자동 배치)

--- a/app/(info)/admin/system/batch/admin-batch-client.tsx
+++ b/app/(info)/admin/system/batch/admin-batch-client.tsx
@@ -18,17 +18,26 @@ import {
 } from "@/components/ui/sheet";
 import { Label } from "@/components/ui/label";
 import { Input } from "@/components/ui/input";
-import { runBatch, getBatchRunHist } from "@/app/actions/admin/run-batch";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { runBatch, getBatchRunHist, getActiveEvents } from "@/app/actions/admin/run-batch";
 import { toast } from "sonner";
 
 export type ParamField = {
   key: string;
   label: string;
-  type: "month" | "date" | "text" | "number" | "boolean";
+  type: "month" | "date" | "text" | "number" | "boolean" | "evt_select";
   required: boolean;
   default?: string | "prev_month" | "today";
   description?: string;
 };
+
+type EventOption = { evt_id: string; evt_nm: string };
 
 type LatestRun = {
   run_id: string;
@@ -116,12 +125,20 @@ export function AdminBatchClient({ initialJobs }: { initialJobs: BatchJob[] }) {
   const [expandedJobId, setExpandedJobId] = useState<string | null>(null);
   const [histMap, setHistMap] = useState<Record<string, HistRow[]>>({});
   const [histLoading, setHistLoading] = useState<string | null>(null);
+  const [eventOptions, setEventOptions] = useState<EventOption[]>([]);
 
-  function openSheet(job: BatchJob) {
+  async function openSheet(job: BatchJob) {
     const schema = job.param_schema_json ?? [];
     const defaults: Record<string, string> = {};
     for (const field of schema) {
       defaults[field.key] = resolveDefault(field.default as string | undefined);
+    }
+    // evt_select 타입 필드가 있으면 이벤트 목록 로드
+    if (schema.some((f) => f.type === "evt_select")) {
+      const events = await getActiveEvents();
+      setEventOptions(events);
+      // 이벤트가 1개면 자동 선택
+      if (events.length === 1) defaults["evt_id"] = events[0].evt_id;
     }
     setParams(defaults);
     setSelectedJob(job);
@@ -295,13 +312,31 @@ export function AdminBatchClient({ initialJobs }: { initialJobs: BatchJob[] }) {
                   {field.label}
                   {field.required && <span className="text-destructive ml-1">*</span>}
                 </Label>
-                <Input
-                  id={field.key}
-                  type={field.type === "month" ? "month" : field.type === "date" ? "date" : "text"}
-                  value={params[field.key] ?? ""}
-                  onChange={(e) => setParams((prev) => ({ ...prev, [field.key]: e.target.value }))}
-                  placeholder={field.description}
-                />
+                {field.type === "evt_select" ? (
+                  <Select
+                    value={params[field.key] ?? ""}
+                    onValueChange={(v) => setParams((prev) => ({ ...prev, [field.key]: v }))}
+                  >
+                    <SelectTrigger className="h-10 rounded-lg">
+                      <SelectValue placeholder="이벤트 선택" />
+                    </SelectTrigger>
+                    <SelectContent className="z-[200]">
+                      {eventOptions.map((e) => (
+                        <SelectItem key={e.evt_id} value={e.evt_id}>
+                          {e.evt_nm}
+                        </SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
+                ) : (
+                  <Input
+                    id={field.key}
+                    type={field.type === "month" ? "month" : field.type === "date" ? "date" : "text"}
+                    value={params[field.key] ?? ""}
+                    onChange={(e) => setParams((prev) => ({ ...prev, [field.key]: e.target.value }))}
+                    placeholder={field.description}
+                  />
+                )}
                 {field.description && (
                   <Caption className="text-muted-foreground">{field.description}</Caption>
                 )}

--- a/app/(info)/admin/system/titles/admin-title-history-client.tsx
+++ b/app/(info)/admin/system/titles/admin-title-history-client.tsx
@@ -80,7 +80,9 @@ export function AdminTitleHistoryClient() {
       <div className="flex items-center gap-2">
         <SectionLabel>전체 칭호 획득 이력</SectionLabel>
         {!loading && (
-          <span className="text-[11px] text-muted-foreground">{rows.length}건</span>
+          <span className="text-[11px] text-muted-foreground">
+            {rows.length}건{rows.length >= 200 && " (최근 200건)"}
+          </span>
         )}
       </div>
 

--- a/app/(info)/admin/system/titles/admin-title-history-client.tsx
+++ b/app/(info)/admin/system/titles/admin-title-history-client.tsx
@@ -1,0 +1,150 @@
+"use client";
+
+import { useCallback, useEffect, useState } from "react";
+
+import Link from "next/link";
+
+import { formatKSTDateTime } from "@/lib/dayjs";
+import { createClient } from "@/lib/supabase/client";
+
+import { revokeTitle } from "@/app/actions/admin/manage-title";
+
+import { EmptyState } from "@/components/common/empty-state";
+import { SectionLabel } from "@/components/common/typography";
+import { CardItem } from "@/components/ui/card";
+import { Skeleton } from "@/components/ui/skeleton";
+
+type HistoryRow = {
+  mem_ttl_id: string;
+  team_mem_id: string;
+  grnt_at: string;
+  grnt_by_mem_id: string | null;
+  grnt_rsn_txt: string | null;
+  team_mem_rel: {
+    mem_mst: {
+      mem_nm: string;
+    };
+  };
+  ttl_mst: {
+    ttl_nm: string;
+  };
+};
+
+export function AdminTitleHistoryClient() {
+  const [rows, setRows] = useState<HistoryRow[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [revokingId, setRevokingId] = useState<string | null>(null);
+
+  const loadHistory = useCallback(async () => {
+    setLoading(true);
+    const supabase = createClient();
+    const { data, error } = await supabase
+      .from("mem_ttl_rel")
+      .select(`
+        mem_ttl_id,
+        team_mem_id,
+        grnt_at,
+        grnt_by_mem_id,
+        grnt_rsn_txt,
+        team_mem_rel!inner(mem_mst!inner(mem_nm)),
+        ttl_mst!inner(ttl_nm)
+      `)
+      .eq("vers", 0)
+      .eq("del_yn", false)
+      .order("grnt_at", { ascending: false })
+      .limit(200);
+
+    if (error) console.error("이력 조회 실패:", error);
+    setRows((data ?? []) as unknown as HistoryRow[]);
+    setLoading(false);
+  }, []);
+
+  useEffect(() => {
+    void loadHistory();
+  }, [loadHistory]);
+
+  const handleRevoke = async (memTtlId: string) => {
+    if (!confirm("이 멤버의 칭호를 회수하시겠습니까?")) return;
+    setRevokingId(memTtlId);
+    const result = await revokeTitle(memTtlId);
+    if (!result.ok) {
+      alert(result.message ?? "회수에 실패했습니다");
+    } else {
+      await loadHistory();
+    }
+    setRevokingId(null);
+  };
+
+  return (
+    <div className="flex flex-col gap-4 px-6 pb-6 pt-4">
+      <div className="flex items-center gap-2">
+        <SectionLabel>전체 칭호 획득 이력</SectionLabel>
+        {!loading && (
+          <span className="text-[11px] text-muted-foreground">{rows.length}건</span>
+        )}
+      </div>
+
+      {loading ? (
+        <CardItem className="flex flex-col gap-2 p-3">
+          {Array.from({ length: 5 }).map((_, i) => (
+            <Skeleton key={i} className="h-8 w-full rounded-lg" />
+          ))}
+        </CardItem>
+      ) : rows.length === 0 ? (
+        <EmptyState message="칭호 획득 이력이 없습니다." />
+      ) : (
+        <CardItem className="p-0">
+          <div className="max-h-[calc(100dvh-200px)] overflow-y-auto overflow-x-auto">
+            <table className="w-full border-collapse text-[11px] [font-variant-numeric:tabular-nums]">
+              <thead className="sticky top-0 bg-muted/80 backdrop-blur-sm">
+                <tr className="border-b">
+                  <th className="px-2 py-1.5 text-center font-medium text-muted-foreground">멤버명</th>
+                  <th className="px-2 py-1.5 text-center font-medium text-muted-foreground">칭호명</th>
+                  <th className="w-10 px-2 py-1.5 text-center font-medium text-muted-foreground">방식</th>
+                  <th className="w-24 px-2 py-1.5 text-center font-medium text-muted-foreground">획득일시</th>
+                  <th className="px-2 py-1.5 text-center font-medium text-muted-foreground">사유</th>
+                  <th className="w-10 px-2 py-1.5 text-center font-medium text-muted-foreground">회수</th>
+                </tr>
+              </thead>
+              <tbody>
+                {rows.map((row) => (
+                  <tr key={row.mem_ttl_id} className="border-b last:border-0 hover:bg-muted/20">
+                    <td className="px-2 py-1.5 text-center font-medium text-foreground">
+                      <Link
+                        href={`/admin/members?member=${row.team_mem_id}`}
+                        className="hover:text-primary hover:underline"
+                      >
+                        {row.team_mem_rel.mem_mst.mem_nm}
+                      </Link>
+                    </td>
+                    <td className="px-2 py-1.5 text-center font-medium text-foreground">
+                      {row.ttl_mst.ttl_nm}
+                    </td>
+                    <td className="px-2 py-1.5 text-center text-muted-foreground">
+                      {row.grnt_by_mem_id === null ? "자동" : "수동"}
+                    </td>
+                    <td className="px-2 py-1.5 text-center text-muted-foreground">
+                      {formatKSTDateTime(row.grnt_at).slice(0, 10)}
+                    </td>
+                    <td className="max-w-[120px] truncate px-2 py-1.5 text-center text-muted-foreground">
+                      {row.grnt_rsn_txt ?? "-"}
+                    </td>
+                    <td className="px-2 py-1.5 text-center">
+                      <button
+                        onClick={() => void handleRevoke(row.mem_ttl_id)}
+                        disabled={revokingId === row.mem_ttl_id}
+                        className="rounded-md px-1.5 py-0.5 text-[10px] font-medium text-destructive/70 transition-colors hover:bg-destructive/10 hover:text-destructive disabled:opacity-50"
+                      >
+                        {revokingId === row.mem_ttl_id ? "..." : "회수"}
+                      </button>
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        </CardItem>
+      )}
+    </div>
+  );
+}

--- a/app/(info)/admin/system/titles/admin-titles-client.tsx
+++ b/app/(info)/admin/system/titles/admin-titles-client.tsx
@@ -4,12 +4,13 @@ import { useCallback, useEffect, useMemo, useState } from "react";
 
 import Link from "next/link";
 
-import { Plus, RefreshCw, Save } from "lucide-react";
+import { Plus, RefreshCw, Save, X } from "lucide-react";
 
 import { formatKSTDateTime } from "@/lib/dayjs";
 import type { CachedCmmCdRow } from "@/lib/queries/cmm-cd-cached";
 import { cmmCdRowsForGrp } from "@/lib/queries/cmm-cd-cached";
 import { createClient } from "@/lib/supabase/client";
+import { cn } from "@/lib/utils";
 
 import { createTitle, grantTitle, revokeTitle, toggleTitleUseYn, updateTitle } from "@/app/actions/admin/manage-title";
 import { sweepAllTitles } from "@/app/actions/admin/sweep-titles";
@@ -57,10 +58,11 @@ type TitleRow = {
   cond_rule_json: unknown | null;
   rarity_level: number;
   ttl_group_cd: number | null;
+  grant_cnt: number;
   prmy_cnt: number;
 };
 
-type SortKey = "ttl_kind_enm" | "ttl_ctgr_cd" | "rarity_level" | "ttl_group_cd" | "event" | "prmy_cnt" | "desc_visibility";
+type SortKey = "ttl_kind_enm" | "ttl_ctgr_cd" | "rarity_level" | "ttl_group_cd" | "event" | "grant_cnt" | "prmy_cnt" | "desc_visibility";
 type SortDir = "asc" | "desc";
 
 type TitleForm = {
@@ -137,12 +139,15 @@ export function AdminTitlesClient({
     buildEmptyForm(defaultCategory),
   );
   const [showCreateForm, setShowCreateForm] = useState(false);
-  const [selectedId, setSelectedId] = useState<string>("");
   const [loading, setLoading] = useState(true);
   const [savingId, setSavingId] = useState<string | null>(null);
   const [creating, setCreating] = useState(false);
   const [sweeping, setSweeping] = useState(false);
   const [togglingId, setTogglingId] = useState<string | null>(null);
+
+  // 바텀시트 상태
+  const [sheetTtlId, setSheetTtlId] = useState<string | null>(null);
+  const [sheetTab, setSheetTab] = useState<"edit" | "grants">("edit");
 
   const loadTitles = useCallback(async () => {
     setLoading(true);
@@ -150,28 +155,29 @@ export function AdminTitlesClient({
     const { data } = await supabase
       .from("ttl_mst")
       .select(
-        "ttl_id, ttl_nm, ttl_kind_enm, ttl_ctgr_cd, ttl_desc, desc_visibility, sort_ord, use_yn, cond_rule_json, rarity_level, ttl_group_cd, mem_ttl_rel(ttl_id)",
+        "ttl_id, ttl_nm, ttl_kind_enm, ttl_ctgr_cd, ttl_desc, desc_visibility, sort_ord, use_yn, cond_rule_json, rarity_level, ttl_group_cd, mem_ttl_rel(ttl_id, is_prmy_yn)",
       )
       .eq("team_id", teamId)
       .eq("vers", 0)
       .eq("del_yn", false)
-      .eq("mem_ttl_rel.is_prmy_yn", true)
       .eq("mem_ttl_rel.del_yn", false)
       .order("sort_ord", { ascending: true })
       .order("rarity_level", { ascending: true });
 
-    const nextRows = ((data ?? []) as unknown as (Omit<TitleRow, "prmy_cnt"> & { mem_ttl_rel: { ttl_id: string }[] })[]).map(
-      (row) => ({ ...row, prmy_cnt: row.mem_ttl_rel?.length ?? 0 }),
-    ) as TitleRow[];
+    const nextRows = (
+      (data ?? []) as unknown as (Omit<TitleRow, "grant_cnt" | "prmy_cnt"> & {
+        mem_ttl_rel: { ttl_id: string; is_prmy_yn: boolean }[];
+      })[]
+    ).map((row) => ({
+      ...row,
+      grant_cnt: row.mem_ttl_rel?.length ?? 0,
+      prmy_cnt: row.mem_ttl_rel?.filter((r) => r.is_prmy_yn).length ?? 0,
+    })) as TitleRow[];
+
     setRows(nextRows);
     setForms(
       Object.fromEntries(nextRows.map((row) => [row.ttl_id, toForm(row)])),
     );
-    setSelectedId((prev) => {
-      if (nextRows.length === 0) return "";
-      if (prev && nextRows.some((row) => row.ttl_id === prev)) return prev;
-      return nextRows[0].ttl_id;
-    });
     setLoading(false);
   }, [teamId]);
 
@@ -260,6 +266,9 @@ export function AdminTitlesClient({
       if (sortKey === "event") {
         av = a.ttl_ctgr_cd === "event" ? 1 : 0;
         bv = b.ttl_ctgr_cd === "event" ? 1 : 0;
+      } else if (sortKey === "grant_cnt") {
+        av = a.grant_cnt;
+        bv = b.grant_cnt;
       } else if (sortKey === "prmy_cnt") {
         av = a.prmy_cnt;
         bv = b.prmy_cnt;
@@ -294,8 +303,17 @@ export function AdminTitlesClient({
     return <span className="ml-0.5 text-primary">{sortDir === "asc" ? "↑" : "↓"}</span>;
   };
 
-  const selectedRow = rows.find((row) => row.ttl_id === selectedId) ?? null;
-  const selectedForm = selectedRow ? forms[selectedRow.ttl_id] ?? toForm(selectedRow) : null;
+  const sheetRow = sheetTtlId ? rows.find((row) => row.ttl_id === sheetTtlId) ?? null : null;
+  const sheetForm = sheetRow ? forms[sheetRow.ttl_id] ?? toForm(sheetRow) : null;
+
+  const openSheet = (ttlId: string) => {
+    setSheetTtlId(ttlId);
+    setSheetTab("edit");
+  };
+
+  const closeSheet = () => {
+    setSheetTtlId(null);
+  };
 
   return (
     <div className="flex flex-col gap-4 px-6 pb-6 pt-4">
@@ -366,39 +384,43 @@ export function AdminTitlesClient({
         <p className="text-sm text-muted-foreground">불러오는 중...</p>
       ) : (
         <CardItem className="p-0">
-          <div className="max-h-60 overflow-y-auto overflow-x-auto">
+          <div className="overflow-x-auto">
             <table className="w-full border-collapse text-[11px] [font-variant-numeric:tabular-nums]">
               <thead className="bg-muted/40">
                 <tr className="border-b">
                   <th className="px-2 py-1.5 text-center font-medium text-muted-foreground">칭호명</th>
                   <th
-                    className="w-10 cursor-pointer select-none px-2 py-1.5 text-center font-medium text-muted-foreground hover:text-foreground"
+                    className="w-12 cursor-pointer select-none px-2 py-1.5 text-center font-medium text-muted-foreground hover:text-foreground"
                     onClick={() => handleSort("ttl_kind_enm")}
                   >유형<SortIcon k="ttl_kind_enm" /></th>
                   <th
-                    className="w-16 cursor-pointer select-none px-2 py-1.5 text-center font-medium text-muted-foreground hover:text-foreground"
+                    className="w-18 cursor-pointer select-none px-2 py-1.5 text-center font-medium text-muted-foreground hover:text-foreground"
                     onClick={() => handleSort("ttl_ctgr_cd")}
                   >카테고리<SortIcon k="ttl_ctgr_cd" /></th>
-                  <th className="w-8 px-2 py-1.5 text-center font-medium text-muted-foreground">정렬</th>
-                  <th className="w-14 px-2 py-1.5 text-center font-medium text-muted-foreground">사용</th>
+                  <th className="w-10 px-2 py-1.5 text-center font-medium text-muted-foreground">정렬</th>
+                  <th className="w-16 px-2 py-1.5 text-center font-medium text-muted-foreground">사용</th>
                   <th
-                    className="w-12 cursor-pointer select-none px-2 py-1.5 text-center font-medium text-muted-foreground hover:text-foreground"
+                    className="w-14 cursor-pointer select-none px-2 py-1.5 text-center font-medium text-muted-foreground hover:text-foreground"
                     onClick={() => handleSort("rarity_level")}
                   >희귀도<SortIcon k="rarity_level" /></th>
                   <th
-                    className="w-8 cursor-pointer select-none px-2 py-1.5 text-center font-medium text-muted-foreground hover:text-foreground"
+                    className="w-10 cursor-pointer select-none px-2 py-1.5 text-center font-medium text-muted-foreground hover:text-foreground"
                     onClick={() => handleSort("ttl_group_cd")}
                   >그룹<SortIcon k="ttl_group_cd" /></th>
                   <th
-                    className="w-12 cursor-pointer select-none px-2 py-1.5 text-center font-medium text-muted-foreground hover:text-foreground"
+                    className="w-14 cursor-pointer select-none px-2 py-1.5 text-center font-medium text-muted-foreground hover:text-foreground"
                     onClick={() => handleSort("event")}
                   >이벤트<SortIcon k="event" /></th>
                   <th
-                    className="w-8 cursor-pointer select-none px-2 py-1.5 text-center font-medium text-muted-foreground hover:text-foreground"
+                    className="w-10 cursor-pointer select-none px-2 py-1.5 text-center font-medium text-muted-foreground hover:text-foreground"
                     onClick={() => handleSort("desc_visibility")}
                   >공개<SortIcon k="desc_visibility" /></th>
                   <th
-                    className="w-10 cursor-pointer select-none px-2 py-1.5 text-center font-medium text-muted-foreground hover:text-foreground"
+                    className="w-12 cursor-pointer select-none px-2 py-1.5 text-center font-medium text-muted-foreground hover:text-foreground"
+                    onClick={() => handleSort("grant_cnt")}
+                  >획득<SortIcon k="grant_cnt" /></th>
+                  <th
+                    className="w-12 cursor-pointer select-none px-2 py-1.5 text-center font-medium text-muted-foreground hover:text-foreground"
                     onClick={() => handleSort("prmy_cnt")}
                   >대표<SortIcon k="prmy_cnt" /></th>
                 </tr>
@@ -407,18 +429,18 @@ export function AdminTitlesClient({
                 {rows.length === 0 ? (
                   <tr>
                     <td
-                      colSpan={9}
+                      colSpan={11}
                       className="px-2 py-6 text-center text-xs text-muted-foreground"
                     >
                       등록된 칭호가 없습니다.
                     </td>
                   </tr>
                 ) : sortedRows.map((row) => {
-                  const active = row.ttl_id === selectedId;
+                  const active = row.ttl_id === sheetTtlId;
                   return (
                     <tr
                       key={row.ttl_id}
-                      onClick={() => setSelectedId(row.ttl_id)}
+                      onClick={() => openSheet(row.ttl_id)}
                       className={`cursor-pointer border-b transition-colors hover:bg-muted/30 ${
                         active ? "bg-primary/5" : ""
                       } ${!row.use_yn ? "opacity-40" : ""}`}
@@ -447,6 +469,9 @@ export function AdminTitlesClient({
                         {({ always: "A", others: "O", held: "H", never: "N" } as Record<string, string>)[row.desc_visibility] ?? "O"}
                       </td>
                       <td className="px-2 py-1.5 text-center tabular-nums text-muted-foreground">
+                        {row.grant_cnt > 0 ? <span className="font-medium text-foreground">{row.grant_cnt}</span> : "-"}
+                      </td>
+                      <td className="px-2 py-1.5 text-center tabular-nums text-muted-foreground">
                         {row.prmy_cnt > 0 ? <span className="font-medium text-foreground">{row.prmy_cnt}</span> : "-"}
                       </td>
                     </tr>
@@ -458,38 +483,85 @@ export function AdminTitlesClient({
         </CardItem>
       )}
 
-      {selectedRow && selectedForm && (
-        <CardItem className="flex flex-col gap-3">
-          <div className="flex items-center justify-between">
-            <p className="text-sm font-semibold text-foreground">
-              선택 칭호 수정: {selectedRow.ttl_nm}
-            </p>
-            <Button
-              size="sm"
-              onClick={() => saveRow(selectedRow.ttl_id)}
-              disabled={savingId === selectedRow.ttl_id}
-              className="h-8 rounded-lg"
-            >
-              <Save className="size-3.5" />
-              {savingId === selectedRow.ttl_id ? "저장 중..." : "저장"}
-            </Button>
-          </div>
-          <TitleFormFields
-            form={selectedForm}
-            categoryOptions={categoryOptions}
-            onChange={(key, value) =>
-              updateFormField(selectedRow.ttl_id, key, value)
-            }
+      {/* ── 바텀시트: 수정 + 획득내역 ── */}
+      {sheetRow && sheetForm && (
+        <>
+          {/* Overlay */}
+          <div
+            className="fixed inset-0 z-[99] bg-black/40"
+            onClick={closeSheet}
           />
-        </CardItem>
-      )}
 
-      {selectedRow && (
-        <TitleGrantList
-          ttlId={selectedRow.ttl_id}
-          teamId={teamId}
-          isAwarded={selectedRow.ttl_kind_enm === "awarded"}
-        />
+          {/* 바텀시트 */}
+          <div className="fixed inset-x-0 bottom-0 z-[100] flex max-h-[70dvh] flex-col rounded-t-2xl bg-background">
+            {/* 시트 헤더 */}
+            <div className="flex items-center justify-between px-6 py-4">
+              <p className="text-sm font-semibold text-foreground">{sheetRow.ttl_nm}</p>
+              <button
+                onClick={closeSheet}
+                aria-label="닫기"
+                className="text-muted-foreground"
+              >
+                <X className="size-5" />
+              </button>
+            </div>
+
+            {/* 시트 탭 */}
+            <div className="flex border-b border-border px-6">
+              {([
+                { key: "edit", label: "수정" },
+                { key: "grants", label: "획득내역" },
+              ] as { key: "edit" | "grants"; label: string }[]).map(({ key, label }) => (
+                <button
+                  key={key}
+                  onClick={() => setSheetTab(key)}
+                  className={cn(
+                    "mr-4 pb-2 text-sm font-medium transition-colors",
+                    sheetTab === key
+                      ? "border-b-2 border-primary text-foreground"
+                      : "text-muted-foreground hover:text-foreground",
+                  )}
+                >
+                  {label}
+                </button>
+              ))}
+            </div>
+
+            {/* 시트 콘텐츠 */}
+            <div className="flex-1 overflow-y-auto px-6 py-4">
+              {sheetTab === "edit" && (
+                <div className="flex flex-col gap-3">
+                  <TitleFormFields
+                    form={sheetForm}
+                    categoryOptions={categoryOptions}
+                    onChange={(key, value) =>
+                      updateFormField(sheetRow.ttl_id, key, value)
+                    }
+                  />
+                  <div className="flex justify-end">
+                    <Button
+                      size="sm"
+                      onClick={() => saveRow(sheetRow.ttl_id)}
+                      disabled={savingId === sheetRow.ttl_id}
+                      className="h-8 rounded-lg"
+                    >
+                      <Save className="size-3.5" />
+                      {savingId === sheetRow.ttl_id ? "저장 중..." : "저장"}
+                    </Button>
+                  </div>
+                </div>
+              )}
+
+              {sheetTab === "grants" && (
+                <TitleGrantList
+                  ttlId={sheetRow.ttl_id}
+                  teamId={teamId}
+                  isAwarded={sheetRow.ttl_kind_enm === "awarded"}
+                />
+              )}
+            </div>
+          </div>
+        </>
       )}
     </div>
   );
@@ -921,7 +993,7 @@ function LabeledSelect({
         <SelectTrigger className="h-10 rounded-lg">
           <SelectValue />
         </SelectTrigger>
-        <SelectContent>
+        <SelectContent className="z-[200]">
           {items.map((item) => (
             <SelectItem key={item.value} value={item.value}>
               {item.label}

--- a/app/(info)/admin/system/titles/admin-titles-client.tsx
+++ b/app/(info)/admin/system/titles/admin-titles-client.tsx
@@ -772,9 +772,7 @@ function TitleGrantList({
                   <th className="w-24 px-2 py-1.5 text-center font-medium text-muted-foreground">수여일</th>
                   <th className="w-12 px-2 py-1.5 text-center font-medium text-muted-foreground">방식</th>
                   <th className="px-2 py-1.5 text-center font-medium text-muted-foreground">사유</th>
-                  {isAwarded && (
-                    <th className="w-12 px-2 py-1.5 text-center font-medium text-muted-foreground">회수</th>
-                  )}
+                  <th className="w-12 px-2 py-1.5 text-center font-medium text-muted-foreground">회수</th>
                 </tr>
               </thead>
               <tbody>
@@ -797,17 +795,15 @@ function TitleGrantList({
                     <td className="max-w-[120px] truncate px-2 py-1.5 text-center text-muted-foreground">
                       {grant.grnt_rsn_txt ?? "-"}
                     </td>
-                    {isAwarded && (
-                      <td className="px-2 py-1.5 text-center">
-                        <button
-                          onClick={() => void handleRevoke(grant.mem_ttl_id)}
-                          disabled={revokingId === grant.mem_ttl_id}
-                          className="rounded-md px-1.5 py-0.5 text-[10px] font-medium text-destructive/70 transition-colors hover:bg-destructive/10 hover:text-destructive"
-                        >
-                          {revokingId === grant.mem_ttl_id ? "..." : "회수"}
-                        </button>
-                      </td>
-                    )}
+                    <td className="px-2 py-1.5 text-center">
+                      <button
+                        onClick={() => void handleRevoke(grant.mem_ttl_id)}
+                        disabled={revokingId === grant.mem_ttl_id}
+                        className="rounded-md px-1.5 py-0.5 text-[10px] font-medium text-destructive/70 transition-colors hover:bg-destructive/10 hover:text-destructive"
+                      >
+                        {revokingId === grant.mem_ttl_id ? "..." : "회수"}
+                      </button>
+                    </td>
                   </tr>
                 ))}
               </tbody>

--- a/app/(info)/admin/system/titles/admin-titles-page-client.tsx
+++ b/app/(info)/admin/system/titles/admin-titles-page-client.tsx
@@ -3,14 +3,16 @@
 import { useState } from "react";
 import { cn } from "@/lib/utils";
 
-type Tab = "titles" | "effects";
+type Tab = "titles" | "effects" | "history";
 
 export function AdminTitlesPageClient({
   titlesContent,
   effectsContent,
+  historyContent,
 }: {
   titlesContent: React.ReactNode;
   effectsContent: React.ReactNode;
+  historyContent: React.ReactNode;
 }) {
   const [tab, setTab] = useState<Tab>("titles");
 
@@ -21,6 +23,7 @@ export function AdminTitlesPageClient({
         {([
           { key: "titles",  label: "칭호 관리" },
           { key: "effects", label: "이펙트 관리" },
+          { key: "history", label: "이력" },
         ] as { key: Tab; label: string }[]).map(({ key, label }) => (
           <button
             key={key}
@@ -42,6 +45,9 @@ export function AdminTitlesPageClient({
       </div>
       <div className={tab === "effects" ? "block" : "hidden"}>
         {effectsContent}
+      </div>
+      <div className={tab === "history" ? "block" : "hidden"}>
+        {historyContent}
       </div>
     </div>
   );

--- a/app/(info)/admin/system/titles/page.tsx
+++ b/app/(info)/admin/system/titles/page.tsx
@@ -5,6 +5,7 @@ import { Skeleton } from "@/components/ui/skeleton";
 import { AdminTitlesClient } from "./admin-titles-client";
 import { AdminEffectsClient } from "./admin-effects-client";
 import { AdminTitlesPageClient } from "./admin-titles-page-client";
+import { AdminTitleHistoryClient } from "./admin-title-history-client";
 
 function Fallback() {
   return (
@@ -21,7 +22,7 @@ async function TitlesTabContent() {
     getRequestTeamContext(),
     getCachedCmmCdRows(),
   ]);
-  return <AdminTitlesClient teamId={teamId} cmmCdRows={cmmCdRows} />;
+return <AdminTitlesClient teamId={teamId} cmmCdRows={cmmCdRows} />;
 }
 
 export default function AdminTitlesPage() {
@@ -33,6 +34,7 @@ export default function AdminTitlesPage() {
         </Suspense>
       }
       effectsContent={<AdminEffectsClient />}
+      historyContent={<AdminTitleHistoryClient />}
     />
   );
 }

--- a/app/actions/admin/batch-mileage-titles.ts
+++ b/app/actions/admin/batch-mileage-titles.ts
@@ -51,12 +51,17 @@ export async function batchMileageTitles(evtId: string, baseMonth?: string): Pro
     return `평가 대상 참여자 없음 (기준 월: ${resolvedMonth})`;
   }
 
-  // mem_id → team_mem_id, team_id 맵 구성
+  // mem_id → team_mem_id, team_id 맵 구성 (이벤트 소속 팀 ID로 필터링 — 다른 팀 멤버 혼재 방지)
   const memIds = [...new Set(prtRows.map((r) => r.mem_id))];
+  const evtTeamIds = [...new Set(prtRows.map((r) => {
+    const evtMst = Array.isArray(r.evt_team_mst) ? r.evt_team_mst[0] : r.evt_team_mst;
+    return (evtMst as { team_id: string }).team_id;
+  }))];
   const { data: teamMemRows } = await db
     .from("team_mem_rel")
     .select("mem_id, team_mem_id, team_id")
     .in("mem_id", memIds)
+    .in("team_id", evtTeamIds)
     .eq("vers", 0)
     .eq("del_yn", false);
 

--- a/app/actions/admin/batch-mileage-titles.ts
+++ b/app/actions/admin/batch-mileage-titles.ts
@@ -40,7 +40,7 @@ export async function batchMileageTitles(baseMonth?: string): Promise<string> {
   // 기준 월이 이벤트 기간 안에 포함된 참여자만 조회
   const { data: prtRows, error } = await db
     .from("evt_team_prt_rel")
-    .select("mem_id, evt_team_mst!inner(team_id, stt_dt, end_dt)")
+    .select("mem_id, evt_id, evt_team_mst!inner(team_id, stt_dt, end_dt)")
     .eq("aprv_yn", true)
     .lte("evt_team_mst.stt_dt", baseMonthLastDay)
     .gte("evt_team_mst.end_dt", baseMonthStart);
@@ -62,16 +62,21 @@ export async function batchMileageTitles(baseMonth?: string): Promise<string> {
     return `팀 멤버 매핑 실패 (기준 월: ${resolvedMonth})`;
   }
 
+  // mem_id → evt_id 맵
+  const memEvtMap = new Map<string, string>();
+  for (const r of prtRows) memEvtMap.set(r.mem_id, r.evt_id);
+
   // team_id별로 team_mem_id 묶기
-  const teamMap = new Map<string, string[]>();
+  const teamMap = new Map<string, { teamMemIds: string[]; evtId: string }>();
   for (const r of teamMemRows) {
-    if (!teamMap.has(r.team_id)) teamMap.set(r.team_id, []);
-    teamMap.get(r.team_id)!.push(r.team_mem_id);
+    const evtId = memEvtMap.get(r.mem_id) ?? "";
+    if (!teamMap.has(r.team_id)) teamMap.set(r.team_id, { teamMemIds: [], evtId });
+    teamMap.get(r.team_id)!.teamMemIds.push(r.team_mem_id);
   }
 
   let totalGranted = 0;
-  for (const [teamId, teamMemIds] of teamMap.entries()) {
-    const { granted } = await batchEvaluateAndGrant(teamId, teamMemIds, resolvedMonth);
+  for (const [teamId, { teamMemIds, evtId }] of teamMap.entries()) {
+    const { granted } = await batchEvaluateAndGrant(teamId, teamMemIds, resolvedMonth, evtId);
     totalGranted += granted;
   }
 

--- a/app/actions/admin/batch-mileage-titles.ts
+++ b/app/actions/admin/batch-mileage-titles.ts
@@ -21,10 +21,11 @@ const KST = "Asia/Seoul";
  *   - 러닝원툴 (mileage_goal_achieved_by_single_sport)
  *   - 수달·두바퀴인생·흙이좋아 (mileage_sport_ratio)
  *
+ * @param evtId 이벤트 ID (필수) — 다중 이벤트 혼재 방지
  * @param baseMonth 기준 월 (YYYY-MM). 생략 시 전월 자동 계산.
  * @returns 결과 메시지
  */
-export async function batchMileageTitles(baseMonth?: string): Promise<string> {
+export async function batchMileageTitles(evtId: string, baseMonth?: string): Promise<string> {
   const admin = await verifyAdmin();
   if (!admin) throw new Error("관리자 권한이 필요합니다");
 
@@ -37,10 +38,11 @@ export async function batchMileageTitles(baseMonth?: string): Promise<string> {
   const baseMonthStart = `${resolvedMonth}-01`;
   const baseMonthLastDay = dayjs(baseMonthStart).tz(KST).endOf("month").format("YYYY-MM-DD");
 
-  // 기준 월이 이벤트 기간 안에 포함된 참여자만 조회
+  // 지정 이벤트의 기준 월 참여자만 조회
   const { data: prtRows, error } = await db
     .from("evt_team_prt_rel")
     .select("mem_id, evt_id, evt_team_mst!inner(team_id, stt_dt, end_dt)")
+    .eq("evt_id", evtId)
     .eq("aprv_yn", true)
     .lte("evt_team_mst.stt_dt", baseMonthLastDay)
     .gte("evt_team_mst.end_dt", baseMonthStart);

--- a/app/actions/admin/manage-title.ts
+++ b/app/actions/admin/manage-title.ts
@@ -258,9 +258,30 @@ export async function revokeTitle(memTtlId: string) {
   const { teamId } = await getRequestTeamContext();
   const db = createAdminClient();
 
+  // 현재 행의 ttl_id, team_mem_id 조회
+  const { data: row } = await db
+    .from("mem_ttl_rel")
+    .select("ttl_id, team_mem_id")
+    .eq("mem_ttl_id", memTtlId)
+    .eq("team_id", teamId)
+    .eq("del_yn", false)
+    .maybeSingle();
+  if (!row) return { ok: false, message: "수여 내역을 찾을 수 없습니다" };
+
+  // 같은 (team_mem_id, ttl_id)의 최대 vers 조회 → +1로 회수
+  const { data: maxRow } = await db
+    .from("mem_ttl_rel")
+    .select("vers")
+    .eq("team_mem_id", row.team_mem_id)
+    .eq("ttl_id", row.ttl_id)
+    .order("vers", { ascending: false })
+    .limit(1)
+    .maybeSingle();
+  const nextVers = (maxRow?.vers ?? 0) + 1;
+
   const { data, error } = await db
     .from("mem_ttl_rel")
-    .update({ del_yn: true })
+    .update({ del_yn: true, vers: nextVers })
     .eq("mem_ttl_id", memTtlId)
     .eq("team_id", teamId)
     .eq("del_yn", false)

--- a/app/actions/admin/manage-title.ts
+++ b/app/actions/admin/manage-title.ts
@@ -260,7 +260,7 @@ export async function revokeTitle(memTtlId: string) {
 
   const { data, error } = await db
     .from("mem_ttl_rel")
-    .update({ del_yn: true, upd_by: admin.id })
+    .update({ del_yn: true })
     .eq("mem_ttl_id", memTtlId)
     .eq("team_id", teamId)
     .eq("del_yn", false)

--- a/app/actions/admin/run-batch.ts
+++ b/app/actions/admin/run-batch.ts
@@ -12,7 +12,10 @@ type ActionResult = { ok: boolean; message: string; runId: string | null };
  * 새 배치 추가 시 여기에만 항목 추가하면 UI 코드 변경 불필요.
  */
 const BATCH_ACTION_MAP: Record<string, (params: BatchParams) => Promise<string>> = {
-  MILEAGE_TITLE_BATCH: (params) => batchMileageTitles(params.base_month),
+  MILEAGE_TITLE_BATCH: (params) => {
+    if (!params.evt_id) throw new Error("evt_id 파라미터가 필요합니다");
+    return batchMileageTitles(params.evt_id, params.base_month);
+  },
 };
 
 /**
@@ -93,6 +96,23 @@ export async function runBatch(jobId: string, params: BatchParams): Promise<Acti
   }
 
   return { ok: status === "success", message: resultMsg, runId };
+}
+
+/**
+ * 활성 마일리지런 이벤트 목록 조회 (배치 파라미터 선택용).
+ */
+export async function getActiveEvents() {
+  const admin = await verifyAdmin();
+  if (!admin) return [];
+
+  const db = createAdminClient();
+  const { data } = await db
+    .from("evt_team_mst")
+    .select("evt_id, evt_nm")
+    .eq("stts_enm", "ACTIVE")
+    .order("stt_dt", { ascending: false });
+
+  return (data ?? []) as { evt_id: string; evt_nm: string }[];
 }
 
 /**

--- a/app/actions/mileage-run.ts
+++ b/app/actions/mileage-run.ts
@@ -40,7 +40,7 @@ export interface ActivityLogInput {
   review: string | null;
 }
 
-type ActionResult = { ok: boolean; message: string | null };
+type ActionResult = { ok: boolean; message: string | null; grantedTitles?: string[] };
 
 // ─────────────────────────────────────────
 // 내부 헬퍼
@@ -326,13 +326,14 @@ export async function logActivity(
   await recalcGoalsFromMonth(evtId, participant.prt_id);
 
   // 칭호 평가 — 즉시 평가 대상 (목표달성·막판스퍼트·올라운더·마지막불꽃)
-  const { data: teamMemRow } = await db
+  const { data: teamMemRow, error: teamMemErr } = await db
     .from("team_mem_rel")
     .select("team_mem_id, team_id")
     .eq("mem_id", member.id)
     .eq("vers", 0)
     .eq("del_yn", false)
     .maybeSingle();
+  console.info("[title-engine] teamMemRow:", teamMemRow, "error:", teamMemErr);
   if (teamMemRow) {
     const ctx = {
       trigger: "mileage_run" as const,
@@ -342,7 +343,8 @@ export async function logActivity(
       actDt: validInput.act_dt,
       prevAchvYn,
     };
-    after(() => evaluateAndGrantTitles(ctx).catch((e) => console.error("[title-engine] mileage_run(log) 평가 실패", e)));
+    console.info("[title-engine] ctx:", ctx);
+    await evaluateAndGrantTitles(ctx).catch((e) => console.error("[title-engine] mileage_run(log) 평가 실패", e));
   }
 
   revalidatePath("/projects");
@@ -423,12 +425,54 @@ export async function logActivitiesBatch(
     });
   }
 
+  // INSERT 전 각 날짜별 prevAchvYn 미리 읽기 (막판스퍼트 판단용)
+  const uniqueDates = [...new Set(validInputs.map((i) => i.act_dt))];
+  const prevAchvYnMap = new Map<string, boolean>();
+  for (const actDt of uniqueDates) {
+    const actMonth = actDt.slice(0, 7) + "-01";
+    const { data: snap } = await db
+      .from("evt_mlg_mth_snap")
+      .select("achv_yn")
+      .eq("prt_id", participant.prt_id)
+      .eq("base_dt", actMonth)
+      .maybeSingle();
+    prevAchvYnMap.set(actDt, snap?.achv_yn ?? false);
+  }
+
   const { error } = await db.from("evt_mlg_act_hist").insert(rows);
   if (error) return { ok: false, message: "활동 기록 저장에 실패했습니다" };
 
   await recalcGoalsFromMonth(evtId, participant.prt_id);
+
+  // 칭호 평가
+  const { data: teamMemRow } = await db
+    .from("team_mem_rel")
+    .select("team_mem_id, team_id")
+    .eq("mem_id", member.id)
+    .eq("vers", 0)
+    .eq("del_yn", false)
+    .maybeSingle();
+  const allGranted: string[] = [];
+  if (teamMemRow) {
+    for (const actDt of uniqueDates) {
+      const ctx = {
+        trigger: "mileage_run" as const,
+        teamId: teamMemRow.team_id,
+        teamMemId: teamMemRow.team_mem_id,
+        projectId: evtId,
+        actDt,
+        prevAchvYn: prevAchvYnMap.get(actDt) ?? false,
+      };
+      const granted = await evaluateAndGrantTitles(ctx).catch((e) => {
+        console.error("[title-engine] mileage_run(batch) 평가 실패", e);
+        return [] as string[];
+      });
+      allGranted.push(...granted);
+    }
+  }
+
   revalidatePath("/projects");
-  return { ok: true, message: null };
+  return { ok: true, message: null, grantedTitles: allGranted };
 }
 
 // ─────────────────────────────────────────
@@ -684,7 +728,7 @@ async function recalcGoalsFromMonth(
     const achvMlg = roundedAchvByMonth.get(month) ?? 0;
     const actCnt = cntByMonth.get(month) ?? 0;
     const lstActDt = lastDtByMonth.get(month) ?? null;
-    const achvYn = achvMlg >= Number(g.goal_mlg);
+    const achvYn = Math.round(achvMlg * 10) / 10 >= Number(g.goal_mlg);
 
     await db
       .from("evt_mlg_mth_snap")
@@ -728,7 +772,7 @@ async function recalcGoalsFromMonth(
         .from("evt_mlg_mth_snap")
         .update({
           goal_mlg: newGoal,
-          achv_yn: (roundedAchvByMonth.get(cur.base_dt as string) ?? 0) >= newGoal,
+          achv_yn: Math.round((roundedAchvByMonth.get(cur.base_dt as string) ?? 0) * 10) / 10 >= newGoal,
           updated_at: dayjs().toISOString(),
         })
         .eq("goal_id", cur.goal_id);

--- a/components/profile/collection-sheet.tsx
+++ b/components/profile/collection-sheet.tsx
@@ -363,7 +363,8 @@ export function CollectionSheet({
                         const blocked = owned && t.use_yn && isBlockedByHigher(t);
                         const selectable = owned && t.use_yn && !blocked;
                         const isSelected = selectedTtlId === t.ttl_id;
-                        const dimmed = !masked && !owned; // always라 마스킹은 없지만 미보유
+                        // always라 마스킹은 없지만 미보유 — blocked(그룹막힘)와 시각적으로 구분
+                        const dimmed = !masked && !owned;
                         return (
                           <TitleBadge
                             key={t.ttl_id}
@@ -379,7 +380,12 @@ export function CollectionSheet({
                             }}
                             tooltipOpen={openTooltipTtlId === t.ttl_id}
                             onTooltipOpen={() => openTooltip(t.ttl_id)}
-                            className={cn((blocked || dimmed) && "opacity-50")}
+                            className={cn(
+                              // blocked(그룹막힘): 보유했지만 더 높은 등급이 있어 선택 불가 → 흐리게
+                              blocked && "opacity-40",
+                              // dimmed(always 미보유): 도감에 보이지만 아직 획득 못 함 → 점선 테두리로 구분, 덜 흐리게
+                              dimmed && "opacity-60 border-dashed",
+                            )}
                             onClick={() => {
                               if (selectable) {
                                 setSelectedTtlId(isSelected ? null : t.ttl_id);

--- a/components/projects/activity-log-batch-form.tsx
+++ b/components/projects/activity-log-batch-form.tsx
@@ -45,7 +45,7 @@ type ActivityDraft = {
 
 type ActivityLogBatchFormProps = {
   evtId: string;
-  onSuccess: (savedCount: number) => void;
+  onSuccess: (savedCount: number, grantedTitles: string[]) => void;
 };
 
 function isMultiplierActive(mult: EventMultiplier, actDt: string): boolean {
@@ -153,7 +153,7 @@ export function ActivityLogBatchForm({ evtId, onSuccess }: ActivityLogBatchFormP
         alert(result.message ?? "오류가 발생했습니다.");
         return;
       }
-      onSuccess(payload.length);
+      onSuccess(payload.length, result.grantedTitles ?? []);
     } catch {
       alert("오류가 발생했습니다. 다시 시도해 주세요.");
     } finally {

--- a/components/projects/activity-log-fab.tsx
+++ b/components/projects/activity-log-fab.tsx
@@ -3,6 +3,7 @@
 import { useEffect, useRef, useState } from "react";
 import { useRouter } from "next/navigation";
 import { Check, Plus } from "lucide-react";
+import { cn } from "@/lib/utils";
 import { Button } from "@/components/ui/button";
 import {
   Sheet,
@@ -21,35 +22,59 @@ export function ActivityLogFab({ evtId, memId: _memId }: ActivityLogFabProps) {
   const [open, setOpen] = useState(false);
   const [showSuccessNotice, setShowSuccessNotice] = useState(false);
   const [savedCount, setSavedCount] = useState(0);
+  const [grantedTitles, setGrantedTitles] = useState<string[]>([]);
+  const [titleDismissable, setTitleDismissable] = useState(false);
   const successTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const titleTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const titleDismissTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const router = useRouter();
 
-  const handleSuccess = (count: number) => {
+  const handleSuccess = (count: number, titles: string[]) => {
     setOpen(false);
     router.refresh();
     window.dispatchEvent(new Event("mileage:refresh"));
     setSavedCount(count);
     setShowSuccessNotice(true);
 
-    if (successTimerRef.current) {
-      clearTimeout(successTimerRef.current);
-    }
+    if (successTimerRef.current) clearTimeout(successTimerRef.current);
     successTimerRef.current = setTimeout(() => {
       setShowSuccessNotice(false);
       successTimerRef.current = null;
+
+      // 동기부여 창 닫힌 후 칭호 알림 표시
+      if (titles.length > 0) {
+        setGrantedTitles(titles);
+        setTitleDismissable(false);
+        if (titleDismissTimerRef.current) clearTimeout(titleDismissTimerRef.current);
+        if (titleTimerRef.current) clearTimeout(titleTimerRef.current);
+        titleDismissTimerRef.current = setTimeout(() => setTitleDismissable(true), 2000);
+        titleTimerRef.current = setTimeout(() => {
+          setGrantedTitles([]);
+          setTitleDismissable(false);
+        }, 6000);
+      }
     }, 3500);
+  };
+
+  const dismissTitle = () => {
+    if (!titleDismissable) return;
+    if (titleTimerRef.current) clearTimeout(titleTimerRef.current);
+    if (titleDismissTimerRef.current) clearTimeout(titleDismissTimerRef.current);
+    setGrantedTitles([]);
+    setTitleDismissable(false);
   };
 
   useEffect(() => {
     return () => {
-      if (successTimerRef.current) {
-        clearTimeout(successTimerRef.current);
-      }
+      if (successTimerRef.current) clearTimeout(successTimerRef.current);
+      if (titleTimerRef.current) clearTimeout(titleTimerRef.current);
+      if (titleDismissTimerRef.current) clearTimeout(titleDismissTimerRef.current);
     };
   }, []);
 
   return (
     <>
+      {/* 동기부여 창 */}
       {showSuccessNotice && (
         <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/40 backdrop-blur-sm">
           <div className="mx-6 w-full max-w-sm rounded-2xl bg-primary px-6 py-7 text-primary-foreground shadow-2xl">
@@ -63,6 +88,32 @@ export function ActivityLogFab({ evtId, memId: _memId }: ActivityLogFabProps) {
                   동기부여를 위해<br />러닝기록을 단톡방에<br />올려주세요!
                 </p>
               </div>
+            </div>
+          </div>
+        </div>
+      )}
+
+      {/* 칭호 획득 알림 */}
+      {grantedTitles.length > 0 && (
+        <div
+          className="fixed inset-0 z-[200] flex items-center justify-center bg-black/50 backdrop-blur-sm"
+          onClick={dismissTitle}
+        >
+          <div className="mx-6 w-full max-w-sm rounded-2xl border border-border bg-background px-6 py-6 shadow-2xl">
+            <div className="flex flex-col items-center gap-3 text-center">
+              <span className="text-2xl">🏅</span>
+              <div className="flex flex-col gap-1">
+                <p className="text-xs text-muted-foreground">칭호 획득</p>
+                <p className="text-base font-bold text-foreground">
+                  {grantedTitles.length === 1
+                    ? <>「{grantedTitles[0]}」 칭호를 획득했습니다!</>
+                    : <>{grantedTitles.map((t) => `「${t}」`).join(", ")} 칭호를 획득했습니다!</>
+                  }
+                </p>
+              </div>
+              <p className={cn("text-[11px] transition-opacity duration-300", titleDismissable ? "text-muted-foreground opacity-100" : "opacity-0")}>
+                탭하면 닫힙니다
+              </p>
             </div>
           </div>
         </div>

--- a/components/projects/my-status.tsx
+++ b/components/projects/my-status.tsx
@@ -118,7 +118,7 @@ export async function MyStatus({
           </Caption>
         </div>
         <div>
-          {goalRow.achv_yn ? (
+          {goalRow.achv_yn || dailyNeeded === "done" ? (
             <Caption className="text-success font-semibold">달성 완료!</Caption>
           ) : dailyNeeded === 0 ? (
             <Caption>월 종료</Caption>
@@ -126,7 +126,7 @@ export async function MyStatus({
             <Caption>
               잔여 일평균{" "}
               <span className="font-semibold text-foreground">
-                {(dailyNeeded as number).toFixed(1)} km
+                {dailyNeeded.toFixed(1)} km
               </span>
             </Caption>
           )}

--- a/components/projects/my-status.tsx
+++ b/components/projects/my-status.tsx
@@ -118,7 +118,7 @@ export async function MyStatus({
           </Caption>
         </div>
         <div>
-          {dailyNeeded === "done" ? (
+          {goalRow.achv_yn ? (
             <Caption className="text-success font-semibold">달성 완료!</Caption>
           ) : dailyNeeded === 0 ? (
             <Caption>월 종료</Caption>

--- a/lib/queries/cmm-cd-cached.ts
+++ b/lib/queries/cmm-cd-cached.ts
@@ -79,7 +79,7 @@ async function loadAllCmmCdRows(): Promise<CachedCmmCdRow[]> {
 
 const getCmmCdRowsUncached = unstable_cache(
   loadAllCmmCdRows,
-  ["cmm-cd-all-rows"],
+  ["cmm-cd-all-rows-v2"],
   { tags: [COMMON_CODES_CACHE_TAG], revalidate: 86400 },
 );
 

--- a/lib/titles/engine.ts
+++ b/lib/titles/engine.ts
@@ -224,10 +224,11 @@ export async function sweepEvaluateAndGrant(
   // 4. bulk 부여 — 활성 행은 항상 vers=0, 회수 시 vers 변경되므로 충돌 없이 INSERT 가능
   let granted = 0;
   if (toGrant.length > 0) {
-    const { data } = await db
+    const { data, error } = await db
       .from("mem_ttl_rel")
       .insert(toGrant)
       .select("mem_ttl_id");
+    if (error) console.error("[sweep] bulk INSERT 실패", error);
     granted = data?.length ?? 0;
     console.info(`[sweep] 칭호 신규 부여 ${granted}건`);
   }
@@ -316,10 +317,11 @@ export async function batchEvaluateAndGrant(
 
   let granted = 0;
   if (toGrant.length > 0) {
-    const { data } = await db
+    const { data, error } = await db
       .from("mem_ttl_rel")
       .insert(toGrant)
       .select("mem_ttl_id");
+    if (error) console.error("[mileage_batch] bulk INSERT 실패", error);
     granted = data?.length ?? 0;
     console.info(`[mileage_batch] 칭호 신규 부여 ${granted}건 (base_month=${baseMonth})`);
   }

--- a/lib/titles/engine.ts
+++ b/lib/titles/engine.ts
@@ -72,6 +72,9 @@ export async function evaluateAndGrantTitles(
     return rule && allowedCondTypes.has(rule.type);
   });
 
+  console.info("[title-engine] trigger:", ctx.trigger, "| allowedCondTypes:", [...allowedCondTypes]);
+  console.info("[title-engine] 평가 대상 칭호:", titles.map(t => t.ttl_nm));
+
   if (titles.length === 0) return [];
 
   // 4. 현재 활성 보유 칭호 ID (vers=0, del_yn=false) — 중복 수여 방지 및 회수 대상 파악
@@ -106,9 +109,8 @@ export async function evaluateAndGrantTitles(
 
     if (!passed) continue;
 
-    // uk_mem_ttl_rel_team_mem_ttl_vers: UNIQUE(team_mem_id, ttl_id, vers)
-    // vers=0으로 INSERT — 이미 활성 보유 중이면 충돌 무시 (동시 호출 중복 수여 방지)
-    const { error } = await db.from("mem_ttl_rel").upsert({
+    // 활성 행은 항상 vers=0 — 회수 시 vers가 변경되므로 재지급 시 충돌 없이 INSERT 가능
+    const { error } = await db.from("mem_ttl_rel").insert({
       team_id: ctx.teamId,
       team_mem_id: ctx.teamMemId,
       ttl_id: title.ttl_id,
@@ -116,7 +118,7 @@ export async function evaluateAndGrantTitles(
       is_prmy_yn: false,
       vers: 0,
       del_yn: false,
-    }, { onConflict: "team_mem_id,ttl_id,vers", ignoreDuplicates: true });
+    });
 
     if (error) {
       console.error(`[title-engine] 칭호 부여 실패 ttl_id=${title.ttl_id}`, error);
@@ -219,15 +221,18 @@ export async function sweepEvaluateAndGrant(
     }
   }
 
-  // 4. bulk 부여
+  // 4. bulk 부여 — 활성 행은 항상 vers=0, 회수 시 vers 변경되므로 충돌 없이 INSERT 가능
+  let granted = 0;
   if (toGrant.length > 0) {
-    await db
+    const { data } = await db
       .from("mem_ttl_rel")
-      .upsert(toGrant, { onConflict: "team_mem_id,ttl_id,vers", ignoreDuplicates: true });
-    console.info(`[sweep] 칭호 신규 부여 ${toGrant.length}건`);
+      .insert(toGrant)
+      .select("mem_ttl_id");
+    granted = data?.length ?? 0;
+    console.info(`[sweep] 칭호 신규 부여 ${granted}건`);
   }
 
-  return { granted: toGrant.length, revoked: 0 };
+  return { granted, revoked: 0 };
 }
 
 /**
@@ -308,12 +313,15 @@ export async function batchEvaluateAndGrant(
     }
   }
 
+  let granted = 0;
   if (toGrant.length > 0) {
-    await db
+    const { data } = await db
       .from("mem_ttl_rel")
-      .upsert(toGrant, { onConflict: "team_mem_id,ttl_id,vers", ignoreDuplicates: true });
-    console.info(`[mileage_batch] 칭호 신규 부여 ${toGrant.length}건 (base_month=${baseMonth})`);
+      .insert(toGrant)
+      .select("mem_ttl_id");
+    granted = data?.length ?? 0;
+    console.info(`[mileage_batch] 칭호 신규 부여 ${granted}건 (base_month=${baseMonth})`);
   }
 
-  return { granted: toGrant.length };
+  return { granted };
 }

--- a/lib/titles/engine.ts
+++ b/lib/titles/engine.ts
@@ -247,12 +247,13 @@ export async function batchEvaluateAndGrant(
   teamId: string,
   teamMemIds: string[],
   baseMonth: string,
+  evtId?: string,
 ): Promise<{ granted: number }> {
   if (teamMemIds.length === 0) return { granted: 0 };
 
   const db = createAdminClient();
 
-  const snapshots = await loadMemberSnapshots(db, teamId, teamMemIds);
+  const snapshots = await loadMemberSnapshots(db, teamId, teamMemIds, evtId);
   if (snapshots.size === 0) return { granted: 0 };
 
   const { data: allTitles } = await db

--- a/lib/titles/evaluators.ts
+++ b/lib/titles/evaluators.ts
@@ -551,18 +551,23 @@ export async function evalMileageGoalAchievedMonthsInternal(
 
   const { data: prtRows } = await db
     .from("evt_team_prt_rel")
-    .select("prt_id")
+    .select("prt_id, evt_team_mst!inner(stt_dt)")
     .eq("mem_id", memRow.mem_id)
     .eq("evt_id", evtId)
     .eq("aprv_yn", true);
   if (!prtRows?.length) return false;
 
   const prtIds = prtRows.map((r) => r.prt_id);
-  const { count } = await db
+  const evtMst = Array.isArray(prtRows[0].evt_team_mst) ? prtRows[0].evt_team_mst[0] : prtRows[0].evt_team_mst;
+  const evtSttDt = (evtMst as { stt_dt: string } | null)?.stt_dt?.slice(0, 7) + "-01";
+
+  let query = db
     .from("evt_mlg_mth_snap")
     .select("*", { count: "exact", head: true })
     .in("prt_id", prtIds)
     .eq("achv_yn", true);
+  if (evtSttDt) query = query.gte("base_dt", evtSttDt);
+  const { count } = await query;
 
   return (count ?? 0) >= rule.count;
 }

--- a/lib/titles/evaluators.ts
+++ b/lib/titles/evaluators.ts
@@ -537,6 +537,7 @@ export async function evalMileageJoinedInternal(
 export async function evalMileageGoalAchievedMonthsInternal(
   rule: CondMileageGoalAchievedMonths,
   teamMemId: string,
+  evtId: string,
   db: DB,
 ): Promise<boolean> {
   const { data: memRow } = await db
@@ -552,6 +553,7 @@ export async function evalMileageGoalAchievedMonthsInternal(
     .from("evt_team_prt_rel")
     .select("prt_id")
     .eq("mem_id", memRow.mem_id)
+    .eq("evt_id", evtId)
     .eq("aprv_yn", true);
   if (!prtRows?.length) return false;
 
@@ -574,11 +576,13 @@ export async function evalMileageGoalAchievedOnLastDayInternal(
   _rule: CondMileageGoalAchievedOnLastDay,
   ctx: TitleEvalContext,
   teamMemId: string,
+  evtId: string,
   db: DB,
 ): Promise<boolean> {
   if (ctx.trigger !== "mileage_run") return false;
   if (ctx.prevAchvYn) return false; // 이미 달성 상태였으면 해당 없음
 
+  // 기준은 운동기록일자(act_dt), 등록일자 아님
   const actDt = ctx.actDt; // YYYY-MM-DD
   const actDay = dayjs(actDt).tz(KST);
   const lastDayOfMonth = actDay.endOf("month").date();
@@ -599,6 +603,7 @@ export async function evalMileageGoalAchievedOnLastDayInternal(
     .from("evt_team_prt_rel")
     .select("prt_id")
     .eq("mem_id", memRow.mem_id)
+    .eq("evt_id", evtId)
     .eq("aprv_yn", true);
   if (!prtRows?.length) return false;
 
@@ -618,6 +623,7 @@ export async function evalMileageAllSportsInMonthInternal(
   rule: CondMileageAllSportsInMonth,
   teamMemId: string,
   actDt: string,
+  evtId: string,
   db: DB,
 ): Promise<boolean> {
   const { data: memRow } = await db
@@ -633,6 +639,7 @@ export async function evalMileageAllSportsInMonthInternal(
     .from("evt_team_prt_rel")
     .select("prt_id")
     .eq("mem_id", memRow.mem_id)
+    .eq("evt_id", evtId)
     .eq("aprv_yn", true);
   if (!prtRows?.length) return false;
 
@@ -651,10 +658,12 @@ export async function evalMileageAllSportsInMonthInternal(
   return rule.sports.every((s) => sportsInMonth.has(s));
 }
 
-/** 월 목표 달성 실패 누적 N개월 이상인 경우 (예: 보증금증발, ATM) — 월초 배치 전용 */
+/** 월 목표 달성 실패 N개월 이상인 경우 (예: 보증금증발, ATM) — 월초 배치 전용 */
 export async function evalMileageGoalFailedMonthsInternal(
   rule: CondMileageGoalFailedMonths,
   teamMemId: string,
+  evtId: string,
+  baseMonth: string,
   db: DB,
 ): Promise<boolean> {
   const { data: memRow } = await db
@@ -670,22 +679,40 @@ export async function evalMileageGoalFailedMonthsInternal(
     .from("evt_team_prt_rel")
     .select("prt_id, evt_team_mst!inner(stt_dt, end_dt)")
     .eq("mem_id", memRow.mem_id)
+    .eq("evt_id", evtId)
     .eq("aprv_yn", true);
   if (!prtRows?.length) return false;
 
-  const today = dayjs().tz(KST).format("YYYY-MM-01");
   let failCount = 0;
   for (const prt of prtRows) {
     const evtMst = Array.isArray(prt.evt_team_mst) ? prt.evt_team_mst[0] : prt.evt_team_mst;
     const { stt_dt, end_dt } = evtMst as { stt_dt: string; end_dt: string };
-    const { data: snaps } = await db
-      .from("evt_mlg_mth_snap")
-      .select("achv_yn, base_dt")
-      .eq("prt_id", prt.prt_id)
-      .gte("base_dt", stt_dt.slice(0, 7) + "-01")
-      .lt("base_dt", today < end_dt.slice(0, 7) + "-01" ? today : end_dt.slice(0, 7) + "-01");
 
-    failCount += (snaps ?? []).filter((s) => !s.achv_yn).length;
+    if (rule.only_base_month) {
+      // 해당 달만 체크 (보증금증발)
+      const targetDt = baseMonth + "-01";
+      // 이벤트 기간 밖이면 스킵
+      if (targetDt < stt_dt.slice(0, 7) + "-01" || targetDt > end_dt.slice(0, 7) + "-01") continue;
+      const { data: snap } = await db
+        .from("evt_mlg_mth_snap")
+        .select("achv_yn")
+        .eq("prt_id", prt.prt_id)
+        .eq("base_dt", targetDt)
+        .maybeSingle();
+      if (snap && !snap.achv_yn) failCount++;
+    } else {
+      // 이벤트 기간 내 누적 (ATM) — baseMonth까지만, 미래 달 제외
+      const evtSttDt = stt_dt.slice(0, 7) + "-01";
+      const evtEndDt = end_dt.slice(0, 7) + "-01";
+      const limitDt = baseMonth + "-01" < evtEndDt ? baseMonth + "-01" : evtEndDt;
+      const { data: snaps } = await db
+        .from("evt_mlg_mth_snap")
+        .select("achv_yn")
+        .eq("prt_id", prt.prt_id)
+        .gte("base_dt", evtSttDt)
+        .lte("base_dt", limitDt);
+      failCount += (snaps ?? []).filter((s) => !s.achv_yn).length;
+    }
   }
 
   return failCount >= rule.count;
@@ -696,6 +723,7 @@ export async function evalMileageRocketInMonthsInternal(
   rule: CondMileageRocketInMonths,
   teamMemId: string,
   actDt: string,
+  evtId: string,
   db: DB,
 ): Promise<boolean> {
   const { data: memRow } = await db
@@ -711,6 +739,7 @@ export async function evalMileageRocketInMonthsInternal(
     .from("evt_team_prt_rel")
     .select("prt_id, evt_team_mst!inner(end_dt)")
     .eq("mem_id", memRow.mem_id)
+    .eq("evt_id", evtId)
     .eq("aprv_yn", true);
   if (!prtRows?.length) return false;
 
@@ -748,6 +777,7 @@ export async function evalMileageGoalAchievedBySingleSportInternal(
   rule: CondMileageGoalAchievedBySingleSport,
   teamMemId: string,
   actDt: string,
+  evtId: string,
   db: DB,
 ): Promise<boolean> {
   const { data: memRow } = await db
@@ -763,6 +793,7 @@ export async function evalMileageGoalAchievedBySingleSportInternal(
     .from("evt_team_prt_rel")
     .select("prt_id")
     .eq("mem_id", memRow.mem_id)
+    .eq("evt_id", evtId)
     .eq("aprv_yn", true);
   if (!prtRows?.length) return false;
 
@@ -798,6 +829,7 @@ export async function evalMileageSportRatioInternal(
   rule: CondMileageSportRatio,
   teamMemId: string,
   actDt: string,
+  evtId: string,
   db: DB,
 ): Promise<boolean> {
   const { data: memRow } = await db
@@ -813,6 +845,7 @@ export async function evalMileageSportRatioInternal(
     .from("evt_team_prt_rel")
     .select("prt_id")
     .eq("mem_id", memRow.mem_id)
+    .eq("evt_id", evtId)
     .eq("aprv_yn", true);
   if (!prtRows?.length) return false;
 
@@ -903,32 +936,50 @@ export async function evaluateCondition(
       return evalMileageJoinedInternal(rule, memId, db);
 
     case "mileage_goal_achieved_months":
-      return evalMileageGoalAchievedMonthsInternal(rule, ctx.teamMemId, db);
+      return ctx.trigger === "mileage_run"
+        ? evalMileageGoalAchievedMonthsInternal(rule, ctx.teamMemId, ctx.projectId, db)
+        : false;
 
     case "mileage_goal_achieved_on_last_day":
-      return evalMileageGoalAchievedOnLastDayInternal(rule, ctx, ctx.teamMemId, db);
+      return evalMileageGoalAchievedOnLastDayInternal(
+        rule, ctx, ctx.teamMemId,
+        ctx.trigger === "mileage_run" ? ctx.projectId : "",
+        db,
+      );
 
     case "mileage_all_sports_in_month":
       return ctx.trigger === "mileage_run"
-        ? evalMileageAllSportsInMonthInternal(rule, ctx.teamMemId, ctx.actDt, db)
+        ? evalMileageAllSportsInMonthInternal(rule, ctx.teamMemId, ctx.actDt, ctx.projectId, db)
         : false;
 
     case "mileage_goal_failed_months":
-      return evalMileageGoalFailedMonthsInternal(rule, ctx.teamMemId, db);
+      if (ctx.trigger === "mileage_batch") {
+        // actDt = 기준 월 마지막 날 (YYYY-MM-DD), slice(0,7)로 YYYY-MM 추출
+        return evalMileageGoalFailedMonthsInternal(rule, ctx.teamMemId, ctx.projectId, ctx.actDt.slice(0, 7), db);
+      }
+      return false;
 
     case "mileage_rocket_in_months":
       return ctx.trigger === "mileage_run"
-        ? evalMileageRocketInMonthsInternal(rule, ctx.teamMemId, ctx.actDt, db)
+        ? evalMileageRocketInMonthsInternal(rule, ctx.teamMemId, ctx.actDt, ctx.projectId, db)
         : false;
 
     case "mileage_goal_achieved_by_single_sport":
       return (ctx.trigger === "mileage_run" || ctx.trigger === "mileage_batch")
-        ? evalMileageGoalAchievedBySingleSportInternal(rule, ctx.teamMemId, ctx.actDt, db)
+        ? evalMileageGoalAchievedBySingleSportInternal(
+            rule, ctx.teamMemId, ctx.actDt,
+            ctx.projectId,
+            db,
+          )
         : false;
 
     case "mileage_sport_ratio":
       return (ctx.trigger === "mileage_run" || ctx.trigger === "mileage_batch")
-        ? evalMileageSportRatioInternal(rule, ctx.teamMemId, ctx.actDt, db)
+        ? evalMileageSportRatioInternal(
+            rule, ctx.teamMemId, ctx.actDt,
+            ctx.projectId,
+            db,
+          )
         : false;
 
     default:

--- a/lib/titles/evaluators.ts
+++ b/lib/titles/evaluators.ts
@@ -579,16 +579,17 @@ export async function evalMileageGoalAchievedOnLastDayInternal(
   evtId: string,
   db: DB,
 ): Promise<boolean> {
-  if (ctx.trigger !== "mileage_run") return false;
-  if (ctx.prevAchvYn) return false; // 이미 달성 상태였으면 해당 없음
+  const LOG = (...args: unknown[]) => console.info("[막판스퍼트]", ...args);
 
-  // 기준은 운동기록일자(act_dt), 등록일자 아님
-  const actDt = ctx.actDt; // YYYY-MM-DD
+  if (ctx.trigger !== "mileage_run") { LOG("trigger 불일치:", ctx.trigger); return false; }
+  if (ctx.prevAchvYn) { LOG("이미 달성 상태 — skip"); return false; }
+
+  const actDt = ctx.actDt;
   const actDay = dayjs(actDt).tz(KST);
   const lastDayOfMonth = actDay.endOf("month").date();
-  if (actDay.date() !== lastDayOfMonth) return false;
+  LOG(`actDt=${actDt}, actDay.date()=${actDay.date()}, lastDayOfMonth=${lastDayOfMonth}`);
+  if (actDay.date() !== lastDayOfMonth) { LOG("마지막 날 아님 — skip"); return false; }
 
-  // 기록 입력 후 당월 achv_yn 확인
   const actMonth = actDt.slice(0, 7) + "-01";
   const { data: memRow } = await db
     .from("team_mem_rel")
@@ -597,6 +598,7 @@ export async function evalMileageGoalAchievedOnLastDayInternal(
     .eq("vers", 0)
     .eq("del_yn", false)
     .maybeSingle();
+  LOG("memRow:", memRow?.mem_id ?? "없음");
   if (!memRow?.mem_id) return false;
 
   const { data: prtRows } = await db
@@ -605,7 +607,8 @@ export async function evalMileageGoalAchievedOnLastDayInternal(
     .eq("mem_id", memRow.mem_id)
     .eq("evt_id", evtId)
     .eq("aprv_yn", true);
-  if (!prtRows?.length) return false;
+  LOG(`evtId=${evtId}, prtRows:`, prtRows?.map(r => r.prt_id));
+  if (!prtRows?.length) { LOG("prtRows 없음 — skip"); return false; }
 
   const prtIds = prtRows.map((r) => r.prt_id);
   const { data: snap } = await db
@@ -614,8 +617,11 @@ export async function evalMileageGoalAchievedOnLastDayInternal(
     .in("prt_id", prtIds)
     .eq("base_dt", actMonth)
     .maybeSingle();
+  LOG(`snap(base_dt=${actMonth}):`, snap);
 
-  return snap?.achv_yn === true;
+  const result = snap?.achv_yn === true;
+  LOG("최종 결과:", result);
+  return result;
 }
 
 /** 한 달 안에 지정 종목을 모두 1회 이상 기록한 경우 (예: 올라운더) */

--- a/lib/titles/evaluators.ts
+++ b/lib/titles/evaluators.ts
@@ -1136,10 +1136,11 @@ export function evaluateConditionFromSnapshot(
     }
 
     case "mileage_goal_failed_months": {
-      // baseMonth 지정 시 해당 월까지만 집계 (미래 달 제외)
-      const snaps = baseMonth
-        ? snapshot.mileageMthSnaps.filter((s) => s.base_dt.slice(0, 7) <= baseMonth)
-        : snapshot.mileageMthSnaps;
+      const snaps = rule.only_base_month
+        ? snapshot.mileageMthSnaps.filter((s) => s.base_dt.slice(0, 7) === baseMonth)
+        : baseMonth
+          ? snapshot.mileageMthSnaps.filter((s) => s.base_dt.slice(0, 7) <= baseMonth)
+          : snapshot.mileageMthSnaps;
       const failed = snaps.filter((s) => !s.achv_yn).length;
       return failed >= rule.count;
     }

--- a/lib/titles/evaluators.ts
+++ b/lib/titles/evaluators.ts
@@ -1112,10 +1112,13 @@ export function evaluateConditionFromSnapshot(
       return snapshot.mileageParticipant;
 
     case "mileage_goal_achieved_months": {
-      // baseMonth 지정 시 해당 월까지만 집계 (미래 달 제외)
-      const snaps = baseMonth
-        ? snapshot.mileageMthSnaps.filter((s) => s.base_dt.slice(0, 7) <= baseMonth)
-        : snapshot.mileageMthSnaps;
+      const evtStt = snapshot.mileageEvtSttDt?.slice(0, 7);
+      const snaps = snapshot.mileageMthSnaps.filter((s) => {
+        const m = s.base_dt.slice(0, 7);
+        if (evtStt && m < evtStt) return false; // 이벤트 시작 전 연습달 제외
+        if (baseMonth && m > baseMonth) return false; // 미래 달 제외
+        return true;
+      });
       const achieved = snaps.filter((s) => s.achv_yn).length;
       return achieved >= rule.count;
     }
@@ -1136,11 +1139,15 @@ export function evaluateConditionFromSnapshot(
     }
 
     case "mileage_goal_failed_months": {
+      const evtStt = snapshot.mileageEvtSttDt?.slice(0, 7);
       const snaps = rule.only_base_month
         ? snapshot.mileageMthSnaps.filter((s) => s.base_dt.slice(0, 7) === baseMonth)
-        : baseMonth
-          ? snapshot.mileageMthSnaps.filter((s) => s.base_dt.slice(0, 7) <= baseMonth)
-          : snapshot.mileageMthSnaps;
+        : snapshot.mileageMthSnaps.filter((s) => {
+            const m = s.base_dt.slice(0, 7);
+            if (evtStt && m < evtStt) return false; // 이벤트 시작 전 연습달 제외
+            if (baseMonth && m > baseMonth) return false; // 미래 달 제외
+            return true;
+          });
       const failed = snaps.filter((s) => !s.achv_yn).length;
       return failed >= rule.count;
     }

--- a/lib/titles/snapshot.ts
+++ b/lib/titles/snapshot.ts
@@ -56,6 +56,8 @@ export type MemberSnapshot = {
   mileageMthSnaps: MileageMthSnapRow[];
   /** 마일리지런 활동 기록 (mileage_all_sports_in_month, mileage_sport_ratio 조건용) */
   mileageActHist: MileageActRow[];
+  /** 이벤트 stt_dt (이벤트 기간 내 스냅 필터링용) */
+  mileageEvtSttDt: string | null;
   /** 이벤트 end_dt (mileage_rocket_in_months 조건용) */
   mileageEvtEndDt: string | null;
 };
@@ -193,18 +195,18 @@ export async function loadMemberSnapshots(
   // 7-1. 참여자 조회 (mem_id → prt_id, evt_id)
   let prtQuery = db
     .from("evt_team_prt_rel")
-    .select("prt_id, mem_id, evt_id, evt_team_mst!inner(end_dt)")
+    .select("prt_id, mem_id, evt_id, evt_team_mst!inner(stt_dt, end_dt)")
     .in("mem_id", memIds)
     .eq("aprv_yn", true);
   if (evtId) prtQuery = prtQuery.eq("evt_id", evtId);
   const { data: prtRows } = await prtQuery;
 
-  const prtByMemId = new Map<string, { prtId: string; evtEndDt: string }>();
+  const prtByMemId = new Map<string, { prtId: string; evtSttDt: string; evtEndDt: string }>();
   const allPrtIds: string[] = [];
   for (const r of prtRows ?? []) {
     const evtMst = Array.isArray(r.evt_team_mst) ? r.evt_team_mst[0] : r.evt_team_mst;
-    const endDt = (evtMst as { end_dt: string }).end_dt;
-    prtByMemId.set(r.mem_id, { prtId: r.prt_id, evtEndDt: endDt });
+    const { stt_dt, end_dt } = evtMst as { stt_dt: string; end_dt: string };
+    prtByMemId.set(r.mem_id, { prtId: r.prt_id, evtSttDt: stt_dt, evtEndDt: end_dt });
     allPrtIds.push(r.prt_id);
   }
 
@@ -276,6 +278,7 @@ export async function loadMemberSnapshots(
       mileageParticipant: prtInfo !== undefined,
       mileageMthSnaps: mthSnaps,
       mileageActHist: actHist,
+      mileageEvtSttDt: prtInfo?.evtSttDt ?? null,
       mileageEvtEndDt: prtInfo?.evtEndDt ?? null,
     });
   }

--- a/lib/titles/snapshot.ts
+++ b/lib/titles/snapshot.ts
@@ -83,6 +83,7 @@ export async function loadMemberSnapshots(
   db: DB,
   teamId: string,
   teamMemIds: string[],
+  evtId?: string,
 ): Promise<Map<string, MemberSnapshotWithHeld>> {
   if (teamMemIds.length === 0) return new Map();
 
@@ -190,11 +191,13 @@ export async function loadMemberSnapshots(
 
   // 7. 마일리지런 데이터 로드 (mileage_* 조건용)
   // 7-1. 참여자 조회 (mem_id → prt_id, evt_id)
-  const { data: prtRows } = await db
+  let prtQuery = db
     .from("evt_team_prt_rel")
     .select("prt_id, mem_id, evt_id, evt_team_mst!inner(end_dt)")
     .in("mem_id", memIds)
     .eq("aprv_yn", true);
+  if (evtId) prtQuery = prtQuery.eq("evt_id", evtId);
+  const { data: prtRows } = await prtQuery;
 
   const prtByMemId = new Map<string, { prtId: string; evtEndDt: string }>();
   const allPrtIds: string[] = [];

--- a/lib/titles/types.ts
+++ b/lib/titles/types.ts
@@ -187,6 +187,8 @@ export type CondMileageAllSportsInMonth = {
 export type CondMileageGoalFailedMonths = {
   type: "mileage_goal_failed_months";
   count: number;
+  /** true: baseMonth 해당 달만 체크 (보증금증발). false/없음: 이벤트 기간 내 누적 (ATM) */
+  only_base_month?: boolean;
 };
 
 /**

--- a/supabase/migrations/20260601120000_ttl_ctgr_cd_mileage.sql
+++ b/supabase/migrations/20260601120000_ttl_ctgr_cd_mileage.sql
@@ -1,0 +1,15 @@
+-- TTL_CTGR_CD에 mileage 카테고리 추가
+INSERT INTO public.cmm_cd_mst (cd_grp_id, cd, cd_nm, cd_desc, sort_ord, is_default_yn, vers, del_yn)
+SELECT g.cd_grp_id, v.cd, v.cd_nm, v.cd_desc, v.sort_ord, false, 0, false
+FROM public.cmm_cd_grp_mst g
+JOIN (
+  VALUES
+    ('mileage', '마일리지런', '마일리지런 이벤트 관련 칭호', 8)
+) AS v(cd, cd_nm, cd_desc, sort_ord) ON true
+WHERE g.cd_grp_cd = 'TTL_CTGR_CD'
+  AND g.vers = 0
+  AND g.del_yn = false
+  AND NOT EXISTS (
+    SELECT 1 FROM public.cmm_cd_mst c
+    WHERE c.cd_grp_id = g.cd_grp_id AND c.cd = v.cd AND c.vers = 0 AND c.del_yn = false
+  );


### PR DESCRIPTION
개요
마일리지런 칭호 시스템의 전반적인 버그를 수정하고, 관리 UI를 개선했습니다.

버그 수정
칭호 엔진
보증금증발 과다지급: 배치 시 미래 달 스냅(achv_yn=false)까지 집계되던 문제 수정 → only_base_month 플래그 추가, 해당 달만 체크
막판스퍼트 미지급: logActivitiesBatch에 칭호 평가 로직 누락 → 추가. prevAchvYn을 INSERT 후가 아닌 전에 읽도록 수정
다중 시즌 혼재: 즉시평가 evaluator 7종에 evt_id 필터 누락 → 추가. 여러 시즌 참여 시 다른 시즌 스냅/기록 섞이던 문제 해결
칭호 재지급 불가: upsert(ignoreDuplicates:true) → insert로 변경. 회수 시 vers=N+1로 변경해 vers=0 슬롯 확보
배치 카운트 부정확: 평가 통과 건수가 아닌 실제 INSERT 건수 기준으로 수정
연습달 포함 문제: mileage_goal_achieved_months, mileage_goal_failed_months 에서 이벤트 stt_dt 이전 스냅 제외
마일리지 달성 판정
recalcGoalsFromMonth의 achv_yn 판정을 소수점 1자리 반올림 기준으로 통일 (화면/DB 불일치 해소)
MyStatus 달성 완료 표시를 실시간 합산이 아닌 DB achv_yn 기준으로 변경
관리자 UI 개선
칭호 관리
칭호 클릭 시 수정/획득내역을 바텀시트 방식으로 변경 (모바일 UX 개선)
칭호 관리 그리드에 획득 인원 컬럼 추가 (대표 컬럼과 별도)
그리드 높이 제한(max-h-60) 제거 → 전체 목록 표시
바텀시트 내 Select 컴포넌트 z-[200] 적용 (드롭다운 가림 현상 수정)
자동 칭호도 관리자가 회수 가능하도록 isAwarded 조건 제거
회수 시 vers=N+1로 변경해 이력 보존 및 재지급 가능
칭호 이력 탭
관리자 칭호 페이지에 3번째 탭 "이력" 추가
전체 칭호 획득 이력 최신순 표시 (멤버명, 칭호명, 방식, 획득일시, 사유)
자동/수동 구분 없이 모두 즉시 회수 가능
내 컬렉션
always 미보유 칭호(도감 공개) vs 그룹막힘 칭호 시각 구분
always 미보유: opacity-60 + border-dashed
그룹막힘: opacity-40
마일리지런 칭호 알림
기록 저장 성공 후 동기부여 창(3.5초) 종료 뒤 칭호 획득 알림 표시
새로 획득한 칭호가 있을 때만 노출
배치 관리
MILEAGE_TITLE_BATCH에 이벤트 ID 필수 파라미터 추가 (다중 이벤트 혼재 방지)
배치 실행 UI에서 이벤트를 드롭다운으로 선택 (ID 직접 입력 → 이벤트명 선택)
DB 변경 (dev + prd 적용 완료)
TTL_CTGR_CD에 mileage(마일리지런) 카테고리 추가
보증금증발 칭호 cond_rule_json에 only_base_month: true 추가
del_yn=true, vers=0 비정상 데이터 3건 수정 (dev)
batch_job_mst param_schema_json evt_select 타입으로 업데이트