### PR TITLE
fix(signup): 연령 제한 86년생부터로 변경

### DIFF
--- a/app/newbie/page.tsx
+++ b/app/newbie/page.tsx
@@ -36,7 +36,7 @@ const announcements = {
 
 const rules = [
   { label: "자유 모임 개설", desc: "누구나 자유롭게 모임을 만들 수 있습니다." },
-  { label: "나이 제한", desc: "88년생부터 가입 가능" },
+  { label: "나이 제한", desc: "86년생부터 가입 가능" },
   {
     label: "카톡 참석 표시",
     desc: "정기 러닝 참석 시 카카오톡에 미리 표시",

--- a/components/auth/member-onboarding-form.tsx
+++ b/components/auth/member-onboarding-form.tsx
@@ -410,7 +410,7 @@ export function MemberOnboardingForm({
 													<FormControl>
 														<Input
 															type="date"
-															min="1988-01-01"
+															min="1986-01-01"
 															max="2008-12-31"
 															{...field}
 														/>


### PR DESCRIPTION
## 관련 이슈

관련 이슈 없음

## 요약

가입 연령 제한을 86년생부터로 변경합니다.

## 변경

- newbie 나이 제한 안내: "88년생부터" → "86년생부터 가입 가능"
- 온보딩 생년월일 입력 min: 1988-01-01 → 1986-01-01

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **변경 사항**
  * 회원 가입 가능한 최소 나이 기준이 조정되었습니다. (1988년생부터 → 1986년생부터 가입 가능)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->