### PR TITLE
feat(analytics): add GA4 custom event tracking

### DIFF
--- a/app/(board)/board/board-client.tsx
+++ b/app/(board)/board/board-client.tsx
@@ -6,6 +6,7 @@ import { PenLine } from "lucide-react";
 import type { BoardPostSummary } from "@/lib/queries/board";
 import { PostList } from "@/components/board/post-list";
 import { SegmentControl } from "@/components/common/segment-control";
+import { analytics } from "@/lib/analytics";
 
 type BoardClientProps = {
   initialNotices: BoardPostSummary[];
@@ -19,6 +20,7 @@ export function BoardClient({ initialNotices, initialUpdates, canWrite }: BoardC
   const tab = (searchParams.get("tab") === "update" ? "update" : "notice") as "notice" | "update";
 
   function handleTabChange(value: "notice" | "update") {
+    analytics.boardTabSwitch(value);
     router.replace(`/board?tab=${value}`);
   }
 

--- a/components/bottom-tab-bar.tsx
+++ b/components/bottom-tab-bar.tsx
@@ -4,13 +4,14 @@ import Link from "next/link";
 import { usePathname } from "next/navigation";
 import { House, Trophy, Medal, User, Zap } from "lucide-react";
 import { cn } from "@/lib/utils";
+import { analytics } from "@/lib/analytics";
 
 const TABS = [
-  { label: "홈", href: "/", icon: House },
-  { label: "대회", href: "/races", icon: Trophy },
-  { label: "프로젝트", href: "/projects", icon: Zap },
-  { label: "랭킹", href: "/records", icon: Medal },
-  { label: "프로필", href: "/profile", icon: User },
+  { label: "홈", href: "/", key: "home", icon: House },
+  { label: "대회", href: "/races", key: "races", icon: Trophy },
+  { label: "프로젝트", href: "/projects", key: "projects", icon: Zap },
+  { label: "랭킹", href: "/records", key: "records", icon: Medal },
+  { label: "프로필", href: "/profile", key: "profile", icon: User },
 ] as const;
 
 export function BottomTabBar() {
@@ -30,6 +31,7 @@ export function BottomTabBar() {
               key={tab.href}
               href={tab.href}
               prefetch={false}
+              onClick={() => analytics.tabClick(tab.key)}
               className={cn(
                 "flex flex-col items-center gap-1 px-3 py-1",
                 isActive

--- a/components/projects/activity-log-fab.tsx
+++ b/components/projects/activity-log-fab.tsx
@@ -12,6 +12,7 @@ import {
   SheetTitle,
 } from "@/components/ui/sheet";
 import { ActivityLogBatchForm } from "./activity-log-batch-form";
+import { analytics } from "@/lib/analytics";
 
 type ActivityLogFabProps = {
   evtId: string;
@@ -29,6 +30,7 @@ export function ActivityLogFab({ evtId, memId: _memId }: ActivityLogFabProps) {
   const router = useRouter();
 
   const handleSuccess = (count: number, titles: string[]) => {
+    analytics.activityLogSaved(count);
     setOpen(false);
     router.refresh();
     window.dispatchEvent(new Event("mileage:refresh"));
@@ -114,7 +116,7 @@ export function ActivityLogFab({ evtId, memId: _memId }: ActivityLogFabProps) {
       <Button
         size="icon"
         className="fixed bottom-24 right-6 z-50 size-14 rounded-full shadow-lg"
-        onClick={() => setOpen(true)}
+        onClick={() => { analytics.activityLogOpened(); setOpen(true); }}
         aria-label="기록 입력"
       >
         <Plus className="size-6" />

--- a/components/projects/join-section.tsx
+++ b/components/projects/join-section.tsx
@@ -15,6 +15,7 @@ import {
 } from "@/lib/mileage";
 
 import { joinProject } from "@/app/actions/mileage-run";
+import { analytics } from "@/lib/analytics";
 
 import { Caption } from "@/components/common/typography";
 import { Button } from "@/components/ui/button";
@@ -130,12 +131,14 @@ export function JoinSection({
 			}
 		}
 
+		analytics.projectJoinStarted(evtId);
 		setSubmitting(true);
 		try {
 			const result = await joinProject(evtId, initGoal, hasSinglet);
 			if (!result.ok) {
 				setError(result.message ?? "오류가 발생했습니다. 다시 시도해 주세요.");
 			} else {
+				analytics.projectJoinCompleted(evtId);
 				setError(null);
 				router.refresh();
 			}

--- a/components/projects/month-navigator.tsx
+++ b/components/projects/month-navigator.tsx
@@ -5,6 +5,7 @@ import { ChevronLeft, ChevronRight, Loader2 } from "lucide-react";
 import { prevMonthStr, nextMonthStr } from "@/lib/dayjs";
 import { Button } from "@/components/ui/button";
 import { useMonthTransition } from "./month-transition";
+import { analytics } from "@/lib/analytics";
 
 export function MonthNavigator({
   currentMonth,
@@ -28,9 +29,10 @@ export function MonthNavigator({
   const hasPrev = prevMonth >= practiceMonth;
   const hasNext = nextMonth <= endMonth;
 
-  function navigate(month: string) {
+  function navigate(month: string, direction: "prev" | "next") {
     // window.location.search로 최신 URL을 읽어 차트 탭(?tab=)이 보존되도록 한다.
     // (탭은 replaceState로 갱신되므로 useSearchParams 스냅샷에는 반영되지 않을 수 있음)
+    analytics.monthNavigated(direction, month);
     const params = new URLSearchParams(window.location.search);
     params.set("month", month);
     startTransition(() => {
@@ -43,7 +45,7 @@ export function MonthNavigator({
       <Button
         variant="ghost"
         size="icon-sm"
-        onClick={() => navigate(prevMonth)}
+        onClick={() => navigate(prevMonth, "prev")}
         disabled={!hasPrev || isPending}
         className="text-muted-foreground active:bg-secondary disabled:opacity-30"
         aria-label="이전 달"
@@ -60,7 +62,7 @@ export function MonthNavigator({
       <Button
         variant="ghost"
         size="icon-sm"
-        onClick={() => navigate(nextMonth)}
+        onClick={() => navigate(nextMonth, "next")}
         disabled={!hasNext || isPending}
         className="text-muted-foreground active:bg-secondary disabled:opacity-30"
         aria-label="다음 달"

--- a/components/races/race-list-view.tsx
+++ b/components/races/race-list-view.tsx
@@ -7,6 +7,7 @@ import { useRouter } from "next/navigation";
 import { ChevronDown, ChevronRight, Plus } from "lucide-react";
 
 import { compEvtTypeContainsHangul } from "@/lib/comp-evt-type";
+import { analytics } from "@/lib/analytics";
 import {
 	fetchMemMstWithTeamRel,
 	mapMstRelToAppMemberProfile,
@@ -508,7 +509,7 @@ export function RaceListView({
 				].map((seg) => (
 					<button
 						key={seg.value}
-						onClick={() => setTab(seg.value)}
+						onClick={() => { analytics.raceTabSwitch(seg.value === "gigang" ? "team" : "all"); setTab(seg.value); }}
 						className={cn(
 							"flex-1 rounded-lg py-2 text-sm font-medium transition-colors",
 							tab === seg.value
@@ -555,6 +556,7 @@ export function RaceListView({
 									>
 										<button
 											onClick={() => {
+												analytics.raceDetailViewed(comp.id, comp.title);
 												setSelectedCompetition(comp);
 												setDetailOpen(true);
 											}}
@@ -693,6 +695,7 @@ export function RaceListView({
 											>
 												<button
 													onClick={() => {
+														analytics.raceDetailViewed(comp.id, comp.title);
 														setSelectedCompetition(comp);
 														setDetailOpen(true);
 													}}

--- a/lib/analytics.ts
+++ b/lib/analytics.ts
@@ -1,0 +1,51 @@
+declare global {
+  interface Window {
+    gtag?: (...args: unknown[]) => void;
+  }
+}
+
+function send(event: string, params?: Record<string, string | number | boolean>) {
+  if (typeof window === "undefined" || !window.gtag) return;
+  window.gtag("event", event, params);
+}
+
+export const analytics = {
+  tabClick: (tab: "home" | "races" | "projects" | "records" | "profile") =>
+    send("tab_click", { tab }),
+
+  boardTabSwitch: (tab: "notice" | "update") =>
+    send("board_tab_switch", { tab }),
+
+  raceTabSwitch: (tab: "team" | "all") =>
+    send("race_tab_switch", { tab }),
+
+  raceDetailViewed: (raceId: string, raceName: string) =>
+    send("race_detail_viewed", { race_id: raceId, race_name: raceName }),
+
+  raceRegistrationOpened: (raceId: string, raceName: string) =>
+    send("race_registration_opened", { race_id: raceId, race_name: raceName }),
+
+  raceRegistrationCompleted: (raceId: string) =>
+    send("race_registration_completed", { race_id: raceId }),
+
+  projectJoinStarted: (evtId: string) =>
+    send("project_join_started", { evt_id: evtId }),
+
+  projectJoinCompleted: (evtId: string) =>
+    send("project_join_completed", { evt_id: evtId }),
+
+  activityLogOpened: () =>
+    send("activity_log_opened"),
+
+  activityLogSaved: (count: number) =>
+    send("activity_log_saved", { count }),
+
+  monthNavigated: (direction: "prev" | "next", toMonth: string) =>
+    send("month_navigated", { direction, to_month: toMonth }),
+
+  feedbackClicked: () =>
+    send("feedback_clicked"),
+
+  onboardingStep: (step: number) =>
+    send("onboarding_step", { step }),
+};


### PR DESCRIPTION
## 변경 내용

`lib/analytics.ts` GA4 이벤트 유틸 생성 후 주요 사용자 행동 포인트에 이벤트 부착.

## 추가된 이벤트

| 이벤트 | 위치 | 파악 가능한 것 |
|--------|------|-------------|
| `tab_click` | BottomTabBar | 탭별 사용 빈도 |
| `board_tab_switch` | BoardClient | 공지 vs 업데이트 관심도 |
| `race_tab_switch` | RaceListView | 기강대회 vs 전체 탭 사용 비율 |
| `race_detail_viewed` | RaceListView | 어떤 대회에 관심 있는지 |
| `month_navigated` | MonthNavigator | 마일리지 과거 월 탐색 빈도 |
| `activity_log_opened` / `activity_log_saved` | ActivityLogFab | 기록 입력 시도 및 완료율 |
| `project_join_started` / `project_join_completed` | JoinSection | 프로젝트 참여 신청 전환율 |

## 목적

UX 개선 우선순위 판단을 위한 데이터 수집 기반 마련.
어떤 탭/기능을 실제로 쓰는지, 어디서 이탈하는지 파악.