### PR TITLE
fix(dues): 회비 계산 기준일시 로직 수정 및 UI 개선

### DIFF
--- a/app/(info)/admin/dues/members/dues-members-client.tsx
+++ b/app/(info)/admin/dues/members/dues-members-client.tsx
@@ -325,7 +325,7 @@ export function DuesMembersClient({
                         </TableCell>
                         <TableCell className="text-center">
                           <Caption className="text-xs whitespace-nowrap">
-                            {m.snap?.last_calc_dt ? dayjs(m.snap.last_calc_dt).format("YYYY.MM.DD") : "-"}
+                            {m.snap?.last_calc_dt ? dayjs(m.snap.last_calc_dt).format("YYYY.MM.DD HH:mm") : "-"}
                           </Caption>
                         </TableCell>
                         <TableCell className="text-center" onClick={(e) => e.stopPropagation()}>

--- a/app/(info)/admin/dues/transactions/dues-transactions-client.tsx
+++ b/app/(info)/admin/dues/transactions/dues-transactions-client.tsx
@@ -883,7 +883,7 @@ function BalanceTab({
                     </TableCell>
                     <TableCell className="text-center">
                       <Caption className="text-xs whitespace-nowrap">
-                        {m.snap?.last_calc_dt ? dayjs(m.snap.last_calc_dt).format("YYYY.MM.DD") : "-"}
+                        {m.snap?.last_calc_dt ? dayjs(m.snap.last_calc_dt).format("YYYY.MM.DD HH:mm") : "-"}
                       </Caption>
                     </TableCell>
                     <TableCell className="text-center">

--- a/app/(info)/admin/dues/transactions/dues-transactions-client.tsx
+++ b/app/(info)/admin/dues/transactions/dues-transactions-client.tsx
@@ -1,10 +1,10 @@
 "use client";
 
-import { useState, useTransition } from "react";
+import { Dispatch, SetStateAction, useState, useTransition } from "react";
 
 import { useRouter } from "next/navigation";
 
-import { RotateCcw, UserMinus } from "lucide-react";
+import { Calculator, RotateCcw, UserMinus } from "lucide-react";
 
 import { dayjs } from "@/lib/dayjs";
 
@@ -42,6 +42,7 @@ import {
 type Txn = {
   txn_id: string;
   txn_dt: string;
+  txn_tm: string | null;
   txn_amt: number;
   txn_io_enm: string;
   raw_name: string;
@@ -258,7 +259,8 @@ function UploadTab({
 // ─── 거래내역 탭 ───────────────────────────────────────────────────────────────
 
 function TransactionsTab({
-  txns: initialTxns,
+  txns,
+  setTxns,
   members,
   feeItemCds,
   initialFilter,
@@ -266,13 +268,13 @@ function TransactionsTab({
   startTransition,
 }: {
   txns: Txn[];
+  setTxns: Dispatch<SetStateAction<Txn[]>>;
   members: Member[];
   feeItemCds: FeeItemCd[];
   initialFilter: "all" | "unconfirmed" | "confirmed";
   isPending: boolean;
   startTransition: ReturnType<typeof useTransition>[1];
 }) {
-  const [txns, setTxns] = useState(initialTxns);
   const [filter, setFilter] = useState<"all" | "unconfirmed" | "confirmed">(initialFilter);
   const [selected, setSelected] = useState<Set<string>>(new Set());
   const [matchDialog, setMatchDialog] = useState<string | null>(null);
@@ -397,7 +399,7 @@ function TransactionsTab({
       const res = await cancelTransaction(txnId);
       if (res.ok) {
         setTxns((prev) =>
-          prev.map((t) => (t.txn_id === txnId ? { ...t, is_cfm_yn: false, is_stale: true } : t))
+          prev.map((t) => (t.txn_id === txnId ? { ...t, is_cfm_yn: false, is_stale: false } : t))
         );
       } else if ("needsRollback" in res && res.needsRollback) {
         alert(`${res.message}\n\n회원별 잔액 탭 > 해당 회원 선택 > Snapshot Rollback 버튼을 먼저 실행하세요.`);
@@ -410,7 +412,7 @@ function TransactionsTab({
   return (
     <div className="flex flex-col gap-4">
       <div className="flex flex-wrap gap-2">
-        {(["unconfirmed", "confirmed", "all"] as const).map((f) => (
+        {(["all", "unconfirmed", "confirmed"] as const).map((f) => (
           <Button
             key={f}
             variant={filter === f ? "default" : "outline"}
@@ -618,11 +620,13 @@ function BalanceTab({
   initialFilter,
   isPending,
   startTransition,
+  unconfirmedCount,
 }: {
   members: MemberRow[];
   initialFilter: "all" | "unpaid";
   isPending: boolean;
   startTransition: ReturnType<typeof useTransition>[1];
+  unconfirmedCount: number;
 }) {
   const router = useRouter();
   const [filter, setFilter] = useState<"all" | "unpaid">(initialFilter);
@@ -772,6 +776,27 @@ function BalanceTab({
           </Button>
         )}
         <div className="flex-1" />
+        <Button
+          size="sm"
+          className="bg-warning text-white hover:bg-warning/90"
+          onClick={() => {
+            if (unconfirmedCount > 0) {
+              alert(`미확정 거래가 ${unconfirmedCount}건 있습니다.\n거래내역 탭에서 모두 확정 처리 후 재계산하세요.`);
+              return;
+            }
+            if (!confirm("⚠️ 거래내역 최신화 후 계산하시기 바랍니다.\n계속하시겠습니까?")) return;
+            startTransition(async () => {
+              const res = await recalculateBalance();
+              if (!res.ok) { alert(res.message); return; }
+              alert(`전체 계산 완료 (${res.updatedCount}명)`);
+              router.refresh();
+            });
+          }}
+          disabled={isPending}
+        >
+          <Calculator className="size-3.5 mr-1" />
+          전체 회비 계산
+        </Button>
         {rollbackTargetIds.length > 0 && (
           <Button
             size="sm"
@@ -805,6 +830,7 @@ function BalanceTab({
                 <TableHead className="text-center text-xs whitespace-nowrap">가입일</TableHead>
                 <TableHead className="text-center text-xs whitespace-nowrap">잔액</TableHead>
                 <TableHead className="text-center text-xs whitespace-nowrap">기준일</TableHead>
+                <TableHead className="text-center text-xs whitespace-nowrap">마지막 거래</TableHead>
                 <TableHead className="text-center text-xs whitespace-nowrap">면제</TableHead>
               </TableRow>
             </TableHeader>
@@ -858,6 +884,11 @@ function BalanceTab({
                     <TableCell className="text-center">
                       <Caption className="text-xs whitespace-nowrap">
                         {m.snap?.last_calc_dt ? dayjs(m.snap.last_calc_dt).format("YYYY.MM.DD") : "-"}
+                      </Caption>
+                    </TableCell>
+                    <TableCell className="text-center">
+                      <Caption className="text-xs whitespace-nowrap">
+                        {m.snap?.last_calc_at ? dayjs(m.snap.last_calc_at).tz("Asia/Seoul").format("YYYY.MM.DD HH:mm") : "-"}
                       </Caption>
                     </TableCell>
                     <TableCell className="text-center" onClick={(e) => e.stopPropagation()}>
@@ -1024,13 +1055,13 @@ function PayHistTab({ payHists }: { payHists: PayHistRow[] }) {
 // ─── 메인 클라이언트 컴포넌트 ──────────────────────────────────────────────────
 
 export function DuesTransactionsClient({
-  txns,
+  txns: initialTxns,
   uploads,
   members,
   memberRows,
   payHists,
   feeItemCds,
-  initialTxnFilter = "unconfirmed",
+  initialTxnFilter = "all",
   initialBalFilter = "all",
   initialTab = "upload",
 }: {
@@ -1046,6 +1077,9 @@ export function DuesTransactionsClient({
 }) {
   const [tab, setTab] = useState<"upload" | "txn" | "balance" | "pays">(initialTab);
   const [isPending, startTransition] = useTransition();
+  const [txns, setTxns] = useState(initialTxns);
+
+  const unconfirmedCount = txns.filter((t) => !t.is_cfm_yn).length;
 
   return (
     <div className="flex flex-col gap-4 px-6 pb-6 pt-2">
@@ -1066,6 +1100,7 @@ export function DuesTransactionsClient({
       {tab === "txn" && (
         <TransactionsTab
           txns={txns}
+          setTxns={setTxns}
           members={members}
           feeItemCds={feeItemCds}
           initialFilter={initialTxnFilter}
@@ -1079,6 +1114,7 @@ export function DuesTransactionsClient({
           initialFilter={initialBalFilter}
           isPending={isPending}
           startTransition={startTransition}
+          unconfirmedCount={unconfirmedCount}
         />
       )}
       {tab === "pays" && <PayHistTab payHists={payHists} />}

--- a/app/(info)/admin/dues/transactions/page.tsx
+++ b/app/(info)/admin/dues/transactions/page.tsx
@@ -1,3 +1,5 @@
+import { dayjs } from "@/lib/dayjs";
+
 import { getRequestTeamContext } from "@/lib/queries/request-team";
 import { createClient } from "@/lib/supabase/server";
 
@@ -23,7 +25,7 @@ export default async function DuesTransactionsPage({
   ] = await Promise.all([
     supabase
       .from("fee_txn_hist")
-      .select("txn_id, txn_dt, txn_amt, txn_io_enm, raw_name, raw_memo, adm_memo_txt, txn_tp_txt, match_st_cd, mem_id, fee_item_cd, is_cfm_yn, cfm_at, mem_mst!fk_fee_txn_hist__mem_mst(mem_nm)")
+      .select("txn_id, txn_dt, txn_tm, txn_amt, txn_io_enm, raw_name, raw_memo, adm_memo_txt, txn_tp_txt, match_st_cd, mem_id, fee_item_cd, is_cfm_yn, cfm_at, mem_mst!fk_fee_txn_hist__mem_mst(mem_nm)")
       .eq("team_id", teamId)
       .eq("del_yn", false)
       .order("txn_dt", { ascending: false })
@@ -61,11 +63,12 @@ export default async function DuesTransactionsPage({
       .order("bal_amt", { ascending: true }),
     supabase
       .from("fee_txn_hist")
-      .select("mem_id, cfm_at")
+      .select("mem_id, txn_dt, txn_tm")
       .eq("team_id", teamId)
       .eq("is_cfm_yn", true)
       .eq("del_yn", false)
-      .order("cfm_at", { ascending: false }),
+      .order("txn_dt", { ascending: false })
+      .order("txn_tm", { ascending: false }),
     supabase
       .from("fee_due_pay_hist")
       .select("pay_id, mem_id, pay_amt, pay_dt, pay_st_cd, fee_txn_hist!inner(fee_item_cd, raw_name), mem_mst!inner(mem_nm)")
@@ -75,22 +78,25 @@ export default async function DuesTransactionsPage({
       .order("pay_dt", { ascending: false }),
   ]);
 
-  // 거래 미반영 판단: snap last_calc_at 기준
+  // 거래 미반영 판단: snap last_calc_at vs 은행 거래일시 기준
   const snapCalcAtMap = new Map((snaps ?? []).map((s) => [s.mem_id, s.last_calc_at]));
 
   // 회원별 잔액 데이터
   const snapMap = new Map((snaps ?? []).map((s) => [s.mem_id, s]));
-  const latestCfmMap = new Map<string, string>();
+  const latestTxnAtMap = new Map<string, string>();
   for (const t of latestCfmTxns ?? []) {
-    if (t.mem_id && t.cfm_at && !latestCfmMap.has(t.mem_id)) {
-      latestCfmMap.set(t.mem_id, t.cfm_at);
+    if (t.mem_id && t.txn_dt && !latestTxnAtMap.has(t.mem_id)) {
+      latestTxnAtMap.set(
+        t.mem_id,
+        dayjs.tz(`${t.txn_dt}T${t.txn_tm ?? "00:00:00"}`, "Asia/Seoul").toISOString(),
+      );
     }
   }
 
   const memberRows = (members ?? []).map((m) => {
     const snap = snapMap.get(m.mem_id) ?? null;
-    const latestCfm = latestCfmMap.get(m.mem_id) ?? null;
-    const is_stale = snap && latestCfm ? latestCfm > (snap.last_calc_at ?? "") : false;
+    const latestTxnAt = latestTxnAtMap.get(m.mem_id) ?? null;
+    const is_stale = !snap || (!!latestTxnAt && latestTxnAt > (snap.last_calc_at ?? ""));
     const rel = Array.isArray(m.team_mem_rel) ? m.team_mem_rel[0] : m.team_mem_rel;
     return {
       mem_id: m.mem_id,
@@ -129,7 +135,7 @@ export default async function DuesTransactionsPage({
   type TxnFilterType = typeof validTxnFilters[number];
   const initialTxnFilter: TxnFilterType = validTxnFilters.includes(filter as TxnFilterType)
     ? (filter as TxnFilterType)
-    : "unconfirmed";
+    : "all";
 
   const initialBalFilter = balFilter === "unpaid" ? "unpaid" : "all";
 
@@ -138,8 +144,9 @@ export default async function DuesTransactionsPage({
       txns={(txns ?? []).map((t) => ({
         ...t,
         is_stale:
-          t.is_cfm_yn && !!t.cfm_at && !!t.mem_id
-            ? t.cfm_at > (snapCalcAtMap.get(t.mem_id!) ?? "")
+          t.is_cfm_yn && !!t.txn_dt && !!t.mem_id
+            ? dayjs.tz(`${t.txn_dt}T${t.txn_tm ?? "00:00:00"}`, "Asia/Seoul").toISOString() >
+              (snapCalcAtMap.get(t.mem_id!) ?? "")
             : false,
       }))}
       uploads={uploads ?? []}

--- a/app/(info)/profile/dues/page.tsx
+++ b/app/(info)/profile/dues/page.tsx
@@ -22,7 +22,7 @@ export default async function MemberDuesPage() {
   const [{ data: snap }, { data: pays }, { data: exms }, { data: otherTxns }, { data: feeItemCds }, { data: policy }] = await Promise.all([
     supabase
       .from("fee_mem_bal_snap")
-      .select("bal_amt, last_calc_dt")
+      .select("bal_amt, last_calc_dt, last_calc_at")
       .eq("team_id", teamId)
       .eq("mem_id", member.id)
       .eq("vers", 0)

--- a/app/(info)/profile/dues/page.tsx
+++ b/app/(info)/profile/dues/page.tsx
@@ -125,7 +125,7 @@ export default async function MemberDuesPage() {
   return (
     <DuesHistoryClient
       balAmt={balAmt}
-      lastCalcDt={snap?.last_calc_dt ? dayjs(snap.last_calc_dt).format("YY.MM.DD") : null}
+      lastCalcDt={snap?.last_calc_dt ? dayjs(snap.last_calc_dt).tz("Asia/Seoul").format("YY.MM.DD HH:mm") : null}
       teamAccount={TEAM_ACCOUNT}
       monthlyFeeAmt={policy?.monthly_fee_amt ?? null}
       items={items}

--- a/app/actions/dues/recalculate-balance.ts
+++ b/app/actions/dues/recalculate-balance.ts
@@ -6,6 +6,15 @@ import { verifyAdmin } from "@/lib/queries/member";
 import { getRequestTeamContext } from "@/lib/queries/request-team";
 import { createAdminClient } from "@/lib/supabase/admin";
 
+type TxnInfo = { txn_dt: string; txn_tm: string | null } | null;
+
+function getTxnInfo(raw: unknown): TxnInfo {
+  if (!raw) return null;
+  const item = Array.isArray(raw) ? raw[0] : raw;
+  if (!item || typeof item !== "object") return null;
+  return item as TxnInfo;
+}
+
 export async function recalculateBalance(memIds?: string[]) {
   const adminUser = await verifyAdmin();
   if (!adminUser) return { ok: false as const, message: "권한이 없습니다." };
@@ -39,14 +48,18 @@ export async function recalculateBalance(memIds?: string[]) {
 
   if (!policies?.length) return { ok: false as const, message: "회비 정책이 없습니다." };
 
-  const today = dayjs().format("YYYY-MM-DD");
+  const today = dayjs().tz("Asia/Seoul").format("YYYY-MM-DD");
   let updatedCount = 0;
+  const errors: string[] = [];
 
-  for (const mid of memberIds) {
+  const CHUNK_SIZE = 20;
+  for (let i = 0; i < memberIds.length; i += CHUNK_SIZE) {
+    const chunk = memberIds.slice(i, i + CHUNK_SIZE);
+    await Promise.all(chunk.map(async (mid) => {
     // 현재 스냅샷 조회
     const { data: snap } = await db
       .from("fee_mem_bal_snap")
-      .select("bal_snap_id, bal_amt, last_calc_dt, vers")
+      .select("bal_snap_id, bal_amt, last_calc_dt, last_calc_at, vers")
       .eq("team_id", teamId)
       .eq("mem_id", mid)
       .eq("vers", 0)
@@ -58,7 +71,7 @@ export async function recalculateBalance(memIds?: string[]) {
 
     if (snap) {
       baseBal = snap.bal_amt;
-      fromDt = dayjs(snap.last_calc_dt).add(1, "day").format("YYYY-MM-DD");
+      fromDt = dayjs(snap.last_calc_dt).format("YYYY-MM-DD");
     } else {
       // 스냅샷 없음 — 가입일부터 전체 계산
       const { data: rel } = await db
@@ -69,25 +82,41 @@ export async function recalculateBalance(memIds?: string[]) {
         .eq("vers", 0)
         .eq("del_yn", false)
         .maybeSingle();
-      if (!rel?.join_dt) continue;
+      if (!rel?.join_dt) return;
       fromDt = dayjs(rel.join_dt).startOf("month").format("YYYY-MM-DD");
     }
 
-    if (fromDt > today) continue;
+      if (fromDt > today) return;
 
-    // fromDt 이후 납부액 합산
-    const { data: pays } = await db
+    // 마지막 계산일시 이후 납부액 합산 (은행 거래일시 기준)
+    const paysQuery = db
       .from("fee_due_pay_hist")
-      .select("pay_id, pay_amt")
+      .select("pay_id, pay_amt, fee_txn_hist!fk_fee_due_pay_hist__fee_txn_hist(txn_dt, txn_tm)")
       .eq("team_id", teamId)
       .eq("mem_id", mid)
       .eq("pay_st_cd", "paid")
       .eq("vers", 0)
-      .eq("del_yn", false)
-      .gte("pay_dt", fromDt)
-      .order("pay_dt", { ascending: false });
+      .eq("del_yn", false);
 
-    const totalPaid = (pays ?? []).reduce((sum, p) => sum + p.pay_amt, 0);
+    const { data: pays } = snap?.last_calc_at
+      ? await paysQuery.gte(
+          "fee_txn_hist.txn_dt",
+          // 1차: KST 날짜 기준 넓게 필터, 2차 코드에서 시분까지 정확히 필터
+          dayjs(snap.last_calc_at).tz("Asia/Seoul").format("YYYY-MM-DD")
+        )
+      : await paysQuery.gte("pay_dt", fromDt);
+
+    // txn_dt + txn_tm으로 2차 필터 (last_calc_at 이후만, KST 기준 비교)
+    const filteredPays = snap?.last_calc_at
+      ? (pays ?? []).filter((p) => {
+          const txn = getTxnInfo(p.fee_txn_hist);
+          if (!txn?.txn_dt) return false;
+          const txnAt = dayjs.tz(`${txn.txn_dt}T${txn.txn_tm ?? "00:00:00"}`, "Asia/Seoul");
+          return txnAt.isAfter(dayjs(snap.last_calc_at));
+        })
+      : (pays ?? []);
+
+    const totalPaid = filteredPays.reduce((sum, p) => sum + p.pay_amt, 0);
 
     // 부과·면제 기준 월: 마지막 계산 월 다음 달부터
     const calcFromMonth = snap
@@ -170,8 +199,15 @@ export async function recalculateBalance(memIds?: string[]) {
 
     const newBal = baseBal + totalPaid + totalExempted - totalCharged;
 
-    // 최신 납부/면제 ID (내림차순 조회이므로 첫 번째가 최신)
-    const lastPay = pays?.at(0);
+    // 마지막 반영 거래의 은행 거래일시 (KST 기준, +1초 저장 → 다음 계산 시 중복 방지)
+    const lastTxnAt = filteredPays.reduce<string | null>((latest, p) => {
+      const txn = getTxnInfo(p.fee_txn_hist);
+      if (!txn?.txn_dt) return latest;
+      const txnAt = dayjs.tz(`${txn.txn_dt}T${txn.txn_tm ?? "00:00:00"}`, "Asia/Seoul").add(1, "second").toISOString();
+      return !latest || txnAt > latest ? txnAt : latest;
+    }, null);
+
+    const lastPay = filteredPays.at(-1);
     const lastExm = exms?.at(0);
 
     if (snap) {
@@ -186,12 +222,11 @@ export async function recalculateBalance(memIds?: string[]) {
         .maybeSingle();
       const nextVers = (maxRow?.vers ?? 0) + 1;
 
-      // 기존 vers=0 → nextVers로 밀기
       const { error: pushErr } = await db
         .from("fee_mem_bal_snap")
         .update({ vers: nextVers })
         .eq("bal_snap_id", snap.bal_snap_id);
-      if (pushErr) return { ok: false as const, message: `스냅샷 버전 밀기 실패 (${mid}): ${pushErr.message}` };
+      if (pushErr) { errors.push(`스냅샷 버전 밀기 실패 (${mid}): ${pushErr.message}`); return; }
     }
 
     // 새 vers=0 INSERT
@@ -200,16 +235,18 @@ export async function recalculateBalance(memIds?: string[]) {
       mem_id: mid,
       bal_amt: newBal,
       last_calc_dt: today,
-      last_calc_at: dayjs().toISOString(),
+      last_calc_at: lastTxnAt ?? snap?.last_calc_at ?? dayjs().toISOString(),
       last_ref_pay_id: lastPay?.pay_id ?? undefined,
       last_ref_exm_hist_id: lastExm?.exm_hist_id ?? undefined,
       vers: 0,
       del_yn: false,
     });
-    if (insertErr) return { ok: false as const, message: `스냅샷 INSERT 실패 (${mid}): ${insertErr.message}` };
+      if (insertErr) { errors.push(`스냅샷 INSERT 실패 (${mid}): ${insertErr.message}`); return; }
 
-    updatedCount++;
+      updatedCount++;
+    }));
   }
 
+  if (errors.length) return { ok: false as const, message: errors.join("\n") };
   return { ok: true as const, message: null, updatedCount };
 }

--- a/app/actions/dues/recalculate-balance.ts
+++ b/app/actions/dues/recalculate-balance.ts
@@ -201,14 +201,18 @@ export async function recalculateBalance(memIds?: string[]) {
     const newBal = baseBal + totalPaid + totalExempted - totalCharged;
 
     // 마지막 반영 거래의 은행 거래일시 (KST 기준, +1초 저장 → 다음 계산 시 중복 방지)
-    const lastTxnAt = filteredPays.reduce<string | null>((latest, p) => {
-      const txn = getTxnInfo(p.fee_txn_hist);
-      if (!txn?.txn_dt) return latest;
-      const txnAt = dayjs.tz(`${txn.txn_dt}T${txn.txn_tm ?? "00:00:00"}`, "Asia/Seoul").add(1, "second").toISOString();
-      return !latest || txnAt > latest ? txnAt : latest;
-    }, null);
-
-    const lastPay = filteredPays.at(-1);
+    const { lastTxnAt, lastPay } = filteredPays.reduce<{
+      lastTxnAt: string | null;
+      lastPay: (typeof filteredPays)[number] | null;
+    }>(
+      (acc, p) => {
+        const txn = getTxnInfo(p.fee_txn_hist);
+        if (!txn?.txn_dt) return acc;
+        const txnAt = dayjs.tz(`${txn.txn_dt}T${txn.txn_tm ?? "00:00:00"}`, "Asia/Seoul").add(1, "second").toISOString();
+        return !acc.lastTxnAt || txnAt > acc.lastTxnAt ? { lastTxnAt: txnAt, lastPay: p } : acc;
+      },
+      { lastTxnAt: null, lastPay: null },
+    );
     const lastExm = exms?.at(0);
 
     if (snap) {

--- a/app/actions/dues/recalculate-balance.ts
+++ b/app/actions/dues/recalculate-balance.ts
@@ -48,7 +48,8 @@ export async function recalculateBalance(memIds?: string[]) {
 
   if (!policies?.length) return { ok: false as const, message: "회비 정책이 없습니다." };
 
-  const today = dayjs().tz("Asia/Seoul").format("YYYY-MM-DD");
+  const now = dayjs().tz("Asia/Seoul");
+  const today = now.format("YYYY-MM-DD");
   let updatedCount = 0;
   const errors: string[] = [];
 
@@ -234,7 +235,7 @@ export async function recalculateBalance(memIds?: string[]) {
       team_id: teamId,
       mem_id: mid,
       bal_amt: newBal,
-      last_calc_dt: today,
+      last_calc_dt: now.toISOString(),
       last_calc_at: lastTxnAt ?? snap?.last_calc_at ?? dayjs().toISOString(),
       last_ref_pay_id: lastPay?.pay_id ?? undefined,
       last_ref_exm_hist_id: lastExm?.exm_hist_id ?? undefined,


### PR DESCRIPTION
배경 / 문제

기존 회비 계산은 last_calc_dt + 1일을 기준으로 납부 거래를 필터링했습니다. 이 방식은 당일 거래를 모두 잡으려면 반드시 자정 직전에 계산을 돌려야 하는 운영 부담이 있었고, 계산을 반복할 때마다 잔액이 계속 증가하는 버그도 존재했습니다.

원인 분석

Supabase PostgREST FK hint를 컬럼명(src_txn_id)으로 쓰면 join이 silent하게 실패 → txn 정보가 null → 모든 납부가 필터를 통과해 중복 반영
txn_dt + txn_tm은 KST 로컬 시간인데 last_calc_at(UTC)과 문자열 직접 비교 → 시간대 불일치로 오계산
변경 내용

계산 기준을 last_calc_dt + 1일(날짜) → last_calc_at(마지막 반영 거래 은행일시, KST 기준) 으로 변경
FK hint를 constraint명(fk_fee_due_pay_hist__fee_txn_hist)으로 수정 → join 정상화
KST 파싱 일관화: dayjs.tz(txn_dt+txn_tm, "Asia/Seoul"), DB 저장은 .toISOString()(UTC)
last_calc_at 저장 시 마지막 거래 시각 +1초 → 다음 계산에서 isAfter 경계값 문제 방지
today를 dayjs().tz("Asia/Seoul")로 산출 → Vercel UTC 서버에서도 KST 날짜 정확
청크 병렬 처리(20명 단위 Promise.all) 도입
전체 회비 계산 버튼 추가 (잔액 탭, 주황색 경고) — 미확정 거래 있으면 차단
거래내역 탭 확정/취소 후 탭 이동 시 상태 초기화 버그 수정 (txns state를 부모로 끌어올림)
회원별 잔액 탭에 "마지막 거래" 컬럼 추가
UI 기준일 표시를 last_calc_at(거래일시) → last_calc_dt(계산 실행일)로 변경
거래내역 기본 필터 미확정 → 전체, 순서 전체/미확정/확정으로 변경

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **버그 수정**
  * 거래 필터 기본값이 '전체'로 변경
  * 거래 취소 처리 로직 수정
  * 마지막 거래 시간이 날짜와 시간으로 더 정확히 표시

* **새로운 기능**
  * 잔액 계산 시 미확정 거래 존재 여부 확인 추가
  * 잔액 재계산 성능 개선

<!-- end of auto-generated comment: release notes by coderabbit.ai -->