### PR TITLE
fix(projects): 월 이동 시 선택한 상단 탭 유지

### DIFF
--- a/.claude/docs/component-conventions.md
+++ b/.claude/docs/component-conventions.md
@@ -76,6 +76,8 @@ badge, button, card, dialog, form, input, label, loading-spinner, select, separa
   월 이동 시 리마운트되므로 차트 상단 탭(`mode`)을 `?tab=`에 동기화 (`crew-progress-chart.tsx`).
 - **탭 클릭처럼 서버 데이터에 영향 없는 갱신은 `window.history.replaceState`** 로
   URL만 조용히 바꾼다 (`router.push`/`replace`는 서버 컴포넌트를 재실행시켜 불필요한 재쿼리 유발).
+  - 단, 1번째 인자에 `null` 대신 **`window.history.state`를 넘겨야** Next.js 라우터가 관리하는
+    스크롤 복원·뒤로가기 상태가 깨지지 않는다.
 - 리마운트 시 복원은 `useState(() => parseFromSearchParams(...))` 초기화 함수로.
 - 다른 client 컴포넌트(예: `month-navigator.tsx`)가 같은 URL을 이어받을 때는
   `useSearchParams()` 스냅샷 대신 **`window.location.search`** 를 읽어야

--- a/.claude/docs/component-conventions.md
+++ b/.claude/docs/component-conventions.md
@@ -66,6 +66,21 @@ badge, button, card, dialog, form, input, label, loading-spinner, select, separa
 - **서버 컴포넌트** (기본): 데이터 패칭, 정적 렌더링
 - **클라이언트 컴포넌트** (`"use client"`): 이벤트 핸들러, 상태, 브라우저 API 필요시
 
+### 리마운트로 초기화되는 클라이언트 상태는 URL에 보존
+
+부모 서버 컴포넌트가 `key={searchParam}`으로 자식을 리마운트하는 패턴에서는
+자식의 `useState`가 매번 초기값으로 리셋된다. 사용자가 유지하길 기대하는
+선택 상태(탭, 정렬 등)는 URL 쿼리에 동기화해 보존한다.
+
+- 예: `app/(main)/projects/page.tsx`의 `<CrewProgressChartServer key={selectedMonth}>` —
+  월 이동 시 리마운트되므로 차트 상단 탭(`mode`)을 `?tab=`에 동기화 (`crew-progress-chart.tsx`).
+- **탭 클릭처럼 서버 데이터에 영향 없는 갱신은 `window.history.replaceState`** 로
+  URL만 조용히 바꾼다 (`router.push`/`replace`는 서버 컴포넌트를 재실행시켜 불필요한 재쿼리 유발).
+- 리마운트 시 복원은 `useState(() => parseFromSearchParams(...))` 초기화 함수로.
+- 다른 client 컴포넌트(예: `month-navigator.tsx`)가 같은 URL을 이어받을 때는
+  `useSearchParams()` 스냅샷 대신 **`window.location.search`** 를 읽어야
+  `replaceState`로 갱신된 최신 값을 놓치지 않는다.
+
 ### 네이밍
 - 파일: kebab-case (`race-list-view.tsx`)
 - 컴포넌트: PascalCase (`RaceListView`)

--- a/components/projects/crew-progress-chart.tsx
+++ b/components/projects/crew-progress-chart.tsx
@@ -8,6 +8,7 @@ import {
   useRef,
   useTransition,
 } from "react";
+import { useSearchParams } from "next/navigation";
 import { Medal } from "lucide-react";
 import {
   LineChart,
@@ -56,7 +57,7 @@ export type ChartInitialData = {
 
 type ChartTooltipProps = TooltipContentProps<TooltipValueType, string | number> & {
   myName: string | null;
-  mode: "mileage" | "percent" | "stats";
+  mode: ChartMode;
 };
 
 /** recharts NameType = string | number — Tooltip 인라인 컴포넌트 방지 */
@@ -116,6 +117,14 @@ type StatsSortKey = "rank" | "goalKm" | "currentKm" | "percent";
 type StatsSortDir = "asc" | "desc";
 type AriaSortValue = "none" | "ascending" | "descending";
 
+/** 상단 탭 모드 — URL `?tab=` 파라미터로 동기화해 월 이동 시에도 유지된다. */
+type ChartMode = "mileage" | "percent" | "stats";
+
+/** URL 쿼리의 tab 값을 안전하게 ChartMode로 파싱 (기본값: mileage) */
+function parseChartTab(value: string | null): ChartMode {
+  return value === "percent" || value === "stats" ? value : "mileage";
+}
+
 type PercentBarTooltipProps = {
   active?: boolean;
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -166,7 +175,11 @@ export function CrewProgressChart({
   month,
   initialData,
 }: CrewProgressChartProps) {
-  const [mode, setMode] = useState<"mileage" | "percent" | "stats">("mileage");
+  const searchParams = useSearchParams();
+  // 탭 상태를 URL에서 초기화 — 월 이동으로 리마운트돼도 선택 탭이 복원된다.
+  const [mode, setMode] = useState<ChartMode>(() =>
+    parseChartTab(searchParams.get("tab")),
+  );
   const [statsSortKey, setStatsSortKey] = useState<StatsSortKey>("currentKm");
   const [statsSortDir, setStatsSortDir] = useState<StatsSortDir>("desc");
   const [mileageData, setMileageData] = useState<DailyPoint[]>(
@@ -336,6 +349,19 @@ export function CrewProgressChart({
     setLoading(false);
     setRefreshing(false);
   }, [evtId, memId, month]);
+
+  // 탭 변경을 URL `?tab=`에 동기화 — 서버 재요청 없이 replaceState로 조용히 갱신.
+  // 월 네비게이터가 이 값을 보존하므로 월 이동 후에도 선택 탭이 유지된다.
+  useEffect(() => {
+    const params = new URLSearchParams(window.location.search);
+    if (mode === "mileage") {
+      params.delete("tab");
+    } else {
+      params.set("tab", mode);
+    }
+    const qs = params.toString();
+    window.history.replaceState(null, "", qs ? `?${qs}` : window.location.pathname);
+  }, [mode]);
 
   // initialData 없을 때만 초기 fetch
   useEffect(() => {
@@ -511,7 +537,7 @@ export function CrewProgressChart({
             { value: "stats", label: "전체 통계" },
           ]}
           value={mode}
-          onValueChange={(v) => setMode(v as "mileage" | "percent" | "stats")}
+          onValueChange={(v) => setMode(v as ChartMode)}
         />
         <Skeleton className="h-56 w-full rounded-2xl" />
       </div>

--- a/components/projects/crew-progress-chart.tsx
+++ b/components/projects/crew-progress-chart.tsx
@@ -354,13 +354,21 @@ export function CrewProgressChart({
   // 월 네비게이터가 이 값을 보존하므로 월 이동 후에도 선택 탭이 유지된다.
   useEffect(() => {
     const params = new URLSearchParams(window.location.search);
-    if (mode === "mileage") {
+    const targetTab = mode === "mileage" ? null : mode;
+    // 이미 URL이 일치하면(예: 리마운트 복원 직후) 불필요한 history 조작을 건너뛴다.
+    if (params.get("tab") === targetTab) return;
+    if (targetTab === null) {
       params.delete("tab");
     } else {
-      params.set("tab", mode);
+      params.set("tab", targetTab);
     }
     const qs = params.toString();
-    window.history.replaceState(null, "", qs ? `?${qs}` : window.location.pathname);
+    // history.state를 보존해야 Next.js 라우터의 스크롤 복원·뒤로가기 상태가 깨지지 않는다.
+    window.history.replaceState(
+      window.history.state,
+      "",
+      qs ? `?${qs}` : window.location.pathname,
+    );
   }, [mode]);
 
   // initialData 없을 때만 초기 fetch
@@ -561,7 +569,7 @@ export function CrewProgressChart({
           { value: "stats", label: "전체 통계" },
         ]}
         value={mode}
-        onValueChange={(v) => setMode(v as "mileage" | "percent" | "stats")}
+        onValueChange={(v) => setMode(v as ChartMode)}
       />
       {(refreshing || isPending) && (
         <Body className="text-xs text-muted-foreground" aria-live="polite">

--- a/components/projects/month-navigator.tsx
+++ b/components/projects/month-navigator.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useRouter, useSearchParams } from "next/navigation";
+import { useRouter } from "next/navigation";
 import { ChevronLeft, ChevronRight, Loader2 } from "lucide-react";
 import { prevMonthStr, nextMonthStr } from "@/lib/dayjs";
 import { Button } from "@/components/ui/button";
@@ -16,7 +16,6 @@ export function MonthNavigator({
   endMonth: string;
 }) {
   const router = useRouter();
-  const searchParams = useSearchParams();
   const { isPending, startTransition } = useMonthTransition();
 
   const displayMonth = Number(currentMonth.split("-")[1]);
@@ -30,7 +29,9 @@ export function MonthNavigator({
   const hasNext = nextMonth <= endMonth;
 
   function navigate(month: string) {
-    const params = new URLSearchParams(searchParams.toString());
+    // window.location.search로 최신 URL을 읽어 차트 탭(?tab=)이 보존되도록 한다.
+    // (탭은 replaceState로 갱신되므로 useSearchParams 스냅샷에는 반영되지 않을 수 있음)
+    const params = new URLSearchParams(window.location.search);
     params.set("month", month);
     startTransition(() => {
       router.push(`?${params.toString()}`, { scroll: false });


### PR DESCRIPTION
## 관련 이슈

관련 이슈 없음

## 요약

프로젝트 탭(`/projects`)의 크루 진행 차트에서 상단 탭(마일리지 / 달성률 / 전체 통계)을 선택한 뒤 월을 이동하면 탭이 항상 **마일리지**로 초기화되던 문제를 수정합니다. 탭 상태를 URL `?tab=` 파라미터에 동기화하여 월 이동 후에도 선택한 탭이 유지됩니다.

> 예: **전체 통계** 선택 → **5월**로 이동 → 전체 통계 탭 그대로 유지

## AS-IS (변경 전)

- 상단 탭은 `crew-progress-chart.tsx`의 로컬 state `mode = useState("mileage")`로만 관리됨
- 월 이동은 `app/(main)/projects/page.tsx`에서 `<CrewProgressChartServer key={selectedMonth}>`로 처리 → 월이 바뀌면 **차트가 통째로 리마운트**됨
- 리마운트되면 `mode`가 초기값 `"mileage"`로 리셋 → **선택했던 탭이 사라짐**

## TO-BE (변경 후)

- 탭 상태(`mode`)를 URL `?tab=` 쿼리에 동기화
  - 탭 클릭 시 `window.history.replaceState`로 **서버 재요청 없이** URL만 조용히 갱신 (탭 전환 즉각적, 불필요한 차트 재쿼리 방지)
  - `history.state`를 보존해 Next.js 라우터의 스크롤 복원·뒤로가기 상태가 깨지지 않도록 처리
- 리마운트 시 `useState` 초기값을 URL `tab`에서 복원 → **선택 탭 유지**
- `month-navigator.tsx`는 `window.location.search`로 최신 URL을 읽어 월 이동 시 `?tab=` 파라미터를 보존
- 부가 효과: `?tab=stats` 상태로 새로고침/직접 진입해도 탭이 복원됨

## 변경 흐름

\`\`\`mermaid
flowchart TD
    A[전체 통계 탭 클릭] --> B["setMode('stats')"]
    B --> C["replaceState로 URL ?tab=stats 갱신<br/>(서버 재요청 없음)"]
    C --> D[월 이동 클릭]
    D --> E["MonthNavigator: window.location.search 읽기<br/>(?tab=stats 포함)"]
    E --> F["router.push: ?month=...&tab=stats"]
    F --> G["page.tsx 재렌더 → key 변경으로<br/>CrewProgressChart 리마운트"]
    G --> H["useState 초기값 = parseChartTab(tab)<br/>= 'stats'"]
    H --> I[전체 통계 탭 유지 ✅]
\`\`\`

## 주요 변경 파일

- \`components/projects/crew-progress-chart.tsx\` — 탭 상태 URL 동기화 (초기값 복원 + replaceState 갱신)
- \`components/projects/month-navigator.tsx\` — 월 이동 시 `window.location.search`로 탭 보존
- \`.claude/docs/component-conventions.md\` — 리마운트 클라이언트 상태의 URL 보존 패턴 문서화

## 검증

- `pnpm run lint`: 신규 에러 0
- `pnpm exec tsc --noEmit`: 변경 파일 에러 0
- `pnpm run build`: 클린 빌드 성공 (`/projects` PPR 정상)
- 프론트엔드 관점 자체 코드 리뷰 1회 → P1 2건 / P2 1건 발견 후 전부 반영

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Documentation**
  * URL 상태 보존에 관한 개발 규칙 추가

* **Improvements**
  * 차트 탭 상태가 URL에 자동 저장되어 페이지 새로고침 후에도 유지됨
  * 월 네비게이션의 URL 파라미터 처리 개선

<!-- end of auto-generated comment: release notes by coderabbit.ai -->