### PR TITLE
feat(newbie): 둘러보기 버튼 추가 및 모임 정보 갱신

### DIFF
--- a/app/newbie/page.tsx
+++ b/app/newbie/page.tsx
@@ -18,7 +18,7 @@ const announcements = {
       heading: "📅 정기 러닝",
       items: [
         "격주 수요일 저녁 7:30 PM",
-        "장소: 양재천 영동1교",
+        "장소: 양재천·한강·여의도·남산 일대 (사전 공지)",
         "카카오톡에서 공지 확인",
       ],
     },
@@ -36,7 +36,7 @@ const announcements = {
 
 const rules = [
   { label: "자유 모임 개설", desc: "누구나 자유롭게 모임을 만들 수 있습니다." },
-  { label: "나이 제한", desc: "89년생부터 가입 가능 (88년생 이상은 불가)" },
+  { label: "나이 제한", desc: "88년생부터 가입 가능" },
   {
     label: "카톡 참석 표시",
     desc: "정기 러닝 참석 시 카카오톡에 미리 표시",
@@ -320,6 +320,15 @@ export default function NewbiePage() {
             </Button>
             <Caption className="mt-2 block text-center">
               카카오 또는 구글로 간편 가입
+            </Caption>
+            <Link
+              href="/"
+              className="mt-3 block text-center text-sm font-medium text-muted-foreground underline"
+            >
+              기강 둘러보기
+            </Link>
+            <Caption className="mt-1 block text-center">
+              전달받은 링크를 다시 누르면 가입 화면으로 돌아올 수 있어요
             </Caption>
           </div>
         </div>

--- a/components/auth/member-onboarding-form.tsx
+++ b/components/auth/member-onboarding-form.tsx
@@ -410,7 +410,7 @@ export function MemberOnboardingForm({
 													<FormControl>
 														<Input
 															type="date"
-															min="1986-01-01"
+															min="1988-01-01"
 															max="2008-12-31"
 															{...field}
 														/>


### PR DESCRIPTION
## 관련 이슈

관련 이슈 없음

## 요약

가입 랜딩(/newbie)에 "둘러보기" 동선을 추가하고, 모임 정보(장소·나이)를 최신으로 갱신합니다.

## AS-IS (변경 전)

- 가입 화면에서 곧장 홈을 둘러볼 동선이 없음
- 정기러닝 장소가 "양재천 영동1교"로 고정 표기
- 나이 안내(89년생부터)와 온보딩 생년월일 제한(min 1986-01-01)이 서로 불일치

## TO-BE (변경 후)

- "기강 둘러보기"(홈으로) 링크 + "전달받은 링크를 다시 누르면 가입 화면으로 돌아올 수 있어요" 안내 추가
- 정기러닝 장소: "양재천·한강·여의도·남산 일대 (사전 공지)"
- 나이 제한을 "88년생부터 가입 가능"으로 통일하고, 온보딩 생년월일 min을 1988-01-01로 정합

## 참고

- 로그인 페이지의 "구경할래요"와 기능(홈 이동)이 동일하나 충돌은 아님. 문구 통일은 후속 논의 가능.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **신규 기능**
  * 신입회원 페이지 하단에 홈페이지 이동 링크 및 안내 문구 추가

* **개선 사항**
  * 신입회원 가입 나이 기준 변경 (89년생부터 → 88년생부터 가능)
  * 정기 러닝 장소 안내 확대 (특정 구간에서 더 넓은 지역으로 변경)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->