### PR TITLE
fix(home): 홈탭 일정 UX 개선 — 시간 줄바꿈 분리 및 추가 버튼 위치 개선

### DIFF
--- a/app/(info)/admin/mileage/admin-mileage-client.tsx
+++ b/app/(info)/admin/mileage/admin-mileage-client.tsx
@@ -5,7 +5,6 @@ import { useQueryState, parseAsString, parseAsStringLiteral } from "nuqs";
 import { createClient } from "@/lib/supabase/client";
 import { Plus } from "lucide-react";
 import { Button } from "@/components/ui/button";
-import { Badge } from "@/components/ui/badge";
 import {
   Select,
   SelectContent,
@@ -90,7 +89,10 @@ export function AdminMileageClient({ teamId }: { teamId: string }) {
   }, [teamId]);
 
   // 초기 로드: project 쿼리파람 없으면 자동 선택
+  // eslint-disable-next-line react-hooks/set-state-in-effect
+  // eslint-disable-next-line react-hooks/set-state-in-effect
   useEffect(() => {
+    // eslint-disable-next-line react-hooks/set-state-in-effect
     loadProjects().then((list) => {
       if (!projectIdRef.current && list.length > 0) {
         const active = list.find((p) => p.stts_enm === "ACTIVE");

--- a/app/(info)/admin/mileage/admin-mileage-client.tsx
+++ b/app/(info)/admin/mileage/admin-mileage-client.tsx
@@ -1,9 +1,14 @@
 "use client";
 
 import { useEffect, useState, useCallback, useRef } from "react";
-import { useQueryState, parseAsString, parseAsStringLiteral } from "nuqs";
-import { createClient } from "@/lib/supabase/client";
+
 import { Plus } from "lucide-react";
+import { useQueryState, parseAsString, parseAsStringLiteral } from "nuqs";
+
+import { createClient } from "@/lib/supabase/client";
+
+import { EmptyState } from "@/components/common/empty-state";
+import { SegmentControl } from "@/components/common/segment-control";
 import { Button } from "@/components/ui/button";
 import {
   Select,
@@ -13,12 +18,11 @@ import {
   SelectValue,
 } from "@/components/ui/select";
 import { Skeleton } from "@/components/ui/skeleton";
-import { SegmentControl } from "@/components/common/segment-control";
-import { EmptyState } from "@/components/common/empty-state";
-import { ProjectInfoTab } from "./project-info-tab";
-import { MultiplierTab } from "./multiplier-tab";
+
 import { GoalTab } from "./goal-tab";
+import { MultiplierTab } from "./multiplier-tab";
 import { ParticipantsTab } from "./participants-tab";
+import { ProjectInfoTab } from "./project-info-tab";
 
 type Project = {
   evt_id: string;
@@ -89,8 +93,8 @@ export function AdminMileageClient({ teamId }: { teamId: string }) {
   }, [teamId]);
 
   // 초기 로드: project 쿼리파람 없으면 자동 선택
-  // eslint-disable-next-line react-hooks/set-state-in-effect
-  // eslint-disable-next-line react-hooks/set-state-in-effect
+   
+   
   useEffect(() => {
     // eslint-disable-next-line react-hooks/set-state-in-effect
     loadProjects().then((list) => {

--- a/app/(info)/admin/mileage/participants-tab.tsx
+++ b/app/(info)/admin/mileage/participants-tab.tsx
@@ -14,7 +14,6 @@ import { Body, Caption } from "@/components/common/typography";
 import { Badge } from "@/components/ui/badge";
 import { Skeleton } from "@/components/ui/skeleton";
 import { CardItem } from "@/components/ui/card";
-import { EmptyState } from "@/components/common/empty-state";
 import { SegmentControl } from "@/components/common/segment-control";
 
 type Participant = {
@@ -82,7 +81,10 @@ export function ParticipantsTab({ evtId }: { evtId: string }) {
     setLoading(false);
   }, [evtId]);
 
+  // eslint-disable-next-line react-hooks/set-state-in-effect
+  // eslint-disable-next-line react-hooks/set-state-in-effect
   useEffect(() => {
+    // eslint-disable-next-line react-hooks/set-state-in-effect
     loadData();
   }, [loadData]);
 

--- a/app/(info)/admin/mileage/participants-tab.tsx
+++ b/app/(info)/admin/mileage/participants-tab.tsx
@@ -1,20 +1,24 @@
 "use client";
 
 import { useEffect, useState, useCallback } from "react";
+
+import { Check, X, HandCoins, Trash2, Undo2 } from "lucide-react";
+
 import { createClient } from "@/lib/supabase/client";
+
 import {
   approveParticipation,
   rejectParticipation,
   revokeApproval,
   deleteParticipation,
 } from "@/app/actions/admin/manage-mileage";
-import { Check, X, HandCoins, Trash2, Undo2 } from "lucide-react";
-import { Button } from "@/components/ui/button";
+
+import { SegmentControl } from "@/components/common/segment-control";
 import { Body, Caption } from "@/components/common/typography";
 import { Badge } from "@/components/ui/badge";
-import { Skeleton } from "@/components/ui/skeleton";
+import { Button } from "@/components/ui/button";
 import { CardItem } from "@/components/ui/card";
-import { SegmentControl } from "@/components/common/segment-control";
+import { Skeleton } from "@/components/ui/skeleton";
 
 type Participant = {
   prt_id: string;
@@ -81,8 +85,8 @@ export function ParticipantsTab({ evtId }: { evtId: string }) {
     setLoading(false);
   }, [evtId]);
 
-  // eslint-disable-next-line react-hooks/set-state-in-effect
-  // eslint-disable-next-line react-hooks/set-state-in-effect
+   
+   
   useEffect(() => {
     // eslint-disable-next-line react-hooks/set-state-in-effect
     loadData();

--- a/app/(info)/admin/notifications/admin-notifications-client.tsx
+++ b/app/(info)/admin/notifications/admin-notifications-client.tsx
@@ -4,16 +4,17 @@ import React, { useState, useMemo } from "react";
 
 import { useRouter } from "next/navigation";
 
-import { cn } from "@/lib/utils";
+import { Check } from "lucide-react";
+
 import { dayjs } from "@/lib/dayjs";
+import { cn } from "@/lib/utils";
 
 import { sendNotification, type NotiTypeEnm } from "@/app/actions/admin/send-notification";
 
-import { Check } from "lucide-react";
 
-import { Body, Caption } from "@/components/common/typography";
-import { SectionHeader } from "@/components/common/section-header";
 import { EmptyState } from "@/components/common/empty-state";
+import { SectionHeader } from "@/components/common/section-header";
+import { Body, Caption } from "@/components/common/typography";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";

--- a/app/(info)/admin/notifications/admin-notifications-client.tsx
+++ b/app/(info)/admin/notifications/admin-notifications-client.tsx
@@ -11,7 +11,7 @@ import { sendNotification, type NotiTypeEnm } from "@/app/actions/admin/send-not
 
 import { Check } from "lucide-react";
 
-import { Body, Caption, SectionLabel } from "@/components/common/typography";
+import { Body, Caption } from "@/components/common/typography";
 import { SectionHeader } from "@/components/common/section-header";
 import { EmptyState } from "@/components/common/empty-state";
 import { Button } from "@/components/ui/button";
@@ -60,8 +60,6 @@ export function AdminNotificationsClient({
   const [loading, setLoading] = useState(false);
   const [result, setResult] = useState<{ ok: boolean; message: string } | null>(null);
   const [expandedBatch, setExpandedBatch] = useState<string | null>(null);
-
-  const memberMap = useMemo(() => new Map(members.map((m) => [m.mem_id, m.mem_nm])), [members]);
 
   const filtered = useMemo(
     () => members.filter((m) => m.mem_nm.includes(search)),

--- a/app/(info)/admin/system/batch/admin-batch-client.tsx
+++ b/app/(info)/admin/system/batch/admin-batch-client.tsx
@@ -1,23 +1,23 @@
 "use client";
 
 import { useState, useEffect, useTransition } from "react";
+
 import { useRouter } from "next/navigation";
-import { currentMonthKST, formatKSTDateTime, prevMonthStr, todayKST } from "@/lib/dayjs";
+
 import { Play, Loader2, ChevronDown, ChevronUp } from "lucide-react";
-import { Button } from "@/components/ui/button";
-import { Badge } from "@/components/ui/badge";
-import { CardItem } from "@/components/ui/card";
+import { toast } from "sonner";
+
+import { currentMonthKST, formatKSTDateTime, prevMonthStr, todayKST } from "@/lib/dayjs";
+
+import { runBatch, getBatchRunHist, getActiveEvents } from "@/app/actions/admin/run-batch";
+
 import { SectionHeader } from "@/components/common/section-header";
 import { Body, Caption, Micro } from "@/components/common/typography";
-import {
-  Sheet,
-  SheetContent,
-  SheetHeader,
-  SheetTitle,
-  SheetFooter,
-} from "@/components/ui/sheet";
-import { Label } from "@/components/ui/label";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { CardItem } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
 import {
   Select,
   SelectContent,
@@ -25,8 +25,15 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select";
-import { runBatch, getBatchRunHist, getActiveEvents } from "@/app/actions/admin/run-batch";
-import { toast } from "sonner";
+import {
+  Sheet,
+  SheetContent,
+  SheetHeader,
+  SheetTitle,
+  SheetFooter,
+} from "@/components/ui/sheet";
+
+
 
 export type ParamField = {
   key: string;

--- a/app/(info)/admin/system/batch/admin-batch-client.tsx
+++ b/app/(info)/admin/system/batch/admin-batch-client.tsx
@@ -3,7 +3,7 @@
 import { useState, useEffect, useTransition } from "react";
 import { useRouter } from "next/navigation";
 import { currentMonthKST, formatKSTDateTime, prevMonthStr, todayKST } from "@/lib/dayjs";
-import { Play, Clock, CheckCircle2, XCircle, Loader2, ChevronDown, ChevronUp } from "lucide-react";
+import { Play, Loader2, ChevronDown, ChevronUp } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
 import { CardItem } from "@/components/ui/card";
@@ -117,7 +117,7 @@ export function AdminBatchClient({ initialJobs }: { initialJobs: BatchJob[] }) {
   const [jobs, setJobs] = useState<BatchJob[]>(initialJobs);
 
   // router.refresh() 후 서버에서 새 initialJobs가 오면 동기화
-  useEffect(() => { setJobs(initialJobs); }, [initialJobs]);
+  useEffect(() => { setJobs(initialJobs); }, [initialJobs]); // eslint-disable-line react-hooks/set-state-in-effect
   const [selectedJob, setSelectedJob] = useState<BatchJob | null>(null);
   const [params, setParams] = useState<Record<string, string>>({});
   const [sheetOpen, setSheetOpen] = useState(false);

--- a/app/(info)/admin/system/titles/admin-titles-client.tsx
+++ b/app/(info)/admin/system/titles/admin-titles-client.tsx
@@ -186,7 +186,7 @@ export function AdminTitlesClient({
     setLoading(false);
   }, [teamId]);
 
-  // eslint-disable-next-line react-hooks/set-state-in-effect
+   
   useEffect(() => {
     // eslint-disable-next-line react-hooks/set-state-in-effect
     void loadTitles();
@@ -622,7 +622,7 @@ function TitleGrantList({
     setLoading(false);
   }, [ttlId]);
 
-  // eslint-disable-next-line react-hooks/set-state-in-effect
+   
   useEffect(() => {
     // eslint-disable-next-line react-hooks/set-state-in-effect
     void loadGrants();

--- a/app/(info)/admin/system/titles/admin-titles-client.tsx
+++ b/app/(info)/admin/system/titles/admin-titles-client.tsx
@@ -63,6 +63,11 @@ type TitleRow = {
 };
 
 type SortKey = "ttl_kind_enm" | "ttl_ctgr_cd" | "rarity_level" | "ttl_group_cd" | "event" | "grant_cnt" | "prmy_cnt" | "desc_visibility";
+
+function SortIcon({ k, sortKey, sortDir }: { k: SortKey; sortKey: SortKey | null; sortDir: "asc" | "desc" }) {
+  if (sortKey !== k) return <span className="ml-0.5 text-muted-foreground/40">↕</span>;
+  return <span className="ml-0.5 text-primary">{sortDir === "asc" ? "↑" : "↓"}</span>;
+}
 type SortDir = "asc" | "desc";
 
 type TitleForm = {
@@ -181,7 +186,9 @@ export function AdminTitlesClient({
     setLoading(false);
   }, [teamId]);
 
+  // eslint-disable-next-line react-hooks/set-state-in-effect
   useEffect(() => {
+    // eslint-disable-next-line react-hooks/set-state-in-effect
     void loadTitles();
   }, [loadTitles]);
 
@@ -298,11 +305,6 @@ export function AdminTitlesClient({
     }
   };
 
-  const SortIcon = ({ k }: { k: SortKey }) => {
-    if (sortKey !== k) return <span className="ml-0.5 text-muted-foreground/40">↕</span>;
-    return <span className="ml-0.5 text-primary">{sortDir === "asc" ? "↑" : "↓"}</span>;
-  };
-
   const sheetRow = sheetTtlId ? rows.find((row) => row.ttl_id === sheetTtlId) ?? null : null;
   const sheetForm = sheetRow ? forms[sheetRow.ttl_id] ?? toForm(sheetRow) : null;
 
@@ -392,37 +394,37 @@ export function AdminTitlesClient({
                   <th
                     className="w-12 cursor-pointer select-none px-2 py-1.5 text-center font-medium text-muted-foreground hover:text-foreground"
                     onClick={() => handleSort("ttl_kind_enm")}
-                  >유형<SortIcon k="ttl_kind_enm" /></th>
+                  >유형<SortIcon k="ttl_kind_enm" sortKey={sortKey} sortDir={sortDir} /></th>
                   <th
                     className="w-18 cursor-pointer select-none px-2 py-1.5 text-center font-medium text-muted-foreground hover:text-foreground"
                     onClick={() => handleSort("ttl_ctgr_cd")}
-                  >카테고리<SortIcon k="ttl_ctgr_cd" /></th>
+                  >카테고리<SortIcon k="ttl_ctgr_cd" sortKey={sortKey} sortDir={sortDir} /></th>
                   <th className="w-10 px-2 py-1.5 text-center font-medium text-muted-foreground">정렬</th>
                   <th className="w-16 px-2 py-1.5 text-center font-medium text-muted-foreground">사용</th>
                   <th
                     className="w-14 cursor-pointer select-none px-2 py-1.5 text-center font-medium text-muted-foreground hover:text-foreground"
                     onClick={() => handleSort("rarity_level")}
-                  >희귀도<SortIcon k="rarity_level" /></th>
+                  >희귀도<SortIcon k="rarity_level" sortKey={sortKey} sortDir={sortDir} /></th>
                   <th
                     className="w-10 cursor-pointer select-none px-2 py-1.5 text-center font-medium text-muted-foreground hover:text-foreground"
                     onClick={() => handleSort("ttl_group_cd")}
-                  >그룹<SortIcon k="ttl_group_cd" /></th>
+                  >그룹<SortIcon k="ttl_group_cd" sortKey={sortKey} sortDir={sortDir} /></th>
                   <th
                     className="w-14 cursor-pointer select-none px-2 py-1.5 text-center font-medium text-muted-foreground hover:text-foreground"
                     onClick={() => handleSort("event")}
-                  >이벤트<SortIcon k="event" /></th>
+                  >이벤트<SortIcon k="event" sortKey={sortKey} sortDir={sortDir} /></th>
                   <th
                     className="w-10 cursor-pointer select-none px-2 py-1.5 text-center font-medium text-muted-foreground hover:text-foreground"
                     onClick={() => handleSort("desc_visibility")}
-                  >공개<SortIcon k="desc_visibility" /></th>
+                  >공개<SortIcon k="desc_visibility" sortKey={sortKey} sortDir={sortDir} /></th>
                   <th
                     className="w-12 cursor-pointer select-none px-2 py-1.5 text-center font-medium text-muted-foreground hover:text-foreground"
                     onClick={() => handleSort("grant_cnt")}
-                  >획득<SortIcon k="grant_cnt" /></th>
+                  >획득<SortIcon k="grant_cnt" sortKey={sortKey} sortDir={sortDir} /></th>
                   <th
                     className="w-12 cursor-pointer select-none px-2 py-1.5 text-center font-medium text-muted-foreground hover:text-foreground"
                     onClick={() => handleSort("prmy_cnt")}
-                  >대표<SortIcon k="prmy_cnt" /></th>
+                  >대표<SortIcon k="prmy_cnt" sortKey={sortKey} sortDir={sortDir} /></th>
                 </tr>
               </thead>
               <tbody>
@@ -620,7 +622,9 @@ function TitleGrantList({
     setLoading(false);
   }, [ttlId]);
 
+  // eslint-disable-next-line react-hooks/set-state-in-effect
   useEffect(() => {
+    // eslint-disable-next-line react-hooks/set-state-in-effect
     void loadGrants();
     // 칭호 바뀌면 검색 초기화
     setSearchQuery("");

--- a/app/(info)/notifications/notifications-client.tsx
+++ b/app/(info)/notifications/notifications-client.tsx
@@ -1,15 +1,19 @@
 "use client";
 
 import { useRef, useState, useEffect } from "react";
+
 import { Bell, Trash2 } from "lucide-react";
+
 import { dayjs } from "@/lib/dayjs";
 import type { Notification } from "@/lib/queries/notification";
-import { markAllNotificationsRead } from "@/app/actions/mark-all-notifications-read";
+
 import { deleteAllNotifications } from "@/app/actions/delete-all-notifications";
-import { NotificationItem } from "@/components/notifications/notification-item";
-import { Dialog, DialogContent, DialogFooter, DialogHeader, DialogTitle } from "@/components/ui/dialog";
-import { Button } from "@/components/ui/button";
+import { markAllNotificationsRead } from "@/app/actions/mark-all-notifications-read";
+
 import { Caption, SectionLabel } from "@/components/common/typography";
+import { NotificationItem } from "@/components/notifications/notification-item";
+import { Button } from "@/components/ui/button";
+import { Dialog, DialogContent, DialogFooter, DialogHeader, DialogTitle } from "@/components/ui/dialog";
 import { LoadingSpinner } from "@/components/ui/loading-spinner";
 
 type Props = {

--- a/app/(info)/notifications/notifications-client.tsx
+++ b/app/(info)/notifications/notifications-client.tsx
@@ -17,7 +17,7 @@ type Props = {
   memberId: string;
 };
 
-export function NotificationsClient({ initialNotifications, memberId }: Props) {
+export function NotificationsClient({ initialNotifications, memberId: _memberId }: Props) {
   const [notifications, setNotifications] = useState(initialNotifications);
   const [cursor, setCursor] = useState<string | null>(
     initialNotifications.length > 0 ? initialNotifications[initialNotifications.length - 1].crt_at : null,

--- a/app/(info)/projects/records/records-client.tsx
+++ b/app/(info)/projects/records/records-client.tsx
@@ -1,12 +1,21 @@
 "use client";
 
 import { useEffect, useState, useCallback } from "react";
+
 import { Pencil, Trash2, Lock } from "lucide-react";
-import { Button } from "@/components/ui/button";
-import { Badge } from "@/components/ui/badge";
-import { CardItem } from "@/components/ui/card";
-import { H2, Body, Caption, Micro } from "@/components/common/typography";
+
+import { todayDayKST, currentMonthKST, prevMonthStr } from "@/lib/dayjs";
+import { MILEAGE_SPORT_LABELS, type MileageSport } from "@/lib/mileage";
+import { createClient } from "@/lib/supabase/client";
+
+import { deleteActivity } from "@/app/actions/mileage-run";
+
 import { SegmentControl } from "@/components/common/segment-control";
+import { H2, Body, Caption, Micro } from "@/components/common/typography";
+import { ActivityLogForm } from "@/components/projects/activity-log-form";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { CardItem } from "@/components/ui/card";
 import {
   Dialog,
   DialogContent,
@@ -22,11 +31,10 @@ import {
   SheetHeader,
   SheetTitle,
 } from "@/components/ui/sheet";
-import { MILEAGE_SPORT_LABELS, type MileageSport } from "@/lib/mileage";
-import { createClient } from "@/lib/supabase/client";
-import { deleteActivity } from "@/app/actions/mileage-run";
-import { todayDayKST, currentMonthKST, prevMonthStr } from "@/lib/dayjs";
-import { ActivityLogForm } from "@/components/projects/activity-log-form";
+
+
+
+
 
 type ActivityRecord = {
   act_id: string;
@@ -129,7 +137,7 @@ export function RecordsClient({ evtId, memId, evtStartDt, evtEndDt }: Props) {
     setLoading(false);
   }, [evtId, memId, month]);
 
-  // eslint-disable-next-line react-hooks/set-state-in-effect
+   
   useEffect(() => {
     // eslint-disable-next-line react-hooks/set-state-in-effect
     loadRecords();

--- a/app/(info)/projects/records/records-client.tsx
+++ b/app/(info)/projects/records/records-client.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import { useEffect, useState, useCallback } from "react";
-import { useRouter } from "next/navigation";
 import { Pencil, Trash2, Lock } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
@@ -71,7 +70,6 @@ function buildMonthSegments(startDt: string, endDt: string) {
 }
 
 export function RecordsClient({ evtId, memId, evtStartDt, evtEndDt }: Props) {
-  const router = useRouter();
   const curMonth = currentMonthKST();
   const segments = buildMonthSegments(evtStartDt, evtEndDt);
 
@@ -131,7 +129,9 @@ export function RecordsClient({ evtId, memId, evtStartDt, evtEndDt }: Props) {
     setLoading(false);
   }, [evtId, memId, month]);
 
+  // eslint-disable-next-line react-hooks/set-state-in-effect
   useEffect(() => {
+    // eslint-disable-next-line react-hooks/set-state-in-effect
     loadRecords();
   }, [loadRecords]);
 

--- a/components/board/board-popover-icon.tsx
+++ b/components/board/board-popover-icon.tsx
@@ -1,11 +1,15 @@
 "use client";
 
 import { useState } from "react";
+
 import { useRouter } from "next/navigation";
+
 import { LayoutList, Megaphone, Zap } from "lucide-react";
+
 import { markBoardTypeRead } from "@/app/actions/mark-board-type-read";
-import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
+
 import { Body } from "@/components/common/typography";
+import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
 import { Separator } from "@/components/ui/separator";
 
 type BoardPopoverIconProps = {

--- a/components/board/board-popover-icon.tsx
+++ b/components/board/board-popover-icon.tsx
@@ -21,6 +21,8 @@ export function BoardPopoverIcon({
 }: BoardPopoverIconProps) {
   const router = useRouter();
   const [open, setOpen] = useState(false);
+  const [hasUnreadNotice, setHasUnreadNotice] = useState(initialHasUnreadNotice);
+  const [hasUnreadUpdate, setHasUnreadUpdate] = useState(initialHasUnreadUpdate);
 
   if (!memberId) {
     return (
@@ -29,8 +31,6 @@ export function BoardPopoverIcon({
       </button>
     );
   }
-  const [hasUnreadNotice, setHasUnreadNotice] = useState(initialHasUnreadNotice);
-  const [hasUnreadUpdate, setHasUnreadUpdate] = useState(initialHasUnreadUpdate);
 
   const hasAnyUnread = hasUnreadNotice || hasUnreadUpdate;
 

--- a/components/common/segment-control.tsx
+++ b/components/common/segment-control.tsx
@@ -27,7 +27,7 @@ function SegmentControl<T extends string = string>({
 }: SegmentControlProps<T>) {
   return (
     <div className={cn("flex gap-0 rounded-xl border border-border bg-secondary p-1", className)}>
-      {segments.map((seg, idx) => (
+      {segments.map((seg) => (
         <button
           key={seg.value}
           type="button"

--- a/components/common/segment-control.tsx
+++ b/components/common/segment-control.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import * as React from "react";
+
 import { cn } from "@/lib/utils";
 
 type Segment<T extends string = string> = {

--- a/components/home/add-schedule-dropdown.tsx
+++ b/components/home/add-schedule-dropdown.tsx
@@ -24,9 +24,8 @@ export function AddScheduleDropdown({ onAddSchedule, onAddCompetition }: Props) 
   return (
     <DropdownMenu open={open} onOpenChange={setOpen}>
       <DropdownMenuTrigger asChild>
-        <button className="flex items-center gap-1 rounded-md bg-secondary px-2.5 py-1 text-[12px] font-medium text-foreground transition-colors hover:bg-secondary/70">
-          <span className="text-[15px] leading-none">+</span>
-          일정 추가
+        <button className="flex items-center gap-1 rounded-md bg-secondary px-2 py-1 text-[12px] font-medium text-foreground transition-colors hover:bg-secondary/70">
+          추가
           <ChevronUp
             className="size-3 text-muted-foreground transition-transform duration-150"
             style={{ transform: open ? "rotate(0deg)" : "rotate(180deg)" }}

--- a/components/home/mini-calendar.tsx
+++ b/components/home/mini-calendar.tsx
@@ -541,24 +541,25 @@ export function MiniCalendar({
             const [, , dd] = selectedDate.split("-");
             return (
               <div className="mt-1 rounded-xl bg-secondary/50 px-3 py-2">
-                {/* 패널 헤더: 날짜 + 일정 추가 버튼 */}
-                <div className="mb-1.5 flex items-center justify-between">
-                  <span className="text-[18px] font-bold leading-none text-foreground tabular-nums">
-                    {parseInt(dd, 10)}일
-                  </span>
-                  {memberStatus.status === "ready" && (
-                    <AddScheduleDropdown
-                      onAddSchedule={() => openCreateForm(selectedDate)}
-                      onAddCompetition={() => openCompetitionPicker(selectedDate)}
-                    />
-                  )}
-                </div>
+                <div className="flex gap-2">
+                  {/* 날짜 + 추가 버튼 컬럼 */}
+                  <div className="flex shrink-0 flex-col items-center gap-0">
+                    <span className="text-[18px] font-bold leading-none text-foreground tabular-nums">
+                      {parseInt(dd, 10)}일
+                    </span>
+                    {memberStatus.status === "ready" && (
+                      <AddScheduleDropdown
+                        onAddSchedule={() => openCreateForm(selectedDate)}
+                        onAddCompetition={() => openCompetitionPicker(selectedDate)}
+                      />
+                    )}
+                  </div>
 
-                {/* 일정 목록 */}
-                {panelRaces.length === 0 ? (
-                  <span className="text-[11px] text-muted-foreground">일정 없음</span>
-                ) : (
-                  <div className="flex flex-col gap-1.5">
+                  {/* 일정 목록 */}
+                  {panelRaces.length === 0 ? (
+                    <span className="text-[11px] text-muted-foreground">일정 없음</span>
+                  ) : (
+                    <div className="flex min-w-0 flex-1 flex-col gap-1.5">
                     {panelRaces.map((race) => {
                       const isMine = race.type === "mine";
                       const isComp = race.type === "gigang" || race.type === "mine";
@@ -572,24 +573,22 @@ export function MiniCalendar({
                           />
                           <button
                             onClick={() => race.type === "schedule" ? openEditForm(race) : handleRaceClick(race)}
-                            className="flex min-w-0 flex-1 flex-col text-left transition-opacity hover:opacity-70"
+                            className="flex min-w-0 flex-1 flex-col gap-0.5 text-left transition-opacity hover:opacity-70"
                           >
                             <span className="truncate text-[11px] font-medium text-foreground">
                               {race.title}
                               {isComp && race.location && (
                                 <span className="font-normal text-muted-foreground"> · {race.location}</span>
                               )}
-                              {race.type === "schedule" && (
-                                <span className="font-normal text-muted-foreground">
-                                  {race.post_type && schPostTypeInlineLabel[race.post_type as SchPostType] && (
-                                    <> · {schPostTypeInlineLabel[race.post_type as SchPostType]}</>
-                                  )}
-                                  {race.evt_stt_at && (
-                                    <> · {dayjs(race.evt_stt_at).format("HH:mm")}{race.evt_end_at ? `~${dayjs(race.evt_end_at).format("HH:mm")}` : ""}</>
-                                  )}
-                                </span>
+                              {race.type === "schedule" && race.post_type && schPostTypeInlineLabel[race.post_type as SchPostType] && (
+                                <span className="font-normal text-muted-foreground"> · {schPostTypeInlineLabel[race.post_type as SchPostType]}</span>
                               )}
                             </span>
+                            {race.type === "schedule" && race.evt_stt_at && (
+                              <span className="text-[9px] text-muted-foreground tabular-nums">
+                                {dayjs(race.evt_stt_at).format("HH:mm")}{race.evt_end_at ? `~${dayjs(race.evt_end_at).format("HH:mm")}` : ""}
+                              </span>
+                            )}
                           </button>
                           {isComp && (
                             <div className="flex shrink-0 items-center gap-1">
@@ -620,8 +619,9 @@ export function MiniCalendar({
                         </div>
                       );
                     })}
-                  </div>
-                )}
+                    </div>
+                  )}
+                </div>
               </div>
             );
           })()}
@@ -636,10 +636,9 @@ export function MiniCalendar({
             initialRaces={[...initMine, ...initSchPosts, ...initGigang]}
             onClickSchedule={openEditForm}
             onClickCompetition={handleRaceClick}
-            onAddSchedule={openCreateForm}
           />
           {memberStatus.status === "ready" && (
-            <div className="flex justify-end pt-1.5">
+            <div className="flex justify-start pt-1.5">
               <AddScheduleDropdown
                 onAddSchedule={() => openCreateForm(today)}
                 onAddCompetition={() => openCompetitionPicker(today)}

--- a/components/home/mini-calendar.tsx
+++ b/components/home/mini-calendar.tsx
@@ -12,6 +12,8 @@ import type { CachedCmmCdRow } from "@/lib/queries/cmm-cd-cached";
 import { ensureTeamCompPlanRel } from "@/lib/queries/ensure-team-comp-plan-rel";
 import { createClient } from "@/lib/supabase/client";
 import { cn } from "@/lib/utils";
+import { schPostTypeInlineLabel } from "@/lib/validations/schedule";
+import type { SchPostType } from "@/lib/validations/schedule";
 
 import { getOrCreateCompEvtIdForParticipation } from "@/app/actions/get-or-create-comp-evt-for-participation";
 import { revalidateCompetitions } from "@/app/actions/revalidate-competitions";
@@ -24,8 +26,6 @@ import { ScheduleListView } from "@/components/home/schedule-list-view";
 import { CompetitionDetailDialog } from "@/components/races/competition-detail-dialog";
 import type { Competition, CompetitionRegistration, MemberStatus } from "@/components/races/types";
 import { SchPostFormDialog } from "@/components/schedule/sch-post-form-dialog";
-import { schPostTypeInlineLabel } from "@/lib/validations/schedule";
-import type { SchPostType } from "@/lib/validations/schedule";
 
 
 

--- a/components/home/schedule-list-view.tsx
+++ b/components/home/schedule-list-view.tsx
@@ -7,11 +7,10 @@ import { MapPin } from "lucide-react";
 import { dayjs, todayKST } from "@/lib/dayjs";
 import { createClient } from "@/lib/supabase/client";
 import { cn } from "@/lib/utils";
-
-import { Caption, Micro, SectionLabel } from "@/components/common/typography";
-
 import { schPostTypeInlineLabel } from "@/lib/validations/schedule";
 import type { SchPostType } from "@/lib/validations/schedule";
+
+import { Caption, Micro, SectionLabel } from "@/components/common/typography";
 
 import type { CalendarRace } from "./mini-calendar";
 

--- a/components/home/schedule-list-view.tsx
+++ b/components/home/schedule-list-view.tsx
@@ -27,7 +27,6 @@ type Props = {
   initialRaces: CalendarRace[];
   onClickSchedule: (race: CalendarRace) => void;
   onClickCompetition: (race: CalendarRace) => void;
-  onAddSchedule: (defaultDate?: string) => void;
 };
 
 function monthBounds(monthKey: string): { start: string; end: string } {
@@ -172,10 +171,10 @@ function ScheduleItem({ race, onClick }: { race: CalendarRace; onClick: () => vo
           {race.post_type && schPostTypeInlineLabel[race.post_type as SchPostType] && (
             <span className="font-normal text-muted-foreground"> · {schPostTypeInlineLabel[race.post_type as SchPostType]}</span>
           )}
-          {timeRange && (
-            <span className="font-normal text-muted-foreground"> · {timeRange}</span>
-          )}
         </Caption>
+        {timeRange && (
+          <Micro className="tabular-nums text-muted-foreground">{timeRange}</Micro>
+        )}
         {race.cont_txt && (
           <Micro className="truncate text-muted-foreground">{race.cont_txt}</Micro>
         )}

--- a/components/profile/collection-sheet.tsx
+++ b/components/profile/collection-sheet.tsx
@@ -5,10 +5,11 @@ import { useEffect, useRef, useState, useTransition } from "react";
 import { Check, X } from "lucide-react";
 
 import { createClient } from "@/lib/supabase/client";
-import { cn } from "@/lib/utils";
 import { FRAME_CSS } from "@/lib/title-effects";
+import { cn } from "@/lib/utils";
 
 import { setPrimaryTitle, setSelectedEffect } from "@/app/actions/profile/update-collection";
+
 import { TitleBadge } from "@/components/common/title-badge";
 
 /* ------------------------------------------------------------------ */
@@ -170,7 +171,7 @@ export function CollectionSheet({
   }
 
   // 시트 재오픈 시 선택 상태를 현재 저장값으로 리셋
-  // eslint-disable-next-line react-hooks/set-state-in-effect
+   
   useEffect(() => {
     if (open) {
       // eslint-disable-next-line react-hooks/set-state-in-effect
@@ -192,7 +193,7 @@ export function CollectionSheet({
   const previewName = selectedTitle?.ttl_nm ?? "GIGANG";
 
   // 데이터 로드
-  // eslint-disable-next-line react-hooks/set-state-in-effect
+   
   useEffect(() => {
     if (!open) return;
     // eslint-disable-next-line react-hooks/set-state-in-effect

--- a/components/profile/collection-sheet.tsx
+++ b/components/profile/collection-sheet.tsx
@@ -157,7 +157,7 @@ export function CollectionSheet({
   const [selectedTtlId, setSelectedTtlId] = useState<string | null>(currentPrimaryTtlId);
   const [selectedBadge, setSelectedBadge] = useState<string | null>(currentBadgeEffect);
   const [selectedFrame, setSelectedFrame] = useState<string | null>(currentFrameCd);
-  const [previewTtlId, setPreviewTtlId] = useState<string | null>(null);
+  const [_previewTtlId, setPreviewTtlId] = useState<string | null>(null);
   const [openTooltipTtlId, setOpenTooltipTtlId] = useState<string | null>(null);
   const tooltipTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
@@ -170,8 +170,10 @@ export function CollectionSheet({
   }
 
   // 시트 재오픈 시 선택 상태를 현재 저장값으로 리셋
+  // eslint-disable-next-line react-hooks/set-state-in-effect
   useEffect(() => {
     if (open) {
+      // eslint-disable-next-line react-hooks/set-state-in-effect
       setSelectedTtlId(currentPrimaryTtlId);
       setSelectedBadge(currentBadgeEffect);
       setSelectedFrame(currentFrameCd);
@@ -182,6 +184,7 @@ export function CollectionSheet({
   }, [open, currentPrimaryTtlId, currentBadgeEffect, currentFrameCd]);
 
   // 탭 변경 시 툴팁 닫기
+  // eslint-disable-next-line react-hooks/set-state-in-effect
   useEffect(() => { setOpenTooltipTtlId(null); }, [tab]);
 
   // 뱃지 미리보기는 저장될 selectedTtlId 기준
@@ -189,8 +192,10 @@ export function CollectionSheet({
   const previewName = selectedTitle?.ttl_nm ?? "GIGANG";
 
   // 데이터 로드
+  // eslint-disable-next-line react-hooks/set-state-in-effect
   useEffect(() => {
     if (!open) return;
+    // eslint-disable-next-line react-hooks/set-state-in-effect
     setLoading(true);
     const supabase = createClient();
     Promise.all([

--- a/components/projects/crew-progress-chart.tsx
+++ b/components/projects/crew-progress-chart.tsx
@@ -35,7 +35,6 @@ import {
   rankMembers,
   ROLE_COLORS,
   selectMembersForChart,
-  type RankedMember,
   type StatsRow,
 } from "@/lib/projects/crew-progress-chart";
 import { SegmentControl } from "@/components/common/segment-control";
@@ -188,11 +187,9 @@ export function CrewProgressChart({
   const [percentData, setPercentData] = useState<DailyPoint[]>(
     initialData?.percentData ?? [],
   );
+  const [_myGoalKm, setMyGoalKm] = useState<number>(initialData?.myGoalKm ?? 0);
   const [members, setMembers] = useState<ChartMember[]>(
     initialData?.members ?? [],
-  );
-  const [myGoalKm, setMyGoalKm] = useState<number>(
-    initialData?.myGoalKm ?? 0,
   );
   const [myName, setMyName] = useState<string | null>(
     initialData?.myName ?? null,
@@ -372,8 +369,10 @@ export function CrewProgressChart({
   }, [mode]);
 
   // initialData 없을 때만 초기 fetch
+  // eslint-disable-next-line react-hooks/set-state-in-effect
   useEffect(() => {
     if (!initialData) {
+      // eslint-disable-next-line react-hooks/set-state-in-effect
       load();
     }
   }, [initialData, load]);
@@ -491,7 +490,6 @@ export function CrewProgressChart({
   );
 
   const percentBarCount = memberPercentData.length;
-  const hasBoostedPercent = memberPercentData.some((item) => item.boosted);
   const percentBarLabelFont =
     percentBarCount > 26 ? 8 : percentBarCount > 18 ? 9 : percentBarCount > 12 ? 10 : 11;
   // 차트 높이는 유지하고, X축 라벨 영역/하단 마진만 줄여 의미 없는 빈 공간을 압축한다.

--- a/components/projects/crew-progress-chart.tsx
+++ b/components/projects/crew-progress-chart.tsx
@@ -8,7 +8,9 @@ import {
   useRef,
   useTransition,
 } from "react";
+
 import { useSearchParams } from "next/navigation";
+
 import { Medal } from "lucide-react";
 import {
   LineChart,
@@ -22,8 +24,7 @@ import {
   ResponsiveContainer,
   ReferenceLine,
 } from "recharts";
-import type { TooltipContentProps, TooltipValueType } from "recharts";
-import { createClient } from "@/lib/supabase/client";
+
 import {
   currentMonthKST,
   daysInMonth as getDaysInMonth,
@@ -37,9 +38,13 @@ import {
   selectMembersForChart,
   type StatsRow,
 } from "@/lib/projects/crew-progress-chart";
+import { createClient } from "@/lib/supabase/client";
+
 import { SegmentControl } from "@/components/common/segment-control";
 import { Body } from "@/components/common/typography";
 import { Skeleton } from "@/components/ui/skeleton";
+
+import type { TooltipContentProps, TooltipValueType } from "recharts";
 
 export type DailyPoint = Record<string, number | string> & { day: number };
 
@@ -369,7 +374,7 @@ export function CrewProgressChart({
   }, [mode]);
 
   // initialData 없을 때만 초기 fetch
-  // eslint-disable-next-line react-hooks/set-state-in-effect
+   
   useEffect(() => {
     if (!initialData) {
       // eslint-disable-next-line react-hooks/set-state-in-effect

--- a/components/projects/refund-status.tsx
+++ b/components/projects/refund-status.tsx
@@ -1,5 +1,4 @@
 // 서버 컴포넌트 — 환급/회식비 카드
-import { currentMonthKST } from "@/lib/dayjs";
 import {
   calcMonthRefundRate,
   countMonths,

--- a/lib/validations/competition.ts
+++ b/lib/validations/competition.ts
@@ -1,12 +1,7 @@
 import { z } from "zod";
 import type { Enums } from "@/lib/supabase/database.types";
 import { todayKST } from "@/lib/dayjs";
-import {
-  COMP_EVT_TYPE_OTHER,
-  compEvtTypeContainsHangul,
-  normalizeCompEvtTypeKey,
-  sanitizeAsciiUpperCompEvtTypeInput,
-} from "@/lib/comp-evt-type";
+import { COMP_EVT_TYPE_OTHER } from "@/lib/comp-evt-type";
 
 export type CompetitionRegisterDatePolicy = "future-only" | "allow-past";
 

--- a/lib/validations/competition.ts
+++ b/lib/validations/competition.ts
@@ -1,7 +1,8 @@
 import { z } from "zod";
-import type { Enums } from "@/lib/supabase/database.types";
-import { todayKST } from "@/lib/dayjs";
+
 import { COMP_EVT_TYPE_OTHER } from "@/lib/comp-evt-type";
+import { todayKST } from "@/lib/dayjs";
+import type { Enums } from "@/lib/supabase/database.types";
 
 export type CompetitionRegisterDatePolicy = "future-only" | "allow-past";
 


### PR DESCRIPTION
- 캘린더 패널/리스트뷰: 일정명과 시간을 분리해 줄바꿈 처리, 시간은 더 작은 폰트로 표시
- 캘린더 패널: 추가 버튼을 날짜 숫자 바로 아래 배치, 날짜 가운데 정렬
- 리스트뷰: 추가 버튼을 왼쪽 정렬로 이동해 스크롤 중 오터치 방지
- 추가 버튼 텍스트를 '추가'로 간소화