### PR TITLE
feat(records): OCR 기록입력 UX 개선 (사진 캐시·대회 추가 직결)

### DIFF
--- a/components/profile/race-record-dialog.tsx
+++ b/components/profile/race-record-dialog.tsx
@@ -9,6 +9,11 @@ import {
 } from "@/lib/comp-evt-type";
 import { timeStringToSeconds, secondsToTime } from "@/lib/dayjs";
 import {
+  getCachedExtraction,
+  hashImageFile,
+  setCachedExtraction,
+} from "@/lib/ocr/ocr-cache";
+import {
   eventTypeCodesForSprtFromCmmRows,
   type CachedCmmCdRow,
 } from "@/lib/queries/cmm-cd-cached";
@@ -357,21 +362,38 @@ export function RaceRecordDialog({
 
   async function handleImageSelected(file: File) {
     setOcrError(null);
-    setOcrLoading(true);
     setImagePreview((prev) => {
       if (prev) URL.revokeObjectURL(prev);
       return URL.createObjectURL(file);
     });
 
+    let hash: string | null = null;
+    try {
+      hash = await hashImageFile(file);
+    } catch {
+      hash = null;
+    }
+
+    // 같은 사진이면 Gemini 재호출 없이 캐시 사용 (토큰 절약)
+    if (hash) {
+      const cached = getCachedExtraction(hash);
+      if (cached) {
+        applyOcrResult(cached);
+        return;
+      }
+    }
+
+    setOcrLoading(true);
     const formData = new FormData();
     formData.append("image", file);
     const result = await extractRaceRecordFromImage(formData);
-
     setOcrLoading(false);
+
     if (!result.ok) {
       setOcrError(result.message);
       return;
     }
+    if (hash) setCachedExtraction(hash, result.data);
     applyOcrResult(result.data);
   }
 
@@ -918,7 +940,21 @@ export function RaceRecordDialog({
           datePolicy="allow-past"
           stackElevated
           prefillStartDate={raceDate.trim() || undefined}
-          onCreated={(_comp) => {}}
+          prefillTitle={searchQuery.trim() || undefined}
+          onCreated={(comp) => {
+            setRegisterOpen(false);
+            handleSelectCompetition(
+              {
+                id: comp.id,
+                title: comp.title,
+                start_date: comp.start_date,
+                location: comp.location,
+                sport: comp.sport ?? "",
+                event_types: comp.event_types,
+              },
+              { useCalendarPickForRecordDate: true },
+            );
+          }}
         />
       )}
 

--- a/components/profile/race-record-dialog.tsx
+++ b/components/profile/race-record-dialog.tsx
@@ -128,6 +128,7 @@ export function RaceRecordDialog({
     bike: string | null;
     run: string | null;
   } | null>(null);
+  const [ocrCompetitionName, setOcrCompetitionName] = useState<string | null>(null);
   const [ocrFilledFields, setOcrFilledFields] = useState<Set<string>>(new Set());
   const fileInputRef = useRef<HTMLInputElement | null>(null);
 
@@ -172,6 +173,7 @@ export function RaceRecordDialog({
         return null;
       });
       setOcrTimes(null);
+      setOcrCompetitionName(null);
       setOcrFilledFields(new Set());
       setSelectedComp(null);
       setRaceDate("");
@@ -404,6 +406,7 @@ export function RaceRecordDialog({
   function applyOcrResult(data: import("@/lib/ocr/race-record").ExtractedRecord) {
     if (data.raceDate) setRaceDate(data.raceDate);
     if (data.competitionName) setSearchQuery(data.competitionName);
+    setOcrCompetitionName(data.competitionName);
     setOcrTimes({
       total: data.totalTime,
       swim: data.swimTime,
@@ -940,7 +943,7 @@ export function RaceRecordDialog({
           datePolicy="allow-past"
           stackElevated
           prefillStartDate={raceDate.trim() || undefined}
-          prefillTitle={searchQuery.trim() || undefined}
+          prefillTitle={ocrCompetitionName?.trim() || undefined}
           onCreated={(comp) => {
             setRegisterOpen(false);
             handleSelectCompetition(

--- a/components/races/competition-register-dialog.tsx
+++ b/components/races/competition-register-dialog.tsx
@@ -86,6 +86,8 @@ interface CompetitionRegisterDialogProps {
   stackElevated?: boolean;
   /** 열 때 시작일(YYYY-MM-DD) 미리 채움 */
   prefillStartDate?: string;
+  /** OCR로 읽은 대회명 prefill (선택) */
+  prefillTitle?: string;
   /** 날짜 정책: 대회 탭은 미래/당일만, 기록 입력은 과거 허용 */
   datePolicy?: CompetitionRegisterDatePolicy;
 }
@@ -98,6 +100,7 @@ export function CompetitionRegisterDialog({
   onCreated,
   stackElevated = false,
   prefillStartDate,
+  prefillTitle,
   datePolicy = "future-only",
 }: CompetitionRegisterDialogProps) {
   const registerSchema = useMemo(
@@ -149,11 +152,12 @@ export function CompetitionRegisterDialog({
         ...defaultValues,
         sport: defaultSport,
         ...(prefillStartDate?.trim() ? { startDate: prefillStartDate.trim() } : {}),
+        ...(prefillTitle?.trim() ? { title: prefillTitle.trim() } : {}),
       });
     }
     // sportOptions는 열릴 때 기본 종목만 채우면 됨. 열려 있는 동안 cmmCdRows 참조 변경으로 reset이 재실행되면 입력 중 값이 날아갈 수 있음.
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [open, prefillStartDate, reset]);
+  }, [open, prefillStartDate, prefillTitle, reset]);
 
   const selectedCourseCount = selectedEventTypes.filter((t) => t !== COMP_EVT_TYPE_OTHER).length;
 

--- a/docs/superpowers/plans/2026-06-14-ocr-기록입력-ux-개선.md
+++ b/docs/superpowers/plans/2026-06-14-ocr-기록입력-ux-개선.md
@@ -1,0 +1,328 @@
+# OCR 기록입력 UX 개선 Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** OCR 기록입력에서 같은 사진의 Gemini 재호출을 막고(토큰 절약), "대회 추가" 우회에서도 OCR 결과가 살아남아 새 대회로 바로 이어지게 한다.
+
+**Architecture:** 클라이언트 전용 캐시 유틸(`lib/ocr/ocr-cache.ts`)이 이미지 SHA-256 해시로 sessionStorage 캐시를 관리한다. `RaceRecordDialog`의 업로드 핸들러가 캐시를 먼저 조회하고, `대회 추가` 다이얼로그의 `onCreated`를 직결해 생성된 대회를 자동 선택한다. `CompetitionRegisterDialog`에 `prefillTitle` prop을 추가해 OCR 대회명을 폼에 prefill한다. 기록↔대회 모델·스키마·랭킹은 변경하지 않는다.
+
+**Tech Stack:** Next.js(App Router) 클라이언트 컴포넌트, Web Crypto(`crypto.subtle`), `sessionStorage`, React Hook Form. 단위 테스트 러너 없음 → 순수 로직은 임시 node 스크립트, UI는 `pnpm exec tsc --noEmit` + `pnpm lint` + 수동 확인.
+
+**참고:** spec `docs/superpowers/specs/2026-06-14-ocr-기록입력-ux-개선-design.md`. 기존 OCR 기능은 `lib/ocr/race-record.ts`(`ExtractedRecord` 타입), `app/actions/extract-race-record.ts`, `components/profile/race-record-dialog.tsx`.
+
+---
+
+## File Structure
+
+| 파일 | 역할 | 변경 |
+|------|------|------|
+| `lib/ocr/ocr-cache.ts` | 이미지 SHA-256 해시 + sessionStorage 캐시 get/set | Create |
+| `components/races/competition-register-dialog.tsx` | `prefillTitle` prop 추가 (대회명 prefill) | Modify |
+| `components/profile/race-record-dialog.tsx` | 업로드 핸들러 캐시 경유 + `onCreated` 직결 + `prefillTitle` 전달 | Modify |
+
+**의존 순서:** Task 1(캐시 유틸) → Task 2(register prefillTitle prop) → Task 3(dialog가 1·2를 사용). Task 3은 1·2가 먼저 있어야 tsc 통과.
+
+---
+
+## Task 1: 이미지 해시 + sessionStorage 캐시 유틸
+
+**Files:**
+- Create: `lib/ocr/ocr-cache.ts`
+- Test: 임시 `tmp-ocr-cache.mjs` (검증 후 삭제)
+
+캐시는 best-effort다. 해시/스토리지 실패 시 조용히 null·무시하고 정상 추출로 폴백한다(기능 차단 금지).
+
+- [ ] **Step 1: 유틸 작성**
+
+Create `lib/ocr/ocr-cache.ts`:
+
+```typescript
+import type { ExtractedRecord } from "@/lib/ocr/race-record";
+
+const KEY_PREFIX = "ocr:";
+
+/** 이미지 바이트 → SHA-256 hex 문자열 */
+export async function hashImageFile(file: File): Promise<string> {
+  const buf = await file.arrayBuffer();
+  const digest = await crypto.subtle.digest("SHA-256", buf);
+  return Array.from(new Uint8Array(digest))
+    .map((b) => b.toString(16).padStart(2, "0"))
+    .join("");
+}
+
+/** sessionStorage "ocr:<hash>" 조회. 없거나 실패하면 null */
+export function getCachedExtraction(hash: string): ExtractedRecord | null {
+  try {
+    const raw = sessionStorage.getItem(KEY_PREFIX + hash);
+    return raw ? (JSON.parse(raw) as ExtractedRecord) : null;
+  } catch {
+    return null;
+  }
+}
+
+/** sessionStorage "ocr:<hash>"에 저장. 실패(용량/미가용)는 무시 */
+export function setCachedExtraction(hash: string, data: ExtractedRecord): void {
+  try {
+    sessionStorage.setItem(KEY_PREFIX + hash, JSON.stringify(data));
+  } catch {
+    // best-effort: quota 초과/스토리지 미가용 시 무시
+  }
+}
+```
+
+- [ ] **Step 2: 검증 스크립트 작성**
+
+Create `tmp-ocr-cache.mjs` (프로젝트 루트). node의 `crypto.subtle`와 인메모리 Storage 모킹으로 로직을 검증:
+
+```javascript
+import assert from "node:assert";
+
+// hashImageFile 로직 재현 (node globalThis.crypto.subtle 사용)
+async function hashBytes(bytes) {
+  const digest = await crypto.subtle.digest("SHA-256", bytes);
+  return Array.from(new Uint8Array(digest))
+    .map((b) => b.toString(16).padStart(2, "0"))
+    .join("");
+}
+
+// 같은 바이트 → 같은 hex, 다른 바이트 → 다른 hex
+const a = new Uint8Array([1, 2, 3, 4]);
+const a2 = new Uint8Array([1, 2, 3, 4]);
+const b = new Uint8Array([9, 9, 9]);
+const ha = await hashBytes(a);
+const ha2 = await hashBytes(a2);
+const hb = await hashBytes(b);
+assert.strictEqual(ha, ha2, "같은 바이트는 같은 해시");
+assert.notStrictEqual(ha, hb, "다른 바이트는 다른 해시");
+assert.match(ha, /^[0-9a-f]{64}$/, "SHA-256 hex 64자");
+
+// get/set 라운드트립 (sessionStorage 모킹)
+const store = new Map();
+const sessionStorage = {
+  getItem: (k) => (store.has(k) ? store.get(k) : null),
+  setItem: (k, v) => store.set(k, v),
+};
+const KEY_PREFIX = "ocr:";
+function getCached(hash) {
+  try { const raw = sessionStorage.getItem(KEY_PREFIX + hash); return raw ? JSON.parse(raw) : null; } catch { return null; }
+}
+function setCached(hash, data) {
+  try { sessionStorage.setItem(KEY_PREFIX + hash, JSON.stringify(data)); } catch {}
+}
+assert.strictEqual(getCached(ha), null, "미저장이면 null");
+const rec = { competitionName: "SEOUL", raceDate: "2025-03-16", totalTime: "3:25:29", swimTime: null, bikeTime: null, runTime: null };
+setCached(ha, rec);
+assert.deepStrictEqual(getCached(ha), rec, "저장 후 동일 객체 반환");
+console.log("ocr-cache 검증 통과");
+```
+
+- [ ] **Step 3: 검증 실행**
+
+Run: `node tmp-ocr-cache.mjs`
+Expected: `ocr-cache 검증 통과`, exit 0.
+
+- [ ] **Step 4: 타입체크 + 스크립트 삭제**
+
+Run: `pnpm exec tsc --noEmit && rm -f tmp-ocr-cache.mjs`
+Expected: 타입 에러 없음.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add lib/ocr/ocr-cache.ts
+git commit -m "feat(ocr): add 이미지 해시 sessionStorage 캐시 유틸"
+```
+
+---
+
+## Task 2: CompetitionRegisterDialog에 prefillTitle prop 추가
+
+**Files:**
+- Modify: `components/races/competition-register-dialog.tsx`
+
+현재 `prefillStartDate`만 지원한다. `prefillTitle`을 같은 패턴으로 추가한다. **먼저 파일을 읽어** props 인터페이스(`CompetitionRegisterDialogProps`, ~78줄), 구조분해 파라미터(~93줄), `reset` 기본값 병합 `useEffect`(~145~156줄, `prefillStartDate` 사용부)의 정확한 위치를 확인하라.
+
+- [ ] **Step 1: props 인터페이스에 추가**
+
+`interface CompetitionRegisterDialogProps { ... }` 안 `prefillStartDate?: string;` 다음 줄에 추가:
+
+```typescript
+  /** OCR로 읽은 대회명 prefill (선택) */
+  prefillTitle?: string;
+```
+
+- [ ] **Step 2: 구조분해 파라미터에 추가**
+
+`export function CompetitionRegisterDialog({ ... })`의 구조분해 목록에서 `prefillStartDate,` 다음에 `prefillTitle,` 추가.
+
+- [ ] **Step 3: reset 기본값 병합에 title 추가**
+
+`reset` 호출의 기본값 객체에서 `prefillStartDate`를 병합하는 부분:
+
+```typescript
+        ...(prefillStartDate?.trim() ? { startDate: prefillStartDate.trim() } : {}),
+```
+
+바로 다음 줄에 추가:
+
+```typescript
+        ...(prefillTitle?.trim() ? { title: prefillTitle.trim() } : {}),
+```
+
+- [ ] **Step 4: useEffect 의존성 배열에 prefillTitle 추가**
+
+해당 `useEffect`의 deps 배열(현재 `[open, prefillStartDate, reset]`)을 `[open, prefillStartDate, prefillTitle, reset]`로 변경.
+
+- [ ] **Step 5: 검증**
+
+Run: `pnpm exec tsc --noEmit && pnpm lint`
+Expected: 타입 에러 없음. 이 파일 새 lint 에러 없음(기존 파일들의 기존 에러는 무관).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add components/races/competition-register-dialog.tsx
+git commit -m "feat(races): add prefillTitle prop to CompetitionRegisterDialog"
+```
+
+---
+
+## Task 3: 다이얼로그 — 캐시 경유 업로드 + onCreated 직결 + prefillTitle 전달
+
+**Files:**
+- Modify: `components/profile/race-record-dialog.tsx`
+
+**먼저 파일을 읽어** `handleImageSelected`(현재 358~376줄), `applyOcrResult`(~382줄), 하단의 `<CompetitionRegisterDialog ... onCreated={(_comp) => {}} />`(~913~921줄), 그리고 로컬 `Competition` 인터페이스(~35~46줄, `id/title/start_date/location/sport/event_types` + 선택 필드)와 `handleSelectCompetition` 시그니처를 확인하라.
+
+주의: `CompetitionRegisterDialog`의 `onCreated`가 넘기는 `Competition`은 `components/races/types`의 타입(`sport: string | null` 등)이라 로컬 `Competition`(`sport: string`)과 형태가 다르다. Step 3에서 명시적으로 매핑한다.
+
+- [ ] **Step 1: import 추가**
+
+상단 import 그룹(`@/lib/ocr/...` 또는 다른 `@/lib` import 근처)에 추가:
+
+```typescript
+import {
+  getCachedExtraction,
+  hashImageFile,
+  setCachedExtraction,
+} from "@/lib/ocr/ocr-cache";
+```
+
+- [ ] **Step 2: `handleImageSelected`를 캐시 경유로 교체**
+
+현재 `handleImageSelected` 함수 전체를 아래로 교체:
+
+```typescript
+  async function handleImageSelected(file: File) {
+    setOcrError(null);
+    setImagePreview((prev) => {
+      if (prev) URL.revokeObjectURL(prev);
+      return URL.createObjectURL(file);
+    });
+
+    let hash: string | null = null;
+    try {
+      hash = await hashImageFile(file);
+    } catch {
+      hash = null;
+    }
+
+    // 같은 사진이면 Gemini 재호출 없이 캐시 사용 (토큰 절약)
+    if (hash) {
+      const cached = getCachedExtraction(hash);
+      if (cached) {
+        applyOcrResult(cached);
+        return;
+      }
+    }
+
+    setOcrLoading(true);
+    const formData = new FormData();
+    formData.append("image", file);
+    const result = await extractRaceRecordFromImage(formData);
+    setOcrLoading(false);
+
+    if (!result.ok) {
+      setOcrError(result.message);
+      return;
+    }
+    if (hash) setCachedExtraction(hash, result.data);
+    applyOcrResult(result.data);
+  }
+```
+
+- [ ] **Step 3: `onCreated` 직결 + `prefillTitle` 전달**
+
+하단 `<CompetitionRegisterDialog ... />`에서 `prefillStartDate={raceDate.trim() || undefined}` 다음에 prop 추가하고, `onCreated={(_comp) => {}}`를 본체로 교체:
+
+```tsx
+          prefillStartDate={raceDate.trim() || undefined}
+          prefillTitle={searchQuery.trim() || undefined}
+          onCreated={(comp) => {
+            setRegisterOpen(false);
+            handleSelectCompetition(
+              {
+                id: comp.id,
+                title: comp.title,
+                start_date: comp.start_date,
+                location: comp.location,
+                sport: comp.sport ?? "",
+                event_types: comp.event_types,
+              },
+              { useCalendarPickForRecordDate: true },
+            );
+          }}
+```
+
+근거: 생성된 대회를 즉시 선택해 OCR 시간 stash를 step 3로 흘려보낸다(`handleSelectCompetition`이 종목 없으면 step 2→코스 선택 시 `applyOcrTimesToStep3` 실행). `sport: comp.sport ?? ""`로 nullable 타입을 로컬 `Competition`(`sport: string`)에 맞춘다. `searchQuery`엔 OCR 대회명이 담겨 있어 `prefillTitle`로 그대로 넘긴다.
+
+- [ ] **Step 4: 검증**
+
+Run: `pnpm exec tsc --noEmit && pnpm lint`
+Expected: 타입 에러 없음. 이 파일 새 lint 에러 없음(기존 `selectedComp` exhaustive-deps 경고 1건은 무관, 그대로 둠).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add components/profile/race-record-dialog.tsx
+git commit -m "feat(ocr): 사진 캐시 경유 업로드 + 대회 추가 직결 + 대회명 prefill"
+```
+
+---
+
+## Task 4: 빌드 검증 + 수동 확인 안내
+
+**Files:** 없음 (검증만)
+
+- [ ] **Step 1: 타입·린트·빌드**
+
+Run: `pnpm exec tsc --noEmit && pnpm lint`
+Expected: 타입 에러 0, 신규 lint 에러 0.
+
+Run: `pnpm build`
+Expected: 컴파일 통과. (로컬 env 부재 시 빌드 막바지 env 검증에서 실패할 수 있으나 코드 문제 아님 — `build-env-validation-limit` 메모 참조. 타입/컴파일 에러가 없는지만 확인.)
+
+- [ ] **Step 2: 임시 파일 잔존 확인**
+
+Run: `git status --porcelain`
+Expected: `tmp-ocr-*.mjs` 등 임시 파일 없음.
+
+- [ ] **Step 3: 수동 확인 항목 정리(실행은 사용자 환경에서)**
+
+로컬 Supabase 기동 후 `pnpm dev`로:
+1. 기록 입력 → 0단계에서 기록증 업로드 → 결과 prefill.
+2. **같은 사진 다시 업로드 → "기록 읽는 중" 없이 즉시 채워짐**(개발자도구 Network에 extract 요청 없음). 토큰 재호출 0.
+3. 날짜에 맞는 대회 없음 → 대회 추가 → **폼에 대회명·날짜 prefill** 확인 → 종목 골라 생성 → **자동으로 그 대회 선택되어 코스 선택 → 시간 prefill**까지 이어짐.
+4. OCR 결과가 대회 추가 우회 후에도 살아 있음.
+
+- [ ] **Step 4: 최종 대조**
+
+spec 요구사항 매핑 확인: 사진 캐시(Task 1·3) ✓, 세션 보존(기존 stash 유지) ✓, 대회 추가 직결(Task 3) ✓, 대회명 prefill(Task 2·3) ✓, 정합성/스키마 무변경 ✓.
+
+---
+
+## Self-Review 결과
+
+- **Spec coverage:** 사진 해시 캐시(Task 1), 업로드 핸들러 캐시 경유(Task 3 Step 2), 대회 추가 직결(Task 3 Step 3), 대회 추가 폼 prefill(Task 2 + Task 3 Step 3), 에러/엣지(캐시 best-effort try/catch, sport null 매핑), 테스트(Task 1 스크립트 + Task 4 수동) — 모두 매핑됨.
+- **Placeholder scan:** 모든 코드 단계에 실제 코드 포함. "적절히 처리" 류 없음.
+- **Type consistency:** `hashImageFile`/`getCachedExtraction`/`setCachedExtraction`(Task 1) ↔ Task 3 import·호출 일치. `ExtractedRecord` 필드 일치. register `Competition`(`sport: string|null`) → 로컬 `Competition`(`sport: string`) 매핑을 Task 3에서 `?? ""`로 명시. `prefillTitle` prop(Task 2) ↔ Task 3 전달 일치.

--- a/docs/superpowers/specs/2026-06-14-ocr-기록입력-ux-개선-design.md
+++ b/docs/superpowers/specs/2026-06-14-ocr-기록입력-ux-개선-design.md
@@ -1,0 +1,128 @@
+# OCR 기록입력 UX 개선 설계
+
+작성일: 2026-06-14
+대상: `RaceRecordDialog` OCR 기반 기록입력 흐름 개선 (기록↔대회 링크 = 정합성 유지)
+
+## 배경
+
+[기록증 OCR 자동입력](2026-06-14-기록증-ocr-자동입력-design.md) 기능 도입 후 실사용에서 마찰 발견:
+
+1. **OCR 결과가 "대회 추가" 우회에서 사라짐.** 매칭되는 대회가 없어 `대회 추가`로 가면, 새 대회를 만들어도 아무 일도 안 일어난다(`race-record-dialog.tsx`의 `onCreated={(_comp) => {}}` 빈 함수). 새 대회가 자동 선택되지 않아 사용자는 진행이 막히고, 추출 결과가 날아간 것처럼 느낀다.
+2. **토큰 재호출 낭비.** 같은 기록증을 다시 올리면 Gemini를 또 호출한다. 비용이 든다.
+
+전제: 기록은 대회에 묶는다(`rec_race_hist.comp_id` 유지). 랭킹·칭호·대회 탭 정합성을 위해 모델·스키마·랭킹 쿼리는 변경하지 않는다. 이 문서는 그 제약 안에서 OCR 입력 UX만 개선한다.
+
+## 목표
+
+- OCR 결과를 세션 내내 보존하고, "대회 추가" 우회를 건너도 살아남게 한다.
+- 같은 사진은 Gemini를 다시 부르지 않는다(토큰 절약).
+- 대회 추가가 거의 자동이 되도록 OCR 정보로 prefill하고, 생성 후 그 대회로 직결한다.
+
+## 변경 단위
+
+### 1. 사진 해시 캐시 — `lib/ocr/ocr-cache.ts` (신규)
+
+클라이언트 전용 유틸. 같은 이미지면 서버 액션(Gemini)을 건너뛴다.
+
+```typescript
+// 이미지 바이트 → SHA-256 hex
+export async function hashImageFile(file: File): Promise<string>;
+
+// sessionStorage "ocr:<hash>" 조회/저장 (ExtractedRecord JSON)
+export function getCachedExtraction(hash: string): ExtractedRecord | null;
+export function setCachedExtraction(hash: string, data: ExtractedRecord): void;
+```
+
+- 해시: `crypto.subtle.digest("SHA-256", await file.arrayBuffer())` → hex 문자열.
+- 저장소: `sessionStorage` (탭 단위, 닫으면 비움 — 누적/스테일 방지). 키 `ocr:<hash>`.
+- 직렬화 실패/용량 초과/`sessionStorage` 미가용 시 조용히 무시(캐시는 best-effort, 실패해도 정상 추출로 폴백).
+- `ExtractedRecord` 타입은 `@/lib/ocr/race-record`에서 import.
+
+### 2. 다이얼로그 업로드 핸들러 — `components/profile/race-record-dialog.tsx`
+
+`handleImageSelected`를 캐시 경유로 변경:
+
+```
+1. setImagePreview (기존)
+2. hash = await hashImageFile(file)
+3. cached = getCachedExtraction(hash)
+   - HIT  → applyOcrResult(cached); 로딩 없이 즉시. (토큰 0)
+   - MISS → setOcrLoading(true) → 서버 액션 호출
+             → 성공: setCachedExtraction(hash, data); applyOcrResult(data)
+             → 실패: setOcrError(메시지)
+```
+
+인메모리 stash(`ocrTimes`/`raceDate`/`searchQuery`)는 기존대로 유지되어 세션 내 보존. 변경 없음.
+
+### 3. 대회 추가 직결 — `components/profile/race-record-dialog.tsx`
+
+`onCreated` 빈 함수를 본체로 교체:
+
+```typescript
+onCreated={(comp) => {
+  setRegisterOpen(false);
+  handleSelectCompetition(comp, { useCalendarPickForRecordDate: true });
+}}
+```
+
+- `handleSelectCompetition`은 이미 `selectedComp` 설정 + (참가종목 있으면) `applyOcrTimesToStep3()` 호출 + step 진행을 한다. 새로 만든 대회는 참가종목이 없으므로 step 2(코스 선택)로 가고, 코스 선택 시 `applyOcrTimesToStep3()`가 시간 prefill.
+- `useCalendarPickForRecordDate: true`로 OCR/달력 날짜(`raceDate`)를 기록일로 사용.
+- 생성된 `comp`(= `Competition`)에는 새 대회라 `event_types`가 비어 있을 수 있다. 그래도 코스 옵션은 종목 기본값 + 기타(직접입력)로 채워지므로(`eventTypeOptions` 기존 로직) 코스 선택 가능.
+
+`Competition` 타입 정합: `CompetitionRegisterDialog.onCreated`가 넘기는 객체가 다이얼로그 내부 `Competition` 형태(`id/title/start_date/location/sport/event_types`)와 호환되는지 확인하고, 필요한 필드만 매핑한다.
+
+### 4. 대회 추가 폼 prefill — `components/races/competition-register-dialog.tsx`
+
+`prefillTitle?: string` prop 추가 (현재 `prefillStartDate`만 존재).
+
+- props 인터페이스에 `prefillTitle?: string` 추가.
+- `reset` 기본값 병합부(현재 `...(prefillStartDate?.trim() ? { startDate: prefillStartDate.trim() } : {})`)에 동일 패턴으로 `...(prefillTitle?.trim() ? { title: prefillTitle.trim() } : {})` 추가.
+- `useEffect` 의존성 배열에 `prefillTitle` 추가.
+
+`race-record-dialog.tsx`에서 전달:
+
+```tsx
+<CompetitionRegisterDialog
+  ...
+  prefillStartDate={raceDate.trim() || undefined}
+  prefillTitle={ocrCompetitionName?.trim() || undefined}
+  onCreated={(comp) => { ... }}
+/>
+```
+
+- OCR로 읽은 대회명은 `applyOcrResult`에서 `searchQuery`에 이미 담긴다. 별도 상태 추가 없이 `searchQuery`를 `prefillTitle`로 넘긴다(검색어 = OCR 대회명).
+
+## 데이터 흐름
+
+```
+사진 선택
+  → SHA-256 해시 → sessionStorage("ocr:<hash>") 조회
+      ├ HIT  → 캐시 ExtractedRecord 즉시 적용 (Gemini 호출 0)
+      └ MISS → 서버 액션(Gemini) → 결과 캐시 저장 → 적용
+  적용(applyOcrResult): raceDate→날짜, competitionName→searchQuery, 시간→ocrTimes stash, step 1
+      │
+  step 1: 날짜로 대회 목록 자동 로딩 + 이름으로 좁힘
+      ├ 맞는 대회 있음 → 선택 → (step 2 코스) → step 3 시간 prefill
+      └ 없음 → 대회 추가(이름·날짜 prefill) → 생성 → onCreated 직결
+                → handleSelectCompetition(새 대회) → step 2 코스 → step 3 시간 prefill
+```
+
+## 에러 / 엣지
+
+- 캐시 실패(스토리지 미가용/용량/직렬화): 조용히 무시하고 정상 서버 호출. 기능 차단 없음.
+- 해시 실패(`crypto.subtle` 미가용): 캐시 건너뛰고 서버 호출.
+- 생성된 대회에 코스 설정 없음: 종목 기본 코스 + 기타로 선택 가능(기존 `resolveOrCreateCompEvtId`가 저장 시 코스 자동 생성).
+- OCR 추출 실패: 기존대로 안내 후 수동 진행.
+
+## 테스트
+
+- `lib/ocr/ocr-cache.ts`: 임시 node 스크립트로 해시 일관성(같은 바이트 → 같은 hex), get/set 라운드트립(sessionStorage 모킹) 검증.
+- 통합(수동, 로컬 Supabase 기동 후): 같은 사진 2회 업로드 시 2번째는 네트워크 호출 없음(개발자도구 Network 확인). 대회 추가 → 자동 선택 → 시간 prefill 확인. 대회 추가 폼에 이름·날짜 prefill 확인.
+- `pnpm exec tsc --noEmit`, `pnpm lint`, `pnpm build` 컴파일.
+
+## 범위 밖 (YAGNI)
+
+- 명시적 중복 경고(step 1 날짜 목록이 후보를 이미 노출).
+- 서버측/DB 캐시(sessionStorage로 충분).
+- 스키마·랭킹 쿼리 변경(정합성 모델 유지).
+- "지난번 결과 이어서" 재오픈 복원 프롬프트(사진 해시 캐시로 같은 사진 재업로드 시 자동 해결).

--- a/lib/ocr/ocr-cache.ts
+++ b/lib/ocr/ocr-cache.ts
@@ -1,0 +1,31 @@
+import type { ExtractedRecord } from "@/lib/ocr/race-record";
+
+const KEY_PREFIX = "ocr:";
+
+/** 이미지 바이트 → SHA-256 hex 문자열 */
+export async function hashImageFile(file: File): Promise<string> {
+  const buf = await file.arrayBuffer();
+  const digest = await crypto.subtle.digest("SHA-256", buf);
+  return Array.from(new Uint8Array(digest))
+    .map((b) => b.toString(16).padStart(2, "0"))
+    .join("");
+}
+
+/** sessionStorage "ocr:<hash>" 조회. 없거나 실패하면 null */
+export function getCachedExtraction(hash: string): ExtractedRecord | null {
+  try {
+    const raw = sessionStorage.getItem(KEY_PREFIX + hash);
+    return raw ? (JSON.parse(raw) as ExtractedRecord) : null;
+  } catch {
+    return null;
+  }
+}
+
+/** sessionStorage "ocr:<hash>"에 저장. 실패(용량/미가용)는 무시 */
+export function setCachedExtraction(hash: string, data: ExtractedRecord): void {
+  try {
+    sessionStorage.setItem(KEY_PREFIX + hash, JSON.stringify(data));
+  } catch {
+    // best-effort: quota 초과/스토리지 미가용 시 무시
+  }
+}


### PR DESCRIPTION
## 관련 이슈

관련 이슈 없음 (기록증 OCR 자동입력 #294 후속 UX 개선)

## 요약

OCR 기록입력의 두 가지 실사용 마찰을 해결한다. 기록↔대회 링크(정합성)는 그대로 두고 입력 UX만 개선했다 — 스키마·랭킹 변경 없음.

## AS-IS (변경 전)

1. 매칭되는 대회가 없어 `대회 추가`로 가면, 새 대회를 만들어도 `onCreated={(_comp) => {}}` 빈 함수라 **아무 일도 안 일어남**. 새 대회가 자동 선택되지 않아 진행이 막히고 OCR 추출 결과가 날아간 것처럼 느껴짐.
2. 같은 기록증을 다시 올리면 **Gemini를 또 호출** → 토큰 낭비.

## TO-BE (변경 후)

1. **대회 추가 직결**: `onCreated`를 연결해 생성된 대회를 자동 선택 → 코스 선택 → OCR로 읽은 시간이 그대로 입력칸에 prefill. 우회를 건너도 결과가 살아남음.
2. **사진 캐시**: 업로드 시 이미지 SHA-256 해시로 `sessionStorage` 캐시 조회. **같은 사진이면 Gemini 재호출 없이 즉시 채움** (토큰 0).
3. **대회 추가 폼 prefill**: OCR로 읽은 대회명·날짜가 `대회 추가` 폼에 자동 입력 → 종목만 고르면 생성.

## 주요 변경 사항

- `lib/ocr/ocr-cache.ts` (신규) — `hashImageFile`(SHA-256), `getCachedExtraction`/`setCachedExtraction`(sessionStorage). 캐시는 best-effort(실패 시 조용히 정상 추출로 폴백).
- `components/races/competition-register-dialog.tsx` — `prefillTitle?` prop 추가 (`prefillStartDate`와 동일 패턴).
- `components/profile/race-record-dialog.tsx` — `handleImageSelected` 캐시 경유, `onCreated` 직결(생성 대회 자동 선택), `prefillTitle`에 OCR 원본 대회명 전달.

## 변경 흐름

```mermaid
flowchart TD
    A[사진 선택] --> B[SHA-256 해시]
    B --> C{sessionStorage 캐시}
    C -->|HIT| D[캐시 결과 즉시 적용 · Gemini 호출 0]
    C -->|MISS| E[서버 액션 Gemini] --> F[결과 캐시 저장] --> D
    D --> G[날짜·이름 prefill + 시간 stash]
    G --> H{맞는 대회 있나}
    H -->|있음| I[선택 → 코스 → 시간 prefill]
    H -->|없음| J[대회 추가: 이름·날짜 prefill]
    J --> K[생성] --> L[onCreated 직결: 자동 선택]
    L --> I
```

## 정합성 / 범위

- 기록은 대회에 묶는 모델 유지 (`rec_race_hist.comp_id`). 랭킹·칭호·대회 탭 영향 없음.
- 스키마·랭킹 RPC 변경 없음.

## 테스트

- `ocr-cache` 단위 검증: 해시 일관성(같은 바이트→같은 hex, 64자) + get/set 라운드트립 통과.
- tsc 0에러, lint 신규 0에러, `pnpm build` 컴파일 통과(`✓ Compiled successfully`).
- 수동 E2E(로컬 Supabase 기동 후 별도): 같은 사진 재업로드 시 네트워크 호출 없음 / 대회 추가 → 자동 선택 → 시간 prefill 확인.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
