### PR TITLE
feat(records): 기록증 OCR로 기록 입력 자동완성

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -10,3 +10,6 @@ E2E_TEST_PASSWORD=your-test-password
 # 클라이언트 개발 전용 UI(이메일 로그인 등). 개발계(Vercel gigang-client-dev)에서만 true 권장.
 # 운영 프로젝트에는 설정하지 마세요. 로컬 `pnpm dev`는 NODE_ENV=development 로 자동 허용되어 생략 가능.
 # NEXT_PUBLIC_ENABLE_DEV_MODE=true
+
+# Gemini API 키 (Google AI Studio) — 기록증 OCR 추출용 (서버 전용)
+GEMINI_API_KEY=

--- a/app/actions/extract-race-record.ts
+++ b/app/actions/extract-race-record.ts
@@ -1,0 +1,54 @@
+"use server";
+
+import { env } from "@/lib/env";
+import {
+  extractRaceRecordFromImageData,
+  type ExtractedRecord,
+} from "@/lib/ocr/race-record";
+import { getCurrentMember, verifyActive } from "@/lib/queries/member";
+
+const MAX_BYTES = 10 * 1024 * 1024; // 10MB
+
+type ExtractResult =
+  | { ok: true; data: ExtractedRecord }
+  | { ok: false; message: string };
+
+export async function extractRaceRecordFromImage(
+  formData: FormData,
+): Promise<ExtractResult> {
+  const { member } = await getCurrentMember();
+  if (!member) {
+    return { ok: false, message: "로그인이 필요합니다." };
+  }
+  const active = await verifyActive();
+  if (!active.ok) {
+    return { ok: false, message: active.message };
+  }
+
+  const file = formData.get("image");
+  if (!(file instanceof File)) {
+    return { ok: false, message: "이미지를 첨부해 주세요." };
+  }
+  if (!file.type.startsWith("image/")) {
+    return { ok: false, message: "이미지 파일만 업로드할 수 있습니다." };
+  }
+  if (file.size > MAX_BYTES) {
+    return { ok: false, message: "이미지 용량은 10MB 이하여야 합니다." };
+  }
+
+  try {
+    const buffer = Buffer.from(await file.arrayBuffer());
+    const data = await extractRaceRecordFromImageData({
+      apiKey: env.GEMINI_API_KEY,
+      base64: buffer.toString("base64"),
+      mimeType: file.type,
+    });
+    return { ok: true, data };
+  } catch (err) {
+    console.error("기록증 OCR 추출 실패:", err);
+    return {
+      ok: false,
+      message: "사진에서 정보를 읽지 못했습니다. 직접 입력해 주세요.",
+    };
+  }
+}

--- a/components/profile/race-record-dialog.tsx
+++ b/components/profile/race-record-dialog.tsx
@@ -15,6 +15,7 @@ import {
 import { createClient } from "@/lib/supabase/client";
 import { cn } from "@/lib/utils";
 
+import { extractRaceRecordFromImage } from "@/app/actions/extract-race-record";
 import { saveRaceRecord } from "@/app/actions/save-race-record";
 import { listCompetitionsByRaceDate } from "@/app/actions/search-competitions";
 
@@ -78,7 +79,7 @@ export function RaceRecordDialog({
   const supabase = useMemo(() => createClient(), []);
 
   // 단계 관리
-  const [step, setStep] = useState<1 | 2 | 3>(1);
+  const [step, setStep] = useState<0 | 1 | 2 | 3>(0);
   const [grantedTitles, setGrantedTitles] = useState<string[]>([]);
   const [grantedDismissable, setGrantedDismissable] = useState(false);
   const grantedDismissTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
@@ -110,6 +111,20 @@ export function RaceRecordDialog({
   const [swimTime, setSwimTime] = useState("");
   const [bikeTime, setBikeTime] = useState("");
   const [runTime, setRunTime] = useState("");
+
+  // OCR (0단계)
+  const [ocrLoading, setOcrLoading] = useState(false);
+  const [ocrError, setOcrError] = useState<string | null>(null);
+  const [imagePreview, setImagePreview] = useState<string | null>(null);
+  // Task 5에서 prefill 연결 시 소비됨
+  const [_ocrTimes, setOcrTimes] = useState<{
+    total: string | null;
+    swim: string | null;
+    bike: string | null;
+    run: string | null;
+  } | null>(null);
+  const [_ocrFilledFields, setOcrFilledFields] = useState<Set<string>>(new Set());
+  const fileInputRef = useRef<HTMLInputElement | null>(null);
 
   // 저장 상태
   const [isSaving, setIsSaving] = useState(false);
@@ -144,7 +159,12 @@ export function RaceRecordDialog({
   // 다이얼로그 열릴 때 초기화 + 대회 목록 불러오기
   useEffect(() => {
     if (open) {
-      setStep(1);
+      setStep(0);
+      setOcrLoading(false);
+      setOcrError(null);
+      setImagePreview(null);
+      setOcrTimes(null);
+      setOcrFilledFields(new Set());
       setSelectedComp(null);
       setRaceDate("");
       setCompsForRaceDate([]);
@@ -326,6 +346,32 @@ export function RaceRecordDialog({
     return true;
   })();
 
+  async function handleImageSelected(file: File) {
+    setOcrError(null);
+    setOcrLoading(true);
+    setImagePreview(URL.createObjectURL(file));
+
+    const formData = new FormData();
+    formData.append("image", file);
+    const result = await extractRaceRecordFromImage(formData);
+
+    setOcrLoading(false);
+    if (!result.ok) {
+      setOcrError(result.message);
+      return;
+    }
+    applyOcrResult(result.data);
+  }
+
+  function skipOcr() {
+    setStep(1);
+  }
+
+  // Task 5에서 본체 구현. 지금은 step 이동만.
+  function applyOcrResult(_data: import("@/lib/ocr/race-record").ExtractedRecord) {
+    setStep(1);
+  }
+
   async function handleSave() {
     if (!canSave || !selectedComp) return;
     setIsSaving(true);
@@ -402,6 +448,7 @@ export function RaceRecordDialog({
         <DialogHeader>
           <DialogTitle>기록 입력</DialogTitle>
           <DialogDescription>
+            {step === 0 && "기록증 사진을 올리거나 직접 입력해 주세요."}
             {step === 1 && "대회를 선택해 주세요."}
             {step === 2 && "코스를 선택해 주세요."}
             {step === 3 && "기록을 입력해 주세요."}
@@ -418,6 +465,65 @@ export function RaceRecordDialog({
           >
             &larr; 뒤로
           </Button>
+        )}
+
+        {/* 단계 0: 기록증 사진 업로드 */}
+        {step === 0 && (
+          <div className="flex flex-col gap-4">
+            <p className="text-sm text-muted-foreground">
+              기록증 사진이 있으면 대회·시간을 자동으로 채워드려요.
+            </p>
+
+            {imagePreview && (
+              // eslint-disable-next-line @next/next/no-img-element
+              <img
+                src={imagePreview}
+                alt="기록증 미리보기"
+                className="max-h-48 w-full rounded-lg border border-border object-contain"
+              />
+            )}
+
+            <input
+              ref={fileInputRef}
+              type="file"
+              accept="image/*"
+              className="hidden"
+              onChange={(e) => {
+                const f = e.target.files?.[0];
+                if (f) void handleImageSelected(f);
+                e.target.value = "";
+              }}
+            />
+
+            <Button
+              type="button"
+              size="lg"
+              disabled={ocrLoading}
+              onClick={() => fileInputRef.current?.click()}
+              className="h-12 w-full rounded-xl font-semibold"
+            >
+              {ocrLoading ? "기록 읽는 중..." : "📷 기록증 사진 올리기"}
+            </Button>
+
+            {ocrError && <p className="text-xs text-destructive">{ocrError}</p>}
+
+            <div className="flex items-center gap-3">
+              <div className="h-px flex-1 bg-border" />
+              <span className="text-xs text-muted-foreground">또는</span>
+              <div className="h-px flex-1 bg-border" />
+            </div>
+
+            <Button
+              type="button"
+              variant="outline"
+              size="lg"
+              disabled={ocrLoading}
+              onClick={skipOcr}
+              className="h-12 w-full rounded-xl"
+            >
+              사진 없이 직접 입력
+            </Button>
+          </div>
         )}
 
         {/* 단계 1: 최근 3개월 참가 대회 + 전체 대회 검색 */}

--- a/components/profile/race-record-dialog.tsx
+++ b/components/profile/race-record-dialog.tsx
@@ -116,14 +116,13 @@ export function RaceRecordDialog({
   const [ocrLoading, setOcrLoading] = useState(false);
   const [ocrError, setOcrError] = useState<string | null>(null);
   const [imagePreview, setImagePreview] = useState<string | null>(null);
-  // Task 5에서 prefill 연결 시 소비됨
-  const [_ocrTimes, setOcrTimes] = useState<{
+  const [ocrTimes, setOcrTimes] = useState<{
     total: string | null;
     swim: string | null;
     bike: string | null;
     run: string | null;
   } | null>(null);
-  const [_ocrFilledFields, setOcrFilledFields] = useState<Set<string>>(new Set());
+  const [ocrFilledFields, setOcrFilledFields] = useState<Set<string>>(new Set());
   const fileInputRef = useRef<HTMLInputElement | null>(null);
 
   // 저장 상태
@@ -283,6 +282,7 @@ export function RaceRecordDialog({
     const registered = (comp.registeredEventType ?? "").trim().toUpperCase();
     setSelectedEventType(registered);
     setCustomEventType("");
+    if (comp.registeredEventType) applyOcrTimesToStep3();
     setStep(comp.registeredEventType ? 3 : 2);
   }
 
@@ -294,12 +294,17 @@ export function RaceRecordDialog({
     setBikeTime("");
     setRunTime("");
     setError(null);
+    applyOcrTimesToStep3();
     setStep(3);
   }
 
   // 뒤로가기 (참가한 대회는 step 2 없이 3으로 왔으므로 step 3에서 뒤로가면 대회 선택으로)
   function handleBack() {
     setError(null);
+    if (step === 1) {
+      setStep(0);
+      return;
+    }
     if (step === 3) {
       if (selectedComp?.registeredEventType) {
         setSelectedComp(null);
@@ -367,9 +372,41 @@ export function RaceRecordDialog({
     setStep(1);
   }
 
-  // Task 5에서 본체 구현. 지금은 step 이동만.
-  function applyOcrResult(_data: import("@/lib/ocr/race-record").ExtractedRecord) {
+  function applyOcrResult(data: import("@/lib/ocr/race-record").ExtractedRecord) {
+    if (data.raceDate) setRaceDate(data.raceDate);
+    if (data.competitionName) setSearchQuery(data.competitionName);
+    setOcrTimes({
+      total: data.totalTime,
+      swim: data.swimTime,
+      bike: data.bikeTime,
+      run: data.runTime,
+    });
     setStep(1);
+  }
+
+  // OCR로 읽은 시간을 step 3 입력칸에 채운다 (사용자가 손대지 않은 빈 칸만).
+  function applyOcrTimesToStep3() {
+    if (!ocrTimes) return;
+    const filled = new Set<string>();
+    const toInput = (v: string | null) =>
+      v ? formatTimeInput(v.replace(/:/g, "")) : "";
+    if (ocrTimes.total) {
+      setTotalTime(toInput(ocrTimes.total));
+      filled.add("total");
+    }
+    if (ocrTimes.swim) {
+      setSwimTime(toInput(ocrTimes.swim));
+      filled.add("swim");
+    }
+    if (ocrTimes.bike) {
+      setBikeTime(toInput(ocrTimes.bike));
+      filled.add("bike");
+    }
+    if (ocrTimes.run) {
+      setRunTime(toInput(ocrTimes.run));
+      filled.add("run");
+    }
+    setOcrFilledFields(filled);
   }
 
   async function handleSave() {
@@ -441,6 +478,11 @@ export function RaceRecordDialog({
     return () => vv.removeEventListener("resize", scrollSearchInputAboveKeyboard);
   }, [scrollSearchInputAboveKeyboard]);
 
+  const ocrHint = (field: string) =>
+    ocrFilledFields.has(field) ? (
+      <p className="text-[11px] text-muted-foreground">· 사진에서 읽음 — 확인해 주세요</p>
+    ) : null;
+
   return (
     <>
     <Dialog open={open} onOpenChange={onOpenChange} modal={!registerOpen}>
@@ -455,7 +497,7 @@ export function RaceRecordDialog({
           </DialogDescription>
         </DialogHeader>
 
-        {step > 1 && (
+        {step >= 1 && (
           <Button
             type="button"
             variant="ghost"
@@ -715,6 +757,7 @@ export function RaceRecordDialog({
                         onClick={() => {
                           setTotalTime("");
                           setError(null);
+                          applyOcrTimesToStep3();
                           setStep(3);
                         }}
                         className="h-12 w-full rounded-xl font-semibold"
@@ -746,8 +789,17 @@ export function RaceRecordDialog({
                     placeholder="HH:MM:SS"
                     inputMode="numeric"
                     value={totalTime}
-                    onChange={(e) => setTotalTime(formatTimeInput(e.target.value))}
+                    onChange={(e) => {
+                      setTotalTime(formatTimeInput(e.target.value));
+                      setOcrFilledFields((p) => {
+                        if (!p.has("total")) return p;
+                        const n = new Set(p);
+                        n.delete("total");
+                        return n;
+                      });
+                    }}
                   />
+                  {ocrHint("total")}
                 </div>
                 <div className="flex flex-col gap-1.5">
                   <label className="text-sm font-medium">수영</label>
@@ -755,8 +807,17 @@ export function RaceRecordDialog({
                     placeholder="HH:MM:SS"
                     inputMode="numeric"
                     value={swimTime}
-                    onChange={(e) => setSwimTime(formatTimeInput(e.target.value))}
+                    onChange={(e) => {
+                      setSwimTime(formatTimeInput(e.target.value));
+                      setOcrFilledFields((p) => {
+                        if (!p.has("swim")) return p;
+                        const n = new Set(p);
+                        n.delete("swim");
+                        return n;
+                      });
+                    }}
                   />
+                  {ocrHint("swim")}
                 </div>
                 <div className="flex flex-col gap-1.5">
                   <label className="text-sm font-medium">자전거</label>
@@ -764,8 +825,17 @@ export function RaceRecordDialog({
                     placeholder="HH:MM:SS"
                     inputMode="numeric"
                     value={bikeTime}
-                    onChange={(e) => setBikeTime(formatTimeInput(e.target.value))}
+                    onChange={(e) => {
+                      setBikeTime(formatTimeInput(e.target.value));
+                      setOcrFilledFields((p) => {
+                        if (!p.has("bike")) return p;
+                        const n = new Set(p);
+                        n.delete("bike");
+                        return n;
+                      });
+                    }}
                   />
+                  {ocrHint("bike")}
                 </div>
                 <div className="flex flex-col gap-1.5">
                   <label className="text-sm font-medium">러닝</label>
@@ -773,8 +843,17 @@ export function RaceRecordDialog({
                     placeholder="HH:MM:SS"
                     inputMode="numeric"
                     value={runTime}
-                    onChange={(e) => setRunTime(formatTimeInput(e.target.value))}
+                    onChange={(e) => {
+                      setRunTime(formatTimeInput(e.target.value));
+                      setOcrFilledFields((p) => {
+                        if (!p.has("run")) return p;
+                        const n = new Set(p);
+                        n.delete("run");
+                        return n;
+                      });
+                    }}
                   />
+                  {ocrHint("run")}
                 </div>
                 <div className="flex flex-col gap-1.5">
                   <label className="text-sm font-medium">트랜지션</label>
@@ -800,8 +879,17 @@ export function RaceRecordDialog({
                   placeholder="HH:MM:SS"
                   inputMode="numeric"
                   value={totalTime}
-                  onChange={(e) => setTotalTime(formatTimeInput(e.target.value))}
+                  onChange={(e) => {
+                    setTotalTime(formatTimeInput(e.target.value));
+                    setOcrFilledFields((p) => {
+                      if (!p.has("total")) return p;
+                      const n = new Set(p);
+                      n.delete("total");
+                      return n;
+                    });
+                  }}
                 />
+                {ocrHint("total")}
               </div>
             )}
 

--- a/components/profile/race-record-dialog.tsx
+++ b/components/profile/race-record-dialog.tsx
@@ -19,6 +19,7 @@ import { extractRaceRecordFromImage } from "@/app/actions/extract-race-record";
 import { saveRaceRecord } from "@/app/actions/save-race-record";
 import { listCompetitionsByRaceDate } from "@/app/actions/search-competitions";
 
+import { Micro } from "@/components/common/typography";
 import { CompetitionRegisterDialog } from "@/components/races/competition-register-dialog";
 import type { MemberStatus } from "@/components/races/types";
 import { Button } from "@/components/ui/button";
@@ -161,7 +162,10 @@ export function RaceRecordDialog({
       setStep(0);
       setOcrLoading(false);
       setOcrError(null);
-      setImagePreview(null);
+      setImagePreview((prev) => {
+        if (prev) URL.revokeObjectURL(prev);
+        return null;
+      });
       setOcrTimes(null);
       setOcrFilledFields(new Set());
       setSelectedComp(null);
@@ -354,7 +358,10 @@ export function RaceRecordDialog({
   async function handleImageSelected(file: File) {
     setOcrError(null);
     setOcrLoading(true);
-    setImagePreview(URL.createObjectURL(file));
+    setImagePreview((prev) => {
+      if (prev) URL.revokeObjectURL(prev);
+      return URL.createObjectURL(file);
+    });
 
     const formData = new FormData();
     formData.append("image", file);
@@ -388,24 +395,15 @@ export function RaceRecordDialog({
   function applyOcrTimesToStep3() {
     if (!ocrTimes) return;
     const filled = new Set<string>();
-    const toInput = (v: string | null) =>
-      v ? formatTimeInput(v.replace(/:/g, "")) : "";
-    if (ocrTimes.total) {
-      setTotalTime(toInput(ocrTimes.total));
-      filled.add("total");
-    }
-    if (ocrTimes.swim) {
-      setSwimTime(toInput(ocrTimes.swim));
-      filled.add("swim");
-    }
-    if (ocrTimes.bike) {
-      setBikeTime(toInput(ocrTimes.bike));
-      filled.add("bike");
-    }
-    if (ocrTimes.run) {
-      setRunTime(toInput(ocrTimes.run));
-      filled.add("run");
-    }
+    const toInput = (v: string | null) => {
+      if (!v) return "";
+      const padded = v.replace(/^(\d):/, "0$1:"); // "3:25:29" → "03:25:29"
+      return formatTimeInput(padded.replace(/:/g, ""));
+    };
+    if (ocrTimes.total && !totalTime) { setTotalTime(toInput(ocrTimes.total)); filled.add("total"); }
+    if (ocrTimes.swim && !swimTime) { setSwimTime(toInput(ocrTimes.swim)); filled.add("swim"); }
+    if (ocrTimes.bike && !bikeTime) { setBikeTime(toInput(ocrTimes.bike)); filled.add("bike"); }
+    if (ocrTimes.run && !runTime) { setRunTime(toInput(ocrTimes.run)); filled.add("run"); }
     setOcrFilledFields(filled);
   }
 
@@ -480,7 +478,7 @@ export function RaceRecordDialog({
 
   const ocrHint = (field: string) =>
     ocrFilledFields.has(field) ? (
-      <p className="text-[11px] text-muted-foreground">· 사진에서 읽음 — 확인해 주세요</p>
+      <Micro>· 사진에서 읽음 — 확인해 주세요</Micro>
     ) : null;
 
   return (

--- a/docs/superpowers/plans/2026-06-14-기록증-ocr-자동입력.md
+++ b/docs/superpowers/plans/2026-06-14-기록증-ocr-자동입력.md
@@ -1,0 +1,747 @@
+# 기록증 OCR 자동입력 Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** 대회 기록증 사진을 Gemini 2.5 Flash로 읽어 `RaceRecordDialog`의 대회 검색·시간 입력칸을 자동으로 채운다.
+
+**Architecture:** 순수 로직(Zod 스키마·프롬프트·시간 정규화·Gemini 호출 코어)을 `lib/ocr/race-record.ts`에 모으고, `app/actions/extract-race-record.ts` 서버 액션이 인증·파일 가드·FormData 파싱을 감싸 호출한다. `RaceRecordDialog`에 0단계 업로드 화면을 추가하고, 추출 결과를 기존 입력칸에 prefill한다. 추출값은 전부 사용자가 확인·수정 가능하며 기존 저장 경로(`saveRaceRecord`)를 그대로 재사용한다.
+
+**Tech Stack:** Next.js(App Router) 서버 액션, `@google/genai`(설치 완료), Zod, React Hook(useState), Tailwind. 단위 테스트 러너는 없으므로 순수 로직은 임시 node 스크립트로 검증, 서버 액션은 실제 기록증 추출 스크립트, UI는 `pnpm lint` + `pnpm build`(타입체크) + 브라우저 수동 E2E로 검증한다.
+
+**참고:** 설계 문서 `docs/superpowers/specs/2026-06-14-기록증-ocr-자동입력-design.md`. 검증 샘플 `C:\Prog\PRIVATE\temp\기록증.jpg` (SEOUL 2025 MARATHON / 이현근 / 03:25:29 / FULL / 2025-03-16). 키는 `.env.development.local`의 `GEMINI_API_KEY`에 이미 입력되어 있음(읽지 말 것). 실제 호출 시 503(모델 과부하)이 간헐적으로 발생하므로 재시도 필요.
+
+---
+
+## File Structure
+
+| 파일 | 역할 | 변경 |
+|------|------|------|
+| `lib/env.ts` | `GEMINI_API_KEY` 서버 환경변수 등록 | Modify |
+| `.env.example` | 키 이름 템플릿 추가 | Modify |
+| `lib/ocr/race-record.ts` | 순수 로직: `ExtractedRecord` 타입/Zod 스키마, Gemini `responseSchema`, 프롬프트, `normalizeOcrTime`, Gemini 호출 코어 `extractRaceRecordFromImageData` | Create |
+| `app/actions/extract-race-record.ts` | `"use server"` 액션: 인증 + 파일 가드 + FormData → 코어 호출 | Create |
+| `components/profile/race-record-dialog.tsx` | 0단계 업로드 UI + prefill 연결 | Modify |
+
+---
+
+## Task 1: 환경변수 등록
+
+**Files:**
+- Modify: `lib/env.ts`
+- Modify: `.env.example`
+
+- [ ] **Step 1: `lib/env.ts` server 블록에 키 추가**
+
+`server: { ... }` 안에 기존 항목 다음 줄로 추가:
+
+```typescript
+    KAKAO_CHAT_PASSWORD: z.string().optional(),
+    GEMINI_API_KEY: z.string().min(1),
+    NODE_ENV: z.enum(["development", "production", "test"]),
+```
+
+그리고 `runtimeEnv: { ... }`에 매핑 추가:
+
+```typescript
+    KAKAO_CHAT_PASSWORD: process.env.KAKAO_CHAT_PASSWORD,
+    GEMINI_API_KEY: process.env.GEMINI_API_KEY,
+    NODE_ENV: process.env.NODE_ENV,
+```
+
+- [ ] **Step 2: `.env.example`에 키 이름 추가**
+
+파일 끝에 한 줄 추가 (값 없이, 주석 포함):
+
+```
+# Gemini API 키 (Google AI Studio) — 기록증 OCR 추출용 (서버 전용)
+GEMINI_API_KEY=
+```
+
+- [ ] **Step 3: 타입체크로 검증**
+
+Run: `pnpm exec tsc --noEmit`
+Expected: 에러 없음 (env 타입에 `GEMINI_API_KEY` 추가됨).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add lib/env.ts .env.example
+git commit -m "chore(env): add GEMINI_API_KEY server env var"
+```
+
+---
+
+## Task 2: OCR 순수 로직 모듈 (스키마 · 프롬프트 · 시간 정규화)
+
+**Files:**
+- Create: `lib/ocr/race-record.ts`
+- Test: 임시 `tmp-ocr-normalize.mjs` (검증 후 삭제)
+
+`@google/genai`의 `Type` enum과 기존 `timeStringToSeconds`(`lib/dayjs`)를 재사용한다. `normalizeOcrTime`은 Gemini가 준 시간 문자열을 `timeStringToSeconds`로 파싱 가능한지 확인하고, 가능하면 `H:MM:SS`/`HH:MM:SS`로 정돈된 문자열을, 불가능하면 `null`을 돌려준다. 폼의 `formatTimeInput`은 숫자만 받으므로 여기서는 콜론 포함 정규화 문자열을 만든다.
+
+- [ ] **Step 1: 모듈 작성**
+
+Create `lib/ocr/race-record.ts`:
+
+```typescript
+import { GoogleGenAI, Type } from "@google/genai";
+import { z } from "zod";
+
+import { timeStringToSeconds, secondsToTime } from "@/lib/dayjs";
+
+/** 기록증에서 추출하는 필드 (없는 값은 null) */
+export const extractedRecordSchema = z.object({
+  competitionName: z.string().nullable(),
+  raceDate: z.string().nullable(),
+  totalTime: z.string().nullable(),
+  swimTime: z.string().nullable(),
+  bikeTime: z.string().nullable(),
+  runTime: z.string().nullable(),
+});
+
+export type ExtractedRecord = z.infer<typeof extractedRecordSchema>;
+
+/** Gemini 구조화 출력 스키마 */
+const geminiResponseSchema = {
+  type: Type.OBJECT,
+  properties: {
+    competitionName: { type: Type.STRING, nullable: true },
+    raceDate: { type: Type.STRING, nullable: true },
+    totalTime: { type: Type.STRING, nullable: true },
+    swimTime: { type: Type.STRING, nullable: true },
+    bikeTime: { type: Type.STRING, nullable: true },
+    runTime: { type: Type.STRING, nullable: true },
+  },
+  required: [
+    "competitionName",
+    "raceDate",
+    "totalTime",
+    "swimTime",
+    "bikeTime",
+    "runTime",
+  ],
+};
+
+const PROMPT = `이 이미지는 러닝/마라톤/철인3종 대회의 기록증(완주증)입니다.
+다음 정보를 추출하세요. 이미지에 명시되지 않은 값은 반드시 null로 두세요. 추측하지 마세요.
+- competitionName: 대회 이름 (예: "SEOUL 2025 MARATHON")
+- raceDate: 대회 날짜를 YYYY-MM-DD 형식으로
+- totalTime: 완주 총 기록을 HH:MM:SS 형식으로
+- swimTime: (철인3종만) 수영 기록 HH:MM:SS, 없으면 null
+- bikeTime: (철인3종만) 자전거 기록 HH:MM:SS, 없으면 null
+- runTime: (철인3종만) 러닝 기록 HH:MM:SS, 없으면 null`;
+
+const YYYY_MM_DD = /^\d{4}-\d{2}-\d{2}$/;
+
+/** Gemini가 준 시간 문자열을 파싱 가능한 정규 형식으로. 실패 시 null */
+export function normalizeOcrTime(raw: string | null | undefined): string | null {
+  if (!raw) return null;
+  const seconds = timeStringToSeconds(raw);
+  if (seconds == null || seconds <= 0) return null;
+  return secondsToTime(seconds);
+}
+
+/** 날짜 문자열이 YYYY-MM-DD 형식이 아니면 null */
+export function normalizeOcrDate(raw: string | null | undefined): string | null {
+  if (!raw) return null;
+  return YYYY_MM_DD.test(raw.trim()) ? raw.trim() : null;
+}
+
+/** 추출 원본을 정규화 + 검증 */
+export function normalizeExtractedRecord(parsed: ExtractedRecord): ExtractedRecord {
+  return {
+    competitionName: parsed.competitionName?.trim() || null,
+    raceDate: normalizeOcrDate(parsed.raceDate),
+    totalTime: normalizeOcrTime(parsed.totalTime),
+    swimTime: normalizeOcrTime(parsed.swimTime),
+    bikeTime: normalizeOcrTime(parsed.bikeTime),
+    runTime: normalizeOcrTime(parsed.runTime),
+  };
+}
+
+/**
+ * 이미지 데이터(base64)에서 기록 정보를 추출하는 코어.
+ * 인증·FormData 처리는 호출하는 서버 액션이 담당한다.
+ * 503(모델 과부하) 대비 최대 3회 재시도.
+ */
+export async function extractRaceRecordFromImageData(params: {
+  apiKey: string;
+  base64: string;
+  mimeType: string;
+}): Promise<ExtractedRecord> {
+  const { apiKey, base64, mimeType } = params;
+  const ai = new GoogleGenAI({ apiKey });
+
+  let lastErr: unknown = null;
+  for (let attempt = 0; attempt < 3; attempt++) {
+    try {
+      const res = await ai.models.generateContent({
+        model: "gemini-2.5-flash",
+        contents: [
+          { inlineData: { mimeType, data: base64 } },
+          { text: PROMPT },
+        ],
+        config: {
+          responseMimeType: "application/json",
+          responseSchema: geminiResponseSchema,
+          temperature: 0,
+        },
+      });
+      const text = res.text;
+      if (!text) throw new Error("empty response");
+      const parsed = extractedRecordSchema.parse(JSON.parse(text));
+      return normalizeExtractedRecord(parsed);
+    } catch (err) {
+      lastErr = err;
+      const status = (err as { status?: number })?.status;
+      if (status === 503 && attempt < 2) {
+        await new Promise((r) => setTimeout(r, 1500 * (attempt + 1)));
+        continue;
+      }
+      throw err;
+    }
+  }
+  throw lastErr;
+}
+```
+
+- [ ] **Step 2: 순수 함수 검증 스크립트 작성**
+
+Create `tmp-ocr-normalize.mjs` (프로젝트 루트):
+
+```javascript
+// normalizeOcrTime/normalizeOcrDate 로직만 인라인 재현해 검증 (모듈은 TS라 직접 import 불가)
+import assert from "node:assert";
+
+// timeStringToSeconds 동작 모사 (H:MM:SS / M:SS)
+function tts(s) {
+  const p = s.trim().split(":").map(Number);
+  if (p.some(Number.isNaN)) return null;
+  if (p.length === 3) { const [h, m, sec] = p; if (h < 0 || m < 0 || m > 59 || sec < 0 || sec > 59) return null; return h*3600+m*60+sec; }
+  if (p.length === 2) { const [m, sec] = p; if (m < 0 || sec < 0 || sec > 59) return null; return m*60+sec; }
+  return null;
+}
+function secondsToTime(t) { const h=Math.floor(t/3600), m=Math.floor((t%3600)/60), s=t%60; const pad=n=>String(n).padStart(2,"0"); return h>0?`${h}:${pad(m)}:${pad(s)}`:`${m}:${pad(s)}`; }
+function normalizeOcrTime(raw){ if(!raw) return null; const s=tts(raw); if(s==null||s<=0) return null; return secondsToTime(s); }
+const YYYY=/^\d{4}-\d{2}-\d{2}$/;
+function normalizeOcrDate(raw){ if(!raw) return null; return YYYY.test(raw.trim())?raw.trim():null; }
+
+assert.strictEqual(normalizeOcrTime("03:25:29"), "3:25:29");
+assert.strictEqual(normalizeOcrTime("3:25:29"), "3:25:29");
+assert.strictEqual(normalizeOcrTime("83분"), null);
+assert.strictEqual(normalizeOcrTime(null), null);
+assert.strictEqual(normalizeOcrTime("00:00:00"), null);
+assert.strictEqual(normalizeOcrDate("2025-03-16"), "2025-03-16");
+assert.strictEqual(normalizeOcrDate("2025년 3월 16일"), null);
+assert.strictEqual(normalizeOcrDate(null), null);
+console.log("normalize 검증 통과");
+```
+
+- [ ] **Step 3: 검증 스크립트 실행**
+
+Run: `node tmp-ocr-normalize.mjs`
+Expected: `normalize 검증 통과` 출력, exit 0.
+
+- [ ] **Step 4: 타입체크 + 스크립트 삭제**
+
+Run: `pnpm exec tsc --noEmit && rm -f tmp-ocr-normalize.mjs`
+Expected: 타입 에러 없음.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add lib/ocr/race-record.ts
+git commit -m "feat(ocr): add 기록증 추출 코어 로직 (스키마·정규화·Gemini 호출)"
+```
+
+---
+
+## Task 3: 서버 액션
+
+**Files:**
+- Create: `app/actions/extract-race-record.ts`
+- Test: 임시 `tmp-ocr-action-test.mjs` (실제 기록증 추출, 검증 후 삭제)
+
+기존 액션 패턴(`app/actions/save-race-record.ts`)을 따른다. `getCurrentMember()`로 로그인 확인, `verifyActive()`로 활성 멤버 확인. FormData에서 `image` 파일을 꺼내 MIME·용량 가드 후 base64로 변환해 코어 호출.
+
+- [ ] **Step 1: 액션 작성**
+
+Create `app/actions/extract-race-record.ts`:
+
+```typescript
+"use server";
+
+import { env } from "@/lib/env";
+import {
+  extractRaceRecordFromImageData,
+  type ExtractedRecord,
+} from "@/lib/ocr/race-record";
+import { getCurrentMember, verifyActive } from "@/lib/queries/member";
+
+const MAX_BYTES = 10 * 1024 * 1024; // 10MB
+
+type ExtractResult =
+  | { ok: true; data: ExtractedRecord }
+  | { ok: false; message: string };
+
+export async function extractRaceRecordFromImage(
+  formData: FormData,
+): Promise<ExtractResult> {
+  const { member } = await getCurrentMember();
+  if (!member) {
+    return { ok: false, message: "로그인이 필요합니다." };
+  }
+  const active = await verifyActive();
+  if (!active.ok) {
+    return { ok: false, message: active.message };
+  }
+
+  const file = formData.get("image");
+  if (!(file instanceof File)) {
+    return { ok: false, message: "이미지를 첨부해 주세요." };
+  }
+  if (!file.type.startsWith("image/")) {
+    return { ok: false, message: "이미지 파일만 업로드할 수 있습니다." };
+  }
+  if (file.size > MAX_BYTES) {
+    return { ok: false, message: "이미지 용량은 10MB 이하여야 합니다." };
+  }
+
+  try {
+    const buffer = Buffer.from(await file.arrayBuffer());
+    const data = await extractRaceRecordFromImageData({
+      apiKey: env.GEMINI_API_KEY,
+      base64: buffer.toString("base64"),
+      mimeType: file.type,
+    });
+    return { ok: true, data };
+  } catch (err) {
+    console.error("기록증 OCR 추출 실패:", err);
+    return {
+      ok: false,
+      message: "사진에서 정보를 읽지 못했습니다. 직접 입력해 주세요.",
+    };
+  }
+}
+```
+
+- [ ] **Step 2: 실제 추출 검증 스크립트 작성**
+
+Create `tmp-ocr-action-test.mjs` (코어 로직을 실제 기록증으로 호출 — 액션은 Next 인증 컨텍스트가 필요하므로 코어를 직접 검증):
+
+```javascript
+import { readFileSync } from "node:fs";
+import { GoogleGenAI, Type } from "@google/genai";
+
+const apiKey = process.env.GEMINI_API_KEY;
+const base64 = readFileSync("C:/Prog/PRIVATE/temp/기록증.jpg").toString("base64");
+const ai = new GoogleGenAI({ apiKey });
+const schema = { type: Type.OBJECT, properties: {
+  competitionName:{type:Type.STRING,nullable:true}, raceDate:{type:Type.STRING,nullable:true},
+  totalTime:{type:Type.STRING,nullable:true}, swimTime:{type:Type.STRING,nullable:true},
+  bikeTime:{type:Type.STRING,nullable:true}, runTime:{type:Type.STRING,nullable:true},
+}, required:["competitionName","raceDate","totalTime","swimTime","bikeTime","runTime"] };
+const PROMPT = `이 이미지는 러닝/마라톤/철인3종 대회의 기록증입니다. 명시되지 않은 값은 null. competitionName, raceDate(YYYY-MM-DD), totalTime(HH:MM:SS), swimTime, bikeTime, runTime 추출.`;
+
+for (let i=0;i<3;i++){
+  try {
+    const res = await ai.models.generateContent({ model:"gemini-2.5-flash",
+      contents:[{inlineData:{mimeType:"image/jpeg",data:base64}},{text:PROMPT}],
+      config:{responseMimeType:"application/json",responseSchema:schema,temperature:0}});
+    console.log("결과:", JSON.parse(res.text)); process.exit(0);
+  } catch(e){ if(e.status===503&&i<2){ await new Promise(r=>setTimeout(r,2000)); continue;} throw e; }
+}
+```
+
+- [ ] **Step 3: 실제 추출 실행**
+
+Run: `node --env-file=.env.development.local tmp-ocr-action-test.mjs`
+Expected: `competitionName: "SEOUL 2025 MARATHON"`, `raceDate: "2025-03-16"`, `totalTime: "03:25:29"`, swim/bike/run `null`. (503 시 자동 재시도)
+
+- [ ] **Step 4: 타입체크 + 스크립트 삭제**
+
+Run: `pnpm exec tsc --noEmit && rm -f tmp-ocr-action-test.mjs`
+Expected: 타입 에러 없음.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/actions/extract-race-record.ts
+git commit -m "feat(ocr): add extract-race-record 서버 액션 (인증·가드·추출)"
+```
+
+---
+
+## Task 4: 클라이언트 — 0단계 업로드 UI
+
+**Files:**
+- Modify: `components/profile/race-record-dialog.tsx`
+
+0단계(업로드)를 추가한다. `step` 타입을 `0 | 1 | 2 | 3`로 바꾸고 초기값 0. 업로드 화면은 파일 선택 버튼 + "사진 없이 직접 입력" 버튼. 추출 호출과 prefill 연결은 Task 5에서.
+
+- [ ] **Step 1: import 및 상태 추가**
+
+`components/profile/race-record-dialog.tsx` 상단 import에 추가:
+
+```typescript
+import { extractRaceRecordFromImage } from "@/app/actions/extract-race-record";
+```
+
+`step` 상태 변경 (기존 `useState<1 | 2 | 3>(1)` → ):
+
+```typescript
+  const [step, setStep] = useState<0 | 1 | 2 | 3>(0);
+```
+
+기록 입력 상태 부근에 OCR 상태 추가:
+
+```typescript
+  // OCR (0단계)
+  const [ocrLoading, setOcrLoading] = useState(false);
+  const [ocrError, setOcrError] = useState<string | null>(null);
+  const [imagePreview, setImagePreview] = useState<string | null>(null);
+  const [ocrTimes, setOcrTimes] = useState<{
+    total: string | null;
+    swim: string | null;
+    bike: string | null;
+    run: string | null;
+  } | null>(null);
+  const [ocrFilledFields, setOcrFilledFields] = useState<Set<string>>(new Set());
+  const fileInputRef = useRef<HTMLInputElement | null>(null);
+```
+
+- [ ] **Step 2: 다이얼로그 초기화에 0단계 리셋 반영**
+
+`useEffect`의 `if (open) { ... }` 안에서 `setStep(1)` → `setStep(0)`로 바꾸고, 초기화 목록에 추가:
+
+```typescript
+      setStep(0);
+      setOcrLoading(false);
+      setOcrError(null);
+      setImagePreview(null);
+      setOcrTimes(null);
+      setOcrFilledFields(new Set());
+```
+
+- [ ] **Step 3: 업로드 핸들러 추가 (prefill 연결은 Task 5에서 완성, 여기서는 step 이동만)**
+
+`handleSave` 함수 앞에 추가:
+
+```typescript
+  async function handleImageSelected(file: File) {
+    setOcrError(null);
+    setOcrLoading(true);
+    setImagePreview(URL.createObjectURL(file));
+
+    const formData = new FormData();
+    formData.append("image", file);
+    const result = await extractRaceRecordFromImage(formData);
+
+    setOcrLoading(false);
+    if (!result.ok) {
+      setOcrError(result.message);
+      return; // 사용자가 다시 시도하거나 "직접 입력"으로 진행
+    }
+    applyOcrResult(result.data);
+  }
+
+  function skipOcr() {
+    setStep(1);
+  }
+```
+
+`applyOcrResult`는 Task 5에서 정의. 임시로 컴파일을 위해 Task 5 전까지는 아래 stub을 같은 위치에 둔다(Task 5에서 교체):
+
+```typescript
+  function applyOcrResult(_data: import("@/lib/ocr/race-record").ExtractedRecord) {
+    setStep(1);
+  }
+```
+
+- [ ] **Step 4: 0단계 렌더링 추가**
+
+`{/* 단계 1: ... */}` 블록 바로 앞에 추가:
+
+```tsx
+        {/* 단계 0: 기록증 사진 업로드 */}
+        {step === 0 && (
+          <div className="flex flex-col gap-4">
+            <p className="text-sm text-muted-foreground">
+              기록증 사진이 있으면 대회·시간을 자동으로 채워드려요.
+            </p>
+
+            {imagePreview && (
+              // eslint-disable-next-line @next/next/no-img-element
+              <img
+                src={imagePreview}
+                alt="기록증 미리보기"
+                className="max-h-48 w-full rounded-lg border border-border object-contain"
+              />
+            )}
+
+            <input
+              ref={fileInputRef}
+              type="file"
+              accept="image/*"
+              className="hidden"
+              onChange={(e) => {
+                const f = e.target.files?.[0];
+                if (f) void handleImageSelected(f);
+                e.target.value = "";
+              }}
+            />
+
+            <Button
+              type="button"
+              size="lg"
+              disabled={ocrLoading}
+              onClick={() => fileInputRef.current?.click()}
+              className="h-12 w-full rounded-xl font-semibold"
+            >
+              {ocrLoading ? "기록 읽는 중..." : "📷 기록증 사진 올리기"}
+            </Button>
+
+            {ocrError && <p className="text-xs text-destructive">{ocrError}</p>}
+
+            <div className="flex items-center gap-3">
+              <div className="h-px flex-1 bg-border" />
+              <span className="text-xs text-muted-foreground">또는</span>
+              <div className="h-px flex-1 bg-border" />
+            </div>
+
+            <Button
+              type="button"
+              variant="outline"
+              size="lg"
+              disabled={ocrLoading}
+              onClick={skipOcr}
+              className="h-12 w-full rounded-xl"
+            >
+              사진 없이 직접 입력
+            </Button>
+          </div>
+        )}
+```
+
+- [ ] **Step 5: DialogDescription에 0단계 문구 추가**
+
+`<DialogDescription>` 안 `{step === 1 && ...}` 앞에 추가:
+
+```tsx
+            {step === 0 && "기록증 사진을 올리거나 직접 입력해 주세요."}
+```
+
+- [ ] **Step 6: 뒤로가기 버튼 노출 조건 확인**
+
+`{step > 1 && (` 로 시작하는 뒤로가기 버튼은 0단계에서 숨겨야 한다(이미 `step > 1`이므로 0·1단계 모두 숨김 — 변경 불필요). 확인만.
+
+- [ ] **Step 7: 타입체크 + lint**
+
+Run: `pnpm exec tsc --noEmit && pnpm lint`
+Expected: 에러 없음.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add components/profile/race-record-dialog.tsx
+git commit -m "feat(ocr): add 기록증 업로드 0단계 UI to RaceRecordDialog"
+```
+
+---
+
+## Task 5: 클라이언트 — prefill 연결 + 프리필 힌트
+
+**Files:**
+- Modify: `components/profile/race-record-dialog.tsx`
+
+추출 결과를 ①단계 날짜·검색어로, 시간은 stash 후 ③단계 입력칸으로 흘려보낸다. AI가 채운 칸에는 힌트를 표시한다.
+
+- [ ] **Step 1: `applyOcrResult` 본체 구현 (Task 4의 stub 교체)**
+
+Task 4에서 둔 stub을 아래로 교체:
+
+```typescript
+  function applyOcrResult(data: import("@/lib/ocr/race-record").ExtractedRecord) {
+    if (data.raceDate) setRaceDate(data.raceDate);
+    if (data.competitionName) setSearchQuery(data.competitionName);
+    setOcrTimes({
+      total: data.totalTime,
+      swim: data.swimTime,
+      bike: data.bikeTime,
+      run: data.runTime,
+    });
+    setStep(1);
+  }
+```
+
+주의: `setSearchQuery`는 날짜가 있어야 의미가 있다(검색 입력이 `disabled={!hasRaceDate}`). 날짜가 없으면 검색어만 채워지고 사용자가 날짜를 고르면 목록이 좁혀진다.
+
+- [ ] **Step 2: step 3 진입 시 시간 prefill — `applyOcrTimesToStep3` 헬퍼 추가**
+
+`handleSelectEventType` 함수 위에 추가:
+
+```typescript
+  // OCR로 읽은 시간을 step 3 입력칸에 채운다 (사용자가 손대지 않은 빈 칸만).
+  function applyOcrTimesToStep3() {
+    if (!ocrTimes) return;
+    const filled = new Set<string>();
+    const toInput = (v: string | null) =>
+      v ? formatTimeInput(v.replace(/:/g, "")) : "";
+    if (ocrTimes.total) {
+      setTotalTime(toInput(ocrTimes.total));
+      filled.add("total");
+    }
+    if (ocrTimes.swim) {
+      setSwimTime(toInput(ocrTimes.swim));
+      filled.add("swim");
+    }
+    if (ocrTimes.bike) {
+      setBikeTime(toInput(ocrTimes.bike));
+      filled.add("bike");
+    }
+    if (ocrTimes.run) {
+      setRunTime(toInput(ocrTimes.run));
+      filled.add("run");
+    }
+    setOcrFilledFields(filled);
+  }
+```
+
+- [ ] **Step 3: step 3 진입 지점에서 헬퍼 호출**
+
+`handleSelectEventType` 안 `setStep(3)` 직전에 `applyOcrTimesToStep3();` 추가:
+
+```typescript
+  function handleSelectEventType(eventType: string) {
+    setSelectedEventType(eventType);
+    setTotalTime("");
+    setSwimTime("");
+    setBikeTime("");
+    setRunTime("");
+    setError(null);
+    applyOcrTimesToStep3();
+    setStep(3);
+  }
+```
+
+참가한 대회는 step 2 없이 step 3로 직행하므로, `handleSelectCompetition` 안 `setStep(comp.registeredEventType ? 3 : 2);` 직전에도 분기 호출:
+
+```typescript
+    if (comp.registeredEventType) applyOcrTimesToStep3();
+    setStep(comp.registeredEventType ? 3 : 2);
+```
+
+기타(직접 입력) 종목의 "다음" 버튼(`onClick={() => { setTotalTime(""); setError(null); setStep(3); }}`)에도 `applyOcrTimesToStep3()` 추가:
+
+```tsx
+                        onClick={() => {
+                          setTotalTime("");
+                          setError(null);
+                          applyOcrTimesToStep3();
+                          setStep(3);
+                        }}
+```
+
+- [ ] **Step 4: 사용자가 시간 입력칸을 수정하면 해당 힌트 제거**
+
+각 시간 `Input`의 `onChange`에서 힌트 필드를 제거한다. 예: 완주 시간(일반 종목)·총 시간(트라이애슬론)의 `onChange`:
+
+```tsx
+                  onChange={(e) => {
+                    setTotalTime(formatTimeInput(e.target.value));
+                    setOcrFilledFields((p) => {
+                      if (!p.has("total")) return p;
+                      const n = new Set(p);
+                      n.delete("total");
+                      return n;
+                    });
+                  }}
+```
+
+수영/자전거/러닝도 동일 패턴으로 각각 `"swim"`/`"bike"`/`"run"` 키를 제거하도록 `onChange` 수정.
+
+- [ ] **Step 5: 프리필 힌트 문구 추가**
+
+힌트를 표시하는 작은 헬퍼를 컴포넌트 내부(JSX 반환 전)에 추가:
+
+```tsx
+  const ocrHint = (field: string) =>
+    ocrFilledFields.has(field) ? (
+      <p className="text-[11px] text-muted-foreground">· 사진에서 읽음 — 확인해 주세요</p>
+    ) : null;
+```
+
+각 시간 입력칸 `Input` 바로 아래에 호출 추가. 예 (일반 종목 완주 시간):
+
+```tsx
+                <Input ... />
+                {ocrHint("total")}
+```
+
+트라이애슬론 총시간/수영/자전거/러닝 칸 아래에도 각각 `{ocrHint("total")}`, `{ocrHint("swim")}`, `{ocrHint("bike")}`, `{ocrHint("run")}` 추가.
+
+- [ ] **Step 6: 뒤로가기에 step 1 → step 0 분기 추가**
+
+`handleBack`에 `step === 1` 분기를 추가한다. 현재 `handleBack`은 step 2·3만 처리하고 step 1에서는 뒤로 버튼이 숨겨져 있다. 0단계 도입으로 step 1에서도 뒤로(=업로드 화면) 갈 수 있게 하려면, 뒤로가기 버튼 노출 조건 `{step > 1 && (` 을 `{step >= 1 && (` 로 바꾸고 `handleBack` 첫 분기로 추가:
+
+```typescript
+  function handleBack() {
+    setError(null);
+    if (step === 1) {
+      setStep(0);
+      return;
+    }
+    if (step === 3) {
+```
+
+- [ ] **Step 7: 타입체크 + lint**
+
+Run: `pnpm exec tsc --noEmit && pnpm lint`
+Expected: 에러 없음.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add components/profile/race-record-dialog.tsx
+git commit -m "feat(ocr): wire OCR 추출 결과 to 대회 검색·시간 prefill + 힌트"
+```
+
+---
+
+## Task 6: 빌드 검증 + 수동 E2E
+
+**Files:** 없음 (검증만)
+
+- [ ] **Step 1: 프로덕션 빌드(타입·번들)**
+
+Run: `pnpm build`
+Expected: 빌드 성공. (로컬 env 없으면 컴파일 후 env 검증 단계에서 실패할 수 있으나, 이는 코드 문제 아님 — `build-env-validation-limit` 메모 참조. 타입/컴파일 에러가 없는지 확인.)
+
+- [ ] **Step 2: dev 서버 + 브라우저 수동 E2E**
+
+Run: `pnpm dev` 후 기록 입력 다이얼로그를 여는 화면(프로필/기록 관련)으로 이동.
+
+확인 항목:
+1. 다이얼로그 열면 0단계(업로드 화면)가 먼저 보인다.
+2. `C:\Prog\PRIVATE\temp\기록증.jpg` 업로드 → "기록 읽는 중..." → ①단계로 이동, 날짜 `2025-03-16` prefill, 검색어 `SEOUL 2025 MARATHON` prefill.
+3. 날짜에 맞는 대회를 선택(없으면 "대회 추가"로 등록) → 코스 FULL 선택 → ③단계에서 완주 시간 `03:25:29` prefill + "사진에서 읽음" 힌트 표시.
+4. 시간 칸을 수정하면 힌트가 사라진다.
+5. "사진 없이 직접 입력" → 기존 수동 플로우 정상 동작.
+6. ①단계에서 "← 뒤로" → 0단계로 복귀.
+
+- [ ] **Step 3: 추적되면 안 되는 임시 파일 없는지 확인**
+
+Run: `git status --porcelain`
+Expected: `tmp-ocr-*.mjs` 등 임시 파일이 남아 있지 않음. 남아 있으면 삭제.
+
+- [ ] **Step 4: 최종 확인**
+
+설계 문서의 모든 요구사항이 구현되었는지 대조: 0단계 업로드 ✓, 대회명·날짜·시간 추출 ✓, prefill ✓, 사람 확정 ✓, 트라이애슬론 split(있을 때만) ✓, 트랜지션 자동계산 유지 ✓, 인증·가드 ✓, 503 재시도 ✓.
+
+---
+
+## Self-Review 결과
+
+- **Spec coverage:** 데이터 흐름(Task 4·5), 서버 액션(Task 3), env(Task 1), 순수 로직/정규화(Task 2), 0단계 UI(Task 4), prefill·힌트(Task 5), 에러/엣지(Task 3 가드 + 503 재시도, Task 5 prefill 안전), 테스트(Task 2·3·6) — 모두 태스크에 매핑됨.
+- **Placeholder scan:** stub은 Task 4→5에서 명시적으로 교체하도록 코드와 함께 지정. "적절히 처리" 류 문구 없음.
+- **Type consistency:** `extractRaceRecordFromImage`(액션, FormData→ExtractResult), `extractRaceRecordFromImageData`(코어, base64→ExtractedRecord), `ExtractedRecord` 필드명(`competitionName/raceDate/totalTime/swimTime/bikeTime/runTime`)이 Task 2·3·5 전반에서 일치. `ocrTimes` 키(`total/swim/bike/run`)와 `ocrFilledFields` 키 일치.

--- a/docs/superpowers/specs/2026-06-14-기록증-ocr-자동입력-design.md
+++ b/docs/superpowers/specs/2026-06-14-기록증-ocr-자동입력-design.md
@@ -1,0 +1,129 @@
+# 기록증 OCR 자동 입력 설계
+
+작성일: 2026-06-14
+대상 기능: 대회 기록증 사진을 Gemini 2.5 Flash로 읽어 기록 입력 폼을 자동으로 채우기
+
+## 배경 / 목적
+
+현재 `RaceRecordDialog`(`components/profile/race-record-dialog.tsx`)는 3단계 수동 입력이다.
+
+1. 대회 선택 (DB에 등록된 대회 — 최근 3개월 참가 목록 또는 날짜+이름 검색)
+2. 종목/코스 선택 (10K / HALF / FULL, 트라이애슬론 등)
+3. 기록 입력 (완주 시간. 트라이애슬론은 수영/바이크/런 분할 + 트랜지션 자동계산)
+
+완주 후 기록증 사진을 들고 시간을 직접 옮겨 적는 마찰을 줄인다. 사용자가 가진 **Google AI Studio Gemini API 키**로 기록증 이미지에서 정보를 추출해 폼을 미리 채운다.
+
+## 역할 분담 (핵심 원칙)
+
+- **사람이 정한다**: 대회(검색·선택·매칭 확정), 종목/코스(자전거/러닝 등 종목, 몇 km 코스).
+- **AI가 채운다**: 대회 이름, 완주 시간. 트라이애슬론은 수영/바이크/런 시간이 기록증에 있을 때만, 없으면 빈칸.
+- **AI는 채우기만, 확정은 사람.** 추출값은 전부 기존 편집 가능한 입력칸에 미리 채워지고, 사용자가 각 단계에서 보고 수정/확인 후 저장한다. 별도 확인 화면 없이 기존 입력칸이 곧 검증 UI다.
+
+## 데이터 흐름
+
+```
+[0단계 업로드 화면]
+  사용자: 기록증 사진 선택 (accept="image/*", 갤러리/카메라)
+      │
+      ▼
+  extractRaceRecordFromImage(FormData)  ← 서버 액션
+      │  Gemini 2.5 Flash 호출 (responseSchema로 JSON 강제, temperature 0)
+      ▼
+  { competitionName, raceDate, totalTime, swimTime, bikeTime, runTime }  (없는 값은 null)
+      │
+      ▼
+  ┌─ raceDate        → ①단계 날짜 피커 prefill → 대회 자동 검색
+  ├─ competitionName → ①단계 검색어 prefill (목록 좁히기)
+  └─ totalTime, swim/bike/run → ocrTimes에 stash → ③단계 입력칸 prefill
+```
+
+대회명·날짜는 **검색을 돕는 prefill일 뿐**, 어느 대회인지는 사람이 ①단계에서 확정한다.
+
+## 컴포넌트 / 책임
+
+### 1. 서버 액션 — `app/actions/extract-race-record.ts`
+
+```typescript
+extractRaceRecordFromImage(formData: FormData):
+  Promise<
+    | { ok: true; data: ExtractedRecord }
+    | { ok: false; message: string }
+  >
+```
+
+- 입력: `FormData`의 `image` 파일 1개.
+- 인증: `getCurrentMember()` + `verifyActive()` — 로그인·활성 멤버만 호출 가능 (우리 API 키 오남용 방지).
+- 가드: MIME `image/*` 화이트리스트 + 용량 상한 10MB. 초과/비이미지면 `{ ok:false }`.
+- 호출: `@google/genai` SDK, 모델 `gemini-2.5-flash`, `config.responseMimeType="application/json"` + `responseSchema`, `temperature: 0`.
+- 응답을 Zod로 한 번 더 검증 → `ExtractedRecord`.
+- 시간 정규화: Gemini가 `1:23:45` / `83분` 등으로 줄 수 있으므로 서버에서 `timeStringToSeconds`(`lib/dayjs`)로 파싱 가능한 `HH:MM:SS`로 정돈. 파싱 실패 항목은 `null`.
+
+`ExtractedRecord`:
+
+```typescript
+{
+  competitionName: string | null,   // 대회명
+  raceDate: string | null,          // "YYYY-MM-DD" (없으면 null)
+  totalTime: string | null,         // "HH:MM:SS" 완주 시간
+  swimTime: string | null,          // 트라이애슬론 수영 (없으면 null)
+  bikeTime: string | null,          // 트라이애슬론 자전거
+  runTime: string | null,           // 트라이애슬론 러닝
+  // 트랜지션은 폼이 total - swim - bike - run 으로 자동계산하므로 추출하지 않음
+}
+```
+
+프롬프트 요지: "기록증 이미지에서 다음을 추출. 없으면 null. 시간은 HH:MM:SS 형식. 날짜는 YYYY-MM-DD. 추측 금지, 이미지에 명시된 값만."
+
+### 2. 환경변수 — `lib/env.ts`
+
+- server에 `GEMINI_API_KEY: z.string().min(1)` 추가 + `runtimeEnv` 매핑.
+- `.env.example`에 `GEMINI_API_KEY=` (값 없이) 한 줄 추가.
+- 키는 `.env.development.local`(gitignore됨)에 보관. 배포는 Vercel 환경변수에 별도 등록.
+
+### 3. 클라이언트 — `components/profile/race-record-dialog.tsx`
+
+- `step` 타입 `0 | 1 | 2 | 3`, 다이얼로그 열릴 때 초기 `step = 0`.
+- **0단계 업로드 화면**: "기록증 사진 올리기"(파일 선택) + "사진 없이 직접 입력"(→ step 1).
+- 업로드 후:
+  - 썸네일 미리보기 + "기록 읽는 중..." 로딩.
+  - 성공: `raceDate`→날짜 prefill, `competitionName`→검색어 prefill, 시간들→`ocrTimes` stash, `step=1`.
+  - 실패/빈 결과: "사진에서 정보를 못 읽었어요. 직접 입력해 주세요." 후 `step=1`.
+- **stash → step 3 prefill**: step 3 진입 시 시간 입력칸이 비어 있으면 `ocrTimes`를 `formatTimeInput` 거쳐 채움. 사용자가 이미 손댄 값은 덮어쓰지 않음.
+- **프리필 투명성**: AI가 채운 칸 아래 `· 사진에서 읽음 — 확인해 주세요` 힌트. 수정하면 힌트 사라짐.
+- 뒤로가기: step 1 → step 0 분기 추가.
+
+추가 상태:
+
+| 상태 | 용도 |
+|------|------|
+| `step: 0` | 업로드 화면 |
+| `imagePreview` | 썸네일 URL (`URL.createObjectURL`) |
+| `ocrLoading` | 추출 중 로딩 |
+| `ocrTimes` | 추출 시간 stash (step 3에서 소비) |
+| `ocrFilledFields` | AI 프리필 칸 추적 (힌트 표시) |
+
+### 변경 없는 것
+
+서버 저장(`saveRaceRecord`), 대회/코스 선택 로직, 트라이애슬론 트랜지션 자동계산은 그대로. OCR은 입력만 거들고 기존 검증·저장 경로를 100% 재사용한다.
+
+## 에러 / 엣지 처리
+
+- Gemini 호출 실패(네트워크/쿼터): `{ ok:false, message }` → 사용자에게 안내 후 수동 진행. 기능 차단 아님.
+- 추출 0건: 모든 필드 null → step 1로 보내고 수동.
+- 오인식: 사람이 각 단계에서 확인·수정. 프리필 힌트로 "AI가 채운 값"임을 표시.
+- 비이미지/대용량 파일: 서버 가드에서 거절.
+- 비로그인/비활성: 액션이 거절.
+
+## 테스트
+
+- 단위: 시간 정규화 함수(`"1:23:45"`→`"01:23:45"`, `"83분"`→`null` 또는 변환, 파싱 실패→null).
+- 통합(수동): 실제 기록증(`SEOUL 2025 MARATHON`, 이현근, 03:25:29, FULL, 2025-03-16)으로 추출 → 기대값
+  `{ competitionName:"SEOUL 2025 MARATHON"(유사), raceDate:"2025-03-16", totalTime:"03:25:29", swim/bike/run:null }`.
+- E2E(수동): 다이얼로그 0단계 업로드 → step 1 검색 prefill 확인 → 대회/코스 선택 → step 3 시간 prefill 확인 → 저장.
+
+## 범위 밖 (YAGNI)
+
+- 트랜지션 직접 추출 (자동계산으로 충분).
+- 대회 자동 생성/매칭 (사람이 확정).
+- 진행률 스트리밍, 여러 장 일괄 처리.
+- 추출 정확도 학습/피드백 루프.

--- a/lib/env.ts
+++ b/lib/env.ts
@@ -6,6 +6,7 @@ export const env = createEnv({
     SUPABASE_SERVICE_ROLE_KEY: z.string().min(1),
     REVALIDATE_SECRET: z.string().min(1),
     KAKAO_CHAT_PASSWORD: z.string().optional(),
+    GEMINI_API_KEY: z.string().min(1),
     NODE_ENV: z.enum(["development", "production", "test"]),
   },
   client: {
@@ -20,6 +21,7 @@ export const env = createEnv({
     SUPABASE_SERVICE_ROLE_KEY: process.env.SUPABASE_SERVICE_ROLE_KEY,
     REVALIDATE_SECRET: process.env.REVALIDATE_SECRET,
     KAKAO_CHAT_PASSWORD: process.env.KAKAO_CHAT_PASSWORD,
+    GEMINI_API_KEY: process.env.GEMINI_API_KEY,
     NODE_ENV: process.env.NODE_ENV,
     NEXT_PUBLIC_SUPABASE_URL: process.env.NEXT_PUBLIC_SUPABASE_URL,
     NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY:

--- a/lib/ocr/race-record.ts
+++ b/lib/ocr/race-record.ts
@@ -1,0 +1,119 @@
+import { GoogleGenAI, Type } from "@google/genai";
+import { z } from "zod";
+
+import { timeStringToSeconds, secondsToTime } from "@/lib/dayjs";
+
+/** 기록증에서 추출하는 필드 (없는 값은 null) */
+export const extractedRecordSchema = z.object({
+  competitionName: z.string().nullable(),
+  raceDate: z.string().nullable(),
+  totalTime: z.string().nullable(),
+  swimTime: z.string().nullable(),
+  bikeTime: z.string().nullable(),
+  runTime: z.string().nullable(),
+});
+
+export type ExtractedRecord = z.infer<typeof extractedRecordSchema>;
+
+/** Gemini 구조화 출력 스키마 */
+const geminiResponseSchema = {
+  type: Type.OBJECT,
+  properties: {
+    competitionName: { type: Type.STRING, nullable: true },
+    raceDate: { type: Type.STRING, nullable: true },
+    totalTime: { type: Type.STRING, nullable: true },
+    swimTime: { type: Type.STRING, nullable: true },
+    bikeTime: { type: Type.STRING, nullable: true },
+    runTime: { type: Type.STRING, nullable: true },
+  },
+  required: [
+    "competitionName",
+    "raceDate",
+    "totalTime",
+    "swimTime",
+    "bikeTime",
+    "runTime",
+  ],
+};
+
+const PROMPT = `이 이미지는 러닝/마라톤/철인3종 대회의 기록증(완주증)입니다.
+다음 정보를 추출하세요. 이미지에 명시되지 않은 값은 반드시 null로 두세요. 추측하지 마세요.
+- competitionName: 대회 이름 (예: "SEOUL 2025 MARATHON")
+- raceDate: 대회 날짜를 YYYY-MM-DD 형식으로
+- totalTime: 완주 총 기록을 HH:MM:SS 형식으로
+- swimTime: (철인3종만) 수영 기록 HH:MM:SS, 없으면 null
+- bikeTime: (철인3종만) 자전거 기록 HH:MM:SS, 없으면 null
+- runTime: (철인3종만) 러닝 기록 HH:MM:SS, 없으면 null`;
+
+const YYYY_MM_DD = /^\d{4}-\d{2}-\d{2}$/;
+
+/** Gemini가 준 시간 문자열을 파싱 가능한 정규 형식으로. 실패 시 null */
+export function normalizeOcrTime(raw: string | null | undefined): string | null {
+  if (!raw) return null;
+  const seconds = timeStringToSeconds(raw);
+  if (seconds == null || seconds <= 0) return null;
+  return secondsToTime(seconds);
+}
+
+/** 날짜 문자열이 YYYY-MM-DD 형식이 아니면 null */
+export function normalizeOcrDate(raw: string | null | undefined): string | null {
+  if (!raw) return null;
+  return YYYY_MM_DD.test(raw.trim()) ? raw.trim() : null;
+}
+
+/** 추출 원본을 정규화 + 검증 */
+export function normalizeExtractedRecord(parsed: ExtractedRecord): ExtractedRecord {
+  return {
+    competitionName: parsed.competitionName?.trim() || null,
+    raceDate: normalizeOcrDate(parsed.raceDate),
+    totalTime: normalizeOcrTime(parsed.totalTime),
+    swimTime: normalizeOcrTime(parsed.swimTime),
+    bikeTime: normalizeOcrTime(parsed.bikeTime),
+    runTime: normalizeOcrTime(parsed.runTime),
+  };
+}
+
+/**
+ * 이미지 데이터(base64)에서 기록 정보를 추출하는 코어.
+ * 인증·FormData 처리는 호출하는 서버 액션이 담당한다.
+ * 503(모델 과부하) 대비 최대 3회 재시도.
+ */
+export async function extractRaceRecordFromImageData(params: {
+  apiKey: string;
+  base64: string;
+  mimeType: string;
+}): Promise<ExtractedRecord> {
+  const { apiKey, base64, mimeType } = params;
+  const ai = new GoogleGenAI({ apiKey });
+
+  let lastErr: unknown = null;
+  for (let attempt = 0; attempt < 3; attempt++) {
+    try {
+      const res = await ai.models.generateContent({
+        model: "gemini-2.5-flash",
+        contents: [
+          { inlineData: { mimeType, data: base64 } },
+          { text: PROMPT },
+        ],
+        config: {
+          responseMimeType: "application/json",
+          responseSchema: geminiResponseSchema,
+          temperature: 0,
+        },
+      });
+      const text = res.text;
+      if (!text) throw new Error("empty response");
+      const parsed = extractedRecordSchema.parse(JSON.parse(text));
+      return normalizeExtractedRecord(parsed);
+    } catch (err) {
+      lastErr = err;
+      const status = (err as { status?: number })?.status;
+      if (status === 503 && attempt < 2) {
+        await new Promise((r) => setTimeout(r, 1500 * (attempt + 1)));
+        continue;
+      }
+      throw err;
+    }
+  }
+  throw lastErr;
+}

--- a/lib/ocr/race-record.ts
+++ b/lib/ocr/race-record.ts
@@ -63,13 +63,19 @@ export function normalizeOcrDate(raw: string | null | undefined): string | null 
 
 /** 추출 원본을 정규화 + 검증 */
 export function normalizeExtractedRecord(parsed: ExtractedRecord): ExtractedRecord {
+  const swimTime = normalizeOcrTime(parsed.swimTime);
+  const bikeTime = normalizeOcrTime(parsed.bikeTime);
+  const runTime = normalizeOcrTime(parsed.runTime);
+  // 트라이애슬론 split은 all-or-nothing: 셋 다 있어야 신뢰. 하나라도 없으면 모두 버림
+  // (마라톤 등에서 모델이 총 기록을 runTime으로 환각하는 경우 방지)
+  const hasAllSplits = Boolean(swimTime && bikeTime && runTime);
   return {
     competitionName: parsed.competitionName?.trim() || null,
     raceDate: normalizeOcrDate(parsed.raceDate),
     totalTime: normalizeOcrTime(parsed.totalTime),
-    swimTime: normalizeOcrTime(parsed.swimTime),
-    bikeTime: normalizeOcrTime(parsed.bikeTime),
-    runTime: normalizeOcrTime(parsed.runTime),
+    swimTime: hasAllSplits ? swimTime : null,
+    bikeTime: hasAllSplits ? bikeTime : null,
+    runTime: hasAllSplits ? runTime : null,
   };
 }
 

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     }
   },
   "dependencies": {
+    "@google/genai": "^2.8.0",
     "@hookform/resolvers": "^5.2.2",
     "@next/third-parties": "^16.1.6",
     "@radix-ui/react-dialog": "^1.1.6",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,9 @@ importers:
 
   .:
     dependencies:
+      '@google/genai':
+        specifier: ^2.8.0
+        version: 2.8.0(@modelcontextprotocol/sdk@1.29.0(zod@4.3.6))
       '@hookform/resolvers':
         specifier: ^5.2.2
         version: 5.2.2(react-hook-form@7.71.2(react@19.2.4))
@@ -687,6 +690,15 @@ packages:
   '@floating-ui/utils@0.2.10':
     resolution: {integrity: sha512-aGTxbpbg8/b5JfU1HXSrbH3wXZuLPJcNEcZQFMxLs3oSzgtVu6nFPkbbGGUvBcUjKV2YyB9Wxxabo+HEH9tcRQ==}
 
+  '@google/genai@2.8.0':
+    resolution: {integrity: sha512-pc2ayxqO5+O7AvnHBqpNHIk7PAZkHZgL31tbyx0gJZBSS9qPYiQoqwK7oYOw/ePmG6QY4EMSu+304vD5QlhXAw==}
+    engines: {node: '>=20.0.0'}
+    peerDependencies:
+      '@modelcontextprotocol/sdk': ^1.25.2
+    peerDependenciesMeta:
+      '@modelcontextprotocol/sdk':
+        optional: true
+
   '@hono/node-server@1.19.14':
     resolution: {integrity: sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==}
     engines: {node: '>=18.14.1'}
@@ -1058,6 +1070,33 @@ packages:
     resolution: {integrity: sha512-akea+6bHYBBfA9uQqSYmlJXn61cTa+jbO87xVLCWbTqbWadRVmhxlXATaOjOgcBaWU4ePo0wB41KMFv3o35IXA==}
     engines: {node: '>=18'}
     hasBin: true
+
+  '@protobufjs/aspromise@1.1.2':
+    resolution: {integrity: sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ==}
+
+  '@protobufjs/base64@1.1.2':
+    resolution: {integrity: sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg==}
+
+  '@protobufjs/codegen@2.0.5':
+    resolution: {integrity: sha512-zgXFLzW3Ap33e6d0Wlj4MGIm6Ce8O89n/apUaGNB/jx+hw+ruWEp7EwGUshdLKVRCxZW12fp9r40E1mQrf/34g==}
+
+  '@protobufjs/eventemitter@1.1.1':
+    resolution: {integrity: sha512-vW1GmwMZNnL+gMRaovlh9yZX74kc+TTU3FObkkurpMaRtBfLP3ldjS9KQWlwZgraRE0+dheEEoAxdzcJQ8eXZg==}
+
+  '@protobufjs/fetch@1.1.1':
+    resolution: {integrity: sha512-GpptLrs57adMSuHi3VNj0mAF8dwh36LMaYF6XyJ6JMWlVsc+t42tm1HSEDmOs3A8fC9yyeisgLhsTVQokOZ0zw==}
+
+  '@protobufjs/float@1.0.2':
+    resolution: {integrity: sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ==}
+
+  '@protobufjs/path@1.1.2':
+    resolution: {integrity: sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA==}
+
+  '@protobufjs/pool@1.1.0':
+    resolution: {integrity: sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw==}
+
+  '@protobufjs/utf8@1.1.1':
+    resolution: {integrity: sha512-oOAWABowe8EAbMyWKM0tYDKi8Yaox52D+HWZhAIJqQXbqe0xI/GV7FhLWqlEKreMkfDjshR5FKgi3mnle0h6Eg==}
 
   '@radix-ui/number@1.1.1':
     resolution: {integrity: sha512-MkKCwxlXTgz6CFoJx3pCwn07GKp36+aZyu/u2Ln2VrA5DcdyCZkASEDBTd8x5whTQQL5CiYf4prXKLcgQdv29g==}
@@ -2301,6 +2340,9 @@ packages:
   '@types/resolve@1.20.6':
     resolution: {integrity: sha512-A4STmOXPhMUtHH+S6ymgE2GiBSMqf4oTvcQZMcHzokuTLVYzXTB8ttjcgxOVaAp2lGwEdzZ0J+cRbbeevQj1UQ==}
 
+  '@types/retry@0.12.0':
+    resolution: {integrity: sha512-wWKOClTTiizcZhXnPY4wikVAwmdYHp8q6DmC+EJUzAMsycb7HB32Kh9RN4+0gExjmPmZSAQjgURXIGATPegAvA==}
+
   '@types/set-cookie-parser@2.4.10':
     resolution: {integrity: sha512-GGmQVGpQWUe5qglJozEjZV/5dyxbOOZ0LHe/lqyWssB88Y4svNfst0uqBVscdDeIKl5Jy5+aPSvy7mI9tYRguw==}
 
@@ -2731,6 +2773,9 @@ packages:
     resolution: {integrity: sha512-QxD8cf2eVqJOOz63z6JIN9BzvVs/dlySa5HGSBH5xtR8dPteIRQnBxxKqkNTiT6jbDTF6jAfrd4oMcND9RGbQg==}
     engines: {node: '>=0.6'}
 
+  bignumber.js@9.3.1:
+    resolution: {integrity: sha512-Ko0uX15oIUS7wJ3Rb30Fs6SkVbLmPBAKdlm7q9+ak9bbIeFf0MwuBsQV6z7+X768/cHsfg+WlysDWJcmthjsjQ==}
+
   bin-links@6.0.0:
     resolution: {integrity: sha512-X4CiKlcV2GjnCMwnKAfbVWpHa++65th9TuzAEYtZoATiOE2DQKhSp4CJlyLoTqdhBKlXjpXjCTYPNNFS33Fi6w==}
     engines: {node: ^20.17.0 || >=22.9.0}
@@ -2772,6 +2817,9 @@ packages:
 
   buffer-crc32@0.2.13:
     resolution: {integrity: sha512-VO9Ht/+p3SN7SKWqcrgEzjGbRSJYTx+Q1pTQC0wrWqHx0vpJraQ6GtHx8tvcg1rlK1byhU5gccxgOgj7B0TDkQ==}
+
+  buffer-equal-constant-time@1.0.1:
+    resolution: {integrity: sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==}
 
   buffer-indexof-polyfill@1.0.2:
     resolution: {integrity: sha512-I7wzHwA3t1/lwXQh+A5PbNvJxgfo5r3xulgpYDB5zckTu/Z9oUK9biouBKQUjEqzaz3HnAT6TYoovmE+GqSf7A==}
@@ -3269,6 +3317,9 @@ packages:
   duplexer2@0.1.4:
     resolution: {integrity: sha512-asLFVfWWtJ90ZyOUHMqk7/S2w2guQKxUI2itj3d92ADHhxUSbCMGi1f1cBcJ7xM1To+pE/Khbwo1yuNbMEPKeA==}
 
+  ecdsa-sig-formatter@1.0.11:
+    resolution: {integrity: sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==}
+
   eciesjs@0.4.18:
     resolution: {integrity: sha512-wG99Zcfcys9fZux7Cft8BAX/YrOJLJSZ3jyYPfhZHqN2E+Ffx+QXBDsv3gubEgPtV6dTzJMSQUwk1H98/t/0wQ==}
     engines: {bun: '>=1', deno: '>=2', node: '>=16'}
@@ -3739,6 +3790,14 @@ packages:
   fuzzysort@3.1.0:
     resolution: {integrity: sha512-sR9BNCjBg6LNgwvxlBd0sBABvQitkLzoVY9MYYROQVX/FvfJ4Mai9LsGhDgd8qYdds0bY77VzYd5iuB+v5rwQQ==}
 
+  gaxios@7.1.5:
+    resolution: {integrity: sha512-5FZy72Rh8LhtjmvDrKkI+lVhrsQrVKVsItxMoDm5mNQE+xR0WVIIs+jzPSJgBvKVsLi24fZhXJIsNI0bihDzFg==}
+    engines: {node: '>=18'}
+
+  gcp-metadata@8.1.2:
+    resolution: {integrity: sha512-zV/5HKTfCeKWnxG0Dmrw51hEWFGfcF2xiXqcA3+J90WDuP0SvoiSO5ORvcBsifmx/FoIjgQN3oNOGaQ5PhLFkg==}
+    engines: {node: '>=18'}
+
   generator-function@2.0.1:
     resolution: {integrity: sha512-SFdFmIJi+ybC0vjlHN0ZGVGHc3lgE0DxPAT0djjVg+kjOnSqclqmj0KQ7ykTOLP6YxoqOvuAODGdcHJn+43q3g==}
     engines: {node: '>= 0.4'}
@@ -3832,6 +3891,14 @@ packages:
 
   globrex@0.1.2:
     resolution: {integrity: sha512-uHJgbwAMwNFf5mLst7IWLNg14x1CkeqglJb/K3doi4dw6q2IvAAmM/Y81kevy83wP+Sst+nutFTYOGg3d1lsxg==}
+
+  google-auth-library@10.7.0:
+    resolution: {integrity: sha512-QpTAbNJ36TliZLx3TTtahR8HG0hN9RllL1e3FymOvQSIKK8JmgV58H924ub2wa2DsS3ANjjP1Aw1N+Ramc8hqQ==}
+    engines: {node: '>=18'}
+
+  google-logging-utils@1.1.3:
+    resolution: {integrity: sha512-eAmLkjDjAFCVXg7A1unxHsLf961m6y17QFqXqAXGj/gVkKFrEICfStRfwUlGNfeCEjNRa32JEWOUTlYXPyyKvA==}
+    engines: {node: '>=14'}
 
   gopd@1.2.0:
     resolution: {integrity: sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==}
@@ -4293,6 +4360,9 @@ packages:
     engines: {node: '>=6'}
     hasBin: true
 
+  json-bigint@1.0.0:
+    resolution: {integrity: sha512-SiPv/8VpZuWbvLSMtTDU8hEfrZWg/mH/nV/b4o0CYbSxu1UIQPLdwKOCIyLQX+VIPO5vrLX3i8qtqFyhdPSUSQ==}
+
   json-buffer@3.0.1:
     resolution: {integrity: sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==}
 
@@ -4329,6 +4399,12 @@ packages:
 
   jszip@3.10.1:
     resolution: {integrity: sha512-xXDvecyTpGLrqFrvkrUSoxxfJI5AH7U8zxxtVclpsUtMCq4JQ290LY8AW5c7Ggnr/Y/oK+bQMbqK2qmtk3pN4g==}
+
+  jwa@2.0.1:
+    resolution: {integrity: sha512-hRF04fqJIP8Abbkq5NKGN0Bbr3JxlQ+qhZufXVr0DvujKy93ZCbXZMHDL4EOtodSbCWxOqR8MS1tXA5hwqCXDg==}
+
+  jws@4.0.1:
+    resolution: {integrity: sha512-EKI/M/yqPncGUUh44xz0PxSidXFr/+r0pA70+gIYhjv+et7yxM+s29Y+VGDkovRofQem0fs7Uvf4+YmAdyRduA==}
 
   keyv@4.5.4:
     resolution: {integrity: sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==}
@@ -4582,6 +4658,9 @@ packages:
   log-update@6.1.0:
     resolution: {integrity: sha512-9ie8ItPR6tjY5uYJh8K/Zrv/RMZ5VOlOWvtZdEHYSTFKZfIBPQa9tOAEeAWhd+AnIneLJ22w5fjOYtoutpWq5w==}
     engines: {node: '>=18'}
+
+  long@5.3.2:
+    resolution: {integrity: sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==}
 
   longest-streak@3.1.0:
     resolution: {integrity: sha512-9Ri+o0JYgehTaVBBDoMqIl8GXtbWg711O3srftcHhZ0dqnETqLaoIK0x17fUw9rFSlK/0NlsKe0Ahhyl5pXE2g==}
@@ -5040,6 +5119,10 @@ packages:
     resolution: {integrity: sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==}
     engines: {node: '>=10'}
 
+  p-retry@4.6.2:
+    resolution: {integrity: sha512-312Id396EbJdvRONlngUx0NydfrIQ5lsYu0znKVUzVvArzEIt08V1qhtyESbGVd1FGX7UKtiFp5uwKZdM8wIuQ==}
+    engines: {node: '>=8'}
+
   pako@1.0.11:
     resolution: {integrity: sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==}
 
@@ -5197,6 +5280,10 @@ packages:
 
   property-information@7.2.0:
     resolution: {integrity: sha512-IAtzIB6sUiWaJYrX9smp3V46pBGbBeLFRGdh25kg1334VcBlD8HzhPeNIWQH9zhGmo2itIe25EHt9dQP7G5hmg==}
+
+  protobufjs@7.6.4:
+    resolution: {integrity: sha512-RJJPTTpvFfHcWLkIa2JFWK4XvtSzS0yEWDmunqHXli1h3JlkbcQZXDZdcWxv+JK3Xsl5/UFDPZ0iGm7DAengYw==}
+    engines: {node: '>=12.0.0'}
 
   proxy-addr@2.0.7:
     resolution: {integrity: sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==}
@@ -5459,6 +5546,10 @@ packages:
   restore-cursor@5.1.0:
     resolution: {integrity: sha512-oMA2dcrw6u0YfxJQXm342bFKX/E4sG9rbTzO9ptUcR/e8A33cHuvStiYOwH7fszkZlZ1z/ta9AAoPk2F4qIOHA==}
     engines: {node: '>=18'}
+
+  retry@0.13.1:
+    resolution: {integrity: sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg==}
+    engines: {node: '>= 4'}
 
   rettime@0.11.8:
     resolution: {integrity: sha512-0fERGXktJTyJ+h8fBEiPxHPEFOu0h15JY7JtwrOVqR5K+vb99ho6IyOo7ekLS3h4sJCzIDy4VWKIbZUfe9njmg==}
@@ -6831,6 +6922,19 @@ snapshots:
 
   '@floating-ui/utils@0.2.10': {}
 
+  '@google/genai@2.8.0(@modelcontextprotocol/sdk@1.29.0(zod@4.3.6))':
+    dependencies:
+      google-auth-library: 10.7.0
+      p-retry: 4.6.2
+      protobufjs: 7.6.4
+      ws: 8.19.0
+    optionalDependencies:
+      '@modelcontextprotocol/sdk': 1.29.0(zod@4.3.6)
+    transitivePeerDependencies:
+      - bufferutil
+      - supports-color
+      - utf-8-validate
+
   '@hono/node-server@1.19.14(hono@4.12.14)':
     dependencies:
       hono: 4.12.14
@@ -7033,6 +7137,29 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@modelcontextprotocol/sdk@1.29.0(zod@4.3.6)':
+    dependencies:
+      '@hono/node-server': 1.19.14(hono@4.12.14)
+      ajv: 8.18.0
+      ajv-formats: 3.0.1(ajv@8.18.0)
+      content-type: 1.0.5
+      cors: 2.8.6
+      cross-spawn: 7.0.6
+      eventsource: 3.0.7
+      eventsource-parser: 3.0.8
+      express: 5.2.1
+      express-rate-limit: 8.4.0(express@5.2.1)
+      hono: 4.12.14
+      jose: 6.2.2
+      json-schema-typed: 8.0.2
+      pkce-challenge: 5.0.1
+      raw-body: 3.0.2
+      zod: 4.3.6
+      zod-to-json-schema: 3.25.2(zod@4.3.6)
+    transitivePeerDependencies:
+      - supports-color
+    optional: true
+
   '@mswjs/interceptors@0.41.5':
     dependencies:
       '@open-draft/deferred-promise': 2.2.0
@@ -7137,6 +7264,26 @@ snapshots:
     dependencies:
       playwright: 1.58.2
     optional: true
+
+  '@protobufjs/aspromise@1.1.2': {}
+
+  '@protobufjs/base64@1.1.2': {}
+
+  '@protobufjs/codegen@2.0.5': {}
+
+  '@protobufjs/eventemitter@1.1.1': {}
+
+  '@protobufjs/fetch@1.1.1':
+    dependencies:
+      '@protobufjs/aspromise': 1.1.2
+
+  '@protobufjs/float@1.0.2': {}
+
+  '@protobufjs/path@1.1.2': {}
+
+  '@protobufjs/pool@1.1.0': {}
+
+  '@protobufjs/utf8@1.1.1': {}
 
   '@radix-ui/number@1.1.1': {}
 
@@ -8389,6 +8536,8 @@ snapshots:
 
   '@types/resolve@1.20.6': {}
 
+  '@types/retry@0.12.0': {}
+
   '@types/set-cookie-parser@2.4.10':
     dependencies:
       '@types/node': 20.19.35
@@ -8870,6 +9019,8 @@ snapshots:
 
   big-integer@1.6.52: {}
 
+  bignumber.js@9.3.1: {}
+
   bin-links@6.0.0:
     dependencies:
       cmd-shim: 8.0.0
@@ -8933,6 +9084,8 @@ snapshots:
       update-browserslist-db: 1.2.3(browserslist@4.28.1)
 
   buffer-crc32@0.2.13: {}
+
+  buffer-equal-constant-time@1.0.1: {}
 
   buffer-indexof-polyfill@1.0.2: {}
 
@@ -9374,6 +9527,10 @@ snapshots:
   duplexer2@0.1.4:
     dependencies:
       readable-stream: 2.3.8
+
+  ecdsa-sig-formatter@1.0.11:
+    dependencies:
+      safe-buffer: 5.2.1
 
   eciesjs@0.4.18:
     dependencies:
@@ -10057,6 +10214,22 @@ snapshots:
 
   fuzzysort@3.1.0: {}
 
+  gaxios@7.1.5:
+    dependencies:
+      extend: 3.0.2
+      https-proxy-agent: 7.0.6
+      node-fetch: 3.3.2
+    transitivePeerDependencies:
+      - supports-color
+
+  gcp-metadata@8.1.2:
+    dependencies:
+      gaxios: 7.1.5
+      google-logging-utils: 1.1.3
+      json-bigint: 1.0.0
+    transitivePeerDependencies:
+      - supports-color
+
   generator-function@2.0.1: {}
 
   gensync@1.0.0-beta.2: {}
@@ -10163,6 +10336,19 @@ snapshots:
       gopd: 1.2.0
 
   globrex@0.1.2: {}
+
+  google-auth-library@10.7.0:
+    dependencies:
+      base64-js: 1.5.1
+      ecdsa-sig-formatter: 1.0.11
+      gaxios: 7.1.5
+      gcp-metadata: 8.1.2
+      google-logging-utils: 1.1.3
+      jws: 4.0.1
+    transitivePeerDependencies:
+      - supports-color
+
+  google-logging-utils@1.1.3: {}
 
   gopd@1.2.0: {}
 
@@ -10657,6 +10843,10 @@ snapshots:
 
   jsesc@3.1.0: {}
 
+  json-bigint@1.0.0:
+    dependencies:
+      bignumber.js: 9.3.1
+
   json-buffer@3.0.1: {}
 
   json-parse-even-better-errors@2.3.1: {}
@@ -10694,6 +10884,17 @@ snapshots:
       pako: 1.0.11
       readable-stream: 2.3.8
       setimmediate: 1.0.5
+
+  jwa@2.0.1:
+    dependencies:
+      buffer-equal-constant-time: 1.0.1
+      ecdsa-sig-formatter: 1.0.11
+      safe-buffer: 5.2.1
+
+  jws@4.0.1:
+    dependencies:
+      jwa: 2.0.1
+      safe-buffer: 5.2.1
 
   keyv@4.5.4:
     dependencies:
@@ -10896,6 +11097,8 @@ snapshots:
       slice-ansi: 7.1.2
       strip-ansi: 7.2.0
       wrap-ansi: 9.0.2
+
+  long@5.3.2: {}
 
   longest-streak@3.1.0: {}
 
@@ -11565,6 +11768,11 @@ snapshots:
     dependencies:
       p-limit: 3.1.0
 
+  p-retry@4.6.2:
+    dependencies:
+      '@types/retry': 0.12.0
+      retry: 0.13.1
+
   pako@1.0.11: {}
 
   parent-module@1.0.1:
@@ -11705,6 +11913,20 @@ snapshots:
       react-is: 16.13.1
 
   property-information@7.2.0: {}
+
+  protobufjs@7.6.4:
+    dependencies:
+      '@protobufjs/aspromise': 1.1.2
+      '@protobufjs/base64': 1.1.2
+      '@protobufjs/codegen': 2.0.5
+      '@protobufjs/eventemitter': 1.1.1
+      '@protobufjs/fetch': 1.1.1
+      '@protobufjs/float': 1.0.2
+      '@protobufjs/path': 1.1.2
+      '@protobufjs/pool': 1.1.0
+      '@protobufjs/utf8': 1.1.1
+      '@types/node': 20.19.35
+      long: 5.3.2
 
   proxy-addr@2.0.7:
     dependencies:
@@ -12119,6 +12341,8 @@ snapshots:
     dependencies:
       onetime: 7.0.0
       signal-exit: 4.1.0
+
+  retry@0.13.1: {}
 
   rettime@0.11.8: {}
 
@@ -13137,6 +13361,11 @@ snapshots:
   zod-to-json-schema@3.25.2(zod@3.25.76):
     dependencies:
       zod: 3.25.76
+
+  zod-to-json-schema@3.25.2(zod@4.3.6):
+    dependencies:
+      zod: 4.3.6
+    optional: true
 
   zod@3.25.76: {}
 


### PR DESCRIPTION
## 관련 이슈

관련 이슈 없음

## 요약

대회 기록증(완주증) 사진을 Gemini 2.5 Flash로 읽어 기록 입력 폼을 자동으로 채워준다. 사용자는 사진 한 장으로 대회명·날짜·완주 시간을 손으로 옮겨 적는 수고를 덜고, 최종 확정만 한다.

## AS-IS (변경 전)

기록 입력 다이얼로그(`RaceRecordDialog`)는 3단계 수동 입력만 제공했다.

1. 대회 선택 (DB 등록 대회 검색)
2. 종목/코스 선택
3. 완주 시간 직접 타이핑 (철인3종은 수영/바이크/런 분할까지)

완주 후 기록증을 보며 시간을 한 자씩 옮겨 적어야 했고, 대회명·날짜도 직접 검색해야 했다.

## TO-BE (변경 후)

다이얼로그 맨 앞에 **0단계 업로드 화면**을 추가했다.

- `📷 기록증 사진 올리기` → Gemini 2.5 Flash가 **대회명·날짜·완주 시간**을 추출.
- 추출값이 흐름에 prefill된다: 날짜 → 대회 검색, 대회명 → 검색어, 완주 시간(+철인 split) → 시간 입력칸.
- AI가 채운 칸엔 `· 사진에서 읽음 — 확인해 주세요` 힌트 표시, 사용자가 수정하면 사라짐.
- `사진 없이 직접 입력`으로 기존 수동 플로우도 그대로 사용 가능.

**역할 분담**: 대회·종목/코스 확정은 사람, 대회명·날짜·시간 추출은 AI. AI는 채우기만 하고 모든 값은 편집 가능하며, 기존 저장·검증 경로(`saveRaceRecord`)를 100% 재사용한다.

## 주요 변경 사항

- `lib/ocr/race-record.ts` (신규) — Zod 스키마, 시간/날짜 정규화, Gemini 2.5 Flash 호출 코어. 503 과부하 시 최대 3회 재시도. **트라이애슬론 split은 셋(수영·바이크·런)이 모두 있을 때만 채택** (마라톤에서 총 기록을 러닝으로 환각하는 경우 방지).
- `app/actions/extract-race-record.ts` (신규) — 서버 액션. `getCurrentMember`+`verifyActive` 인증, 이미지 MIME·10MB 가드. API 키는 서버에만 머문다.
- `components/profile/race-record-dialog.tsx` — 0단계 업로드 UI + prefill 연결 + 프리필 힌트 + 뒤로가기(step 1→0).
- `lib/env.ts`, `.env.example` — `GEMINI_API_KEY` 서버 환경변수 등록.
- `docs/superpowers/` — 설계·구현 계획 문서.

## 변경 흐름

```mermaid
flowchart TD
    A[다이얼로그 열기] --> B[0단계: 기록증 사진 업로드]
    B -->|사진 선택| C[extractRaceRecordFromImage 서버 액션]
    C -->|Gemini 2.5 Flash| D{추출 결과}
    D -->|날짜| E[1단계: 날짜 prefill → 대회 검색]
    D -->|대회명| F[검색어 prefill]
    D -->|완주시간·split| G[stash]
    E --> H[대회 선택]
    F --> H
    H --> I[2단계: 코스 선택]
    I --> J[3단계: 시간 prefill + 힌트]
    G --> J
    J --> K[사용자 확인·수정 후 저장]
    B -->|사진 없이 직접 입력| E
```

## 배포 참고

배포 환경에서 동작하려면 **Vercel 환경변수에 `GEMINI_API_KEY` 등록**이 필요하다.

## 테스트

- Gemini 추출 실검증: 실제 기록증(SEOUL 2025 MARATHON) → `대회명/2025-03-16/03:25:29/split null` 정확 추출 확인.
- 시간 정규화 단위 검증(1~9시간 변환 버그 수정 포함), tsc 0에러, lint 신규 0에러, build 컴파일 통과.
- 인증 상태 브라우저 클릭스루 E2E는 로컬 Supabase 기동 후 별도 확인 예정.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 기록증 사진 업로드를 통한 OCR 자동 입력 기능 추가
  * 추출된 대회 정보, 날짜, 기록 시간을 입력 폼에 자동 프리필
  * 사용자가 수정한 입력값은 자동입력 힌트 제외

* **문서화**
  * 기록증 OCR 자동입력 기능 설계 및 구현 계획 문서 추가

* **Chores**
  * Gemini API 의존성 추가
  * 서버 환경변수 설정 업데이트

<!-- end of auto-generated comment: release notes by coderabbit.ai -->