### PR TITLE
fix(theme): 시스템 색상 설정을 따르도록 변경

### DIFF
--- a/components/providers.tsx
+++ b/components/providers.tsx
@@ -4,7 +4,7 @@ import { ThemeProvider } from "next-themes";
 
 export function Providers({ children }: { children: React.ReactNode }) {
   return (
-    <ThemeProvider attribute="class" defaultTheme="dark" enableSystem={false} disableTransitionOnChange>
+    <ThemeProvider attribute="class" defaultTheme="system" enableSystem disableTransitionOnChange>
       {children}
     </ThemeProvider>
   );


### PR DESCRIPTION
## 관련 이슈

관련 이슈 없음

## 요약

앱이 다크모드를 강제하던 것을 사용자 OS의 색상 설정(라이트/다크)을 따르도록 변경합니다.

## AS-IS (변경 전)

- ThemeProvider defaultTheme="dark", enableSystem={false}
- 사용자 OS 설정과 무관하게 항상 다크모드로 렌더

## TO-BE (변경 후)

- defaultTheme="system", enableSystem
- OS의 라이트/다크 설정을 그대로 따름

## 주의

그동안 다크모드가 강제돼 있어 라이트모드 화면은 실제로 검증된 적이 없습니다. globals.css에 라이트/다크 토큰은 모두 정의돼 있으나, 하드코딩 색(카카오·인스타 브랜드색 등)이 라이트 배경에서 어색할 수 있어 라이트모드 비주얼 QA를 권장합니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)