### PR TITLE
fix(newbie): 하단 CTA 동급 2버튼화 및 가림 문제 해소

### DIFF
--- a/app/newbie/page.tsx
+++ b/app/newbie/page.tsx
@@ -124,7 +124,7 @@ export default function NewbiePage() {
   return (
     <InAppBrowserGate>
       <SignupProgress step={1} />
-      <div className="mx-auto max-w-md px-6 pb-28 pt-[calc(env(safe-area-inset-top,0px)+5rem)]">
+      <div className="mx-auto max-w-md px-6 pb-44 pt-[calc(env(safe-area-inset-top,0px)+5rem)]">
         {/* 1. 히어로 */}
         <section className="text-center">
           <Caption className="tracking-[3px]">WELCOME TO</Caption>
@@ -315,20 +315,22 @@ export default function NewbiePage() {
         {/* 6. 하단 고정 CTA */}
         <div className="fixed inset-x-0 bottom-0 z-50 bg-gradient-to-t from-background via-background/90 to-transparent px-4 pb-4 pt-6">
           <div className="mx-auto max-w-md">
-            <Button asChild size="lg" className="w-full rounded-2xl font-bold">
-              <Link href="/auth/login?next=%2Fonboarding">시작하기 →</Link>
-            </Button>
-            <Caption className="mt-2 block text-center">
-              카카오 또는 구글로 간편 가입
-            </Caption>
-            <Link
-              href="/"
-              className="mt-3 block text-center text-sm font-medium text-muted-foreground underline"
-            >
-              기강 둘러보기
-            </Link>
-            <Caption className="mt-1 block text-center">
-              전달받은 링크를 다시 누르면 가입 화면으로 돌아올 수 있어요
+            <div className="grid grid-cols-2 gap-2.5">
+              <Button
+                asChild
+                variant="outline"
+                size="lg"
+                className="rounded-2xl font-bold"
+              >
+                <Link href="/">기강 둘러보기</Link>
+              </Button>
+              <Button asChild size="lg" className="rounded-2xl font-bold">
+                <Link href="/auth/login?next=%2Fonboarding">시작하기 →</Link>
+              </Button>
+            </div>
+            <Caption className="mt-2 block text-center leading-relaxed">
+              카카오·구글로 간편 가입 · 전달받은 링크를 다시 누르면 가입 화면으로
+              돌아와요
             </Caption>
           </div>
         </div>


### PR DESCRIPTION
## 관련 이슈

관련 이슈 없음

## 요약

가입 랜딩(/newbie) 하단 고정 CTA에서 "시작하기"와 "기강 둘러보기"를 동급 버튼으로 맞추고, 맨 아래 접이식이 CTA에 가려 클릭되지 않던 문제를 해소합니다.

## AS-IS (변경 전)

- "시작하기"는 큰 primary 버튼, "기강 둘러보기"는 작은 텍스트 링크로 위계가 달랐음
- 콘텐츠 하단 여백(pb-28)이 부족해, "더 알아보기" 접이식(러닝팁 등)을 펼치면 끝부분이 고정 CTA 뒤에 깔려 클릭 불가

## TO-BE (변경 후)

- "기강 둘러보기"(outline) + "시작하기"(primary)를 가로 2분할 동급 버튼으로
- 안내 문구를 한 줄로 통합
- 콘텐츠 하단 여백을 pb-28→pb-44로 늘려 가림 해소

🤖 Generated with [Claude Code](https://claude.com/claude-code)