### PR TITLE
fix(comment,notification): 멘션 알림 버그 수정 및 댓글·알림 UX 개선

### DIFF
--- a/.claude/docs/comment-system-design.md
+++ b/.claude/docs/comment-system-design.md
@@ -1,0 +1,168 @@
+# 댓글(Comment) 시스템 설계 문서
+
+> 작성일: 2026-06-15
+> 상태: **구현 중**
+> 브랜치: `feature/comment-system`
+
+---
+
+## 개요
+
+소식(`sch_post_mst`)·대회(`comp_mst`)에 댓글/답글/멘션 기능 추가.
+범용 폴리모픽 구조로 나중에 모임(`gthr_mst`)에도 재사용.
+
+---
+
+## 확정 스펙
+
+### 댓글 기능
+
+| 항목 | 결정 |
+|------|------|
+| 답글 깊이 | 1단계만 (답글의 답글 없음) |
+| 답글 달린 댓글 | 수정/삭제 불가 |
+| 삭제된 댓글 처리 | `del_yn=true` soft delete. 답글 있으면 "삭제된 댓글입니다" 자리표시자 유지 |
+| 수정됨 표시 | `edit_yn=true` → "(수정됨)" 텍스트 표시 |
+| 실시간 업데이트 | Supabase Realtime (`postgres_changes`) 구독 |
+| 멘션 | `@이름` 자동완성. `cont_txt`에 `@이름` 텍스트 저장, `cmnt_mention_rel`에 mem_id 구조화 |
+
+### 권한
+
+| 행위 | 일반 멤버 | 관리자 |
+|------|----------|--------|
+| 댓글 작성 | ✅ | ✅ |
+| 댓글 수정 | 본인만 (답글 없을 때) | ❌ |
+| 댓글 삭제 | 본인만 (답글 없을 때) | ✅ (답글 있어도) |
+
+### 알림 규칙
+
+| 이벤트 | `noti_type_enm` | 수신자 |
+|--------|-----------------|--------|
+| 댓글에서 멘션됨 | `cmnt_mention` | 멘션된 멤버 |
+| 내 댓글에 답글 달림 | `cmnt_reply` | 원댓글 작성자 |
+| 모임 댓글 달림 (나중에) | `gthr_cmnt` | 모임 개설자 |
+
+**중첩 알림** (나중에): 같은 엔티티 댓글 알림 여러 개 → 한 줄 + `+N` 묶음 처리
+
+---
+
+## DB 스키마
+
+> 약어 규칙: `.claude/docs/database-abbreviation-dictionary.md`
+> 마이그레이션: `supabase/migrations/20260615110000_cmnt_mst.sql`
+
+### `cmnt_mst` — 범용 댓글
+
+```sql
+CREATE TABLE public.cmnt_mst (
+  cmnt_id      uuid        PRIMARY KEY DEFAULT gen_random_uuid(),
+  team_id      uuid        NOT NULL REFERENCES public.team_mst(team_id),
+  entity_type  text        NOT NULL
+               CHECK (entity_type IN ('sch_post', 'comp', 'gathering')),
+  entity_id    uuid        NOT NULL,             -- sch_post_id / comp_id / gthr_id
+  prnt_id      uuid        REFERENCES public.cmnt_mst(cmnt_id),  -- null=루트, 있으면 1단계 답글
+  mem_id       uuid        NOT NULL REFERENCES public.mem_mst(mem_id),
+  cont_txt     text        NOT NULL,
+  edit_yn      boolean     NOT NULL DEFAULT false,
+  del_yn       boolean     NOT NULL DEFAULT false,
+  crt_at       timestamptz NOT NULL DEFAULT now(),
+  upd_at       timestamptz NOT NULL DEFAULT now()
+);
+```
+
+### `cmnt_mention_rel` — 멘션 관계
+
+```sql
+CREATE TABLE public.cmnt_mention_rel (
+  cmnt_id  uuid NOT NULL REFERENCES public.cmnt_mst(cmnt_id),
+  mem_id   uuid NOT NULL REFERENCES public.mem_mst(mem_id),
+  PRIMARY KEY (cmnt_id, mem_id)
+);
+```
+
+### RLS 요약
+
+| 테이블 | SELECT | INSERT | UPDATE |
+|--------|--------|--------|--------|
+| `cmnt_mst` | 팀 멤버 전체 (del_yn 무관 — 자리표시자용) | 팀 멤버 본인 작성 | 본인 OR 관리자 |
+| `cmnt_mention_rel` | 팀 멤버 | service role만 | — |
+
+---
+
+## 컴포넌트 구조
+
+```
+components/comment/
+├── mention-input.tsx      -- @멘션 자동완성 입력창 (독립 재사용 가능)
+├── comment-item.tsx       -- 댓글 단일 아이템 (수정/삭제/답글 버튼)
+└── comment-section.tsx    -- 댓글 목록 + 입력창 + Realtime 구독
+```
+
+### 재사용 방법
+
+`entityType`과 `entityId`만 넘기면 어디서든 붙일 수 있음:
+
+```tsx
+// 소식
+<CommentSection entityType="sch_post" entityId={schPostId} ... />
+
+// 대회
+<CommentSection entityType="comp" entityId={compId} ... />
+
+// 모임 (나중에)
+<CommentSection entityType="gathering" entityId={gthrId} ... />
+```
+
+### MentionInput 재사용
+
+댓글 외에 글쓰기, 모임 생성 비고란 등 텍스트 입력이 있는 곳이면 어디든:
+
+```tsx
+import { MentionInput } from "@/components/comment/mention-input"
+
+<MentionInput
+  value={text}
+  onChange={setText}
+  onMentionsChange={setMentionedIds}
+  members={members}  // { mem_id, mem_nm }[]
+  placeholder="내용 입력..."
+/>
+```
+
+---
+
+## 서버 액션
+
+| 함수 | 파일 | 설명 |
+|------|------|------|
+| `createComment` | `app/actions/comment/manage-comment.ts` | 작성 + 멘션 저장 + 알림 |
+| `updateComment` | 동일 | 수정 (답글 없는 본인 댓글만) + 멘션 갱신 |
+| `deleteComment` | 동일 | soft delete (본인 또는 관리자) |
+| `getCommentData` | `app/actions/comment/get-comment-data.ts` | 초기 댓글 목록 + 팀 멤버 목록 조회 |
+
+---
+
+## 알림 타입
+
+`noti_mst.noti_type_enm` CHECK 제약:
+```
+'ttl_grnt', 'adm_cust', 'dues_check_req', 'dues_notice', 'cmnt_reply', 'cmnt_mention'
+```
+마이그레이션: `supabase/migrations/20260615120000_cmnt_noti_types.sql`
+
+---
+
+## 기타 사항
+
+- `sch_post` → `sch_post_mst` 테이블 리네임: 마이그레이션 완료 (`20260615100000`), 코드 참조 5곳 업데이트 필요 (Task 1에서 처리)
+- Realtime은 `entity_id=eq.{entityId}` 필터로 해당 엔티티 댓글만 구독
+- `mem_nm`은 Realtime payload에 포함되지 않으므로, INSERT 이벤트 수신 시 `members` prop에서 `mem_id`로 조회
+
+---
+
+## 관련 문서
+
+- `gathering-design.md` — 모임 기능 (댓글 연동 예정)
+- `schedule-feature-progress.md` — `sch_post_mst` 리네임 작업 포함
+- `notice-update-notification.md` — 알림 시스템 구조
+- `database-abbreviation-dictionary.md` — DB 약어 규칙

--- a/.claude/docs/dialog-to-drawer-migration.md
+++ b/.claude/docs/dialog-to-drawer-migration.md
@@ -1,0 +1,109 @@
+# Dialog → Drawer 전환 작업
+
+## 목표
+
+모든 다이얼로그를 shadcn `Drawer`(vaul 기반 바텀 시트)로 통일.
+
+**이유**: 현재 다이얼로그가 중구난방이고, 모바일 PWA에서 바텀 시트가 훨씬 자연스러움. 닫기 버튼을 위로 올라가서 누르는 UX 문제도 해결됨 (드래그 다운으로 닫기).
+
+---
+
+## 작업 순서
+
+### 1. shadcn Drawer 설치
+
+```bash
+pnpm dlx shadcn@latest add drawer
+```
+
+`components/ui/drawer.tsx`가 생성됨.
+
+---
+
+### 2. ResponsiveDrawer 공통 래퍼 생성
+
+`components/common/responsive-drawer.tsx` 신규 생성.
+
+- 모바일(`max-width: 768px`)에서는 → `Drawer` (바텀 시트)
+- 데스크탑에서는 → `Dialog`
+- 사용 인터페이스는 `Dialog`와 동일하게 맞춤
+
+```tsx
+// 사용 예시
+<ResponsiveDrawer open={open} onOpenChange={onOpenChange}>
+  <ResponsiveDrawerContent>
+    <ResponsiveDrawerHeader>
+      <ResponsiveDrawerTitle>제목</ResponsiveDrawerTitle>
+    </ResponsiveDrawerHeader>
+    {/* 내용 */}
+  </ResponsiveDrawerContent>
+</ResponsiveDrawer>
+```
+
+구현 참고: [shadcn useMediaQuery + Drawer/Dialog 패턴](https://ui.shadcn.com/docs/components/drawer) — "Responsive Dialog" 예시 코드 있음.
+
+---
+
+### 3. 기존 다이얼로그 전환 대상 목록
+
+아래 파일들을 `ResponsiveDrawer`로 교체.
+
+| 파일 | 현재 | 비고 |
+|------|------|------|
+| `components/schedule/sch-post-detail-dialog.tsx` | Dialog | 댓글 포함, 콘텐츠 많음 → 우선순위 높음 |
+| `components/schedule/sch-post-form-dialog.tsx` | Dialog | 소식 추가/수정 폼 |
+| `components/admin/*` | Dialog (있다면) | 관리자 다이얼로그 |
+| 그 외 Dialog 사용처 | - | `grep -r "Dialog"` 로 찾기 |
+
+전체 목록 확인 명령:
+```bash
+grep -r "from \"@/components/ui/dialog\"" components/ app/ --include="*.tsx" -l
+```
+
+---
+
+### 4. 전환 방법 (파일별 동일 패턴)
+
+**Before:**
+```tsx
+import { Dialog, DialogContent, DialogHeader, DialogTitle } from "@/components/ui/dialog"
+
+<Dialog open={open} onOpenChange={onOpenChange}>
+  <DialogContent className="max-w-md">
+    <DialogHeader>
+      <DialogTitle>제목</DialogTitle>
+    </DialogHeader>
+    ...
+  </DialogContent>
+</Dialog>
+```
+
+**After:**
+```tsx
+import { ResponsiveDrawer, ResponsiveDrawerContent, ResponsiveDrawerHeader, ResponsiveDrawerTitle } from "@/components/common/responsive-drawer"
+
+<ResponsiveDrawer open={open} onOpenChange={onOpenChange}>
+  <ResponsiveDrawerContent>
+    <ResponsiveDrawerHeader>
+      <ResponsiveDrawerTitle>제목</ResponsiveDrawerTitle>
+    </ResponsiveDrawerHeader>
+    ...
+  </ResponsiveDrawerContent>
+</ResponsiveDrawer>
+```
+
+---
+
+### 5. SchPostDetailDialog 추가 개선 (Drawer 전환 시 같이)
+
+- 고정 높이: `h-[85dvh]` 또는 `max-h-[85dvh]`
+- 헤더 고정 + 내용만 스크롤
+- 댓글 입력창은 하단 고정 (스크롤해도 항상 보이게)
+
+---
+
+## 주의사항
+
+- `SchPostDetailDialog`의 댓글 섹션은 높이 고정 + 내부 스크롤 구조로 맞춰야 댓글 입력창이 항상 접근 가능
+- Drawer는 `open=false`일 때 `display:none` 처리 방식이 Dialog와 다를 수 있음 — 언마운트 타이밍 확인 필요
+- 기존 `max-w-md` 같은 너비 제한은 Drawer에서 의미 없음 (전체 너비) — 데스크탑 Dialog 모드에서만 적용

--- a/.claude/docs/schedule-feature-progress.md
+++ b/.claude/docs/schedule-feature-progress.md
@@ -1,8 +1,9 @@
 # 일정(Schedule) 기능 개발 진행 상황
 
-> 브랜치: `feature/home-calendar-schedule`
+> 브랜치: `feature/home-calendar-schedule` → **dev 머지 완료**
 > 작성일: 2026-06-11
-> 상태: **진행 중** — DB/서버액션/폼 구현 완료, UI 다듬기 중
+> 최종 수정: 2026-06-15
+> 상태: **대부분 완료** — 소소한 미완성 항목만 남음
 
 ---
 
@@ -10,18 +11,21 @@
 
 ### 1. DB — `sch_post` 테이블
 
-**마이그레이션 파일**: `supabase/migrations/20260611100000_sch_post.sql`
-**개발 DB 적용 완료** (MCP로 직접 적용)
+**마이그레이션 파일**:
+- `supabase/migrations/20260611100000_sch_post.sql` — 테이블 생성
+- `supabase/migrations/20260614100000_sch_post_add_post_type.sql` — `post_type` 컬럼 추가
 
 ```sql
 CREATE TABLE public.sch_post (
   sch_post_id  uuid        PRIMARY KEY DEFAULT gen_random_uuid(),
   team_id      uuid        NOT NULL REFERENCES public.team_mst(team_id),
-  sch_nm       text        NOT NULL,          -- 일정명
-  evt_stt_at   timestamptz NOT NULL,          -- 시작 일시
-  evt_end_at   timestamptz,                   -- 종료 일시 (선택)
-  url          text,                          -- 관련 링크 (선택)
-  cont_txt     text,                          -- 본문 내용 (선택)
+  sch_nm       text        NOT NULL,
+  evt_stt_at   timestamptz NOT NULL,
+  evt_end_at   timestamptz,
+  url          text,
+  cont_txt     text,
+  post_type    text        NOT NULL DEFAULT 'general'
+                           CHECK (post_type IN ('general', 'race_entry', 'event')),
   crt_by       uuid        NOT NULL REFERENCES public.mem_mst(mem_id),
   crt_at       timestamptz NOT NULL DEFAULT now(),
   upd_at       timestamptz NOT NULL DEFAULT now(),
@@ -39,9 +43,6 @@ CREATE TABLE public.sch_post (
 **파일**: `.claude/docs/database-abbreviation-dictionary.md`
 
 - 도메인 약어에 `sch` (schedule) 추가
-- 테이블 목록에 `sch_post` 추가
-- `sch_post` 도메인 컬럼 약어 섹션 추가
-- 네이밍 규칙에 `도메인_nm` 패턴, `*_at` vs `*_dt` 구분 규칙 추가
 
 ### 3. Zod 스키마
 
@@ -69,9 +70,8 @@ export const updateSchPostSchema  // createSchPostSchema.partial() + sch_post_id
 - 필드: 일정명, 시작 일시(`datetime-local`), 종료 일시, URL, 내용
 - 수정 모드: [삭제] [취소] [저장하기]
 - 등록 모드: [취소] [등록하기]
-- 삭제 시 `window.confirm` 확인
 
-### 6. CalendarRace 타입 확장
+### 6. CalendarRace 타입
 
 **파일**: `components/home/mini-calendar.tsx`
 
@@ -81,12 +81,13 @@ export type CalendarRace = {
   title: string;
   start_date: string;
   type: "gigang" | "mine" | "schedule";
+  post_type?: string | null;
   end_date?: string | null;
-  location?: string | null;    // 대회 장소
-  url?: string | null;         // sch_post 전용
-  cont_txt?: string | null;    // sch_post 전용
-  crt_by?: string;             // 수정 권한 확인용
-  evt_stt_at?: string | null;  // 시간 표시용 원본 일시
+  location?: string | null;
+  url?: string | null;
+  cont_txt?: string | null;
+  crt_by?: string;
+  evt_stt_at?: string | null;
   evt_end_at?: string | null;
 };
 ```
@@ -100,66 +101,42 @@ export type CalendarRace = {
 - 리스트 뷰일 때 헤더 오른쪽에 `+ 일정 추가` 버튼 (로그인 멤버만)
 - 캘린더 셀: 날짜 패널 하단 `+` 버튼으로 해당 날짜 기본값 세팅해 일정 등록
 - `schedule` 타입 도트: `bg-info/15 text-info`
-- 대회 클릭 → `handleRaceClick` (참가 팝업), 일정 클릭 → `openEditForm` (수정 폼)
-- 참가/수정/취소 성공 시 `handleSchPostSuccess()` 호출 → 캘린더 데이터 자동 리프레시
 
 ### 8. ScheduleListView — 무한 스크롤 리스트 뷰
 
 **파일**: `components/home/schedule-list-view.tsx`
 
-- 높이: `h-[320px]` 고정 (캘린더 뷰와 비슷한 높이)
+- 높이: `h-[320px]` 고정
 - 기준 달로 초기화, 위로 스크롤 → 과거 달 자동 로드, 아래로 → 미래 달
-- IntersectionObserver `root: containerRef.current` 설정 → 마운트 시 자동 발화 없음
-- **sticky 월 헤더**: 스크롤 컨테이너 내에서 상단 고정 (일정 많아도 현재 달 표시 유지)
-- 같은 id 중복 제거 (`seenIds`)
+- sticky 월 헤더
 - 아이템 디자인:
-  - `schedule` (공유 일정): 왼쪽 파란 세로선 + 제목 / 시간범위 / URL 또는 내용
-  - `gigang`/`mine` (대회): 왼쪽 컬러 세로선 + 제목 / 날짜 / 장소 + 우측 **참가** 버튼
-    - 내 대회(`mine`): 참가 버튼 초록색
-    - 기강 대회(`gigang`): 참가 버튼 기본 스타일
-- Props 명시적 분리: `onClickSchedule` / `onClickCompetition` → 타입 혼선 완전 차단
+  - `schedule`: 왼쪽 파란 세로선 + 제목 / 시간범위 / URL 또는 내용
+  - `gigang`/`mine`: 왼쪽 컬러 세로선 + 제목 / 날짜 / 장소 + 우측 참가 버튼
 
-### 9. CompetitionDetailDialog 개선
-
-**파일**: `components/races/competition-detail-dialog.tsx`
-
-- 팝업 닫을 때 `editing` 상태 리셋 → 다음 대회 클릭 시 수정 모드로 열리던 버그 수정
-- 참가/신청 폼 맨 아래 **닫기** 버튼 추가 (스크롤 내려도 닫기 접근 가능)
-
-### 10. page.tsx — 데이터 패칭 추가
+### 9. page.tsx — 데이터 패칭
 
 **파일**: `app/(main)/page.tsx`
 
-- `sch_post` 이번 달 조회 추가 → `calendarSchPosts` → `MiniCalendar`에 `schPosts` prop으로 전달
-- `calendarSchPosts` 매핑에 `evt_stt_at`, `evt_end_at` 포함
-- `calendarMyRaces` 매핑에 `location: comp.loc_nm` 포함
-- `calendarGigangRaces` 매핑에 `location: row.loc_nm` 포함
+- `sch_post` 이번 달 조회 → `calendarSchPosts` → `MiniCalendar`에 `schPosts` prop 전달
+- `post_type` 포함 SELECT
 
 ---
 
-## 남은 작업 (다음 세션)
+## 남은 작업
 
 ### 우선순위 높음
 
-- [ ] **리스트뷰 새로 로드된 달** (`fetchMonth` 결과)에서도 `location` / `evt_stt_at` / `evt_end_at` 정상 전달 확인
-  - `ScheduleListView` 내부 `fetchMonth`의 `calendarMyRaces` 부분: `loc_nm` SELECT에 포함 완료 (`comp_mst!inner(comp_id, comp_nm, stt_dt, loc_nm)`)
-  - `gigangRows`의 `loc_nm` 포함 완료 (RPC 자체가 `loc_nm` 반환)
-- [ ] **리스트뷰 UI 최종 확인** — 개발 서버 띄워서 실제 동작 점검
-  - 공유 일정 클릭 → 수정 폼 팝업 확인
-  - 대회 클릭 → 참가 팝업 확인
-  - 위/아래 스크롤 → 과거/미래 달 로드 확인
-  - sticky 월 헤더 동작 확인
+- [ ] **`sch_post` → `sch_post_mst` 테이블 리네임** — 약어 사전 `_mst` 규칙과 불일치. 댓글 기능 구현 전에 마이그레이션 올릴 것 (`ALTER TABLE sch_post RENAME TO sch_post_mst`)
 
 ### 우선순위 중간
 
-- [ ] **공유 일정 상세 팝업** — 현재 편집 폼만 있음. 비작성자가 클릭했을 때 상세 뷰가 없음
+- [ ] **공유 일정 상세 팝업** — 비작성자가 클릭했을 때 상세 뷰 없음
   - 작성자/관리자: 수정 폼 팝업
-  - 일반 멤버: 일정 상세 보기 팝업 (제목/시간/URL/내용 표시, 닫기만)
-- [ ] **리스트뷰 `+ 일정 추가` 버튼** — 현재 prop으로는 전달되지만 `ScheduleListView` 내부에서 실제로 렌더링 안 됨 (기능 확인 필요)
+  - 일반 멤버: 읽기 전용 상세 팝업 (제목/시간/URL/내용, 닫기만)
 
 ### 우선순위 낮음 (모임 기능 구현 후)
 
-- [ ] 리스트뷰에 `gthr_mst` (모임) 타입 추가 — `gathering-design.md` 참고
+- [ ] 리스트뷰 / 캘린더에 `gthr_mst` (모임) 타입 추가 — `gathering-design.md` 참고
 - [ ] 알림 설정에 `신규 일정` 카테고리 추가
 
 ---
@@ -168,13 +145,12 @@ export type CalendarRace = {
 
 | 파일 | 역할 | 상태 |
 |------|------|------|
-| `supabase/migrations/20260611100000_sch_post.sql` | DB 마이그레이션 | ✅ 완료 |
-| `lib/validations/schedule.ts` | Zod 스키마 | ✅ 완료 |
-| `app/actions/schedule/manage-sch-post.ts` | 서버 액션 | ✅ 완료 |
-| `components/schedule/sch-post-form-dialog.tsx` | 등록/수정 폼 다이얼로그 | ✅ 완료 |
-| `components/home/mini-calendar.tsx` | 캘린더/리스트 뷰 전환, 일정 상태 관리 | ✅ 완료 |
-| `components/home/schedule-list-view.tsx` | 무한 스크롤 리스트 뷰 | ✅ 완료 |
-| `components/races/competition-detail-dialog.tsx` | 대회 참가 팝업 (editing 리셋, 닫기 버튼) | ✅ 완료 |
-| `app/(main)/page.tsx` | 서버 데이터 패칭 + props 전달 | ✅ 완료 |
-| `lib/supabase/database.types.ts` | Supabase 타입 (sch_post 포함) | ✅ 완료 |
-| `.claude/docs/database-abbreviation-dictionary.md` | 약어 사전 | ✅ 완료 |
+| `supabase/migrations/20260611100000_sch_post.sql` | DB 마이그레이션 | ✅ |
+| `supabase/migrations/20260614100000_sch_post_add_post_type.sql` | post_type 추가 | ✅ |
+| `lib/validations/schedule.ts` | Zod 스키마 | ✅ |
+| `app/actions/schedule/manage-sch-post.ts` | 서버 액션 | ✅ |
+| `components/schedule/sch-post-form-dialog.tsx` | 등록/수정 폼 다이얼로그 | ✅ |
+| `components/home/mini-calendar.tsx` | 캘린더/리스트 뷰 전환 | ✅ |
+| `components/home/schedule-list-view.tsx` | 무한 스크롤 리스트 뷰 | ✅ |
+| `app/(main)/page.tsx` | 서버 데이터 패칭 | ✅ |
+| `lib/supabase/database.types.ts` | Supabase 타입 | ✅ |

--- a/app/(info)/admin/notifications/admin-notifications-client.tsx
+++ b/app/(info)/admin/notifications/admin-notifications-client.tsx
@@ -34,6 +34,8 @@ type Member = { mem_id: string; mem_nm: string };
 const NOTI_TYPE_LABELS: Record<NotiTypeEnm, string> = {
   adm_cust: "일반",
   dues_notice: "회비 안내",
+  cmnt_reply: "댓글 답글",
+  cmnt_mention: "댓글 멘션",
 };
 
 export function AdminNotificationsClient({

--- a/app/(main)/page.tsx
+++ b/app/(main)/page.tsx
@@ -185,7 +185,7 @@ async function HomeContent() {
 
   // sch_post (이번 달)
   const { data: schPostRows } = await supabase
-    .from("sch_post")
+    .from("sch_post_mst")
     .select("sch_post_id, sch_nm, post_type, evt_stt_at, evt_end_at, url, cont_txt, crt_by")
     .eq("team_id", teamId)
     .gte("evt_stt_at", monthStart)

--- a/app/(main)/page.tsx
+++ b/app/(main)/page.tsx
@@ -458,16 +458,18 @@ async function HomeContent() {
 
       <div className="flex flex-col gap-7 px-6 pb-6">
       {/* 2. SCHEDULE 캘린더 */}
-      <MiniCalendar
-        gigangRaces={calendarGigangRaces}
-        myRaces={calendarMyRaces}
-        schPosts={calendarSchPosts}
-        teamId={teamId}
-        memberId={currentMember?.id}
-        cmmCdRows={cmmCdRows}
-        initialMemberStatus={initialMemberStatus}
-        initialRegistrationsByCompetitionId={initialRegistrationsByCompetitionId}
-      />
+      <Suspense>
+        <MiniCalendar
+          gigangRaces={calendarGigangRaces}
+          myRaces={calendarMyRaces}
+          schPosts={calendarSchPosts}
+          teamId={teamId}
+          memberId={currentMember?.id}
+          cmmCdRows={cmmCdRows}
+          initialMemberStatus={initialMemberStatus}
+          initialRegistrationsByCompetitionId={initialRegistrationsByCompetitionId}
+        />
+      </Suspense>
 
       {/* 3. UPCOMING RACES 압축 리스트 */}
       <UpcomingRaces

--- a/app/actions/admin/send-notification.ts
+++ b/app/actions/admin/send-notification.ts
@@ -4,7 +4,7 @@ import { verifyAdmin } from "@/lib/queries/member";
 import { getRequestTeamContext } from "@/lib/queries/request-team";
 import { createUntypedAdminClient } from "@/lib/supabase/admin";
 
-export type NotiTypeEnm = "adm_cust" | "dues_notice";
+export type NotiTypeEnm = "adm_cust" | "dues_notice" | "cmnt_reply" | "cmnt_mention";
 
 export async function sendNotification(input: {
   target: "all" | string[];

--- a/app/actions/comment/get-comment-data.ts
+++ b/app/actions/comment/get-comment-data.ts
@@ -1,0 +1,65 @@
+"use server"
+
+import { getCurrentMember } from "@/lib/queries/member"
+import { getRequestTeamContext } from "@/lib/queries/request-team"
+import { createAdminClient } from "@/lib/supabase/admin"
+
+export type CmntRowData = {
+  cmnt_id: string
+  prnt_id: string | null
+  mem_id: string
+  mem_nm: string
+  avatar_url: string | null
+  cont_txt: string
+  edit_yn: boolean
+  del_yn: boolean
+  crt_at: string
+  upd_at: string
+}
+
+export async function getCommentData(entityType: string, entityId: string) {
+  const { member } = await getCurrentMember()
+  if (!member) return { comments: [] as CmntRowData[], members: [] as { mem_id: string; mem_nm: string }[] }
+
+  const { teamId } = await getRequestTeamContext()
+  const admin = createAdminClient()
+
+  const [{ data: cmntRows }, { data: memRows }] = await Promise.all([
+    admin
+      .from("cmnt_mst")
+      .select("cmnt_id, prnt_id, mem_id, cont_txt, edit_yn, del_yn, crt_at, upd_at, mem_mst!inner(mem_nm, avatar_url)")
+      .eq("entity_type", entityType)
+      .eq("entity_id", entityId)
+      .eq("team_id", teamId)
+      .order("crt_at", { ascending: true }),
+    admin
+      .from("team_mem_rel")
+      .select("mem_id, mem_mst!inner(mem_nm)")
+      .eq("team_id", teamId)
+      .eq("mem_st_cd", "active")
+      .eq("del_yn", false),
+  ])
+
+  const comments: CmntRowData[] = (cmntRows ?? []).map((row) => {
+    const mem = Array.isArray(row.mem_mst) ? row.mem_mst[0] : row.mem_mst
+    return {
+      cmnt_id: row.cmnt_id,
+      prnt_id: row.prnt_id,
+      mem_id: row.mem_id,
+      mem_nm: (mem as { mem_nm: string }).mem_nm,
+      avatar_url: (mem as { avatar_url?: string | null }).avatar_url ?? null,
+      cont_txt: row.cont_txt,
+      edit_yn: row.edit_yn,
+      del_yn: row.del_yn,
+      crt_at: row.crt_at,
+      upd_at: row.upd_at,
+    }
+  })
+
+  const members = (memRows ?? []).map((row) => {
+    const mem = Array.isArray(row.mem_mst) ? row.mem_mst[0] : row.mem_mst
+    return { mem_id: row.mem_id, mem_nm: (mem as { mem_nm: string }).mem_nm }
+  })
+
+  return { comments, members }
+}

--- a/app/actions/comment/get-comment-data.ts
+++ b/app/actions/comment/get-comment-data.ts
@@ -18,16 +18,16 @@ export type CmntRowData = {
 }
 
 export async function getCommentData(entityType: string, entityId: string) {
-  const { member } = await getCurrentMember()
+  const { member, supabase } = await getCurrentMember()
   if (!member) return { comments: [] as CmntRowData[], members: [] as { mem_id: string; mem_nm: string }[] }
 
   const { teamId } = await getRequestTeamContext()
   const admin = createAdminClient()
 
-  const [{ data: cmntRows }, { data: memRows }] = await Promise.all([
-    admin
+  const [{ data: cmntRows, error: cmntError }, { data: memRows }] = await Promise.all([
+    supabase
       .from("cmnt_mst")
-      .select("cmnt_id, prnt_id, mem_id, cont_txt, edit_yn, del_yn, crt_at, upd_at, mem_mst!inner(mem_nm, avatar_url)")
+      .select("cmnt_id, prnt_id, mem_id, cont_txt, edit_yn, del_yn, crt_at, upd_at, mem_mst!cmnt_mst_mem_id_fkey(mem_nm, avatar_url)")
       .eq("entity_type", entityType)
       .eq("entity_id", entityId)
       .eq("team_id", teamId)
@@ -39,6 +39,8 @@ export async function getCommentData(entityType: string, entityId: string) {
       .eq("mem_st_cd", "active")
       .eq("del_yn", false),
   ])
+
+  if (cmntError) console.error("[getCommentData] cmnt_mst query error:", cmntError)
 
   const comments: CmntRowData[] = (cmntRows ?? []).map((row) => {
     const mem = Array.isArray(row.mem_mst) ? row.mem_mst[0] : row.mem_mst

--- a/app/actions/comment/manage-comment.ts
+++ b/app/actions/comment/manage-comment.ts
@@ -127,14 +127,15 @@ export async function updateComment(input: UpdateCommentInput) {
     .eq("del_yn", false)
   if ((count ?? 0) > 0) return { ok: false as const, message: "답글이 달린 댓글은 수정할 수 없습니다." }
 
-  const { error } = await supabase
+  const { error, data: updated } = await supabase
     .from("cmnt_mst")
     .update({ cont_txt: parsed.contTxt, edit_yn: true, upd_at: dayjs().toISOString() })
     .eq("cmnt_id", parsed.cmntId)
     .eq("mem_id", member.id)
     .eq("del_yn", false)
+    .select("cmnt_id")
 
-  if (error) return { ok: false as const, message: "댓글 수정 실패" }
+  if (error || !updated?.length) return { ok: false as const, message: "댓글 수정 실패" }
 
   // 멘션 갱신
   await admin.from("cmnt_mention_rel").delete().eq("cmnt_id", parsed.cmntId)

--- a/app/actions/comment/manage-comment.ts
+++ b/app/actions/comment/manage-comment.ts
@@ -155,6 +155,7 @@ export async function deleteComment(input: DeleteCommentInput) {
   const { member, supabase } = await getCurrentMember()
   if (!member) return { ok: false as const, message: "로그인 필요" }
 
+  const { teamId } = await getRequestTeamContext()
   const admin = createAdminClient()
 
   if (!member.admin) {
@@ -167,12 +168,13 @@ export async function deleteComment(input: DeleteCommentInput) {
     if ((count ?? 0) > 0) return { ok: false as const, message: "답글이 달린 댓글은 삭제할 수 없습니다." }
   }
 
-  // 관리자: admin client(RLS bypass), 일반: supabase(RLS — 본인만)
+  // 관리자: admin client(RLS bypass) + team_id 강제, 일반: supabase(RLS — 본인만)
   const db = member.admin ? admin : supabase
-  const { error } = await db
+  const query = db
     .from("cmnt_mst")
     .update({ del_yn: true, upd_at: dayjs().toISOString() })
     .eq("cmnt_id", parsed.cmntId)
+  const { error } = await (member.admin ? query.eq("team_id", teamId) : query)
 
   if (error) return { ok: false as const, message: "댓글 삭제 실패" }
 

--- a/app/actions/comment/manage-comment.ts
+++ b/app/actions/comment/manage-comment.ts
@@ -67,7 +67,7 @@ export async function createComment(input: CreateCommentInput) {
     )
   }
 
-  // 소식 댓글 알림 — 소식 작성자 (루트 댓글만, 본인·멘션 중복 제외, 같은 글 알림 그룹핑)
+  // 피드 댓글 알림 — 피드 작성자 (루트 댓글만, 본인·멘션 중복 제외, 같은 글 알림 그룹핑)
   if (!parsed.prntId && parsed.entityType === "sch_post") {
     const { data: post } = await admin
       .from("sch_post_mst")

--- a/app/actions/comment/manage-comment.ts
+++ b/app/actions/comment/manage-comment.ts
@@ -67,19 +67,19 @@ export async function createComment(input: CreateCommentInput) {
     )
   }
 
-  // 답글 알림 — 원댓글 작성자 (본인·멘션 중복 제외)
-  if (parsed.prntId) {
-    const { data: parent } = await admin
-      .from("cmnt_mst")
-      .select("mem_id")
-      .eq("cmnt_id", parsed.prntId)
+  // 소식 댓글 알림 — 소식 작성자 (루트 댓글만, 본인·멘션 중복 제외)
+  if (!parsed.prntId && parsed.entityType === "sch_post") {
+    const { data: post } = await admin
+      .from("sch_post_mst")
+      .select("crt_by")
+      .eq("sch_post_id", parsed.entityId)
       .single()
-    if (parent && parent.mem_id !== member.id && !uniqueMentions.includes(parent.mem_id)) {
+    if (post && post.crt_by !== member.id && !uniqueMentions.includes(post.crt_by)) {
       await admin.from("noti_mst").insert({
         team_id: teamId,
-        mem_id: parent.mem_id,
-        noti_type_enm: "cmnt_reply",
-        noti_nm: `${member.full_name}님이 댓글에 답글을 달았습니다`,
+        mem_id: post.crt_by,
+        noti_type_enm: "sch_post_cmnt",
+        noti_nm: `${member.full_name}님이 소식에 댓글을 달았습니다`,
         noti_cont: parsed.contTxt.slice(0, 100),
         ref_id: cmnt.cmnt_id,
         ref_type_enm: "cmnt",

--- a/app/actions/comment/manage-comment.ts
+++ b/app/actions/comment/manage-comment.ts
@@ -1,0 +1,159 @@
+"use server"
+
+import { revalidatePath } from "next/cache"
+
+import { dayjs } from "@/lib/dayjs"
+import { getCurrentMember } from "@/lib/queries/member"
+import { getRequestTeamContext } from "@/lib/queries/request-team"
+import { createAdminClient } from "@/lib/supabase/admin"
+import {
+  createCommentSchema,
+  updateCommentSchema,
+  deleteCommentSchema,
+  type CreateCommentInput,
+  type UpdateCommentInput,
+  type DeleteCommentInput,
+} from "@/lib/validations/comment"
+
+export async function createComment(input: CreateCommentInput) {
+  const parsed = createCommentSchema.parse(input)
+  const { member, supabase } = await getCurrentMember()
+  if (!member) return { ok: false as const, message: "로그인 필요" }
+
+  const { teamId } = await getRequestTeamContext()
+  const admin = createAdminClient()
+
+  // 1단계 답글만 허용 — prnt_id가 루트 댓글인지 확인
+  if (parsed.prntId) {
+    const { data: parent } = await supabase
+      .from("cmnt_mst")
+      .select("prnt_id")
+      .eq("cmnt_id", parsed.prntId)
+      .single()
+    if (parent?.prnt_id) return { ok: false as const, message: "답글의 답글은 허용되지 않습니다." }
+  }
+
+  const { data: cmnt, error } = await supabase
+    .from("cmnt_mst")
+    .insert({
+      team_id: teamId,
+      entity_type: parsed.entityType,
+      entity_id: parsed.entityId,
+      prnt_id: parsed.prntId ?? null,
+      mem_id: member.id,
+      cont_txt: parsed.contTxt,
+    })
+    .select()
+    .single()
+
+  if (error || !cmnt) return { ok: false as const, message: "댓글 저장 실패" }
+
+  // 멘션 저장 + 알림
+  const uniqueMentions = [...new Set(parsed.mentionedMemIds)].filter((id) => id !== member.id)
+  if (uniqueMentions.length > 0) {
+    await admin
+      .from("cmnt_mention_rel")
+      .insert(uniqueMentions.map((memId) => ({ cmnt_id: cmnt.cmnt_id, mem_id: memId })))
+    await admin.from("noti_mst").insert(
+      uniqueMentions.map((memId) => ({
+        team_id: teamId,
+        mem_id: memId,
+        noti_type_enm: "cmnt_mention",
+        noti_nm: `${member.full_name}님이 댓글에서 멘션했습니다`,
+        noti_cont: parsed.contTxt.slice(0, 100),
+        ref_id: cmnt.cmnt_id,
+        ref_type_enm: "cmnt",
+      }))
+    )
+  }
+
+  // 답글 알림 — 원댓글 작성자 (본인·멘션 중복 제외)
+  if (parsed.prntId) {
+    const { data: parent } = await admin
+      .from("cmnt_mst")
+      .select("mem_id")
+      .eq("cmnt_id", parsed.prntId)
+      .single()
+    if (parent && parent.mem_id !== member.id && !uniqueMentions.includes(parent.mem_id)) {
+      await admin.from("noti_mst").insert({
+        team_id: teamId,
+        mem_id: parent.mem_id,
+        noti_type_enm: "cmnt_reply",
+        noti_nm: `${member.full_name}님이 댓글에 답글을 달았습니다`,
+        noti_cont: parsed.contTxt.slice(0, 100),
+        ref_id: cmnt.cmnt_id,
+        ref_type_enm: "cmnt",
+      })
+    }
+  }
+
+  revalidatePath("/")
+  return { ok: true as const, data: cmnt }
+}
+
+export async function updateComment(input: UpdateCommentInput) {
+  const parsed = updateCommentSchema.parse(input)
+  const { member, supabase } = await getCurrentMember()
+  if (!member) return { ok: false as const, message: "로그인 필요" }
+
+  const admin = createAdminClient()
+
+  // 답글 달린 댓글 수정 불가
+  const { count } = await supabase
+    .from("cmnt_mst")
+    .select("cmnt_id", { count: "exact", head: true })
+    .eq("prnt_id", parsed.cmntId)
+    .eq("del_yn", false)
+  if ((count ?? 0) > 0) return { ok: false as const, message: "답글이 달린 댓글은 수정할 수 없습니다." }
+
+  const { error } = await supabase
+    .from("cmnt_mst")
+    .update({ cont_txt: parsed.contTxt, edit_yn: true, upd_at: dayjs().toISOString() })
+    .eq("cmnt_id", parsed.cmntId)
+    .eq("mem_id", member.id)
+    .eq("del_yn", false)
+
+  if (error) return { ok: false as const, message: "댓글 수정 실패" }
+
+  // 멘션 갱신
+  await admin.from("cmnt_mention_rel").delete().eq("cmnt_id", parsed.cmntId)
+  const uniqueMentions = [...new Set(parsed.mentionedMemIds)].filter((id) => id !== member.id)
+  if (uniqueMentions.length > 0) {
+    await admin
+      .from("cmnt_mention_rel")
+      .insert(uniqueMentions.map((memId) => ({ cmnt_id: parsed.cmntId, mem_id: memId })))
+  }
+
+  revalidatePath("/")
+  return { ok: true as const }
+}
+
+export async function deleteComment(input: DeleteCommentInput) {
+  const parsed = deleteCommentSchema.parse(input)
+  const { member, supabase } = await getCurrentMember()
+  if (!member) return { ok: false as const, message: "로그인 필요" }
+
+  const admin = createAdminClient()
+
+  if (!member.admin) {
+    // 일반 멤버: 답글 달린 댓글 삭제 불가
+    const { count } = await supabase
+      .from("cmnt_mst")
+      .select("cmnt_id", { count: "exact", head: true })
+      .eq("prnt_id", parsed.cmntId)
+      .eq("del_yn", false)
+    if ((count ?? 0) > 0) return { ok: false as const, message: "답글이 달린 댓글은 삭제할 수 없습니다." }
+  }
+
+  // 관리자: admin client(RLS bypass), 일반: supabase(RLS — 본인만)
+  const db = member.admin ? admin : supabase
+  const { error } = await db
+    .from("cmnt_mst")
+    .update({ del_yn: true, upd_at: dayjs().toISOString() })
+    .eq("cmnt_id", parsed.cmntId)
+
+  if (error) return { ok: false as const, message: "댓글 삭제 실패" }
+
+  revalidatePath("/")
+  return { ok: true as const }
+}

--- a/app/actions/comment/manage-comment.ts
+++ b/app/actions/comment/manage-comment.ts
@@ -61,29 +61,50 @@ export async function createComment(input: CreateCommentInput) {
         noti_type_enm: "cmnt_mention",
         noti_nm: `${member.full_name}님이 댓글에서 멘션했습니다`,
         noti_cont: parsed.contTxt.slice(0, 100),
-        ref_id: cmnt.cmnt_id,
-        ref_type_enm: "cmnt",
+        ref_id: parsed.entityId,
+        ref_type_enm: parsed.entityType,
       }))
     )
   }
 
-  // 소식 댓글 알림 — 소식 작성자 (루트 댓글만, 본인·멘션 중복 제외)
+  // 소식 댓글 알림 — 소식 작성자 (루트 댓글만, 본인·멘션 중복 제외, 같은 글 알림 그룹핑)
   if (!parsed.prntId && parsed.entityType === "sch_post") {
     const { data: post } = await admin
       .from("sch_post_mst")
-      .select("crt_by")
+      .select("crt_by, sch_nm")
       .eq("sch_post_id", parsed.entityId)
       .single()
     if (post && post.crt_by !== member.id && !uniqueMentions.includes(post.crt_by)) {
-      await admin.from("noti_mst").insert({
-        team_id: teamId,
-        mem_id: post.crt_by,
-        noti_type_enm: "sch_post_cmnt",
-        noti_nm: `${member.full_name}님이 소식에 댓글을 달았습니다`,
-        noti_cont: parsed.contTxt.slice(0, 100),
-        ref_id: cmnt.cmnt_id,
-        ref_type_enm: "cmnt",
-      })
+      const { data: existingNoti } = await admin
+        .from("noti_mst")
+        .select("noti_id, noti_nm")
+        .eq("mem_id", post.crt_by)
+        .eq("ref_id", parsed.entityId)
+        .eq("noti_type_enm", "sch_post_cmnt")
+        .eq("read_yn", false)
+        .eq("del_yn", false)
+        .maybeSingle()
+
+      if (existingNoti) {
+        // 기존 메시지에서 카운트 파싱 후 +1 (DB 재조회 없이 race condition 최소화)
+        const match = existingNoti.noti_nm.match(/새 댓글 (\d+)개/)
+        const prevCount = match ? parseInt(match[1], 10) : 1
+        const count = prevCount + 1
+        await admin.from("noti_mst").update({
+          noti_nm: `'${post.sch_nm}'에 새 댓글 ${count}개가 달렸습니다`,
+          noti_cont: parsed.contTxt.slice(0, 100),
+        }).eq("noti_id", existingNoti.noti_id)
+      } else {
+        await admin.from("noti_mst").insert({
+          team_id: teamId,
+          mem_id: post.crt_by,
+          noti_type_enm: "sch_post_cmnt",
+          noti_nm: `'${post.sch_nm}'에 새 댓글이 달렸습니다`,
+          noti_cont: parsed.contTxt.slice(0, 100),
+          ref_id: parsed.entityId,
+          ref_type_enm: "sch_post",
+        })
+      }
     }
   }
 

--- a/app/actions/comment/manage-comment.ts
+++ b/app/actions/comment/manage-comment.ts
@@ -59,7 +59,7 @@ export async function createComment(input: CreateCommentInput) {
         team_id: teamId,
         mem_id: memId,
         noti_type_enm: "cmnt_mention",
-        noti_nm: `${member.full_name}님이 댓글에서 멘션했습니다`,
+        noti_nm: `${member.full_name}님이 댓글에서 멘션했습니다.`,
         noti_cont: parsed.contTxt.slice(0, 100),
         ref_id: parsed.entityId,
         ref_type_enm: parsed.entityType,
@@ -91,7 +91,7 @@ export async function createComment(input: CreateCommentInput) {
         const prevCount = match ? parseInt(match[1], 10) : 1
         const count = prevCount + 1
         await admin.from("noti_mst").update({
-          noti_nm: `'${post.sch_nm}'에 새 댓글 ${count}개가 달렸습니다`,
+          noti_nm: `'${post.sch_nm}'에 새 댓글 ${count}개가 달렸습니다.`,
           noti_cont: parsed.contTxt.slice(0, 100),
         }).eq("noti_id", existingNoti.noti_id)
       } else {
@@ -99,7 +99,7 @@ export async function createComment(input: CreateCommentInput) {
           team_id: teamId,
           mem_id: post.crt_by,
           noti_type_enm: "sch_post_cmnt",
-          noti_nm: `'${post.sch_nm}'에 새 댓글이 달렸습니다`,
+          noti_nm: `'${post.sch_nm}'에 새 댓글이 달렸습니다.`,
           noti_cont: parsed.contTxt.slice(0, 100),
           ref_id: parsed.entityId,
           ref_type_enm: "sch_post",

--- a/app/actions/extract-race-record.ts
+++ b/app/actions/extract-race-record.ts
@@ -36,6 +36,10 @@ export async function extractRaceRecordFromImage(
     return { ok: false, message: "이미지 용량은 10MB 이하여야 합니다." };
   }
 
+  if (!env.GEMINI_API_KEY) {
+    return { ok: false, message: "OCR 기능을 사용할 수 없습니다." };
+  }
+
   try {
     const buffer = Buffer.from(await file.arrayBuffer());
     const data = await extractRaceRecordFromImageData({

--- a/app/actions/schedule/manage-sch-post.ts
+++ b/app/actions/schedule/manage-sch-post.ts
@@ -1,8 +1,10 @@
 "use server";
 
+import { after } from "next/server";
 import { revalidatePath } from "next/cache";
 
 import { dayjs } from "@/lib/dayjs";
+import { createUntypedAdminClient } from "@/lib/supabase/admin";
 import { getCurrentMember } from "@/lib/queries/member";
 import { getRequestTeamContext } from "@/lib/queries/request-team";
 import { createSchPostSchema, updateSchPostSchema } from "@/lib/validations/schedule";
@@ -40,8 +42,56 @@ export async function createSchPost(input: {
 
   if (error || !data) throw new Error("일정 등록에 실패했습니다.");
 
+  const postId = data.sch_post_id;
+  const authorId = member.id;
+  const postName = parsed.sch_nm;
+
+  after(async () => {
+    try {
+      const admin = createUntypedAdminClient();
+
+      // 팀 전체 활성 멤버 조회 (작성자 제외)
+      const { data: members } = await admin
+        .from("team_mem_rel")
+        .select("mem_id")
+        .eq("team_id", teamId)
+        .eq("vers", 0)
+        .eq("del_yn", false)
+        .neq("mem_id", authorId);
+
+      if (!members?.length) return;
+
+      // 알림 설정 확인 후 발송 대상 필터링
+      const { data: disabledPrefs } = await admin
+        .from("noti_pref_cfg")
+        .select("mem_id")
+        .in("mem_id", members.map((m) => m.mem_id))
+        .eq("noti_type_enm", "sch_post_new")
+        .eq("enabled_yn", false);
+
+      const disabledSet = new Set((disabledPrefs ?? []).map((p) => p.mem_id));
+      const targets = members.filter((m) => !disabledSet.has(m.mem_id));
+
+      if (!targets.length) return;
+
+      await admin.from("noti_mst").insert(
+        targets.map((m) => ({
+          team_id: teamId,
+          mem_id: m.mem_id,
+          noti_type_enm: "sch_post_new",
+          noti_nm: `${dayjs().format("M월 D일")} 새 피드가 등록됐습니다.`,
+          noti_cont: postName,
+          ref_id: postId,
+          ref_type_enm: "sch_post",
+        })),
+      );
+    } catch (e) {
+      console.error("[sch_post_new] 알림 발송 실패", e);
+    }
+  });
+
   revalidatePath("/");
-  return { sch_post_id: data.sch_post_id };
+  return { sch_post_id: postId };
 }
 
 export async function updateSchPost(input: {

--- a/app/actions/schedule/manage-sch-post.ts
+++ b/app/actions/schedule/manage-sch-post.ts
@@ -1,6 +1,7 @@
 "use server";
 
 import { revalidatePath } from "next/cache";
+
 import { dayjs } from "@/lib/dayjs";
 import { getCurrentMember } from "@/lib/queries/member";
 import { getRequestTeamContext } from "@/lib/queries/request-team";

--- a/app/actions/schedule/manage-sch-post.ts
+++ b/app/actions/schedule/manage-sch-post.ts
@@ -1,12 +1,12 @@
 "use server";
 
-import { after } from "next/server";
 import { revalidatePath } from "next/cache";
+import { after } from "next/server";
 
 import { dayjs } from "@/lib/dayjs";
-import { createUntypedAdminClient } from "@/lib/supabase/admin";
 import { getCurrentMember } from "@/lib/queries/member";
 import { getRequestTeamContext } from "@/lib/queries/request-team";
+import { createUntypedAdminClient } from "@/lib/supabase/admin";
 import { createSchPostSchema, updateSchPostSchema } from "@/lib/validations/schedule";
 
 export async function createSchPost(input: {

--- a/app/actions/schedule/manage-sch-post.ts
+++ b/app/actions/schedule/manage-sch-post.ts
@@ -21,7 +21,7 @@ export async function createSchPost(input: {
   const parsed = createSchPostSchema.parse({ ...input, team_id: teamId });
 
   const { data, error } = await supabase
-    .from("sch_post")
+    .from("sch_post_mst")
     .insert({
       team_id: parsed.team_id,
       sch_nm: parsed.sch_nm,
@@ -59,7 +59,7 @@ export async function updateSchPost(input: {
   const { sch_post_id, ...fields } = parsed;
 
   const { error } = await supabase
-    .from("sch_post")
+    .from("sch_post_mst")
     .update({ ...fields, url: fields.url || null, upd_at: dayjs().toISOString() })
     .eq("sch_post_id", sch_post_id);
 
@@ -73,7 +73,7 @@ export async function deleteSchPost(sch_post_id: string) {
   if (!member) throw new Error("로그인이 필요합니다.");
 
   const { error } = await supabase
-    .from("sch_post")
+    .from("sch_post_mst")
     .update({ del_yn: true, upd_at: dayjs().toISOString() })
     .eq("sch_post_id", sch_post_id);
 

--- a/app/api/notifications/route.ts
+++ b/app/api/notifications/route.ts
@@ -1,4 +1,5 @@
 import { NextRequest, NextResponse } from "next/server";
+
 import { getCurrentMember } from "@/lib/queries/member";
 import { getNotifications } from "@/lib/queries/notification";
 

--- a/app/api/notifications/route.ts
+++ b/app/api/notifications/route.ts
@@ -11,6 +11,10 @@ export async function GET(request: NextRequest) {
   const limit = Math.min(parseInt(searchParams.get("limit") ?? "20", 10), 50);
   const cursor = searchParams.get("cursor") ?? undefined;
 
-  const notifications = await getNotifications(member.id, { cursor, limit });
-  return NextResponse.json({ notifications });
+  try {
+    const notifications = await getNotifications(member.id, { cursor, limit });
+    return NextResponse.json({ notifications });
+  } catch {
+    return NextResponse.json({ error: "알림 조회 실패" }, { status: 500 });
+  }
 }

--- a/app/api/notifications/route.ts
+++ b/app/api/notifications/route.ts
@@ -1,6 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
-import { createUntypedAdminClient } from "@/lib/supabase/admin";
 import { getCurrentMember } from "@/lib/queries/member";
+import { getNotifications } from "@/lib/queries/notification";
 
 export async function GET(request: NextRequest) {
   const { member } = await getCurrentMember();
@@ -8,25 +8,8 @@ export async function GET(request: NextRequest) {
 
   const { searchParams } = new URL(request.url);
   const limit = Math.min(parseInt(searchParams.get("limit") ?? "20", 10), 50);
-  const cursor = searchParams.get("cursor");
+  const cursor = searchParams.get("cursor") ?? undefined;
 
-  const admin = createUntypedAdminClient();
-  let query = admin
-    .from("noti_mst")
-    .select(
-      "noti_id, team_id, mem_id, noti_type_enm, noti_nm, noti_cont, ref_id, ref_type_enm, read_yn, crt_at",
-    )
-    .eq("mem_id", member.id)
-    .eq("del_yn", false)
-    .order("crt_at", { ascending: false })
-    .limit(limit);
-
-  if (cursor) {
-    query = query.lt("crt_at", cursor);
-  }
-
-  const { data, error } = await query;
-  if (error) return NextResponse.json({ error: "조회 중 오류가 발생했습니다." }, { status: 500 });
-
-  return NextResponse.json({ notifications: data ?? [] });
+  const notifications = await getNotifications(member.id, { cursor, limit });
+  return NextResponse.json({ notifications });
 }

--- a/components/comment/comment-item.tsx
+++ b/components/comment/comment-item.tsx
@@ -1,0 +1,142 @@
+"use client"
+
+import { useState } from "react"
+import { dayjs } from "@/lib/dayjs"
+import { Avatar } from "@/components/common/avatar"
+import { Body, Caption } from "@/components/common/typography"
+import { Button } from "@/components/ui/button"
+import { MentionInput, renderMentions, type MemberOption } from "./mention-input"
+import { updateComment, deleteComment } from "@/app/actions/comment/manage-comment"
+
+export type CmntRow = {
+  cmnt_id: string
+  prnt_id: string | null
+  mem_id: string
+  mem_nm: string
+  avatar_url?: string | null
+  cont_txt: string
+  edit_yn: boolean
+  del_yn: boolean
+  crt_at: string
+  upd_at: string
+  has_replies?: boolean
+}
+
+interface CommentItemProps {
+  comment: CmntRow
+  currentMemberId?: string
+  isAdmin?: boolean
+  members: MemberOption[]
+  onReply?: (cmnt: CmntRow) => void
+  isReply?: boolean
+}
+
+export function CommentItem({
+  comment,
+  currentMemberId,
+  isAdmin,
+  members,
+  onReply,
+  isReply,
+}: CommentItemProps) {
+  const [editing, setEditing] = useState(false)
+  const [editText, setEditText] = useState(comment.cont_txt)
+  const [editMentions, setEditMentions] = useState<string[]>([])
+  const [loading, setLoading] = useState(false)
+
+  const isMine = comment.mem_id === currentMemberId
+  const canEdit = isMine && !comment.del_yn && !comment.has_replies
+  const canDelete = (isMine || isAdmin) && !comment.del_yn && !comment.has_replies
+
+  if (comment.del_yn) {
+    return (
+      <div className={`py-2 ${isReply ? "pl-10" : ""}`}>
+        <Caption className="italic opacity-50">삭제된 댓글입니다.</Caption>
+      </div>
+    )
+  }
+
+  const handleUpdate = async () => {
+    if (!editText.trim()) return
+    setLoading(true)
+    await updateComment({ cmntId: comment.cmnt_id, contTxt: editText.trim(), mentionedMemIds: editMentions })
+    setLoading(false)
+    setEditing(false)
+  }
+
+  const handleDelete = async () => {
+    if (!confirm("댓글을 삭제할까요?")) return
+    setLoading(true)
+    await deleteComment({ cmntId: comment.cmnt_id })
+    setLoading(false)
+  }
+
+  return (
+    <div className={`flex gap-2.5 py-2.5 ${isReply ? "pl-10" : ""}`}>
+      <Avatar src={comment.avatar_url} size="sm" />
+      <div className="flex-1 min-w-0">
+        <div className="flex flex-wrap items-baseline gap-x-2 gap-y-0.5">
+          <Body className="text-sm font-semibold">{comment.mem_nm}</Body>
+          <Caption className="text-xs">{dayjs(comment.crt_at).fromNow()}</Caption>
+          {comment.edit_yn && <Caption className="text-xs opacity-60">(수정됨)</Caption>}
+        </div>
+
+        {editing ? (
+          <div className="mt-1.5 flex flex-col gap-2">
+            <MentionInput
+              value={editText}
+              onChange={setEditText}
+              onMentionsChange={setEditMentions}
+              members={members}
+              rows={2}
+            />
+            <div className="flex gap-2">
+              <Button size="sm" onClick={handleUpdate} disabled={loading || !editText.trim()}>
+                저장
+              </Button>
+              <Button
+                size="sm"
+                variant="ghost"
+                onClick={() => { setEditing(false); setEditText(comment.cont_txt) }}
+              >
+                취소
+              </Button>
+            </div>
+          </div>
+        ) : (
+          <p className="mt-0.5 text-sm leading-relaxed break-words">
+            {renderMentions(comment.cont_txt)}
+          </p>
+        )}
+
+        <div className="mt-1 flex gap-3">
+          {!isReply && onReply && (
+            <button
+              className="text-xs text-muted-foreground hover:text-foreground transition-colors"
+              onClick={() => onReply(comment)}
+            >
+              답글
+            </button>
+          )}
+          {canEdit && !editing && (
+            <button
+              className="text-xs text-muted-foreground hover:text-foreground transition-colors"
+              onClick={() => setEditing(true)}
+            >
+              수정
+            </button>
+          )}
+          {canDelete && !editing && (
+            <button
+              className="text-xs text-muted-foreground hover:text-destructive transition-colors"
+              onClick={handleDelete}
+              disabled={loading}
+            >
+              삭제
+            </button>
+          )}
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/components/comment/comment-item.tsx
+++ b/components/comment/comment-item.tsx
@@ -1,12 +1,16 @@
 "use client"
 
 import { useState } from "react"
+
 import { dayjs } from "@/lib/dayjs"
+
+import { updateComment, deleteComment } from "@/app/actions/comment/manage-comment"
+
 import { Avatar } from "@/components/common/avatar"
 import { Body, Caption } from "@/components/common/typography"
 import { Button } from "@/components/ui/button"
+
 import { MentionInput, renderMentions, type MemberOption } from "./mention-input"
-import { updateComment, deleteComment } from "@/app/actions/comment/manage-comment"
 
 export type CmntRow = {
   cmnt_id: string

--- a/components/comment/comment-item.tsx
+++ b/components/comment/comment-item.tsx
@@ -49,7 +49,7 @@ export function CommentItem({
 
   const isMine = comment.mem_id === currentMemberId
   const canEdit = isMine && !comment.del_yn && !comment.has_replies
-  const canDelete = (isMine || isAdmin) && !comment.del_yn && !comment.has_replies
+  const canDelete = (isMine || isAdmin) && !comment.del_yn && (isAdmin || !comment.has_replies)
 
   if (comment.del_yn) {
     return (

--- a/components/comment/comment-item.tsx
+++ b/components/comment/comment-item.tsx
@@ -79,10 +79,39 @@ export function CommentItem({
     <div className={`flex gap-2.5 py-2.5 ${isReply ? "pl-10" : ""}`}>
       <Avatar src={comment.avatar_url} size="sm" />
       <div className="flex-1 min-w-0">
-        <div className="flex flex-wrap items-baseline gap-x-2 gap-y-0.5">
+        <div className="flex items-center gap-x-2">
           <Body className="text-sm font-semibold">{comment.mem_nm}</Body>
           <Caption className="text-xs">{dayjs(comment.crt_at).fromNow()}</Caption>
           {comment.edit_yn && <Caption className="text-xs opacity-60">(수정됨)</Caption>}
+          {!editing && (
+            <div className="ml-auto flex gap-3">
+              {onReply && (
+                <button
+                  className="text-xs text-muted-foreground hover:text-foreground transition-colors"
+                  onClick={() => onReply(comment)}
+                >
+                  답글
+                </button>
+              )}
+              {canEdit && (
+                <button
+                  className="text-xs text-muted-foreground hover:text-foreground transition-colors"
+                  onClick={() => setEditing(true)}
+                >
+                  수정
+                </button>
+              )}
+              {canDelete && (
+                <button
+                  className="text-xs text-muted-foreground hover:text-destructive transition-colors"
+                  onClick={handleDelete}
+                  disabled={loading}
+                >
+                  삭제
+                </button>
+              )}
+            </div>
+          )}
         </div>
 
         {editing ? (
@@ -113,33 +142,6 @@ export function CommentItem({
           </p>
         )}
 
-        <div className="mt-1 flex gap-3">
-          {!isReply && onReply && (
-            <button
-              className="text-xs text-muted-foreground hover:text-foreground transition-colors"
-              onClick={() => onReply(comment)}
-            >
-              답글
-            </button>
-          )}
-          {canEdit && !editing && (
-            <button
-              className="text-xs text-muted-foreground hover:text-foreground transition-colors"
-              onClick={() => setEditing(true)}
-            >
-              수정
-            </button>
-          )}
-          {canDelete && !editing && (
-            <button
-              className="text-xs text-muted-foreground hover:text-destructive transition-colors"
-              onClick={handleDelete}
-              disabled={loading}
-            >
-              삭제
-            </button>
-          )}
-        </div>
       </div>
     </div>
   )

--- a/components/comment/comment-item.tsx
+++ b/components/comment/comment-item.tsx
@@ -10,7 +10,7 @@ import { Avatar } from "@/components/common/avatar"
 import { Body, Caption } from "@/components/common/typography"
 import { Button } from "@/components/ui/button"
 
-import { MentionInput, renderMentions, type MemberOption } from "./mention-input"
+import { MentionInput, parseMentionsFromText, renderMentions, type MemberOption } from "./mention-input"
 
 export type CmntRow = {
   cmnt_id: string
@@ -45,7 +45,6 @@ export function CommentItem({
 }: CommentItemProps) {
   const [editing, setEditing] = useState(false)
   const [editText, setEditText] = useState(comment.cont_txt)
-  const [editMentions, setEditMentions] = useState<string[]>([])
   const [loading, setLoading] = useState(false)
 
   const isMine = comment.mem_id === currentMemberId
@@ -63,7 +62,7 @@ export function CommentItem({
   const handleUpdate = async () => {
     if (!editText.trim()) return
     setLoading(true)
-    await updateComment({ cmntId: comment.cmnt_id, contTxt: editText.trim(), mentionedMemIds: editMentions })
+    await updateComment({ cmntId: comment.cmnt_id, contTxt: editText.trim(), mentionedMemIds: parseMentionsFromText(editText.trim(), members) })
     setLoading(false)
     setEditing(false)
   }
@@ -119,7 +118,6 @@ export function CommentItem({
             <MentionInput
               value={editText}
               onChange={setEditText}
-              onMentionsChange={setEditMentions}
               members={members}
               rows={2}
             />
@@ -138,7 +136,7 @@ export function CommentItem({
           </div>
         ) : (
           <p className="mt-0.5 text-sm leading-relaxed break-words">
-            {renderMentions(comment.cont_txt)}
+            {renderMentions(comment.cont_txt, members)}
           </p>
         )}
 

--- a/components/comment/comment-section.tsx
+++ b/components/comment/comment-section.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import { useEffect, useState } from "react"
+import { useEffect, useMemo, useRef, useState } from "react"
 
 import { createClient } from "@/lib/supabase/client"
 
@@ -10,7 +10,7 @@ import { SectionLabel } from "@/components/common/typography"
 import { Button } from "@/components/ui/button"
 
 import { CommentItem, type CmntRow } from "./comment-item"
-import { MentionInput, type MemberOption } from "./mention-input"
+import { MentionInput, parseMentionsFromText, type MemberOption } from "./mention-input"
 
 interface CommentSectionProps {
   entityType: "sch_post" | "comp" | "gathering"
@@ -48,12 +48,15 @@ export function CommentSection({
 }: CommentSectionProps) {
   const [comments, setComments] = useState<CmntRow[]>(initialComments)
   const [newText, setNewText] = useState("")
-  const [newMentions, setNewMentions] = useState<string[]>([])
   const [replyTo, setReplyTo] = useState<CmntRow | null>(null)
   const [replyText, setReplyText] = useState("")
-  const [replyMentions, setReplyMentions] = useState<string[]>([])
   const [loading, setLoading] = useState(false)
-  const supabase = createClient()
+
+  // 렌더마다 재생성 방지 — 재생성 시 useEffect deps 변경으로 매 렌더마다 채널 재구독됨
+  const supabase = useMemo(() => createClient(), [])
+  // members가 바뀌어도 채널을 재구독하지 않도록 ref로 최신값 유지
+  const membersRef = useRef(members)
+  useEffect(() => { membersRef.current = members }, [members])
 
   useEffect(() => {
     const channel = supabase
@@ -71,7 +74,7 @@ export function CommentSection({
             const incoming = payload.new as CmntRow
             setComments((prev) => {
               if (prev.some((c) => c.cmnt_id === incoming.cmnt_id)) return prev
-              const mem = members.find((m) => m.mem_id === incoming.mem_id)
+              const mem = membersRef.current.find((m) => m.mem_id === incoming.mem_id)
               return [...prev, { ...incoming, mem_nm: mem?.mem_nm ?? "멤버" }]
             })
           } else if (payload.eventType === "UPDATE") {
@@ -90,7 +93,7 @@ export function CommentSection({
     return () => {
       supabase.removeChannel(channel)
     }
-  }, [entityType, entityId, supabase, members])
+  }, [entityType, entityId, supabase])
 
   const handleSubmitComment = async () => {
     if (!newText.trim() || !currentMemberId) return
@@ -100,7 +103,7 @@ export function CommentSection({
         entityType,
         entityId,
         contTxt: newText.trim(),
-        mentionedMemIds: newMentions,
+        mentionedMemIds: parseMentionsFromText(newText, members),
       })
       if (result.ok) {
         const me = members.find((m) => m.mem_id === currentMemberId)
@@ -120,7 +123,6 @@ export function CommentSection({
           },
         ])
         setNewText("")
-        setNewMentions([])
       }
     } finally {
       setLoading(false)
@@ -131,16 +133,12 @@ export function CommentSection({
     if (!replyText.trim() || !currentMemberId || !replyTo) return
     setLoading(true)
     try {
-      const mentionInText = replyText.includes(`@${replyTo.mem_nm}`)
-      const allMentions = mentionInText
-        ? [...new Set([replyTo.mem_id, ...replyMentions])]
-        : replyMentions
       const result = await createComment({
         entityType,
         entityId,
         contTxt: replyText.trim(),
         prntId: replyTo.prnt_id ?? replyTo.cmnt_id,
-        mentionedMemIds: allMentions,
+        mentionedMemIds: parseMentionsFromText(replyText, members),
       })
       if (result.ok) {
         const me = members.find((m) => m.mem_id === currentMemberId)
@@ -160,7 +158,6 @@ export function CommentSection({
           },
         ])
         setReplyText("")
-        setReplyMentions([])
         setReplyTo(null)
       }
     } finally {
@@ -168,8 +165,8 @@ export function CommentSection({
     }
   }
 
-  const visibleCount = comments.filter((c) => !c.del_yn).length
-  const tree = buildTree(comments)
+  const visibleCount = useMemo(() => comments.filter((c) => !c.del_yn).length, [comments])
+  const tree = useMemo(() => buildTree(comments), [comments])
 
   return (
     <div className="flex flex-col gap-3">
@@ -188,7 +185,7 @@ export function CommentSection({
                 currentMemberId={currentMemberId}
                 isAdmin={isAdmin}
                 members={members}
-                onReply={currentMemberId ? (c) => { setReplyTo(c); setReplyText(`@${c.mem_nm} `); setReplyMentions([]) } : undefined}
+                onReply={currentMemberId ? (c) => { setReplyTo(c); setReplyText(`@${c.mem_nm} `) } : undefined}
               />
               {cmnt.replies.map((reply) => (
                 <CommentItem
@@ -198,7 +195,7 @@ export function CommentSection({
                   isAdmin={isAdmin}
                   members={members}
                   isReply
-                  onReply={currentMemberId ? (c) => { setReplyTo(c); setReplyText(`@${c.mem_nm} `); setReplyMentions([]) } : undefined}
+                  onReply={currentMemberId ? (c) => { setReplyTo(c); setReplyText(`@${c.mem_nm} `) } : undefined}
                 />
               ))}
 
@@ -207,7 +204,6 @@ export function CommentSection({
                   <MentionInput
                     value={replyText}
                     onChange={setReplyText}
-                    onMentionsChange={setReplyMentions}
                     members={members}
                     placeholder="답글을 입력하세요..."
                     rows={2}
@@ -241,7 +237,6 @@ export function CommentSection({
           <MentionInput
             value={newText}
             onChange={setNewText}
-            onMentionsChange={setNewMentions}
             members={members}
             placeholder="댓글을 입력하세요..."
             rows={2}

--- a/components/comment/comment-section.tsx
+++ b/components/comment/comment-section.tsx
@@ -1,0 +1,193 @@
+"use client"
+
+import { useEffect, useState } from "react"
+import { createClient } from "@/lib/supabase/client"
+import { SectionLabel } from "@/components/common/typography"
+import { Button } from "@/components/ui/button"
+import { CommentItem, type CmntRow } from "./comment-item"
+import { MentionInput, type MemberOption } from "./mention-input"
+import { createComment } from "@/app/actions/comment/manage-comment"
+
+interface CommentSectionProps {
+  entityType: "sch_post" | "comp" | "gathering"
+  entityId: string
+  currentMemberId?: string
+  isAdmin?: boolean
+  members: MemberOption[]
+  initialComments: CmntRow[]
+}
+
+type CommentWithReplies = CmntRow & { replies: CmntRow[] }
+
+function buildTree(flat: CmntRow[]): CommentWithReplies[] {
+  const replyParentIds = new Set(
+    flat.filter((c) => c.prnt_id && !c.del_yn).map((c) => c.prnt_id as string)
+  )
+  return flat
+    .filter((c) => !c.prnt_id)
+    .map((c) => ({
+      ...c,
+      has_replies: replyParentIds.has(c.cmnt_id),
+      replies: flat
+        .filter((r) => r.prnt_id === c.cmnt_id)
+        .map((r) => ({ ...r, replies: [] })),
+    }))
+}
+
+export function CommentSection({
+  entityType,
+  entityId,
+  currentMemberId,
+  isAdmin,
+  members,
+  initialComments,
+}: CommentSectionProps) {
+  const [comments, setComments] = useState<CmntRow[]>(initialComments)
+  const [newText, setNewText] = useState("")
+  const [newMentions, setNewMentions] = useState<string[]>([])
+  const [replyTo, setReplyTo] = useState<CmntRow | null>(null)
+  const [loading, setLoading] = useState(false)
+  const supabase = createClient()
+
+  useEffect(() => {
+    const channel = supabase
+      .channel(`cmnt:${entityType}:${entityId}`)
+      .on(
+        "postgres_changes",
+        {
+          event: "*",
+          schema: "public",
+          table: "cmnt_mst",
+          filter: `entity_id=eq.${entityId}`,
+        },
+        (payload) => {
+          if (payload.eventType === "INSERT") {
+            const incoming = payload.new as CmntRow
+            setComments((prev) => {
+              if (prev.some((c) => c.cmnt_id === incoming.cmnt_id)) return prev
+              const mem = members.find((m) => m.mem_id === incoming.mem_id)
+              return [...prev, { ...incoming, mem_nm: mem?.mem_nm ?? "멤버" }]
+            })
+          } else if (payload.eventType === "UPDATE") {
+            setComments((prev) =>
+              prev.map((c) =>
+                c.cmnt_id === (payload.new as CmntRow).cmnt_id
+                  ? { ...c, ...(payload.new as CmntRow) }
+                  : c
+              )
+            )
+          }
+        }
+      )
+      .subscribe()
+
+    return () => {
+      supabase.removeChannel(channel)
+    }
+  }, [entityType, entityId, supabase, members])
+
+  const handleSubmit = async () => {
+    if (!newText.trim() || !currentMemberId) return
+    setLoading(true)
+    try {
+      const result = await createComment({
+        entityType,
+        entityId,
+        contTxt: newText.trim(),
+        prntId: replyTo?.cmnt_id,
+        mentionedMemIds: newMentions,
+      })
+      if (result.ok) {
+        const me = members.find((m) => m.mem_id === currentMemberId)
+        setComments((prev) => [
+          ...prev,
+          {
+            cmnt_id: result.data.cmnt_id,
+            prnt_id: result.data.prnt_id,
+            mem_id: result.data.mem_id,
+            mem_nm: me?.mem_nm ?? "나",
+            avatar_url: null,
+            cont_txt: result.data.cont_txt,
+            edit_yn: result.data.edit_yn,
+            del_yn: result.data.del_yn,
+            crt_at: result.data.crt_at,
+            upd_at: result.data.upd_at,
+          },
+        ])
+        setNewText("")
+        setNewMentions([])
+        setReplyTo(null)
+      }
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  const visibleCount = comments.filter((c) => !c.del_yn).length
+  const tree = buildTree(comments)
+
+  return (
+    <div className="flex flex-col gap-3">
+      <SectionLabel>
+        {`COMMENTS${visibleCount > 0 ? ` · ${visibleCount}` : ""}`}
+      </SectionLabel>
+
+      {tree.length === 0 ? (
+        <p className="text-sm text-muted-foreground py-2">아직 댓글이 없습니다.</p>
+      ) : (
+        <div className="flex flex-col divide-y divide-border">
+          {tree.map((cmnt) => (
+            <div key={cmnt.cmnt_id}>
+              <CommentItem
+                comment={cmnt}
+                currentMemberId={currentMemberId}
+                isAdmin={isAdmin}
+                members={members}
+                onReply={currentMemberId ? setReplyTo : undefined}
+              />
+              {cmnt.replies.map((reply) => (
+                <CommentItem
+                  key={reply.cmnt_id}
+                  comment={reply}
+                  currentMemberId={currentMemberId}
+                  isAdmin={isAdmin}
+                  members={members}
+                  isReply
+                />
+              ))}
+            </div>
+          ))}
+        </div>
+      )}
+
+      {currentMemberId && (
+        <div className="flex flex-col gap-2 pt-1">
+          {replyTo && (
+            <div className="flex items-center gap-2 text-xs text-muted-foreground">
+              <span>↩ @{replyTo.mem_nm}에게 답글</span>
+              <button onClick={() => setReplyTo(null)} className="hover:text-foreground">
+                ✕
+              </button>
+            </div>
+          )}
+          <MentionInput
+            value={newText}
+            onChange={setNewText}
+            onMentionsChange={setNewMentions}
+            members={members}
+            placeholder={replyTo ? "답글을 입력하세요..." : "댓글을 입력하세요..."}
+            rows={2}
+          />
+          <Button
+            size="sm"
+            onClick={handleSubmit}
+            disabled={loading || !newText.trim()}
+            className="self-end"
+          >
+            {replyTo ? "답글 달기" : "댓글 달기"}
+          </Button>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/components/comment/comment-section.tsx
+++ b/components/comment/comment-section.tsx
@@ -131,12 +131,16 @@ export function CommentSection({
     if (!replyText.trim() || !currentMemberId || !replyTo) return
     setLoading(true)
     try {
+      const mentionInText = replyText.includes(`@${replyTo.mem_nm}`)
+      const allMentions = mentionInText
+        ? [...new Set([replyTo.mem_id, ...replyMentions])]
+        : replyMentions
       const result = await createComment({
         entityType,
         entityId,
         contTxt: replyText.trim(),
         prntId: replyTo.prnt_id ?? replyTo.cmnt_id,
-        mentionedMemIds: replyMentions,
+        mentionedMemIds: allMentions,
       })
       if (result.ok) {
         const me = members.find((m) => m.mem_id === currentMemberId)
@@ -184,7 +188,7 @@ export function CommentSection({
                 currentMemberId={currentMemberId}
                 isAdmin={isAdmin}
                 members={members}
-                onReply={currentMemberId ? (c) => { setReplyTo(c); setReplyText("") } : undefined}
+                onReply={currentMemberId ? (c) => { setReplyTo(c); setReplyText(`@${c.mem_nm} `); setReplyMentions([]) } : undefined}
               />
               {cmnt.replies.map((reply) => (
                 <CommentItem
@@ -194,7 +198,7 @@ export function CommentSection({
                   isAdmin={isAdmin}
                   members={members}
                   isReply
-                  onReply={currentMemberId ? (c) => { setReplyTo(c); setReplyText("") } : undefined}
+                  onReply={currentMemberId ? (c) => { setReplyTo(c); setReplyText(`@${c.mem_nm} `); setReplyMentions([]) } : undefined}
                 />
               ))}
 
@@ -205,7 +209,7 @@ export function CommentSection({
                     onChange={setReplyText}
                     onMentionsChange={setReplyMentions}
                     members={members}
-                    placeholder={`@${replyTo.mem_nm}에게 답글...`}
+                    placeholder="답글을 입력하세요..."
                     rows={2}
                   />
                   <div className="flex gap-2">

--- a/components/comment/comment-section.tsx
+++ b/components/comment/comment-section.tsx
@@ -50,6 +50,8 @@ export function CommentSection({
   const [newText, setNewText] = useState("")
   const [newMentions, setNewMentions] = useState<string[]>([])
   const [replyTo, setReplyTo] = useState<CmntRow | null>(null)
+  const [replyText, setReplyText] = useState("")
+  const [replyMentions, setReplyMentions] = useState<string[]>([])
   const [loading, setLoading] = useState(false)
   const supabase = createClient()
 
@@ -90,7 +92,7 @@ export function CommentSection({
     }
   }, [entityType, entityId, supabase, members])
 
-  const handleSubmit = async () => {
+  const handleSubmitComment = async () => {
     if (!newText.trim() || !currentMemberId) return
     setLoading(true)
     try {
@@ -98,7 +100,6 @@ export function CommentSection({
         entityType,
         entityId,
         contTxt: newText.trim(),
-        prntId: replyTo?.cmnt_id,
         mentionedMemIds: newMentions,
       })
       if (result.ok) {
@@ -120,6 +121,42 @@ export function CommentSection({
         ])
         setNewText("")
         setNewMentions([])
+      }
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  const handleSubmitReply = async () => {
+    if (!replyText.trim() || !currentMemberId || !replyTo) return
+    setLoading(true)
+    try {
+      const result = await createComment({
+        entityType,
+        entityId,
+        contTxt: replyText.trim(),
+        prntId: replyTo.prnt_id ?? replyTo.cmnt_id,
+        mentionedMemIds: replyMentions,
+      })
+      if (result.ok) {
+        const me = members.find((m) => m.mem_id === currentMemberId)
+        setComments((prev) => [
+          ...prev,
+          {
+            cmnt_id: result.data.cmnt_id,
+            prnt_id: result.data.prnt_id,
+            mem_id: result.data.mem_id,
+            mem_nm: me?.mem_nm ?? "나",
+            avatar_url: null,
+            cont_txt: result.data.cont_txt,
+            edit_yn: result.data.edit_yn,
+            del_yn: result.data.del_yn,
+            crt_at: result.data.crt_at,
+            upd_at: result.data.upd_at,
+          },
+        ])
+        setReplyText("")
+        setReplyMentions([])
         setReplyTo(null)
       }
     } finally {
@@ -147,7 +184,7 @@ export function CommentSection({
                 currentMemberId={currentMemberId}
                 isAdmin={isAdmin}
                 members={members}
-                onReply={currentMemberId ? setReplyTo : undefined}
+                onReply={currentMemberId ? (c) => { setReplyTo(c); setReplyText("") } : undefined}
               />
               {cmnt.replies.map((reply) => (
                 <CommentItem
@@ -157,8 +194,39 @@ export function CommentSection({
                   isAdmin={isAdmin}
                   members={members}
                   isReply
+                  onReply={currentMemberId ? (c) => { setReplyTo(c); setReplyText("") } : undefined}
                 />
               ))}
+
+              {replyTo && (replyTo.cmnt_id === cmnt.cmnt_id || replyTo.prnt_id === cmnt.cmnt_id) && currentMemberId && (
+                <div className="pl-10 pb-3 pt-1 flex flex-col gap-2">
+                  <MentionInput
+                    value={replyText}
+                    onChange={setReplyText}
+                    onMentionsChange={setReplyMentions}
+                    members={members}
+                    placeholder={`@${replyTo.mem_nm}에게 답글...`}
+                    rows={2}
+                  />
+                  <div className="flex gap-2">
+                    <Button
+                      size="sm"
+                      onClick={handleSubmitReply}
+                      disabled={loading || !replyText.trim()}
+                    >
+                      답글 달기
+                    </Button>
+                    <Button
+                      size="sm"
+                      variant="ghost"
+                      onClick={() => { setReplyTo(null); setReplyText("") }}
+                      className="text-muted-foreground"
+                    >
+                      취소
+                    </Button>
+                  </div>
+                </div>
+              )}
             </div>
           ))}
         </div>
@@ -166,29 +234,21 @@ export function CommentSection({
 
       {currentMemberId && (
         <div className="flex flex-col gap-2 pt-1">
-          {replyTo && (
-            <div className="flex items-center gap-2 text-xs text-muted-foreground">
-              <span>↩ @{replyTo.mem_nm}에게 답글</span>
-              <button onClick={() => setReplyTo(null)} className="hover:text-foreground">
-                ✕
-              </button>
-            </div>
-          )}
           <MentionInput
             value={newText}
             onChange={setNewText}
             onMentionsChange={setNewMentions}
             members={members}
-            placeholder={replyTo ? "답글을 입력하세요..." : "댓글을 입력하세요..."}
+            placeholder="댓글을 입력하세요..."
             rows={2}
           />
           <Button
             size="sm"
-            onClick={handleSubmit}
+            onClick={handleSubmitComment}
             disabled={loading || !newText.trim()}
             className="self-end"
           >
-            {replyTo ? "답글 달기" : "댓글 달기"}
+            댓글 달기
           </Button>
         </div>
       )}

--- a/components/comment/comment-section.tsx
+++ b/components/comment/comment-section.tsx
@@ -1,12 +1,16 @@
 "use client"
 
 import { useEffect, useState } from "react"
+
 import { createClient } from "@/lib/supabase/client"
+
+import { createComment } from "@/app/actions/comment/manage-comment"
+
 import { SectionLabel } from "@/components/common/typography"
 import { Button } from "@/components/ui/button"
+
 import { CommentItem, type CmntRow } from "./comment-item"
 import { MentionInput, type MemberOption } from "./mention-input"
-import { createComment } from "@/app/actions/comment/manage-comment"
 
 interface CommentSectionProps {
   entityType: "sch_post" | "comp" | "gathering"

--- a/components/comment/mention-input.tsx
+++ b/components/comment/mention-input.tsx
@@ -1,0 +1,133 @@
+"use client"
+
+import { useCallback, useRef, useState } from "react"
+import { Textarea } from "@/components/ui/textarea"
+
+export type MemberOption = { mem_id: string; mem_nm: string }
+
+interface MentionInputProps {
+  value: string
+  onChange: (value: string) => void
+  onMentionsChange: (memIds: string[]) => void
+  members: MemberOption[]
+  placeholder?: string
+  rows?: number
+  className?: string
+}
+
+function parseMentionQuery(text: string, cursorPos: number): { query: string; start: number } | null {
+  const before = text.slice(0, cursorPos)
+  const match = before.match(/@([가-힣a-zA-Z0-9_]*)$/)
+  if (!match) return null
+  return { query: match[1], start: cursorPos - match[0].length }
+}
+
+// @이름 텍스트를 파란색으로 강조 — 공용 유틸, 외부에서 import해서 사용
+export function renderMentions(text: string) {
+  const parts = text.split(/(@[가-힣a-zA-Z0-9_]+)/)
+  return parts.map((part, i) =>
+    part.startsWith("@") ? (
+      <span key={i} className="text-primary font-medium">{part}</span>
+    ) : (
+      <span key={i}>{part}</span>
+    )
+  )
+}
+
+export function MentionInput({
+  value,
+  onChange,
+  onMentionsChange,
+  members,
+  placeholder,
+  rows = 3,
+  className,
+}: MentionInputProps) {
+  const textareaRef = useRef<HTMLTextAreaElement>(null)
+  const mentionedIds = useRef<Set<string>>(new Set())
+  const [mentionState, setMentionState] = useState<{
+    query: string
+    start: number
+    filtered: MemberOption[]
+  } | null>(null)
+
+  const handleChange = useCallback(
+    (e: React.ChangeEvent<HTMLTextAreaElement>) => {
+      const text = e.target.value
+      const cursor = e.target.selectionStart ?? text.length
+      onChange(text)
+
+      const parsed = parseMentionQuery(text, cursor)
+      if (parsed) {
+        const filtered = members.filter((m) =>
+          m.mem_nm.toLowerCase().includes(parsed.query.toLowerCase())
+        )
+        setMentionState(filtered.length > 0 ? { ...parsed, filtered } : null)
+      } else {
+        setMentionState(null)
+      }
+    },
+    [members, onChange]
+  )
+
+  const selectMember = useCallback(
+    (member: MemberOption) => {
+      if (!mentionState) return
+      const cursor = textareaRef.current?.selectionStart ?? value.length
+      const before = value.slice(0, mentionState.start)
+      const after = value.slice(cursor)
+      const newText = `${before}@${member.mem_nm} ${after}`
+      onChange(newText)
+      mentionedIds.current.add(member.mem_id)
+      onMentionsChange([...mentionedIds.current])
+      setMentionState(null)
+      setTimeout(() => {
+        const pos = before.length + member.mem_nm.length + 2
+        textareaRef.current?.focus()
+        textareaRef.current?.setSelectionRange(pos, pos)
+      }, 0)
+    },
+    [mentionState, value, onChange, onMentionsChange]
+  )
+
+  const handleKeyDown = useCallback(
+    (e: React.KeyboardEvent) => {
+      if (e.key === "Escape" && mentionState) {
+        setMentionState(null)
+        e.preventDefault()
+      }
+    },
+    [mentionState]
+  )
+
+  return (
+    <div className="relative">
+      <Textarea
+        ref={textareaRef}
+        value={value}
+        onChange={handleChange}
+        onKeyDown={handleKeyDown}
+        placeholder={placeholder}
+        rows={rows}
+        className={`resize-none ${className ?? ""}`}
+      />
+      {mentionState && (
+        <div className="absolute bottom-full left-0 z-50 mb-1 w-48 overflow-hidden rounded-lg border border-border bg-background shadow-md">
+          {mentionState.filtered.slice(0, 5).map((m) => (
+            <button
+              key={m.mem_id}
+              type="button"
+              className="w-full px-3 py-2 text-left text-sm hover:bg-muted"
+              onMouseDown={(e) => {
+                e.preventDefault()
+                selectMember(m)
+              }}
+            >
+              @{m.mem_nm}
+            </button>
+          ))}
+        </div>
+      )}
+    </div>
+  )
+}

--- a/components/comment/mention-input.tsx
+++ b/components/comment/mention-input.tsx
@@ -6,10 +6,19 @@ import { Textarea } from "@/components/ui/textarea"
 
 export type MemberOption = { mem_id: string; mem_nm: string }
 
+export function parseMentionsFromText(text: string, members: MemberOption[]): string[] {
+  return members
+    .filter((m) => {
+      const escaped = m.mem_nm.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")
+      return new RegExp(`@${escaped}(?=[\\s]|$)`).test(text)
+    })
+    .map((m) => m.mem_id)
+}
+
 interface MentionInputProps {
   value: string
   onChange: (value: string) => void
-  onMentionsChange: (memIds: string[]) => void
+  onMentionsChange?: (memIds: string[]) => void
   members: MemberOption[]
   placeholder?: string
   rows?: number
@@ -23,11 +32,11 @@ function parseMentionQuery(text: string, cursorPos: number): { query: string; st
   return { query: match[1], start: cursorPos - match[0].length }
 }
 
-// @이름 텍스트를 파란색으로 강조 — 공용 유틸, 외부에서 import해서 사용
-export function renderMentions(text: string) {
+export function renderMentions(text: string, members: MemberOption[]) {
+  const memberNames = new Set(members.map((m) => m.mem_nm))
   const parts = text.split(/(@[가-힣a-zA-Z0-9_]+)/)
   return parts.map((part, i) =>
-    part.startsWith("@") ? (
+    part.startsWith("@") && memberNames.has(part.slice(1)) ? (
       <span key={i} className="text-primary font-medium">{part}</span>
     ) : (
       <span key={i}>{part}</span>
@@ -80,7 +89,7 @@ export function MentionInput({
       const newText = `${before}@${member.mem_nm} ${after}`
       onChange(newText)
       mentionedIds.current.add(member.mem_id)
-      onMentionsChange([...mentionedIds.current])
+      onMentionsChange?.([...mentionedIds.current])
       setMentionState(null)
       setTimeout(() => {
         const pos = before.length + member.mem_nm.length + 2

--- a/components/comment/mention-input.tsx
+++ b/components/comment/mention-input.tsx
@@ -1,6 +1,7 @@
 "use client"
 
 import { useCallback, useRef, useState } from "react"
+
 import { Textarea } from "@/components/ui/textarea"
 
 export type MemberOption = { mem_id: string; mem_nm: string }

--- a/components/common/responsive-drawer.tsx
+++ b/components/common/responsive-drawer.tsx
@@ -3,6 +3,7 @@
 import * as React from "react"
 
 import { cn } from "@/lib/utils"
+
 import {
   Dialog,
   DialogClose,

--- a/components/common/responsive-drawer.tsx
+++ b/components/common/responsive-drawer.tsx
@@ -1,0 +1,164 @@
+"use client"
+
+import * as React from "react"
+
+import { cn } from "@/lib/utils"
+import {
+  Dialog,
+  DialogClose,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog"
+import {
+  Drawer,
+  DrawerClose,
+  DrawerContent,
+  DrawerDescription,
+  DrawerHeader,
+  DrawerTitle,
+} from "@/components/ui/drawer"
+
+function useMediaQuery(query: string) {
+  const [matches, setMatches] = React.useState(false)
+  React.useEffect(() => {
+    const media = window.matchMedia(query)
+    // eslint-disable-next-line react-hooks/set-state-in-effect
+    setMatches(media.matches)
+    const onChange = (e: MediaQueryListEvent) => setMatches(e.matches)
+    media.addEventListener("change", onChange)
+    return () => media.removeEventListener("change", onChange)
+  }, [query])
+  return matches
+}
+
+const ResponsiveDrawerContext = React.createContext<{ isDesktop: boolean }>({
+  isDesktop: false,
+})
+
+interface ResponsiveDrawerProps {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  children: React.ReactNode
+}
+
+function ResponsiveDrawer({ open, onOpenChange, children }: ResponsiveDrawerProps) {
+  const isDesktop = useMediaQuery("(min-width: 768px)")
+  return (
+    <ResponsiveDrawerContext.Provider value={{ isDesktop }}>
+      {isDesktop ? (
+        <Dialog open={open} onOpenChange={onOpenChange}>
+          {children}
+        </Dialog>
+      ) : (
+        <Drawer open={open} onOpenChange={onOpenChange}>
+          {children}
+        </Drawer>
+      )}
+    </ResponsiveDrawerContext.Provider>
+  )
+}
+
+interface ResponsiveDrawerContentProps {
+  children: React.ReactNode
+  className?: string
+  dialogClassName?: string
+  drawerClassName?: string
+}
+
+function ResponsiveDrawerContent({
+  children,
+  className,
+  dialogClassName,
+  drawerClassName,
+}: ResponsiveDrawerContentProps) {
+  const { isDesktop } = React.useContext(ResponsiveDrawerContext)
+  if (isDesktop) {
+    return (
+      <DialogContent className={cn(className, dialogClassName)}>
+        {children}
+      </DialogContent>
+    )
+  }
+  return (
+    <DrawerContent className={cn(className, drawerClassName)}>
+      {children}
+    </DrawerContent>
+  )
+}
+
+function ResponsiveDrawerHeader({
+  children,
+  className,
+}: {
+  children: React.ReactNode
+  className?: string
+}) {
+  const { isDesktop } = React.useContext(ResponsiveDrawerContext)
+  if (isDesktop) {
+    return <DialogHeader className={className}>{children}</DialogHeader>
+  }
+  return <DrawerHeader className={className}>{children}</DrawerHeader>
+}
+
+function ResponsiveDrawerTitle({
+  children,
+  className,
+}: {
+  children: React.ReactNode
+  className?: string
+}) {
+  const { isDesktop } = React.useContext(ResponsiveDrawerContext)
+  if (isDesktop) {
+    return <DialogTitle className={className}>{children}</DialogTitle>
+  }
+  return <DrawerTitle className={className}>{children}</DrawerTitle>
+}
+
+function ResponsiveDrawerDescription({
+  children,
+  className,
+}: {
+  children: React.ReactNode
+  className?: string
+}) {
+  const { isDesktop } = React.useContext(ResponsiveDrawerContext)
+  if (isDesktop) {
+    return <DialogDescription className={className}>{children}</DialogDescription>
+  }
+  return <DrawerDescription className={className}>{children}</DrawerDescription>
+}
+
+function ResponsiveDrawerClose({
+  children,
+  className,
+  asChild,
+}: {
+  children: React.ReactNode
+  className?: string
+  asChild?: boolean
+}) {
+  const { isDesktop } = React.useContext(ResponsiveDrawerContext)
+  if (isDesktop) {
+    return (
+      <DialogClose asChild={asChild} className={className}>
+        {children}
+      </DialogClose>
+    )
+  }
+  return (
+    <DrawerClose asChild={asChild} className={className}>
+      {children}
+    </DrawerClose>
+  )
+}
+
+export {
+  ResponsiveDrawer,
+  ResponsiveDrawerContent,
+  ResponsiveDrawerHeader,
+  ResponsiveDrawerTitle,
+  ResponsiveDrawerDescription,
+  ResponsiveDrawerClose,
+}

--- a/components/home/add-schedule-dropdown.tsx
+++ b/components/home/add-schedule-dropdown.tsx
@@ -24,10 +24,10 @@ export function AddScheduleDropdown({ onAddSchedule, onAddCompetition }: Props) 
   return (
     <DropdownMenu open={open} onOpenChange={setOpen}>
       <DropdownMenuTrigger asChild>
-        <button className="flex items-center gap-1 rounded-md bg-secondary px-2 py-1 text-[12px] font-medium text-foreground transition-colors hover:bg-secondary/70">
+        <button className="flex items-center gap-1 rounded-md bg-primary px-2 py-1 text-[12px] font-medium text-primary-foreground transition-colors hover:bg-primary/90">
           추가
           <ChevronUp
-            className="size-3 text-muted-foreground transition-transform duration-150"
+            className="size-3 text-primary-foreground/70 transition-transform duration-150"
             style={{ transform: open ? "rotate(0deg)" : "rotate(180deg)" }}
           />
         </button>

--- a/components/home/add-schedule-dropdown.tsx
+++ b/components/home/add-schedule-dropdown.tsx
@@ -50,7 +50,7 @@ export function AddScheduleDropdown({ onAddSchedule, onAddCompetition }: Props) 
         >
           <FileText className="size-4 shrink-0 text-info" />
           <div className="flex flex-col gap-0.5">
-            <span className="text-[13px] font-medium">소식</span>
+            <span className="text-[13px] font-medium">피드</span>
             <span className="text-[11px] text-muted-foreground">대회 접수, 세일, 세션 등</span>
           </div>
         </DropdownMenuItem>

--- a/components/home/mini-calendar.tsx
+++ b/components/home/mini-calendar.tsx
@@ -1,8 +1,8 @@
 "use client";
 
-import { useMemo, useState, useTransition } from "react";
+import { useEffect, useMemo, useState, useTransition } from "react";
 
-import { useRouter } from "next/navigation";
+import { useRouter, useSearchParams } from "next/navigation";
 
 import { CalendarDays, ChevronLeft, ChevronRight, List } from "lucide-react";
 
@@ -109,6 +109,65 @@ export function MiniCalendar({
     useState<Record<string, CompetitionRegistration>>(initialRegistrationsByCompetitionId);
 
   const memberStatus = initialMemberStatus;
+
+  // 알림 딥링크: /?post=<id> 또는 /?comp=<id>로 진입 시 해당 상세 자동 오픈
+  const searchParams = useSearchParams()
+  const deepLinkPostId = searchParams.get("post")
+  const deepLinkCompId = searchParams.get("comp")
+
+  useEffect(() => {
+    if (deepLinkPostId) {
+      supabase
+        .from("sch_post_mst")
+        .select("sch_post_id, sch_nm, post_type, evt_stt_at, evt_end_at, url, cont_txt, crt_by")
+        .eq("sch_post_id", deepLinkPostId)
+        .single()
+        .then(({ data }) => {
+          if (!data) return
+          setSchDetailPost({
+            id: data.sch_post_id,
+            title: data.sch_nm,
+            start_date: data.evt_stt_at ? dayjs(data.evt_stt_at).format("YYYY-MM-DD") : dayjs().format("YYYY-MM-DD"),
+            type: "schedule",
+            url: data.url ?? null,
+            cont_txt: data.cont_txt ?? null,
+            crt_by: data.crt_by ?? undefined,
+            post_type: data.post_type ?? null,
+            evt_stt_at: data.evt_stt_at ?? null,
+            evt_end_at: data.evt_end_at ?? null,
+          })
+          setSchDetailOpen(true)
+          router.replace("/")
+        })
+    }
+
+    if (deepLinkCompId) {
+      supabase
+        .from("comp_mst")
+        .select("comp_id, comp_nm, comp_sprt_cd, stt_dt, end_dt, loc_nm, src_url, comp_evt_cfg(comp_evt_type)")
+        .eq("comp_id", deepLinkCompId)
+        .single()
+        .then(({ data }) => {
+          if (!data) return
+          setSelectedCompetition({
+            id: data.comp_id,
+            external_id: "",
+            sport: data.comp_sprt_cd ?? null,
+            title: data.comp_nm,
+            start_date: data.stt_dt,
+            end_date: data.end_dt ?? null,
+            location: data.loc_nm ?? null,
+            event_types: (data.comp_evt_cfg as { comp_evt_type: string | null }[])
+              .map((e) => e.comp_evt_type?.toUpperCase())
+              .filter((e): e is string => Boolean(e)),
+            source_url: data.src_url ?? null,
+          })
+          setDetailOpen(true)
+          router.replace("/")
+        })
+    }
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [deepLinkPostId, deepLinkCompId])
 
   const today = todayKST();
   const [yearStr, monthStr] = viewMonth.split("-");

--- a/components/home/mini-calendar.tsx
+++ b/components/home/mini-calendar.tsx
@@ -304,9 +304,9 @@ export function MiniCalendar({
       });
     }
 
-    // sch_post 조회
+    // sch_post_mst 조회
     const { data: schPostRows } = await supabase
-      .from("sch_post")
+      .from("sch_post_mst")
       .select("sch_post_id, sch_nm, post_type, evt_stt_at, evt_end_at, url, cont_txt, crt_by")
       .eq("team_id", teamId)
       .gte("evt_stt_at", newMonth)

--- a/components/home/mini-calendar.tsx
+++ b/components/home/mini-calendar.tsx
@@ -25,6 +25,7 @@ import { CompetitionPickerDialog } from "@/components/home/competition-picker-di
 import { ScheduleListView } from "@/components/home/schedule-list-view";
 import { CompetitionDetailDialog } from "@/components/races/competition-detail-dialog";
 import type { Competition, CompetitionRegistration, MemberStatus } from "@/components/races/types";
+import { SchPostDetailDialog } from "@/components/schedule/sch-post-detail-dialog";
 import { SchPostFormDialog } from "@/components/schedule/sch-post-form-dialog";
 
 
@@ -88,9 +89,13 @@ export function MiniCalendar({
 
   // 일정 폼 다이얼로그 상태
   const [formOpen, setFormOpen] = useState(false);
-  const [formMode, setFormMode] = useState<"create" | "edit" | "view">("create");
+  const [formMode, setFormMode] = useState<"create" | "edit">("create");
   const [formPostType, setFormPostType] = useState<SchPostType>("general");
   const [editTarget, setEditTarget] = useState<CalendarRace | null>(null);
+
+  // 소식 상세 다이얼로그 상태 (일반 멤버용)
+  const [schDetailPost, setSchDetailPost] = useState<CalendarRace | null>(null);
+  const [schDetailOpen, setSchDetailOpen] = useState(false);
 
   // 대회 선택 다이얼로그 상태
   const [pickerOpen, setPickerOpen] = useState(false);
@@ -367,9 +372,8 @@ export function MiniCalendar({
   }
 
   function openEditForm(race: CalendarRace) {
-    setFormMode("view");
-    setEditTarget(race);
-    setFormOpen(true);
+    setSchDetailPost(race);
+    setSchDetailOpen(true);
   }
 
   async function handleSchPostSuccess() {
@@ -659,16 +663,31 @@ export function MiniCalendar({
         onCompetitionCreated={handleCompetitionCreated}
       />
 
+      {/* 소식 상세 다이얼로그 */}
+      <SchPostDetailDialog
+        post={schDetailPost}
+        open={schDetailOpen}
+        onOpenChange={setSchDetailOpen}
+        currentMemberId={memberStatus.status === "ready" ? memberStatus.memberId : undefined}
+        isAdmin={memberStatus.status === "ready" ? memberStatus.admin : false}
+        onEdit={() => {
+          if (!schDetailPost) return;
+          setSchDetailOpen(false);
+          setFormMode("edit");
+          setEditTarget(schDetailPost);
+          setFormOpen(true);
+        }}
+        onDelete={handleSchPostSuccess}
+      />
+
       {/* 일정 등록/수정 다이얼로그 */}
       <SchPostFormDialog
         open={formOpen}
         onOpenChange={setFormOpen}
         mode={formMode}
         defaultPostType={formPostType}
-        currentMemberId={memberStatus.status === "ready" ? memberStatus.memberId : undefined}
-        isAdmin={memberStatus.status === "ready" ? memberStatus.admin : false}
         initialData={
-          (formMode === "view" || formMode === "edit") && editTarget
+          formMode === "edit" && editTarget
             ? {
                 sch_post_id: editTarget.id,
                 sch_nm: editTarget.title,

--- a/components/home/schedule-list-view.tsx
+++ b/components/home/schedule-list-view.tsx
@@ -252,7 +252,7 @@ export function ScheduleListView({
   const today = todayKST();
 
   const [months, setMonths] = useState<MonthData[]>([
-    { monthKey: initialMonthKey, races: initialRaces },
+    { monthKey: initialMonthKey, races: [...initialRaces].sort((a, b) => a.start_date.localeCompare(b.start_date)) },
   ]);
   const [loadingPrev, setLoadingPrev] = useState(false);
   const [loadingNext, setLoadingNext] = useState(false);

--- a/components/home/schedule-list-view.tsx
+++ b/components/home/schedule-list-view.tsx
@@ -54,7 +54,7 @@ async function fetchMonth(
 
   const [{ data: schRows }, { data: gigangRows }, myRows] = await Promise.all([
     supabase
-      .from("sch_post")
+      .from("sch_post_mst")
       .select("sch_post_id, sch_nm, post_type, evt_stt_at, evt_end_at, url, cont_txt, crt_by")
       .eq("team_id", teamId)
       .gte("evt_stt_at", start)

--- a/components/notifications/notification-bell-icon.tsx
+++ b/components/notifications/notification-bell-icon.tsx
@@ -106,9 +106,13 @@ export function NotificationBellIcon({ initialCount, memberId, disabled }: Notif
       }, (payload) => {
         const updated = payload.new as Notification;
         setNotifications((prev) => {
-          const next = prev.map((n) => n.noti_id === updated.noti_id ? { ...n, ...updated } : n);
-          setUnreadCount(next.filter((n) => !n.read_yn).length);
-          return next;
+          const existing = prev.find((n) => n.noti_id === updated.noti_id);
+          if (existing && !existing.read_yn && updated.read_yn) {
+            setUnreadCount((c) => Math.max(0, c - 1));
+          } else if (existing && existing.read_yn && !updated.read_yn) {
+            setUnreadCount((c) => c + 1);
+          }
+          return prev.map((n) => n.noti_id === updated.noti_id ? { ...n, ...updated } : n);
         });
       })
       .subscribe();

--- a/components/notifications/notification-bell-icon.tsx
+++ b/components/notifications/notification-bell-icon.tsx
@@ -11,7 +11,6 @@ import { upsertNotiPref } from "@/app/actions/upsert-noti-pref";
 import { NotificationItem } from "./notification-item";
 import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
 import { Switch } from "@/components/ui/switch";
-import { Separator } from "@/components/ui/separator";
 import { Button } from "@/components/ui/button";
 import { Dialog, DialogContent, DialogFooter, DialogHeader, DialogTitle } from "@/components/ui/dialog";
 import { Body, Caption, SectionLabel } from "@/components/common/typography";
@@ -74,7 +73,9 @@ export function NotificationBellIcon({ initialCount, memberId, disabled }: Notif
   useEffect(() => {
     if (!open || !memberId) return;
 
+    // eslint-disable-next-line react-hooks/set-state-in-effect
     setCursor(null);
+    // eslint-disable-next-line react-hooks/set-state-in-effect
     setHasMore(true);
     fetchNotifications(true, null);
 
@@ -90,6 +91,17 @@ export function NotificationBellIcon({ initialCount, memberId, disabled }: Notif
         const noti = payload.new as Notification;
         setNotifications((prev) => [noti, ...prev]);
         setUnreadCount((c) => c + 1);
+      })
+      .on("postgres_changes", {
+        event: "UPDATE",
+        schema: "public",
+        table: "noti_mst",
+        filter: `mem_id=eq.${memberId}`,
+      }, (payload) => {
+        const updated = payload.new as Notification;
+        setNotifications((prev) =>
+          prev.map((n) => n.noti_id === updated.noti_id ? { ...n, ...updated } : n)
+        );
       })
       .subscribe();
 

--- a/components/notifications/notification-bell-icon.tsx
+++ b/components/notifications/notification-bell-icon.tsx
@@ -104,9 +104,11 @@ export function NotificationBellIcon({ initialCount, memberId, disabled }: Notif
         filter: `mem_id=eq.${memberId}`,
       }, (payload) => {
         const updated = payload.new as Notification;
-        setNotifications((prev) =>
-          prev.map((n) => n.noti_id === updated.noti_id ? { ...n, ...updated } : n)
-        );
+        setNotifications((prev) => {
+          const next = prev.map((n) => n.noti_id === updated.noti_id ? { ...n, ...updated } : n);
+          setUnreadCount(next.filter((n) => !n.read_yn).length);
+          return next;
+        });
       })
       .subscribe();
 

--- a/components/notifications/notification-bell-icon.tsx
+++ b/components/notifications/notification-bell-icon.tsx
@@ -1,19 +1,24 @@
 "use client";
 
 import { useEffect, useRef, useState } from "react";
+
 import { Bell, Settings, Trash2, ChevronLeft } from "lucide-react";
+
 import { dayjs } from "@/lib/dayjs";
-import { createClient } from "@/lib/supabase/client";
 import type { Notification, NotificationPref } from "@/lib/queries/notification";
-import { markAllNotificationsRead } from "@/app/actions/mark-all-notifications-read";
+import { createClient } from "@/lib/supabase/client";
+
 import { deleteAllNotifications } from "@/app/actions/delete-all-notifications";
+import { markAllNotificationsRead } from "@/app/actions/mark-all-notifications-read";
 import { upsertNotiPref } from "@/app/actions/upsert-noti-pref";
-import { NotificationItem } from "./notification-item";
-import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
-import { Switch } from "@/components/ui/switch";
+
+import { Body, Caption, SectionLabel } from "@/components/common/typography";
 import { Button } from "@/components/ui/button";
 import { Dialog, DialogContent, DialogFooter, DialogHeader, DialogTitle } from "@/components/ui/dialog";
-import { Body, Caption, SectionLabel } from "@/components/common/typography";
+import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
+import { Switch } from "@/components/ui/switch";
+
+import { NotificationItem } from "./notification-item";
 
 type NotificationBellIconProps = {
   initialCount: number;
@@ -75,7 +80,7 @@ export function NotificationBellIcon({ initialCount, memberId, disabled }: Notif
 
     // eslint-disable-next-line react-hooks/set-state-in-effect
     setCursor(null);
-    // eslint-disable-next-line react-hooks/set-state-in-effect
+     
     setHasMore(true);
     fetchNotifications(true, null);
 

--- a/components/notifications/notification-bell-icon.tsx
+++ b/components/notifications/notification-bell-icon.tsx
@@ -28,6 +28,7 @@ type NotificationBellIconProps = {
 
 const NOTI_TYPE_LABELS: Record<string, string> = {
   ttl_grnt: "칭호 획득",
+  sch_post_new: "피드 등록",
 };
 
 type ViewType = "list" | "settings";

--- a/components/notifications/notification-item.tsx
+++ b/components/notifications/notification-item.tsx
@@ -33,6 +33,7 @@ const NOTI_ROUTE: Record<string, (refId: string | null, refType: string | null) 
   dues_check_req: () => null,
   sch_post_cmnt: (refId) => refId ? `/?post=${refId}` : "/",
   cmnt_mention: (refId, refType) => refType === "comp" ? `/?comp=${refId}` : refId ? `/?post=${refId}` : "/",
+  cmnt_reply: (refId, refType) => refType === "comp" ? `/?comp=${refId}` : refId ? `/?post=${refId}` : "/",
 };
 
 function formatRelative(crtAt: string) {

--- a/components/notifications/notification-item.tsx
+++ b/components/notifications/notification-item.tsx
@@ -2,7 +2,7 @@
 
 import { useState, useRef, useEffect } from "react";
 import { useRouter } from "next/navigation";
-import { Bell, Coins, Trophy, Trash2, ChevronRight } from "lucide-react";
+import { Bell, Coins, MessageCircle, Trophy, Trash2, ChevronRight } from "lucide-react";
 import { dayjs } from "@/lib/dayjs";
 import type { Notification } from "@/lib/queries/notification";
 import { markNotificationRead } from "@/app/actions/mark-notification-read";
@@ -15,6 +15,9 @@ const NOTI_ICON: Record<string, React.ElementType> = {
   adm_cust: Bell,
   dues_notice: Coins,
   dues_check_req: Coins,
+  cmnt_mention: MessageCircle,
+  cmnt_reply: MessageCircle,
+  sch_post_cmnt: MessageCircle,
 };
 
 const NOTI_ROUTE: Record<string, (refId: string | null) => string | null> = {
@@ -50,6 +53,7 @@ export function NotificationItem({ noti, onDelete, onRead, onClose }: Notificati
 
   // 부모에서 read_yn이 바뀌면(모두 읽음 등) 동기화
   useEffect(() => {
+    // eslint-disable-next-line react-hooks/set-state-in-effect
     setIsRead(noti.read_yn);
   }, [noti.read_yn]);
 

--- a/components/notifications/notification-item.tsx
+++ b/components/notifications/notification-item.tsx
@@ -4,7 +4,7 @@ import { useState, useRef, useEffect } from "react";
 
 import { useRouter } from "next/navigation";
 
-import { Bell, Coins, MessageCircle, Trophy, Trash2, ChevronRight } from "lucide-react";
+import { Bell, Coins, MessageCircle, Trophy, Trash2, ChevronRight, FileText } from "lucide-react";
 
 import { dayjs } from "@/lib/dayjs";
 import type { Notification } from "@/lib/queries/notification";
@@ -24,6 +24,7 @@ const NOTI_ICON: Record<string, React.ElementType> = {
   cmnt_mention: MessageCircle,
   cmnt_reply: MessageCircle,
   sch_post_cmnt: MessageCircle,
+  sch_post_new: FileText,
 };
 
 const NOTI_ROUTE: Record<string, (refId: string | null, refType: string | null) => string | null> = {
@@ -32,6 +33,7 @@ const NOTI_ROUTE: Record<string, (refId: string | null, refType: string | null) 
   dues_notice: () => "/profile/dues",
   dues_check_req: () => null,
   sch_post_cmnt: (refId) => refId ? `/?post=${refId}` : "/",
+  sch_post_new: (refId) => refId ? `/?post=${refId}` : "/",
   cmnt_mention: (refId, refType) => refType === "comp" ? `/?comp=${refId}` : refId ? `/?post=${refId}` : "/",
   cmnt_reply: (refId, refType) => refType === "comp" ? `/?comp=${refId}` : refId ? `/?post=${refId}` : "/",
 };

--- a/components/notifications/notification-item.tsx
+++ b/components/notifications/notification-item.tsx
@@ -1,14 +1,20 @@
 "use client";
 
 import { useState, useRef, useEffect } from "react";
+
 import { useRouter } from "next/navigation";
+
 import { Bell, Coins, MessageCircle, Trophy, Trash2, ChevronRight } from "lucide-react";
+
 import { dayjs } from "@/lib/dayjs";
 import type { Notification } from "@/lib/queries/notification";
-import { markNotificationRead } from "@/app/actions/mark-notification-read";
-import { deleteNotification } from "@/app/actions/delete-notification";
-import { Body, Caption } from "@/components/common/typography";
 import { cn } from "@/lib/utils";
+
+import { deleteNotification } from "@/app/actions/delete-notification";
+import { markNotificationRead } from "@/app/actions/mark-notification-read";
+
+import { Body, Caption } from "@/components/common/typography";
+
 
 const NOTI_ICON: Record<string, React.ElementType> = {
   ttl_grnt: Trophy,
@@ -20,11 +26,13 @@ const NOTI_ICON: Record<string, React.ElementType> = {
   sch_post_cmnt: MessageCircle,
 };
 
-const NOTI_ROUTE: Record<string, (refId: string | null) => string | null> = {
+const NOTI_ROUTE: Record<string, (refId: string | null, refType: string | null) => string | null> = {
   ttl_grnt: () => "/profile",
   adm_cust: () => null,
   dues_notice: () => "/profile/dues",
   dues_check_req: () => null,
+  sch_post_cmnt: (refId) => refId ? `/?post=${refId}` : "/",
+  cmnt_mention: (refId, refType) => refType === "comp" ? `/?comp=${refId}` : refId ? `/?post=${refId}` : "/",
 };
 
 function formatRelative(crtAt: string) {
@@ -58,7 +66,7 @@ export function NotificationItem({ noti, onDelete, onRead, onClose }: Notificati
   }, [noti.read_yn]);
 
   const Icon = NOTI_ICON[noti.noti_type_enm] ?? Bell;
-  const route = NOTI_ROUTE[noti.noti_type_enm]?.(noti.ref_id) ?? null;
+  const route = NOTI_ROUTE[noti.noti_type_enm]?.(noti.ref_id, noti.ref_type_enm) ?? null;
 
   async function handleRead() {
     if (!isRead) {

--- a/components/profile/race-history-dialog.tsx
+++ b/components/profile/race-history-dialog.tsx
@@ -1,19 +1,24 @@
 "use client";
 
 import { useState, useEffect, useMemo } from "react";
+
+import { Trash2, Pencil } from "lucide-react";
+
+import { secondsToTime, timeStringToSeconds } from "@/lib/dayjs";
 import { createClient } from "@/lib/supabase/client";
+
+import { deleteRaceRecord, updateRaceRecord } from "@/app/actions/save-race-record";
+
+import {
+  ResponsiveDrawer,
+  ResponsiveDrawerClose,
+  ResponsiveDrawerContent,
+  ResponsiveDrawerDescription,
+  ResponsiveDrawerHeader,
+  ResponsiveDrawerTitle,
+} from "@/components/common/responsive-drawer";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
-import {
-  Dialog,
-  DialogContent,
-  DialogHeader,
-  DialogTitle,
-  DialogDescription,
-} from "@/components/ui/dialog";
-import { Trash2, Pencil } from "lucide-react";
-import { secondsToTime, timeStringToSeconds } from "@/lib/dayjs";
-import { deleteRaceRecord, updateRaceRecord } from "@/app/actions/save-race-record";
 
 /* ---------- 타입 ---------- */
 
@@ -50,7 +55,9 @@ export function RaceHistoryDialog({
 
   useEffect(() => {
     if (open) {
+      // eslint-disable-next-line react-hooks/set-state-in-effect
       setEditingId(null);
+      // eslint-disable-next-line react-hooks/immutability
       fetchRecords();
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -112,93 +119,106 @@ export function RaceHistoryDialog({
   };
 
   return (
-    <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent className="max-h-[85vh] overflow-y-auto sm:max-w-lg">
-        <DialogHeader>
-          <DialogTitle>과거 기록</DialogTitle>
-          <DialogDescription>기록을 조회하고 수정하거나 삭제할 수 있습니다.</DialogDescription>
-        </DialogHeader>
+    <ResponsiveDrawer open={open} onOpenChange={onOpenChange}>
+      <ResponsiveDrawerContent
+        dialogClassName="max-h-[85dvh] max-w-lg flex flex-col gap-0 p-0 overflow-hidden"
+        drawerClassName="h-[85dvh] max-h-[85dvh]"
+      >
+        <ResponsiveDrawerHeader className="shrink-0 border-b border-border px-4 py-4 text-left">
+          <ResponsiveDrawerTitle>과거 기록</ResponsiveDrawerTitle>
+          <ResponsiveDrawerDescription>기록을 조회하고 수정하거나 삭제할 수 있습니다.</ResponsiveDrawerDescription>
+        </ResponsiveDrawerHeader>
 
-        {loading ? (
-          <p className="py-8 text-center text-sm text-muted-foreground">불러오는 중...</p>
-        ) : records.length === 0 ? (
-          <p className="py-8 text-center text-sm text-muted-foreground">등록된 기록이 없습니다.</p>
-        ) : (
-          <div className="flex flex-col divide-y divide-border">
-            {records.map((r) => (
-              <div key={r.id} className="flex items-center gap-3 py-3">
-                <div className="flex min-w-0 flex-1 flex-col gap-0.5">
-                  <div className="flex items-start gap-2">
-                    <span className="min-w-0 flex-1 text-sm font-semibold text-foreground line-clamp-2 wrap-break-word">
-                      {r.race_name}
-                    </span>
-                    <span className="shrink-0 rounded-full bg-muted px-2 py-0.5 text-[10px] font-medium text-muted-foreground">
-                      {eventLabel(r.event_type)}
-                    </span>
+        <div className="flex-1 overflow-y-auto px-4 pb-6 pt-4">
+          {loading ? (
+            <p className="py-8 text-center text-sm text-muted-foreground">불러오는 중...</p>
+          ) : records.length === 0 ? (
+            <p className="py-8 text-center text-sm text-muted-foreground">등록된 기록이 없습니다.</p>
+          ) : (
+            <div className="flex flex-col divide-y divide-border">
+              {records.map((r) => (
+                <div key={r.id} className="flex items-center gap-3 py-3">
+                  <div className="flex min-w-0 flex-1 flex-col gap-0.5">
+                    <div className="flex items-start gap-2">
+                      <span className="min-w-0 flex-1 text-sm font-semibold text-foreground line-clamp-2 wrap-break-word">
+                        {r.race_name}
+                      </span>
+                      <span className="shrink-0 rounded-full bg-muted px-2 py-0.5 text-[10px] font-medium text-muted-foreground">
+                        {eventLabel(r.event_type)}
+                      </span>
+                    </div>
+                    <span className="text-xs text-muted-foreground">{r.race_date}</span>
+
+                    {editingId === r.id ? (
+                      <div className="mt-1 flex items-center gap-2">
+                        <Input
+                          value={editTime}
+                          onChange={(e) => setEditTime(e.target.value)}
+                          placeholder="HH:MM:SS"
+                          className="h-8 w-32 font-mono text-sm"
+                        />
+                        <Button
+                          type="button"
+                          size="xs"
+                          disabled={saving || timeStringToSeconds(editTime) === null}
+                          onClick={() => handleSaveEdit(r.id)}
+                          className="font-semibold"
+                        >
+                          {saving ? "..." : "저장"}
+                        </Button>
+                        <Button
+                          type="button"
+                          variant="ghost"
+                          size="xs"
+                          onClick={() => setEditingId(null)}
+                          className="text-muted-foreground"
+                        >
+                          취소
+                        </Button>
+                      </div>
+                    ) : (
+                      <span className="font-mono text-base font-bold text-foreground">
+                        {secondsToTime(r.record_time_sec)}
+                      </span>
+                    )}
                   </div>
-                  <span className="text-xs text-muted-foreground">{r.race_date}</span>
 
-                  {editingId === r.id ? (
-                    <div className="mt-1 flex items-center gap-2">
-                      <Input
-                        value={editTime}
-                        onChange={(e) => setEditTime(e.target.value)}
-                        placeholder="HH:MM:SS"
-                        className="h-8 w-32 font-mono text-sm"
-                      />
+                  {editingId !== r.id && (
+                    <div className="flex shrink-0 gap-1">
                       <Button
                         type="button"
-                        size="xs"
-                        disabled={saving || timeStringToSeconds(editTime) === null}
-                        onClick={() => handleSaveEdit(r.id)}
-                        className="font-semibold"
+                        variant="ghost"
+                        size="icon-sm"
+                        onClick={() => startEdit(r)}
+                        className="text-muted-foreground"
                       >
-                        {saving ? "..." : "저장"}
+                        <Pencil className="size-4" />
                       </Button>
                       <Button
                         type="button"
                         variant="ghost"
-                        size="xs"
-                        onClick={() => setEditingId(null)}
-                        className="text-muted-foreground"
+                        size="icon-sm"
+                        onClick={() => handleDelete(r.id)}
+                        className="text-muted-foreground hover:bg-destructive/10 hover:text-destructive"
                       >
-                        취소
+                        <Trash2 className="size-4" />
                       </Button>
                     </div>
-                  ) : (
-                    <span className="font-mono text-base font-bold text-foreground">
-                      {secondsToTime(r.record_time_sec)}
-                    </span>
                   )}
                 </div>
+              ))}
+            </div>
+          )}
 
-                {editingId !== r.id && (
-                  <div className="flex shrink-0 gap-1">
-                    <Button
-                      type="button"
-                      variant="ghost"
-                      size="icon-sm"
-                      onClick={() => startEdit(r)}
-                      className="text-muted-foreground"
-                    >
-                      <Pencil className="size-4" />
-                    </Button>
-                    <Button
-                      type="button"
-                      variant="ghost"
-                      size="icon-sm"
-                      onClick={() => handleDelete(r.id)}
-                      className="text-muted-foreground hover:bg-destructive/10 hover:text-destructive"
-                    >
-                      <Trash2 className="size-4" />
-                    </Button>
-                  </div>
-                )}
-              </div>
-            ))}
+          <div className="mt-4 flex justify-center">
+            <ResponsiveDrawerClose asChild>
+              <Button type="button" variant="ghost" size="sm" className="text-muted-foreground">
+                닫기
+              </Button>
+            </ResponsiveDrawerClose>
           </div>
-        )}
-      </DialogContent>
-    </Dialog>
+        </div>
+      </ResponsiveDrawerContent>
+    </ResponsiveDrawer>
   );
 }

--- a/components/races/competition-detail-dialog.tsx
+++ b/components/races/competition-detail-dialog.tsx
@@ -28,9 +28,13 @@ import {
 } from "@/lib/validations/competition";
 
 import { updateCompetition } from "@/app/actions/admin/manage-competition";
+import { getCommentData } from "@/app/actions/comment/get-comment-data";
 import { getPublicTeamCompRegDisplayCounts } from "@/app/actions/get-public-team-comp-reg-display-counts";
 import { revalidateCompetitions } from "@/app/actions/revalidate-competitions";
 
+import type { CmntRow } from "@/components/comment/comment-item";
+import { CommentSection } from "@/components/comment/comment-section";
+import type { MemberOption } from "@/components/comment/mention-input";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import {
@@ -53,10 +57,6 @@ import {
 } from "@/components/ui/select";
 import { Separator } from "@/components/ui/separator";
 
-import { getCommentData } from "@/app/actions/comment/get-comment-data";
-import { CommentSection } from "@/components/comment/comment-section";
-import type { CmntRow } from "@/components/comment/comment-item";
-import type { MemberOption } from "@/components/comment/mention-input";
 
 import type { Competition, CompetitionRegistration, MemberStatus } from "./types";
 

--- a/components/races/competition-detail-dialog.tsx
+++ b/components/races/competition-detail-dialog.tsx
@@ -138,7 +138,11 @@ export function CompetitionDetailDialog({
 
   useEffect(() => {
     if (!open || !competition) return;
-    getCommentData("comp", competition.id).then(setCmntData);
+    let cancelled = false;
+    getCommentData("comp", competition.id).then((data) => {
+      if (!cancelled) setCmntData(data);
+    });
+    return () => { cancelled = true; };
   }, [open, competition?.id]);
 
   const editForm = useForm<CompetitionEditValues>({

--- a/components/races/competition-detail-dialog.tsx
+++ b/components/races/competition-detail-dialog.tsx
@@ -35,17 +35,16 @@ import { revalidateCompetitions } from "@/app/actions/revalidate-competitions";
 import type { CmntRow } from "@/components/comment/comment-item";
 import { CommentSection } from "@/components/comment/comment-section";
 import type { MemberOption } from "@/components/comment/mention-input";
+import {
+  ResponsiveDrawer,
+  ResponsiveDrawerClose,
+  ResponsiveDrawerContent,
+  ResponsiveDrawerDescription,
+  ResponsiveDrawerHeader,
+  ResponsiveDrawerTitle,
+} from "@/components/common/responsive-drawer";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
-import {
-  Dialog,
-  DialogClose,
-  DialogContent,
-  DialogDescription,
-  DialogFooter,
-  DialogHeader,
-  DialogTitle,
-} from "@/components/ui/dialog";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import {
@@ -362,13 +361,19 @@ export function CompetitionDetailDialog({
   }
 
   return (
-    <Dialog open={open} onOpenChange={(v) => { if (!v) setEditing(false); onOpenChange(v); }}>
-      <DialogContent className="max-h-[85vh] overflow-y-auto sm:max-w-lg">
-        <DialogHeader>
-          <DialogTitle className="text-balance">{competition.title}</DialogTitle>
-          <DialogDescription className="sr-only">
+    <ResponsiveDrawer
+      open={open}
+      onOpenChange={(v) => { if (!v) setEditing(false); onOpenChange(v); }}
+    >
+      <ResponsiveDrawerContent
+        dialogClassName="max-h-[85dvh] max-w-lg flex flex-col gap-0 p-0 overflow-hidden"
+        drawerClassName="h-[85dvh] max-h-[85dvh]"
+      >
+        <ResponsiveDrawerHeader className="shrink-0 border-b border-border px-4 py-4 text-left">
+          <ResponsiveDrawerTitle className="text-balance">{competition.title}</ResponsiveDrawerTitle>
+          <ResponsiveDrawerDescription className="sr-only">
             대회 상세 정보 및 참가 신청
-          </DialogDescription>
+          </ResponsiveDrawerDescription>
           <div className="flex flex-wrap gap-2 pt-1">
             {competition.sport && (
               <Badge variant="secondary">
@@ -384,348 +389,354 @@ export function CompetitionDetailDialog({
               <Badge variant="outline">+{competition.event_types!.length - 3}</Badge>
             )}
           </div>
-        </DialogHeader>
+        </ResponsiveDrawerHeader>
 
-        {editing ? (
-          <form onSubmit={editForm.handleSubmit(handleEditSave)} className="flex flex-col gap-3">
-            <div className="flex flex-col gap-1.5">
-              <Label>대회명</Label>
-              <Input {...editForm.register("title")} />
-            </div>
-            <div className="flex flex-col gap-1.5">
-              <Label>종목</Label>
-              <Select value={editSport} onValueChange={(v) => { editForm.setValue("sport", v); editForm.setValue("eventTypes", []); }}>
-                <SelectTrigger><SelectValue /></SelectTrigger>
-                <SelectContent>
-                  {sportSprtOptions.map((s) => (
-                    <SelectItem key={s.cd} value={s.cd}>
-                      {s.cd_nm}
-                    </SelectItem>
-                  ))}
-                </SelectContent>
-              </Select>
-            </div>
-            <div className="flex flex-col gap-1.5">
-              <Label>시작일</Label>
-              <Input type="date" max="9999-12-31" {...editForm.register("startDate")} />
-            </div>
-            <div className="flex flex-col gap-1.5">
-              <Label>종료일</Label>
-              <Input type="date" max="9999-12-31" {...editForm.register("endDate")} />
-            </div>
-            <div className="flex flex-col gap-1.5">
-              <Label>장소</Label>
-              <Input {...editForm.register("location")} />
-            </div>
-            <div className="flex flex-col gap-1.5">
-              <Label>참가 코스</Label>
-              {editEventTypeOptions.length > 0 ? (
-                <div className="flex flex-wrap gap-1.5">
-                  {editEventTypeOptions.map(type => (
-                    <Button
-                      key={type}
-                      type="button"
-                      size="xs"
-                      onClick={() => {
-                        const current = editForm.getValues("eventTypes");
-                        editForm.setValue("eventTypes", current.includes(type) ? current.filter(t => t !== type) : [...current, type]);
-                      }}
-                      variant={editEventTypes.includes(type) ? "default" : "outline"}
-                      className={cn(
-                        "rounded-full",
-                        !editEventTypes.includes(type) && "text-muted-foreground hover:border-primary/50",
-                      )}
-                    >
-                      {type}
-                    </Button>
-                  ))}
-                </div>
-              ) : (
-                <p className="text-xs text-muted-foreground">종목을 먼저 선택해 주세요.</p>
-              )}
-            </div>
-            <div className="flex flex-col gap-1.5">
-              <Label>대회 링크</Label>
-              <Input type="url" {...editForm.register("sourceUrl")} />
-            </div>
-            {editForm.formState.errors.endDate && <p className="text-xs text-destructive">{editForm.formState.errors.endDate.message}</p>}
-            {editForm.formState.errors.root && <p className="text-xs text-destructive">{editForm.formState.errors.root.message}</p>}
-            <div className="flex gap-2">
-              <Button type="submit" disabled={editForm.formState.isSubmitting} className="flex-1">
-                {editForm.formState.isSubmitting ? "저장 중..." : "저장"}
-              </Button>
-              <Button type="button" variant="outline" onClick={() => setEditing(false)} disabled={editForm.formState.isSubmitting} className="flex-1">
-                취소
-              </Button>
-            </div>
-          </form>
-        ) : (
-        <div className="flex flex-col gap-3 text-sm">
-          <div className="flex items-center gap-2 text-muted-foreground">
-            <Calendar className="size-4 shrink-0" />
-            <span>{formattedDate}</span>
-          </div>
-          {competition.location && (
-            <div className="flex items-center gap-2 text-muted-foreground">
-              <MapPin className="size-4 shrink-0" />
-              <span>{competition.location}</span>
-            </div>
-          )}
-          {competition.source_url && /^https?:\/\//.test(competition.source_url) && (
-            <a
-              href={competition.source_url}
-              target="_blank"
-              rel="noreferrer"
-              className="flex items-center gap-2 text-primary hover:underline"
-            >
-              <ExternalLink className="size-4" />
-              대회 페이지 보기
-            </a>
-          )}
-        </div>
-        )}
-
-        {isAdmin && !editing && (
-          <Button
-            variant="outline"
-            size="sm"
-            onClick={startEditing}
-            className="self-start"
-          >
-            <Pencil className="size-3.5 mr-1.5" />
-            대회 정보 수정
-          </Button>
-        )}
-
-        {/* 참가 현황: 회원은 상세 행·이름, 비회원·온보딩 전 등은 RPC 집계만(이름 없음) */}
-        {(() => {
-          if (!competition) return null;
-
-          const sportEvents = eventTypeCodesForSprtFromCmmRows(
-            cmmCdRows,
-            competition.sport,
-          );
-          const hardestFirst = [...sportEvents].reverse();
-
-          const getDisplayKey = (p: RegistrationWithMember) =>
-            p.event_type ??
-            (p.role === "participant"
-              ? "미정"
-              : roleLabels[p.role as keyof typeof roleLabels] ?? p.role);
-
-          const sortOrder = (key: string) => {
-            const idx = hardestFirst.indexOf(key);
-            if (idx !== -1) return idx;
-            if (key === "미정") return hardestFirst.length;
-            if (key === "봉사") return hardestFirst.length + 1;
-            if (key === "응원") return hardestFirst.length + 2;
-            return hardestFirst.length + 3;
-          };
-
-          const publicTotal = publicDisplayCounts.reduce((s, r) => s + r.cnt, 0);
-          const hasMemberRows = participants.length > 0;
-          const showPublicOnly = !hasMemberRows && publicTotal > 0;
-          if (!hasMemberRows && !showPublicOnly) return null;
-
-          let sortedCounts: [string, number][] = [];
-          let sortedParticipants: RegistrationWithMember[] = [];
-
-          if (hasMemberRows) {
-            const eventCounts = new Map<string, number>();
-            participants.forEach((p) => {
-              const key = getDisplayKey(p);
-              eventCounts.set(key, (eventCounts.get(key) ?? 0) + 1);
-            });
-            sortedCounts = Array.from(eventCounts.entries()).sort(
-              (a, b) => sortOrder(a[0]) - sortOrder(b[0]),
-            );
-            sortedParticipants = [...participants].sort((a, b) => {
-              const orderDiff = sortOrder(getDisplayKey(a)) - sortOrder(getDisplayKey(b));
-              if (orderDiff !== 0) return orderDiff;
-              return a.created_at.localeCompare(b.created_at);
-            });
-          } else {
-            sortedCounts = [...publicDisplayCounts]
-              .map((r) => [r.display_key, r.cnt] as [string, number])
-              .sort((a, b) => sortOrder(a[0]) - sortOrder(b[0]));
-          }
-
-          const totalPeople = hasMemberRows ? participants.length : publicTotal;
-          const showNameRows = memberStatus.status === "ready" && hasMemberRows;
-
-          return (
-            <>
-              <Separator />
-              <div className="flex flex-col gap-2">
-                <div className="flex items-center gap-2 text-sm font-semibold text-foreground">
-                  <Users className="size-4" />
-                  참가 현황 ({totalPeople}명)
-                </div>
-                <div className="flex flex-wrap gap-1.5">
-                  {sortedCounts.map(([event, count]) => (
-                    <span
-                      key={event}
-                      className="rounded-full bg-muted px-2.5 py-1 text-xs font-medium text-foreground"
-                    >
-                      {event} {count}명
-                    </span>
-                  ))}
-                </div>
-                {showNameRows && (
-                  <div className="flex flex-col gap-1.5 text-xs">
-                    {sortedCounts.map(([event]) => {
-                      const group = sortedParticipants.filter((p) => getDisplayKey(p) === event);
-                      return (
-                        <div key={event} className="flex items-baseline gap-2">
-                          <span className="shrink-0 font-semibold text-foreground">{event}</span>
-                          <span className="text-muted-foreground">
-                            {group.map((p) => p.member?.mem_nm ?? "이름 없음").join(", ")}
-                          </span>
-                        </div>
-                      );
-                    })}
-                  </div>
-                )}
-              </div>
-            </>
-          );
-        })()}
-
-        <Separator />
-
-        {showInactiveMessage ? (
-          <div className="flex flex-col gap-2 text-sm">
-            <p className="text-destructive">비활성화된 회원입니다. 관리자에게 문의하세요.</p>
-          </div>
-        ) : showAuthMessage ? (
-          <div className="flex flex-col gap-3 text-sm">
-            {memberStatus.status === "signed-out" && (
-              <p>로그인 후 참가 신청을 할 수 있습니다.</p>
-            )}
-            {memberStatus.status === "needs-onboarding" && (
-              <p>참가 신청 전에 회원 정보를 먼저 입력해 주세요.</p>
-            )}
-            {memberStatus.status === "member-fetch-error" && (
-              <p>회원 정보를 불러오지 못했습니다. 새로고침 후 다시 시도해 주세요.</p>
-            )}
-            {memberStatus.status === "member-fetch-error" ? (
-              <Button
-                type="button"
-                className="w-full"
-                onClick={() => window.location.reload()}
-              >
-                새로고침
-              </Button>
-            ) : (
-              <Button asChild className="w-full">
-                <Link
-                  href={
-                    memberStatus.status === "signed-out"
-                      ? "/auth/login?next=%2Fraces"
-                      : "/onboarding"
-                  }
-                >
-                  {memberStatus.status === "signed-out" ? "로그인" : "회원정보 입력"}
-                </Link>
-              </Button>
-            )}
-          </div>
-        ) : (
-          <form onSubmit={handleSubmit} className="flex flex-col gap-4">
-            <div className="flex flex-col gap-1.5">
-              <Label htmlFor="role">참여 방식</Label>
-              <Select value={role} onValueChange={(value) => setRole(value as typeof role)}>
-                <SelectTrigger id="role">
-                  <SelectValue />
-                </SelectTrigger>
-                <SelectContent>
-                  <SelectItem value="participant">참가</SelectItem>
-                  <SelectItem value="cheering">응원</SelectItem>
-                  <SelectItem value="volunteer">봉사</SelectItem>
-                </SelectContent>
-              </Select>
-            </div>
-
-            {isParticipant && (
+        <div className="flex-1 overflow-y-auto px-4 pb-6 pt-4">
+          {editing ? (
+            <form onSubmit={editForm.handleSubmit(handleEditSave)} className="flex flex-col gap-3">
               <div className="flex flex-col gap-1.5">
-                <Label htmlFor="event-type">참가 종목</Label>
-                <Select
-                  value={eventType}
-                  onValueChange={(value) => setEventType(value)}
-                >
-                  <SelectTrigger id="event-type">
-                    <SelectValue placeholder="종목 선택" />
-                  </SelectTrigger>
+                <Label>대회명</Label>
+                <Input {...editForm.register("title")} />
+              </div>
+              <div className="flex flex-col gap-1.5">
+                <Label>종목</Label>
+                <Select value={editSport} onValueChange={(v) => { editForm.setValue("sport", v); editForm.setValue("eventTypes", []); }}>
+                  <SelectTrigger><SelectValue /></SelectTrigger>
                   <SelectContent>
-                    {eventTypeOptions.map((type) => (
-                      <SelectItem key={type} value={type}>
-                        {type}
+                    {sportSprtOptions.map((s) => (
+                      <SelectItem key={s.cd} value={s.cd}>
+                        {s.cd_nm}
                       </SelectItem>
                     ))}
-                    <SelectItem value={EVENT_TYPE_OTHER}>
-                      기타 (직접 입력)
-                    </SelectItem>
                   </SelectContent>
                 </Select>
-                {eventType === EVENT_TYPE_OTHER && (
-                  <Input
-                    placeholder="예: 10K, HALF (영문·숫자만)"
-                    value={otherEventType}
-                    onChange={(e) =>
-                      setOtherEventType(sanitizeAsciiUpperCompEvtTypeInput(e.target.value))
-                    }
-                    className="mt-1"
-                  />
+              </div>
+              <div className="flex flex-col gap-1.5">
+                <Label>시작일</Label>
+                <Input type="date" max="9999-12-31" {...editForm.register("startDate")} />
+              </div>
+              <div className="flex flex-col gap-1.5">
+                <Label>종료일</Label>
+                <Input type="date" max="9999-12-31" {...editForm.register("endDate")} />
+              </div>
+              <div className="flex flex-col gap-1.5">
+                <Label>장소</Label>
+                <Input {...editForm.register("location")} />
+              </div>
+              <div className="flex flex-col gap-1.5">
+                <Label>참가 코스</Label>
+                {editEventTypeOptions.length > 0 ? (
+                  <div className="flex flex-wrap gap-1.5">
+                    {editEventTypeOptions.map(type => (
+                      <Button
+                        key={type}
+                        type="button"
+                        size="xs"
+                        onClick={() => {
+                          const current = editForm.getValues("eventTypes");
+                          editForm.setValue("eventTypes", current.includes(type) ? current.filter(t => t !== type) : [...current, type]);
+                        }}
+                        variant={editEventTypes.includes(type) ? "default" : "outline"}
+                        className={cn(
+                          "rounded-full",
+                          !editEventTypes.includes(type) && "text-muted-foreground hover:border-primary/50",
+                        )}
+                      >
+                        {type}
+                      </Button>
+                    ))}
+                  </div>
+                ) : (
+                  <p className="text-xs text-muted-foreground">종목을 먼저 선택해 주세요.</p>
                 )}
               </div>
-            )}
-
-            {registration && (
-              <div className="rounded-md border border-border bg-muted/40 px-3 py-2 text-xs text-muted-foreground">
-                현재 상태: {roleLabels[registration.role]}
-                {registration.event_type && ` · ${registration.event_type}`}
+              <div className="flex flex-col gap-1.5">
+                <Label>대회 링크</Label>
+                <Input type="url" {...editForm.register("sourceUrl")} />
               </div>
-            )}
+              {editForm.formState.errors.endDate && <p className="text-xs text-destructive">{editForm.formState.errors.endDate.message}</p>}
+              {editForm.formState.errors.root && <p className="text-xs text-destructive">{editForm.formState.errors.root.message}</p>}
+              <div className="flex gap-2">
+                <Button type="submit" disabled={editForm.formState.isSubmitting} className="flex-1">
+                  {editForm.formState.isSubmitting ? "저장 중..." : "저장"}
+                </Button>
+                <Button type="button" variant="outline" onClick={() => setEditing(false)} disabled={editForm.formState.isSubmitting} className="flex-1">
+                  취소
+                </Button>
+              </div>
+            </form>
+          ) : (
+            <div className="flex flex-col gap-3 text-sm">
+              <div className="flex items-center gap-2 text-muted-foreground">
+                <Calendar className="size-4 shrink-0" />
+                <span>{formattedDate}</span>
+              </div>
+              {competition.location && (
+                <div className="flex items-center gap-2 text-muted-foreground">
+                  <MapPin className="size-4 shrink-0" />
+                  <span>{competition.location}</span>
+                </div>
+              )}
+              {competition.source_url && /^https?:\/\//.test(competition.source_url) && (
+                <a
+                  href={competition.source_url}
+                  target="_blank"
+                  rel="noreferrer"
+                  className="flex items-center gap-2 text-primary hover:underline"
+                >
+                  <ExternalLink className="size-4" />
+                  대회 페이지 보기
+                </a>
+              )}
+            </div>
+          )}
 
-            {statusMessage && (
-              <p className={`text-xs ${statusMessage.ok ? "text-muted-foreground" : "text-destructive"}`}>
-                {statusMessage.text}
-              </p>
-            )}
+          {isAdmin && !editing && (
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={startEditing}
+              className="mt-3 self-start"
+            >
+              <Pencil className="size-3.5 mr-1.5" />
+              대회 정보 수정
+            </Button>
+          )}
 
-            <DialogFooter className="gap-2 sm:gap-0">
-              <Button type="submit" disabled={!canSubmit || isSaving}>
-                {registration ? "정보 수정" : "참가 신청"}
-              </Button>
-              {registration && (
+          {/* 참가 현황 */}
+          {(() => {
+            if (!competition) return null;
+
+            const sportEvents = eventTypeCodesForSprtFromCmmRows(
+              cmmCdRows,
+              competition.sport,
+            );
+            const hardestFirst = [...sportEvents].reverse();
+
+            const getDisplayKey = (p: RegistrationWithMember) =>
+              p.event_type ??
+              (p.role === "participant"
+                ? "미정"
+                : roleLabels[p.role as keyof typeof roleLabels] ?? p.role);
+
+            const sortOrder = (key: string) => {
+              const idx = hardestFirst.indexOf(key);
+              if (idx !== -1) return idx;
+              if (key === "미정") return hardestFirst.length;
+              if (key === "봉사") return hardestFirst.length + 1;
+              if (key === "응원") return hardestFirst.length + 2;
+              return hardestFirst.length + 3;
+            };
+
+            const publicTotal = publicDisplayCounts.reduce((s, r) => s + r.cnt, 0);
+            const hasMemberRows = participants.length > 0;
+            const showPublicOnly = !hasMemberRows && publicTotal > 0;
+            if (!hasMemberRows && !showPublicOnly) return null;
+
+            let sortedCounts: [string, number][] = [];
+            let sortedParticipants: RegistrationWithMember[] = [];
+
+            if (hasMemberRows) {
+              const eventCounts = new Map<string, number>();
+              participants.forEach((p) => {
+                const key = getDisplayKey(p);
+                eventCounts.set(key, (eventCounts.get(key) ?? 0) + 1);
+              });
+              sortedCounts = Array.from(eventCounts.entries()).sort(
+                (a, b) => sortOrder(a[0]) - sortOrder(b[0]),
+              );
+              sortedParticipants = [...participants].sort((a, b) => {
+                const orderDiff = sortOrder(getDisplayKey(a)) - sortOrder(getDisplayKey(b));
+                if (orderDiff !== 0) return orderDiff;
+                return a.created_at.localeCompare(b.created_at);
+              });
+            } else {
+              sortedCounts = [...publicDisplayCounts]
+                .map((r) => [r.display_key, r.cnt] as [string, number])
+                .sort((a, b) => sortOrder(a[0]) - sortOrder(b[0]));
+            }
+
+            const totalPeople = hasMemberRows ? participants.length : publicTotal;
+            const showNameRows = memberStatus.status === "ready" && hasMemberRows;
+
+            return (
+              <>
+                <Separator className="my-3" />
+                <div className="flex flex-col gap-2">
+                  <div className="flex items-center gap-2 text-sm font-semibold text-foreground">
+                    <Users className="size-4" />
+                    참가 현황 ({totalPeople}명)
+                  </div>
+                  <div className="flex flex-wrap gap-1.5">
+                    {sortedCounts.map(([event, count]) => (
+                      <span
+                        key={event}
+                        className="rounded-full bg-muted px-2.5 py-1 text-xs font-medium text-foreground"
+                      >
+                        {event} {count}명
+                      </span>
+                    ))}
+                  </div>
+                  {showNameRows && (
+                    <div className="flex flex-col gap-1.5 text-xs">
+                      {sortedCounts.map(([event]) => {
+                        const group = sortedParticipants.filter((p) => getDisplayKey(p) === event);
+                        return (
+                          <div key={event} className="flex items-baseline gap-2">
+                            <span className="shrink-0 font-semibold text-foreground">{event}</span>
+                            <span className="text-muted-foreground">
+                              {group.map((p) => p.member?.mem_nm ?? "이름 없음").join(", ")}
+                            </span>
+                          </div>
+                        );
+                      })}
+                    </div>
+                  )}
+                </div>
+              </>
+            );
+          })()}
+
+          <Separator className="my-3" />
+
+          {showInactiveMessage ? (
+            <div className="flex flex-col gap-2 text-sm">
+              <p className="text-destructive">비활성화된 회원입니다. 관리자에게 문의하세요.</p>
+            </div>
+          ) : showAuthMessage ? (
+            <div className="flex flex-col gap-3 text-sm">
+              {memberStatus.status === "signed-out" && (
+                <p>로그인 후 참가 신청을 할 수 있습니다.</p>
+              )}
+              {memberStatus.status === "needs-onboarding" && (
+                <p>참가 신청 전에 회원 정보를 먼저 입력해 주세요.</p>
+              )}
+              {memberStatus.status === "member-fetch-error" && (
+                <p>회원 정보를 불러오지 못했습니다. 새로고침 후 다시 시도해 주세요.</p>
+              )}
+              {memberStatus.status === "member-fetch-error" ? (
                 <Button
                   type="button"
-                  variant="outline"
-                  onClick={handleDelete}
-                  disabled={isSaving}
+                  className="w-full"
+                  onClick={() => window.location.reload()}
                 >
-                  신청 취소
+                  새로고침
+                </Button>
+              ) : (
+                <Button asChild className="w-full">
+                  <Link
+                    href={
+                      memberStatus.status === "signed-out"
+                        ? "/auth/login?next=%2Fraces"
+                        : "/onboarding"
+                    }
+                  >
+                    {memberStatus.status === "signed-out" ? "로그인" : "회원정보 입력"}
+                  </Link>
                 </Button>
               )}
-            </DialogFooter>
-            <DialogClose asChild>
-              <Button type="button" variant="ghost" className="w-full text-muted-foreground">
+            </div>
+          ) : (
+            <form onSubmit={handleSubmit} className="flex flex-col gap-4">
+              <div className="flex flex-col gap-1.5">
+                <Label htmlFor="role">참여 방식</Label>
+                <Select value={role} onValueChange={(value) => setRole(value as typeof role)}>
+                  <SelectTrigger id="role">
+                    <SelectValue />
+                  </SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value="participant">참가</SelectItem>
+                    <SelectItem value="cheering">응원</SelectItem>
+                    <SelectItem value="volunteer">봉사</SelectItem>
+                  </SelectContent>
+                </Select>
+              </div>
+
+              {isParticipant && (
+                <div className="flex flex-col gap-1.5">
+                  <Label htmlFor="event-type">참가 종목</Label>
+                  <Select
+                    value={eventType}
+                    onValueChange={(value) => setEventType(value)}
+                  >
+                    <SelectTrigger id="event-type">
+                      <SelectValue placeholder="종목 선택" />
+                    </SelectTrigger>
+                    <SelectContent>
+                      {eventTypeOptions.map((type) => (
+                        <SelectItem key={type} value={type}>
+                          {type}
+                        </SelectItem>
+                      ))}
+                      <SelectItem value={EVENT_TYPE_OTHER}>
+                        기타 (직접 입력)
+                      </SelectItem>
+                    </SelectContent>
+                  </Select>
+                  {eventType === EVENT_TYPE_OTHER && (
+                    <Input
+                      placeholder="예: 10K, HALF (영문·숫자만)"
+                      value={otherEventType}
+                      onChange={(e) =>
+                        setOtherEventType(sanitizeAsciiUpperCompEvtTypeInput(e.target.value))
+                      }
+                      className="mt-1"
+                    />
+                  )}
+                </div>
+              )}
+
+              {registration && (
+                <div className="rounded-md border border-border bg-muted/40 px-3 py-2 text-xs text-muted-foreground">
+                  현재 상태: {roleLabels[registration.role]}
+                  {registration.event_type && ` · ${registration.event_type}`}
+                </div>
+              )}
+
+              {statusMessage && (
+                <p className={`text-xs ${statusMessage.ok ? "text-muted-foreground" : "text-destructive"}`}>
+                  {statusMessage.text}
+                </p>
+              )}
+
+              <div className="flex flex-col-reverse gap-2 sm:flex-row sm:justify-end">
+                <Button type="submit" disabled={!canSubmit || isSaving}>
+                  {registration ? "정보 수정" : "참가 신청"}
+                </Button>
+                {registration && (
+                  <Button
+                    type="button"
+                    variant="outline"
+                    onClick={handleDelete}
+                    disabled={isSaving}
+                  >
+                    신청 취소
+                  </Button>
+                )}
+              </div>
+            </form>
+          )}
+
+          <div className="border-t border-border mt-4 pt-4">
+            <CommentSection
+              entityType="comp"
+              entityId={competition.id}
+              currentMemberId={memberStatus.status === "ready" ? memberStatus.memberId : undefined}
+              isAdmin={isAdmin}
+              members={cmntData.members}
+              initialComments={cmntData.comments}
+            />
+          </div>
+
+          <div className="mt-4 flex justify-center">
+            <ResponsiveDrawerClose asChild>
+              <Button type="button" variant="ghost" size="sm" className="text-muted-foreground">
                 닫기
               </Button>
-            </DialogClose>
-          </form>
-        )}
-        <div className="border-t border-border pt-4 mt-2">
-          <CommentSection
-            entityType="comp"
-            entityId={competition.id}
-            currentMemberId={memberStatus.status === "ready" ? memberStatus.memberId : undefined}
-            isAdmin={isAdmin}
-            members={cmntData.members}
-            initialComments={cmntData.comments}
-          />
+            </ResponsiveDrawerClose>
+          </div>
         </div>
-      </DialogContent>
-    </Dialog>
+      </ResponsiveDrawerContent>
+    </ResponsiveDrawer>
   );
 }

--- a/components/races/competition-detail-dialog.tsx
+++ b/components/races/competition-detail-dialog.tsx
@@ -53,6 +53,10 @@ import {
 } from "@/components/ui/select";
 import { Separator } from "@/components/ui/separator";
 
+import { getCommentData } from "@/app/actions/comment/get-comment-data";
+import { CommentSection } from "@/components/comment/comment-section";
+import type { CmntRow } from "@/components/comment/comment-item";
+import type { MemberOption } from "@/components/comment/mention-input";
 
 import type { Competition, CompetitionRegistration, MemberStatus } from "./types";
 
@@ -127,6 +131,16 @@ export function CompetitionDetailDialog({
   // 관리자 수정 모드
   const isAdmin = memberStatus.status === "ready" && memberStatus.admin;
   const [editing, setEditing] = useState(false);
+
+  const [cmntData, setCmntData] = useState<{ comments: CmntRow[]; members: MemberOption[] }>({
+    comments: [],
+    members: [],
+  });
+
+  useEffect(() => {
+    if (!open || !competition) return;
+    getCommentData("comp", competition.id).then(setCmntData);
+  }, [open, competition?.id]);
 
   const editForm = useForm<CompetitionEditValues>({
     defaultValues: { title: "", sport: "", startDate: "", endDate: "", location: "", sourceUrl: "", eventTypes: [] },
@@ -701,6 +715,16 @@ export function CompetitionDetailDialog({
             </DialogClose>
           </form>
         )}
+        <div className="border-t border-border pt-4 mt-2">
+          <CommentSection
+            entityType="comp"
+            entityId={competition.id}
+            currentMemberId={memberStatus.status === "ready" ? memberStatus.memberId : undefined}
+            isAdmin={isAdmin}
+            members={cmntData.members}
+            initialComments={cmntData.comments}
+          />
+        </div>
       </DialogContent>
     </Dialog>
   );

--- a/components/schedule/sch-post-detail-dialog.tsx
+++ b/components/schedule/sch-post-detail-dialog.tsx
@@ -48,21 +48,23 @@ export function SchPostDetailDialog({
 
   useEffect(() => {
     if (!open || !post) return
+    let cancelled = false
     // eslint-disable-next-line react-hooks/set-state-in-effect
     setLoading(true)
     getCommentData("sch_post", post.id)
       .then(({ comments, members }) => {
-        console.log("[SchPostDetailDialog] comments loaded:", comments.length, comments)
+        if (cancelled) return
         setComments(comments)
         setMembers(members)
       })
       .catch((err) => {
-        console.error("[SchPostDetailDialog] getCommentData failed:", err)
+        if (!cancelled) console.error("[SchPostDetailDialog] getCommentData failed:", err)
       })
       .finally(() => {
-        setLoading(false)
+        if (!cancelled) setLoading(false)
       })
-  }, [open, post])
+    return () => { cancelled = true }
+  }, [open, post?.id])
 
   async function handleDelete() {
     if (!post) return

--- a/components/schedule/sch-post-detail-dialog.tsx
+++ b/components/schedule/sch-post-detail-dialog.tsx
@@ -13,8 +13,14 @@ import type { CmntRow } from "@/components/comment/comment-item"
 import { CommentSection } from "@/components/comment/comment-section"
 import type { MemberOption } from "@/components/comment/mention-input"
 import type { CalendarRace } from "@/components/home/mini-calendar"
+import {
+  ResponsiveDrawer,
+  ResponsiveDrawerClose,
+  ResponsiveDrawerContent,
+  ResponsiveDrawerHeader,
+  ResponsiveDrawerTitle,
+} from "@/components/common/responsive-drawer"
 import { Button } from "@/components/ui/button"
-import { Dialog, DialogContent, DialogHeader, DialogTitle } from "@/components/ui/dialog"
 
 interface SchPostDetailDialogProps {
   post: CalendarRace | null
@@ -78,69 +84,82 @@ export function SchPostDetailDialog({
   const isAuthor = currentMemberId === post.crt_by
 
   return (
-    <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent className="max-w-md max-h-[85vh] overflow-y-auto">
-        <DialogHeader>
-          <DialogTitle className="text-left">{post.title}</DialogTitle>
-        </DialogHeader>
+    <ResponsiveDrawer open={open} onOpenChange={onOpenChange}>
+      <ResponsiveDrawerContent
+        dialogClassName="max-w-md max-h-[85dvh] flex flex-col gap-0 p-0 overflow-hidden"
+        drawerClassName="h-[85dvh] max-h-[85dvh]"
+      >
+        <ResponsiveDrawerHeader className="shrink-0 border-b border-border px-4 py-4 text-left">
+          <ResponsiveDrawerTitle>{post.title}</ResponsiveDrawerTitle>
+        </ResponsiveDrawerHeader>
 
-        <div className="flex flex-col gap-4">
-          <p className="text-sm text-muted-foreground">
-            {startAt.format("YYYY년 M월 D일 (ddd) HH:mm")}
-            {endAt && ` ~ ${endAt.format("HH:mm")}`}
-          </p>
+        <div className="flex-1 overflow-y-auto px-4 pb-6 pt-4">
+          <div className="flex flex-col gap-4">
+            <p className="text-sm text-muted-foreground">
+              {startAt.format("YYYY년 M월 D일 (ddd) HH:mm")}
+              {endAt && ` ~ ${endAt.format("HH:mm")}`}
+            </p>
 
-          {post.url && (
-            <a
-              href={post.url}
-              target="_blank"
-              rel="noopener noreferrer"
-              className="flex items-center justify-center gap-2 rounded-md border border-border py-2 text-sm transition-colors hover:bg-muted"
-            >
-              <ExternalLink className="size-3.5" />
-              링크 바로가기
-            </a>
-          )}
-
-          {post.cont_txt && (
-            <p className="text-sm leading-relaxed whitespace-pre-wrap">{post.cont_txt}</p>
-          )}
-
-          {isAuthor && (
-            <div className="flex gap-2 self-end">
-              <Button variant="outline" size="sm" onClick={onEdit} disabled={deleting}>
-                <Pencil className="size-3.5" />
-                수정
-              </Button>
-              <Button
-                variant="outline"
-                size="sm"
-                className="border-destructive/30 text-destructive hover:bg-destructive/5 hover:text-destructive"
-                onClick={handleDelete}
-                disabled={deleting}
+            {post.url && (
+              <a
+                href={post.url}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="flex items-center justify-center gap-2 rounded-md border border-border py-2 text-sm transition-colors hover:bg-muted"
               >
-                <Trash2 className="size-3.5" />
-                {deleting ? "삭제 중..." : "삭제"}
-              </Button>
-            </div>
-          )}
-
-          <div className="border-t border-border pt-4">
-            {loading ? (
-              <p className="text-sm text-muted-foreground">댓글 불러오는 중...</p>
-            ) : (
-              <CommentSection
-                entityType="sch_post"
-                entityId={post.id}
-                currentMemberId={currentMemberId}
-                isAdmin={isAdmin}
-                members={members}
-                initialComments={comments}
-              />
+                <ExternalLink className="size-3.5" />
+                링크 바로가기
+              </a>
             )}
+
+            {post.cont_txt && (
+              <p className="text-sm leading-relaxed whitespace-pre-wrap">{post.cont_txt}</p>
+            )}
+
+            {isAuthor && (
+              <div className="flex gap-2 self-end">
+                <Button variant="outline" size="sm" onClick={onEdit} disabled={deleting}>
+                  <Pencil className="size-3.5" />
+                  수정
+                </Button>
+                <Button
+                  variant="outline"
+                  size="sm"
+                  className="border-destructive/30 text-destructive hover:bg-destructive/5 hover:text-destructive"
+                  onClick={handleDelete}
+                  disabled={deleting}
+                >
+                  <Trash2 className="size-3.5" />
+                  {deleting ? "삭제 중..." : "삭제"}
+                </Button>
+              </div>
+            )}
+
+            <div className="border-t border-border pt-4">
+              {loading ? (
+                <p className="text-sm text-muted-foreground">댓글 불러오는 중...</p>
+              ) : (
+                <CommentSection
+                  entityType="sch_post"
+                  entityId={post.id}
+                  currentMemberId={currentMemberId}
+                  isAdmin={isAdmin}
+                  members={members}
+                  initialComments={comments}
+                />
+              )}
+            </div>
+
+            <div className="mt-4 flex justify-center">
+              <ResponsiveDrawerClose asChild>
+                <Button type="button" variant="ghost" size="sm" className="text-muted-foreground">
+                  닫기
+                </Button>
+              </ResponsiveDrawerClose>
+            </div>
           </div>
         </div>
-      </DialogContent>
-    </Dialog>
+      </ResponsiveDrawerContent>
+    </ResponsiveDrawer>
   )
 }

--- a/components/schedule/sch-post-detail-dialog.tsx
+++ b/components/schedule/sch-post-detail-dialog.tsx
@@ -6,8 +6,8 @@ import { ExternalLink, Pencil, Trash2 } from "lucide-react"
 
 import { dayjs } from "@/lib/dayjs"
 
-import { deleteSchPost } from "@/app/actions/schedule/manage-sch-post"
 import { getCommentData } from "@/app/actions/comment/get-comment-data"
+import { deleteSchPost } from "@/app/actions/schedule/manage-sch-post"
 
 import type { CmntRow } from "@/components/comment/comment-item"
 import { CommentSection } from "@/components/comment/comment-section"

--- a/components/schedule/sch-post-detail-dialog.tsx
+++ b/components/schedule/sch-post-detail-dialog.tsx
@@ -66,7 +66,7 @@ export function SchPostDetailDialog({
 
   async function handleDelete() {
     if (!post) return
-    if (!window.confirm("이 소식을 삭제하시겠습니까?")) return
+    if (!window.confirm("이 피드를 삭제하시겠습니까?")) return
     setDeleting(true)
     try {
       await deleteSchPost(post.id)

--- a/components/schedule/sch-post-detail-dialog.tsx
+++ b/components/schedule/sch-post-detail-dialog.tsx
@@ -1,0 +1,146 @@
+"use client"
+
+import { useEffect, useState } from "react"
+
+import { ExternalLink, Pencil, Trash2 } from "lucide-react"
+
+import { dayjs } from "@/lib/dayjs"
+
+import { deleteSchPost } from "@/app/actions/schedule/manage-sch-post"
+import { getCommentData } from "@/app/actions/comment/get-comment-data"
+
+import type { CmntRow } from "@/components/comment/comment-item"
+import { CommentSection } from "@/components/comment/comment-section"
+import type { MemberOption } from "@/components/comment/mention-input"
+import type { CalendarRace } from "@/components/home/mini-calendar"
+import { Button } from "@/components/ui/button"
+import { Dialog, DialogContent, DialogHeader, DialogTitle } from "@/components/ui/dialog"
+
+interface SchPostDetailDialogProps {
+  post: CalendarRace | null
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  currentMemberId?: string
+  isAdmin?: boolean
+  onEdit?: () => void
+  onDelete?: () => void
+}
+
+export function SchPostDetailDialog({
+  post,
+  open,
+  onOpenChange,
+  currentMemberId,
+  isAdmin,
+  onEdit,
+  onDelete,
+}: SchPostDetailDialogProps) {
+  const [comments, setComments] = useState<CmntRow[]>([])
+  const [members, setMembers] = useState<MemberOption[]>([])
+  const [loading, setLoading] = useState(true)
+  const [deleting, setDeleting] = useState(false)
+
+  useEffect(() => {
+    if (!open || !post) return
+    // eslint-disable-next-line react-hooks/set-state-in-effect
+    setLoading(true)
+    getCommentData("sch_post", post.id)
+      .then(({ comments, members }) => {
+        console.log("[SchPostDetailDialog] comments loaded:", comments.length, comments)
+        setComments(comments)
+        setMembers(members)
+      })
+      .catch((err) => {
+        console.error("[SchPostDetailDialog] getCommentData failed:", err)
+      })
+      .finally(() => {
+        setLoading(false)
+      })
+  }, [open, post])
+
+  async function handleDelete() {
+    if (!post) return
+    if (!window.confirm("이 소식을 삭제하시겠습니까?")) return
+    setDeleting(true)
+    try {
+      await deleteSchPost(post.id)
+      onOpenChange(false)
+      onDelete?.()
+    } finally {
+      setDeleting(false)
+    }
+  }
+
+  if (!post) return null
+
+  const startAt = post.evt_stt_at ? dayjs(post.evt_stt_at) : dayjs(post.start_date)
+  const endAt = post.evt_end_at ? dayjs(post.evt_end_at) : null
+  const isAuthor = currentMemberId === post.crt_by
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="max-w-md max-h-[85vh] overflow-y-auto">
+        <DialogHeader>
+          <DialogTitle className="text-left">{post.title}</DialogTitle>
+        </DialogHeader>
+
+        <div className="flex flex-col gap-4">
+          <p className="text-sm text-muted-foreground">
+            {startAt.format("YYYY년 M월 D일 (ddd) HH:mm")}
+            {endAt && ` ~ ${endAt.format("HH:mm")}`}
+          </p>
+
+          {post.url && (
+            <a
+              href={post.url}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="flex items-center justify-center gap-2 rounded-md border border-border py-2 text-sm transition-colors hover:bg-muted"
+            >
+              <ExternalLink className="size-3.5" />
+              링크 바로가기
+            </a>
+          )}
+
+          {post.cont_txt && (
+            <p className="text-sm leading-relaxed whitespace-pre-wrap">{post.cont_txt}</p>
+          )}
+
+          {isAuthor && (
+            <div className="flex gap-2 self-end">
+              <Button variant="outline" size="sm" onClick={onEdit} disabled={deleting}>
+                <Pencil className="size-3.5" />
+                수정
+              </Button>
+              <Button
+                variant="outline"
+                size="sm"
+                className="border-destructive/30 text-destructive hover:bg-destructive/5 hover:text-destructive"
+                onClick={handleDelete}
+                disabled={deleting}
+              >
+                <Trash2 className="size-3.5" />
+                {deleting ? "삭제 중..." : "삭제"}
+              </Button>
+            </div>
+          )}
+
+          <div className="border-t border-border pt-4">
+            {loading ? (
+              <p className="text-sm text-muted-foreground">댓글 불러오는 중...</p>
+            ) : (
+              <CommentSection
+                entityType="sch_post"
+                entityId={post.id}
+                currentMemberId={currentMemberId}
+                isAdmin={isAdmin}
+                members={members}
+                initialComments={comments}
+              />
+            )}
+          </div>
+        </div>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/components/schedule/sch-post-detail-dialog.tsx
+++ b/components/schedule/sch-post-detail-dialog.tsx
@@ -12,7 +12,6 @@ import { deleteSchPost } from "@/app/actions/schedule/manage-sch-post"
 import type { CmntRow } from "@/components/comment/comment-item"
 import { CommentSection } from "@/components/comment/comment-section"
 import type { MemberOption } from "@/components/comment/mention-input"
-import type { CalendarRace } from "@/components/home/mini-calendar"
 import {
   ResponsiveDrawer,
   ResponsiveDrawerClose,
@@ -20,6 +19,7 @@ import {
   ResponsiveDrawerHeader,
   ResponsiveDrawerTitle,
 } from "@/components/common/responsive-drawer"
+import type { CalendarRace } from "@/components/home/mini-calendar"
 import { Button } from "@/components/ui/button"
 
 interface SchPostDetailDialogProps {

--- a/components/schedule/sch-post-form-dialog.tsx
+++ b/components/schedule/sch-post-form-dialog.tsx
@@ -147,7 +147,7 @@ export function SchPostFormDialog({
       <DialogContent className="flex max-h-[85dvh] flex-col gap-0 p-0">
 
         <DialogHeader className="px-5 pb-3 pt-5">
-          <DialogTitle>{mode === "create" ? "소식 추가" : "소식 수정"}</DialogTitle>
+          <DialogTitle>{mode === "create" ? "피드 추가" : "피드 수정"}</DialogTitle>
         </DialogHeader>
 
         <Separator />

--- a/components/schedule/sch-post-form-dialog.tsx
+++ b/components/schedule/sch-post-form-dialog.tsx
@@ -3,13 +3,11 @@
 import { useEffect, useState } from "react";
 
 import { zodResolver } from "@hookform/resolvers/zod";
-import { ArrowLeft, Calendar, ExternalLink, Pencil, Trash2 } from "lucide-react";
 import { useForm } from "react-hook-form";
 import { z } from "zod";
 
 import {
   createSchPost,
-  deleteSchPost,
   updateSchPost,
 } from "@/app/actions/schedule/manage-sch-post";
 import { dayjs } from "@/lib/dayjs";
@@ -48,10 +46,8 @@ type FormValues = z.infer<typeof formSchema>;
 export type SchPostFormDialogProps = {
   open: boolean;
   onOpenChange: (open: boolean) => void;
-  mode: "create" | "view" | "edit";
+  mode: "create" | "edit";
   defaultPostType?: SchPostType;
-  currentMemberId?: string;
-  isAdmin?: boolean;
   initialData?: {
     sch_post_id: string;
     sch_nm: string;
@@ -68,18 +64,12 @@ export type SchPostFormDialogProps = {
 export function SchPostFormDialog({
   open,
   onOpenChange,
-  mode: initialMode,
+  mode,
   defaultPostType = "general",
-  currentMemberId,
-  isAdmin,
   initialData,
   onSuccess,
 }: SchPostFormDialogProps) {
-  const [mode, setMode] = useState(initialMode);
   const [rootError, setRootError] = useState<string | null>(null);
-  const [deleting, setDeleting] = useState(false);
-
-  const canEdit = isAdmin || (!!currentMemberId && currentMemberId === initialData?.crt_by);
 
   const form = useForm<FormValues>({
     resolver: zodResolver(formSchema),
@@ -97,9 +87,9 @@ export function SchPostFormDialog({
 
   useEffect(() => {
     if (!open) return;
-    setMode(initialMode);
+    // eslint-disable-next-line react-hooks/set-state-in-effect
     setRootError(null);
-    if (initialMode === "edit" && initialData) {
+    if (mode === "edit" && initialData) {
       form.reset({
         sch_nm: initialData.sch_nm,
         post_type: initialData.post_type ?? "general",
@@ -108,7 +98,7 @@ export function SchPostFormDialog({
         url: initialData.url ?? null,
         cont_txt: initialData.cont_txt ?? null,
       });
-    } else if (initialMode === "create") {
+    } else if (mode === "create") {
       form.reset({
         sch_nm: "",
         post_type: defaultPostType,
@@ -118,25 +108,12 @@ export function SchPostFormDialog({
         cont_txt: null,
       });
     }
-  }, [open, initialMode, initialData, form]);
-
-  function startEditing() {
-    form.reset({
-      sch_nm: initialData?.sch_nm ?? "",
-      post_type: initialData?.post_type ?? "general",
-      evt_stt_at: initialData?.evt_stt_at ? toDatetimeLocal(initialData.evt_stt_at) : "",
-      evt_end_at: initialData?.evt_end_at ? toDatetimeLocal(initialData.evt_end_at) : null,
-      url: initialData?.url ?? null,
-      cont_txt: initialData?.cont_txt ?? null,
-    });
-    setRootError(null);
-    setMode("edit");
-  }
+  }, [open, mode, initialData, defaultPostType, form]);
 
   async function onSubmit(values: FormValues) {
     setRootError(null);
     try {
-      if (initialMode === "create") {
+      if (mode === "create") {
         await createSchPost({
           sch_nm: values.sch_nm,
           post_type: values.post_type,
@@ -164,242 +141,56 @@ export function SchPostFormDialog({
     }
   }
 
-  async function handleDelete() {
-    if (!initialData?.sch_post_id) return;
-    const confirmed = window.confirm("이 소식을 삭제하시겠습니까?");
-    if (!confirmed) return;
-    setDeleting(true);
-    setRootError(null);
-    try {
-      await deleteSchPost(initialData.sch_post_id);
-      onOpenChange(false);
-      onSuccess?.();
-    } catch (err) {
-      setRootError(err instanceof Error ? err.message : "삭제 중 오류가 발생했습니다.");
-      setDeleting(false);
-    }
-  }
-
-  const titleMap = { create: "소식 추가", view: initialData?.sch_nm ?? "소식", edit: "소식 수정" };
-
   return (
-    <Dialog open={open} onOpenChange={(v) => { if (!v) { setMode(initialMode); setDeleting(false); } onOpenChange(v); }}>
+    <Dialog open={open} onOpenChange={(v) => { if (!v) setRootError(null); onOpenChange(v); }}>
       <DialogContent className="flex max-h-[85dvh] flex-col gap-0 p-0">
 
-        {/* 헤더 */}
         <DialogHeader className="px-5 pb-3 pt-5">
-          {mode === "edit" && initialMode === "view" && (
-            <button
-              onClick={() => setMode("view")}
-              className="mb-1 flex items-center gap-1 text-[12px] text-muted-foreground hover:text-foreground w-fit"
-            >
-              <ArrowLeft className="size-3" />
-              돌아가기
-            </button>
-          )}
-          <DialogTitle className="truncate">{titleMap[mode]}</DialogTitle>
+          <DialogTitle>{mode === "create" ? "소식 추가" : "소식 수정"}</DialogTitle>
         </DialogHeader>
 
         <Separator />
 
-        {/* 상세 보기 */}
-        {mode === "view" && initialData && (
-          <div className="flex flex-col overflow-y-auto">
-            {/* 메타 정보 영역 */}
-            <div className="flex flex-col gap-3 px-5 py-4">
-              {/* 유형 + 날짜 */}
-              <div className="flex items-center gap-2">
-                <span className="rounded-full bg-info/10 px-2.5 py-0.5 text-[11px] font-semibold text-info">
-                  {schPostTypeLabels[initialData.post_type ?? "general"]}
-                </span>
-                <span className="flex items-center gap-1 text-[12px] text-muted-foreground">
-                  <Calendar className="size-3" />
-                  {dayjs(initialData.evt_stt_at).format("M월 D일 (ddd) HH:mm")}
-                  {initialData.evt_end_at && (
-                    <> ~ {dayjs(initialData.evt_end_at).format("M월 D일 (ddd) HH:mm")}</>
-                  )}
-                </span>
-              </div>
-
-              {/* 링크 바로가기 */}
-              {initialData.url && (
-                <Button
-                  type="button"
-                  variant="outline"
-                  size="sm"
-                  className="w-full gap-1.5 rounded-lg text-[13px]"
-                  onClick={() => window.open(initialData.url!, "_blank", "noopener,noreferrer")}
-                >
-                  <ExternalLink className="size-3.5" />
-                  링크 바로가기
-                </Button>
+        <Form {...form}>
+          <form onSubmit={form.handleSubmit(onSubmit)} className="flex flex-col gap-4 overflow-y-auto px-5 py-4">
+            <FormField
+              control={form.control}
+              name="sch_nm"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>일정명 <span className="text-destructive">*</span></FormLabel>
+                  <FormControl>
+                    <Input placeholder="일정명을 입력해 주세요." {...field} />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
               )}
-            </div>
+            />
 
-            {/* 내용 */}
-            {initialData.cont_txt && (
-              <>
-                <Separator />
-                <div className="px-5 py-4">
-                  <p className="whitespace-pre-wrap text-[14px] leading-relaxed text-foreground">
-                    {initialData.cont_txt}
-                  </p>
-                </div>
-              </>
-            )}
-
-            {rootError && (
-              <p className="px-5 text-[12px] font-medium text-destructive">{rootError}</p>
-            )}
-
-            {/* 하단 액션 */}
-            {canEdit && (
-              <>
-                <Separator />
-                <div className="flex gap-2 px-5 py-3">
-                  <Button
-                    type="button"
-                    variant="outline"
-                    size="sm"
-                    className="flex-1 gap-1.5"
-                    onClick={startEditing}
-                    disabled={deleting}
-                  >
-                    <Pencil className="size-3.5" />
-                    수정
-                  </Button>
-                  <Button
-                    type="button"
-                    variant="outline"
-                    size="sm"
-                    className="flex-1 gap-1.5 border-destructive/30 text-destructive hover:bg-destructive/5 hover:text-destructive"
-                    onClick={handleDelete}
-                    disabled={deleting}
-                  >
-                    <Trash2 className="size-3.5" />
-                    {deleting ? "삭제 중..." : "삭제"}
-                  </Button>
-                </div>
-              </>
-            )}
-          </div>
-        )}
-
-        {/* 등록/수정 폼 */}
-        {(mode === "create" || mode === "edit") && (
-          <Form {...form}>
-            <form onSubmit={form.handleSubmit(onSubmit)} className="flex flex-col gap-4 overflow-y-auto px-5 py-4">
-              {/* 일정명 */}
+            <div className="grid grid-cols-2 gap-3">
               <FormField
                 control={form.control}
-                name="sch_nm"
+                name="evt_stt_at"
                 render={({ field }) => (
                   <FormItem>
-                    <FormLabel>일정명 <span className="text-destructive">*</span></FormLabel>
+                    <FormLabel>시작일시 <span className="text-destructive">*</span></FormLabel>
                     <FormControl>
-                      <Input placeholder="일정명을 입력해 주세요." {...field} />
+                      <Input type="datetime-local" className="text-[13px]" {...field} value={field.value ?? ""} />
                     </FormControl>
                     <FormMessage />
                   </FormItem>
                 )}
               />
-
-              {/* 시작일시 / 종료일시 */}
-              <div className="grid grid-cols-2 gap-3">
-                <FormField
-                  control={form.control}
-                  name="evt_stt_at"
-                  render={({ field }) => (
-                    <FormItem>
-                      <FormLabel>시작일시 <span className="text-destructive">*</span></FormLabel>
-                      <FormControl>
-                        <Input type="datetime-local" className="text-[13px]" {...field} value={field.value ?? ""} />
-                      </FormControl>
-                      <FormMessage />
-                    </FormItem>
-                  )}
-                />
-                <FormField
-                  control={form.control}
-                  name="evt_end_at"
-                  render={({ field }) => (
-                    <FormItem>
-                      <FormLabel>종료일시</FormLabel>
-                      <FormControl>
-                        <Input
-                          type="datetime-local"
-                          className="text-[13px]"
-                          {...field}
-                          value={field.value ?? ""}
-                          onChange={(e) => field.onChange(e.target.value || null)}
-                        />
-                      </FormControl>
-                      <FormMessage />
-                    </FormItem>
-                  )}
-                />
-              </div>
-
-              {/* 유형 / 링크 */}
-              <div className="grid grid-cols-2 gap-3">
-                <FormField
-                  control={form.control}
-                  name="post_type"
-                  render={({ field }) => (
-                    <FormItem>
-                      <FormLabel>유형</FormLabel>
-                      <FormControl>
-                        <Select value={field.value} onValueChange={field.onChange}>
-                          <SelectTrigger className="text-[13px]">
-                            <SelectValue />
-                          </SelectTrigger>
-                          <SelectContent>
-                            {SCH_POST_TYPES.map((type) => (
-                              <SelectItem key={type} value={type}>
-                                {schPostTypeLabels[type]}
-                              </SelectItem>
-                            ))}
-                          </SelectContent>
-                        </Select>
-                      </FormControl>
-                      <FormMessage />
-                    </FormItem>
-                  )}
-                />
-                <FormField
-                  control={form.control}
-                  name="url"
-                  render={({ field }) => (
-                    <FormItem>
-                      <FormLabel>링크</FormLabel>
-                      <FormControl>
-                        <Input
-                          type="url"
-                          placeholder="https://"
-                          className="text-[13px]"
-                          {...field}
-                          value={field.value ?? ""}
-                          onChange={(e) => field.onChange(e.target.value || null)}
-                        />
-                      </FormControl>
-                      <FormMessage />
-                    </FormItem>
-                  )}
-                />
-              </div>
-
-              {/* 내용 */}
               <FormField
                 control={form.control}
-                name="cont_txt"
+                name="evt_end_at"
                 render={({ field }) => (
                   <FormItem>
-                    <FormLabel>내용</FormLabel>
+                    <FormLabel>종료일시</FormLabel>
                     <FormControl>
-                      <textarea
-                        rows={4}
-                        placeholder="내용을 입력해 주세요."
-                        className="flex w-full resize-none rounded-md border border-input bg-transparent px-3 py-2 text-[13px] shadow-sm placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-50"
+                      <Input
+                        type="datetime-local"
+                        className="text-[13px]"
                         {...field}
                         value={field.value ?? ""}
                         onChange={(e) => field.onChange(e.target.value || null)}
@@ -409,35 +200,101 @@ export function SchPostFormDialog({
                   </FormItem>
                 )}
               />
+            </div>
 
-              {rootError && (
-                <p className="text-[12px] font-medium text-destructive">{rootError}</p>
+            <div className="grid grid-cols-2 gap-3">
+              <FormField
+                control={form.control}
+                name="post_type"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>유형</FormLabel>
+                    <FormControl>
+                      <Select value={field.value} onValueChange={field.onChange}>
+                        <SelectTrigger className="text-[13px]">
+                          <SelectValue />
+                        </SelectTrigger>
+                        <SelectContent>
+                          {SCH_POST_TYPES.map((type) => (
+                            <SelectItem key={type} value={type}>
+                              {schPostTypeLabels[type]}
+                            </SelectItem>
+                          ))}
+                        </SelectContent>
+                      </Select>
+                    </FormControl>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+              <FormField
+                control={form.control}
+                name="url"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>링크</FormLabel>
+                    <FormControl>
+                      <Input
+                        type="url"
+                        placeholder="https://"
+                        className="text-[13px]"
+                        {...field}
+                        value={field.value ?? ""}
+                        onChange={(e) => field.onChange(e.target.value || null)}
+                      />
+                    </FormControl>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+            </div>
+
+            <FormField
+              control={form.control}
+              name="cont_txt"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>내용</FormLabel>
+                  <FormControl>
+                    <textarea
+                      rows={4}
+                      placeholder="내용을 입력해 주세요."
+                      className="flex w-full resize-none rounded-md border border-input bg-transparent px-3 py-2 text-[13px] shadow-sm placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-50"
+                      {...field}
+                      value={field.value ?? ""}
+                      onChange={(e) => field.onChange(e.target.value || null)}
+                    />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
               )}
+            />
 
-              <div className="flex justify-end gap-2 pb-1">
-                <Button type="button" variant="outline" onClick={() => onOpenChange(false)} disabled={isSubmitting}>
-                  취소
-                </Button>
-                <Button type="submit" disabled={isSubmitting}>
-                  {isSubmitting
-                    ? (mode === "create" ? "등록 중..." : "저장 중...")
-                    : (mode === "create" ? "등록" : "저장")}
-                </Button>
-              </div>
-            </form>
-          </Form>
-        )}
+            {rootError && (
+              <p className="text-[12px] font-medium text-destructive">{rootError}</p>
+            )}
+
+            <div className="flex justify-end gap-2 pb-1">
+              <Button type="button" variant="outline" onClick={() => onOpenChange(false)} disabled={isSubmitting}>
+                취소
+              </Button>
+              <Button type="submit" disabled={isSubmitting}>
+                {isSubmitting
+                  ? (mode === "create" ? "등록 중..." : "저장 중...")
+                  : (mode === "create" ? "등록" : "저장")}
+              </Button>
+            </div>
+          </form>
+        </Form>
       </DialogContent>
     </Dialog>
   );
 }
 
-// ISO 문자열 → "YYYY-MM-DDTHH:mm" (datetime-local input 형식, KST 기준)
 function toDatetimeLocal(isoString: string): string {
   return dayjs(isoString).format("YYYY-MM-DDTHH:mm");
 }
 
-// 날짜만("YYYY-MM-DD") 또는 ISO 문자열 → datetime-local 형식
 function toDateInput(value: string): string {
   if (value.length === 10) return `${value}T00:00`;
   return toDatetimeLocal(value);

--- a/components/schedule/sch-post-form-dialog.tsx
+++ b/components/schedule/sch-post-form-dialog.tsx
@@ -6,12 +6,13 @@ import { zodResolver } from "@hookform/resolvers/zod";
 import { useForm } from "react-hook-form";
 import { z } from "zod";
 
+import { dayjs } from "@/lib/dayjs";
+import { createSchPostSchema, SCH_POST_TYPES, schPostTypeLabels, type SchPostType } from "@/lib/validations/schedule";
+
 import {
   createSchPost,
   updateSchPost,
 } from "@/app/actions/schedule/manage-sch-post";
-import { dayjs } from "@/lib/dayjs";
-import { createSchPostSchema, SCH_POST_TYPES, schPostTypeLabels, type SchPostType } from "@/lib/validations/schedule";
 
 import { Button } from "@/components/ui/button";
 import {
@@ -29,7 +30,6 @@ import {
   FormMessage,
 } from "@/components/ui/form";
 import { Input } from "@/components/ui/input";
-import { Separator } from "@/components/ui/separator";
 import {
   Select,
   SelectContent,
@@ -37,6 +37,7 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select";
+import { Separator } from "@/components/ui/separator";
 
 const formSchema = createSchPostSchema.omit({ team_id: true }).extend({
   post_type: z.enum(SCH_POST_TYPES),

--- a/components/ui/drawer.tsx
+++ b/components/ui/drawer.tsx
@@ -1,6 +1,7 @@
 "use client"
 
 import * as React from "react"
+
 import { Drawer as DrawerPrimitive } from "vaul"
 
 import { cn } from "@/lib/utils"

--- a/components/ui/drawer.tsx
+++ b/components/ui/drawer.tsx
@@ -1,0 +1,135 @@
+"use client"
+
+import * as React from "react"
+import { Drawer as DrawerPrimitive } from "vaul"
+
+import { cn } from "@/lib/utils"
+
+function Drawer({
+  ...props
+}: React.ComponentProps<typeof DrawerPrimitive.Root>) {
+  return <DrawerPrimitive.Root data-slot="drawer" {...props} />
+}
+
+function DrawerTrigger({
+  ...props
+}: React.ComponentProps<typeof DrawerPrimitive.Trigger>) {
+  return <DrawerPrimitive.Trigger data-slot="drawer-trigger" {...props} />
+}
+
+function DrawerPortal({
+  ...props
+}: React.ComponentProps<typeof DrawerPrimitive.Portal>) {
+  return <DrawerPrimitive.Portal data-slot="drawer-portal" {...props} />
+}
+
+function DrawerClose({
+  ...props
+}: React.ComponentProps<typeof DrawerPrimitive.Close>) {
+  return <DrawerPrimitive.Close data-slot="drawer-close" {...props} />
+}
+
+function DrawerOverlay({
+  className,
+  ...props
+}: React.ComponentProps<typeof DrawerPrimitive.Overlay>) {
+  return (
+    <DrawerPrimitive.Overlay
+      data-slot="drawer-overlay"
+      className={cn(
+        "fixed inset-0 z-50 bg-black/50 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:animate-in data-[state=open]:fade-in-0",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function DrawerContent({
+  className,
+  children,
+  ...props
+}: React.ComponentProps<typeof DrawerPrimitive.Content>) {
+  return (
+    <DrawerPortal data-slot="drawer-portal">
+      <DrawerOverlay />
+      <DrawerPrimitive.Content
+        data-slot="drawer-content"
+        className={cn(
+          "group/drawer-content fixed z-50 flex h-auto flex-col bg-background",
+          "data-[vaul-drawer-direction=top]:inset-x-0 data-[vaul-drawer-direction=top]:top-0 data-[vaul-drawer-direction=top]:mb-24 data-[vaul-drawer-direction=top]:max-h-[80vh] data-[vaul-drawer-direction=top]:rounded-b-lg data-[vaul-drawer-direction=top]:border-b",
+          "data-[vaul-drawer-direction=bottom]:inset-x-0 data-[vaul-drawer-direction=bottom]:bottom-0 data-[vaul-drawer-direction=bottom]:mt-24 data-[vaul-drawer-direction=bottom]:max-h-[80vh] data-[vaul-drawer-direction=bottom]:rounded-t-lg data-[vaul-drawer-direction=bottom]:border-t",
+          "data-[vaul-drawer-direction=right]:inset-y-0 data-[vaul-drawer-direction=right]:right-0 data-[vaul-drawer-direction=right]:w-3/4 data-[vaul-drawer-direction=right]:border-l data-[vaul-drawer-direction=right]:sm:max-w-sm",
+          "data-[vaul-drawer-direction=left]:inset-y-0 data-[vaul-drawer-direction=left]:left-0 data-[vaul-drawer-direction=left]:w-3/4 data-[vaul-drawer-direction=left]:border-r data-[vaul-drawer-direction=left]:sm:max-w-sm",
+          className
+        )}
+        {...props}
+      >
+        <div className="mx-auto mt-4 hidden h-2 w-[100px] shrink-0 rounded-full bg-muted group-data-[vaul-drawer-direction=bottom]/drawer-content:block" />
+        {children}
+      </DrawerPrimitive.Content>
+    </DrawerPortal>
+  )
+}
+
+function DrawerHeader({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="drawer-header"
+      className={cn(
+        "flex flex-col gap-0.5 p-4 group-data-[vaul-drawer-direction=bottom]/drawer-content:text-center group-data-[vaul-drawer-direction=top]/drawer-content:text-center md:gap-1.5 md:text-left",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function DrawerFooter({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="drawer-footer"
+      className={cn("mt-auto flex flex-col gap-2 p-4", className)}
+      {...props}
+    />
+  )
+}
+
+function DrawerTitle({
+  className,
+  ...props
+}: React.ComponentProps<typeof DrawerPrimitive.Title>) {
+  return (
+    <DrawerPrimitive.Title
+      data-slot="drawer-title"
+      className={cn("font-semibold text-foreground", className)}
+      {...props}
+    />
+  )
+}
+
+function DrawerDescription({
+  className,
+  ...props
+}: React.ComponentProps<typeof DrawerPrimitive.Description>) {
+  return (
+    <DrawerPrimitive.Description
+      data-slot="drawer-description"
+      className={cn("text-sm text-muted-foreground", className)}
+      {...props}
+    />
+  )
+}
+
+export {
+  Drawer,
+  DrawerPortal,
+  DrawerOverlay,
+  DrawerTrigger,
+  DrawerClose,
+  DrawerContent,
+  DrawerHeader,
+  DrawerFooter,
+  DrawerTitle,
+  DrawerDescription,
+}

--- a/components/ui/textarea.tsx
+++ b/components/ui/textarea.tsx
@@ -1,0 +1,20 @@
+import * as React from "react";
+
+import { cn } from "@/lib/utils";
+
+const Textarea = React.forwardRef<
+  HTMLTextAreaElement,
+  React.ComponentProps<"textarea">
+>(({ className, ...props }, ref) => (
+  <textarea
+    className={cn(
+      "flex min-h-[80px] w-full rounded-md border border-input bg-transparent px-3 py-2 text-base shadow-sm placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-50 md:text-sm",
+      className,
+    )}
+    ref={ref}
+    {...props}
+  />
+));
+Textarea.displayName = "Textarea";
+
+export { Textarea };

--- a/docs/superpowers/plans/2026-06-15-comment-system.md
+++ b/docs/superpowers/plans/2026-06-15-comment-system.md
@@ -1,0 +1,1089 @@
+# Comment System Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** 소식·대회에 댓글/답글/멘션 기능 추가. 범용 구조로 나중에 모임에도 재사용.
+
+**Architecture:** `cmnt_mst` 폴리모픽 테이블(entity_type + entity_id)이 소식·대회·모임 댓글을 공용 관리. `CommentSection` 클라이언트 컴포넌트가 Supabase Realtime 구독으로 실시간 반영. `MentionInput`은 독립 컴포넌트로 어디서든 재사용. 서버 액션이 CRUD + 멘션(`cmnt_mention_rel`) 저장 + `noti_mst` 알림 트리거 담당.
+
+**Tech Stack:** Next.js App Router, Supabase JS (Realtime + RLS), Zod, Tailwind CSS, shadcn/ui
+
+---
+
+## 파일 맵
+
+| 상태 | 파일 | 역할 |
+|------|------|------|
+| 신규 | `supabase/migrations/20260615120000_cmnt_noti_types.sql` | noti_type_enm CHECK 업데이트 |
+| 신규 | `lib/validations/comment.ts` | Zod 스키마 |
+| 신규 | `app/actions/comment/manage-comment.ts` | CRUD 서버 액션 + 알림 |
+| 신규 | `app/actions/comment/get-comment-data.ts` | 초기 데이터 조회 서버 액션 |
+| 신규 | `components/comment/mention-input.tsx` | @멘션 입력창 (재사용 가능) |
+| 신규 | `components/comment/comment-item.tsx` | 댓글 단일 아이템 |
+| 신규 | `components/comment/comment-section.tsx` | 댓글 목록 + 입력 + Realtime |
+| 신규 | `components/schedule/sch-post-detail-dialog.tsx` | 소식 상세 팝업 + 댓글 |
+| 수정 | `lib/supabase/database.types.ts` | 타입 재생성 (MCP) |
+| 수정 | `app/actions/admin/send-notification.ts` | NotiTypeEnm 타입 확장 |
+| 수정 | `app/(main)/page.tsx` | `sch_post` → `sch_post_mst` |
+| 수정 | `app/actions/schedule/manage-sch-post.ts` | `sch_post` → `sch_post_mst` |
+| 수정 | `components/home/mini-calendar.tsx` | `sch_post` → `sch_post_mst`, 클릭 → 상세 팝업 |
+| 수정 | `components/home/schedule-list-view.tsx` | `sch_post` → `sch_post_mst`, 클릭 → 상세 팝업 |
+| 수정 | `components/races/competition-detail-dialog.tsx` | 하단에 CommentSection 추가 |
+
+---
+
+## Task 1: noti_type 마이그레이션 + DB 타입 재생성 + sch_post_mst 코드 업데이트
+
+**Files:**
+- Create: `supabase/migrations/20260615120000_cmnt_noti_types.sql`
+- Modify: `lib/supabase/database.types.ts` (MCP 재생성)
+- Modify: `app/actions/admin/send-notification.ts`
+- Modify: `app/(main)/page.tsx`
+- Modify: `app/actions/schedule/manage-sch-post.ts`
+- Modify: `components/home/mini-calendar.tsx`
+- Modify: `components/home/schedule-list-view.tsx`
+
+- [ ] **Step 1: noti_type 마이그레이션 파일 작성**
+
+```sql
+-- supabase/migrations/20260615120000_cmnt_noti_types.sql
+ALTER TABLE noti_mst
+  DROP CONSTRAINT IF EXISTS noti_mst_noti_type_enm_check;
+
+ALTER TABLE noti_mst
+  ADD CONSTRAINT noti_mst_noti_type_enm_check
+  CHECK (noti_type_enm IN (
+    'ttl_grnt', 'adm_cust', 'dues_check_req', 'dues_notice',
+    'cmnt_reply', 'cmnt_mention'
+  ));
+```
+
+- [ ] **Step 2: dev DB에 마이그레이션 적용** (MCP `apply_migration` 사용)
+
+- [ ] **Step 3: database.types.ts 재생성** (MCP `generate_typescript_types` 사용 → 파일 덮어쓰기)
+
+- [ ] **Step 4: NotiTypeEnm 타입 확장**
+
+`app/actions/admin/send-notification.ts` 1번 줄:
+```typescript
+export type NotiTypeEnm = "adm_cust" | "dues_notice" | "cmnt_reply" | "cmnt_mention";
+```
+
+- [ ] **Step 5: sch_post → sch_post_mst 참조 5곳 일괄 수정**
+
+다음 파일들에서 `.from("sch_post")` → `.from("sch_post_mst")` 교체:
+- `app/(main)/page.tsx:188`
+- `app/actions/schedule/manage-sch-post.ts:24,62,76`
+- `components/home/mini-calendar.tsx:309`
+- `components/home/schedule-list-view.tsx:57`
+
+- [ ] **Step 6: 빌드 확인**
+
+```bash
+pnpm run build
+```
+Expected: 에러 없음
+
+- [ ] **Step 7: 커밋**
+
+```bash
+git add supabase/migrations/20260615120000_cmnt_noti_types.sql lib/supabase/database.types.ts app/actions/admin/send-notification.ts app/(main)/page.tsx app/actions/schedule/manage-sch-post.ts components/home/mini-calendar.tsx components/home/schedule-list-view.tsx
+git commit -m "chore: sch_post→sch_post_mst 리네임 코드 반영 + cmnt noti_type 추가"
+```
+
+---
+
+## Task 2: Zod 스키마
+
+**Files:**
+- Create: `lib/validations/comment.ts`
+
+- [ ] **Step 1: 스키마 파일 작성**
+
+```typescript
+// lib/validations/comment.ts
+import { z } from "zod"
+
+export const createCommentSchema = z.object({
+  entityType: z.enum(["sch_post", "comp", "gathering"]),
+  entityId: z.string().uuid(),
+  contTxt: z.string().min(1, "내용을 입력해주세요").max(1000, "1000자 이내로 입력해주세요"),
+  prntId: z.string().uuid().optional(),
+  mentionedMemIds: z.array(z.string().uuid()).default([]),
+})
+
+export const updateCommentSchema = z.object({
+  cmntId: z.string().uuid(),
+  contTxt: z.string().min(1).max(1000),
+  mentionedMemIds: z.array(z.string().uuid()).default([]),
+})
+
+export const deleteCommentSchema = z.object({
+  cmntId: z.string().uuid(),
+})
+
+export type CreateCommentInput = z.infer<typeof createCommentSchema>
+export type UpdateCommentInput = z.infer<typeof updateCommentSchema>
+export type DeleteCommentInput = z.infer<typeof deleteCommentSchema>
+```
+
+- [ ] **Step 2: 커밋**
+
+```bash
+git add lib/validations/comment.ts
+git commit -m "feat(comment): Zod 스키마 추가"
+```
+
+---
+
+## Task 3: 서버 액션 (CRUD + 알림 + 초기 데이터)
+
+**Files:**
+- Create: `app/actions/comment/manage-comment.ts`
+- Create: `app/actions/comment/get-comment-data.ts`
+
+- [ ] **Step 1: CRUD 서버 액션 작성**
+
+```typescript
+// app/actions/comment/manage-comment.ts
+"use server"
+
+import { revalidatePath } from "next/cache"
+import { getCurrentMember } from "@/lib/queries/member"
+import { getRequestTeamContext } from "@/lib/queries/request-team"
+import { createAdminClient } from "@/lib/supabase/admin"
+import {
+  createCommentSchema,
+  updateCommentSchema,
+  deleteCommentSchema,
+  type CreateCommentInput,
+  type UpdateCommentInput,
+  type DeleteCommentInput,
+} from "@/lib/validations/comment"
+
+export async function createComment(input: CreateCommentInput) {
+  const parsed = createCommentSchema.parse(input)
+  const { member, supabase } = await getCurrentMember()
+  if (!member) return { ok: false as const, message: "로그인 필요" }
+
+  const { teamId } = await getRequestTeamContext()
+  const admin = createAdminClient()
+
+  // 1단계 답글만 허용
+  if (parsed.prntId) {
+    const { data: parent } = await supabase
+      .from("cmnt_mst")
+      .select("prnt_id")
+      .eq("cmnt_id", parsed.prntId)
+      .single()
+    if (parent?.prnt_id) return { ok: false as const, message: "답글의 답글은 허용되지 않습니다." }
+  }
+
+  const { data: cmnt, error } = await supabase
+    .from("cmnt_mst")
+    .insert({
+      team_id: teamId,
+      entity_type: parsed.entityType,
+      entity_id: parsed.entityId,
+      prnt_id: parsed.prntId ?? null,
+      mem_id: member.id,
+      cont_txt: parsed.contTxt,
+    })
+    .select()
+    .single()
+
+  if (error || !cmnt) return { ok: false as const, message: "댓글 저장 실패" }
+
+  // 멘션 저장 + 알림
+  const uniqueMentions = [...new Set(parsed.mentionedMemIds)].filter((id) => id !== member.id)
+  if (uniqueMentions.length > 0) {
+    await admin
+      .from("cmnt_mention_rel")
+      .insert(uniqueMentions.map((memId) => ({ cmnt_id: cmnt.cmnt_id, mem_id: memId })))
+    await admin.from("noti_mst").insert(
+      uniqueMentions.map((memId) => ({
+        team_id: teamId,
+        mem_id: memId,
+        noti_type_enm: "cmnt_mention",
+        noti_nm: `${member.full_name}님이 댓글에서 멘션했습니다`,
+        noti_cont: parsed.contTxt.slice(0, 100),
+        ref_id: cmnt.cmnt_id,
+        ref_type_enm: "cmnt",
+      }))
+    )
+  }
+
+  // 답글 알림 — 원댓글 작성자 (본인 제외, 멘션 중복 제외)
+  if (parsed.prntId) {
+    const { data: parent } = await admin
+      .from("cmnt_mst")
+      .select("mem_id")
+      .eq("cmnt_id", parsed.prntId)
+      .single()
+    if (parent && parent.mem_id !== member.id && !uniqueMentions.includes(parent.mem_id)) {
+      await admin.from("noti_mst").insert({
+        team_id: teamId,
+        mem_id: parent.mem_id,
+        noti_type_enm: "cmnt_reply",
+        noti_nm: `${member.full_name}님이 댓글에 답글을 달았습니다`,
+        noti_cont: parsed.contTxt.slice(0, 100),
+        ref_id: cmnt.cmnt_id,
+        ref_type_enm: "cmnt",
+      })
+    }
+  }
+
+  revalidatePath("/")
+  return { ok: true as const, data: cmnt }
+}
+
+export async function updateComment(input: UpdateCommentInput) {
+  const parsed = updateCommentSchema.parse(input)
+  const { member, supabase } = await getCurrentMember()
+  if (!member) return { ok: false as const, message: "로그인 필요" }
+
+  const admin = createAdminClient()
+
+  // 답글 달린 댓글 수정 불가
+  const { count } = await supabase
+    .from("cmnt_mst")
+    .select("cmnt_id", { count: "exact", head: true })
+    .eq("prnt_id", parsed.cmntId)
+    .eq("del_yn", false)
+  if ((count ?? 0) > 0) return { ok: false as const, message: "답글이 달린 댓글은 수정할 수 없습니다." }
+
+  const { error } = await supabase
+    .from("cmnt_mst")
+    .update({ cont_txt: parsed.contTxt, edit_yn: true, upd_at: new Date().toISOString() })
+    .eq("cmnt_id", parsed.cmntId)
+    .eq("mem_id", member.id)
+    .eq("del_yn", false)
+
+  if (error) return { ok: false as const, message: "댓글 수정 실패" }
+
+  // 멘션 갱신
+  await admin.from("cmnt_mention_rel").delete().eq("cmnt_id", parsed.cmntId)
+  const uniqueMentions = [...new Set(parsed.mentionedMemIds)].filter((id) => id !== member.id)
+  if (uniqueMentions.length > 0) {
+    await admin
+      .from("cmnt_mention_rel")
+      .insert(uniqueMentions.map((memId) => ({ cmnt_id: parsed.cmntId, mem_id: memId })))
+  }
+
+  revalidatePath("/")
+  return { ok: true as const }
+}
+
+export async function deleteComment(input: DeleteCommentInput) {
+  const parsed = deleteCommentSchema.parse(input)
+  const { member, supabase } = await getCurrentMember()
+  if (!member) return { ok: false as const, message: "로그인 필요" }
+
+  const admin = createAdminClient()
+
+  if (!member.admin) {
+    // 일반 멤버: 답글 달린 댓글 삭제 불가
+    const { count } = await supabase
+      .from("cmnt_mst")
+      .select("cmnt_id", { count: "exact", head: true })
+      .eq("prnt_id", parsed.cmntId)
+      .eq("del_yn", false)
+    if ((count ?? 0) > 0) return { ok: false as const, message: "답글이 달린 댓글은 삭제할 수 없습니다." }
+  }
+
+  // 관리자는 admin client(RLS bypass), 일반 멤버는 supabase(RLS — 본인 댓글만 허용)
+  const db = member.admin ? admin : supabase
+  const { error } = await db
+    .from("cmnt_mst")
+    .update({ del_yn: true, upd_at: new Date().toISOString() })
+    .eq("cmnt_id", parsed.cmntId)
+
+  if (error) return { ok: false as const, message: "댓글 삭제 실패" }
+
+  revalidatePath("/")
+  return { ok: true as const }
+}
+```
+
+- [ ] **Step 2: 초기 데이터 조회 서버 액션 작성**
+
+```typescript
+// app/actions/comment/get-comment-data.ts
+"use server"
+
+import { getCurrentMember } from "@/lib/queries/member"
+import { getRequestTeamContext } from "@/lib/queries/request-team"
+import { createAdminClient } from "@/lib/supabase/admin"
+import type { CmntRow } from "@/components/comment/comment-item"
+
+export async function getCommentData(entityType: string, entityId: string) {
+  const { member } = await getCurrentMember()
+  if (!member) return { comments: [], members: [] }
+
+  const { teamId } = await getRequestTeamContext()
+  const admin = createAdminClient()
+
+  const [{ data: cmntRows }, { data: memRows }] = await Promise.all([
+    admin
+      .from("cmnt_mst")
+      .select("cmnt_id, prnt_id, mem_id, cont_txt, edit_yn, del_yn, crt_at, upd_at, mem_mst!inner(mem_nm, avatar_url)")
+      .eq("entity_type", entityType)
+      .eq("entity_id", entityId)
+      .eq("team_id", teamId)
+      .order("crt_at", { ascending: true }),
+    admin
+      .from("team_mem_rel")
+      .select("mem_id, mem_mst!inner(mem_nm)")
+      .eq("team_id", teamId)
+      .eq("mem_st_cd", "active")
+      .eq("del_yn", false),
+  ])
+
+  const comments: CmntRow[] = (cmntRows ?? []).map((row) => {
+    const mem = Array.isArray(row.mem_mst) ? row.mem_mst[0] : row.mem_mst
+    return {
+      cmnt_id: row.cmnt_id,
+      prnt_id: row.prnt_id,
+      mem_id: row.mem_id,
+      mem_nm: (mem as { mem_nm: string }).mem_nm,
+      avatar_url: (mem as { avatar_url?: string | null }).avatar_url ?? null,
+      cont_txt: row.cont_txt,
+      edit_yn: row.edit_yn,
+      del_yn: row.del_yn,
+      crt_at: row.crt_at,
+      upd_at: row.upd_at,
+    }
+  })
+
+  const members = (memRows ?? []).map((row) => {
+    const mem = Array.isArray(row.mem_mst) ? row.mem_mst[0] : row.mem_mst
+    return { mem_id: row.mem_id, mem_nm: (mem as { mem_nm: string }).mem_nm }
+  })
+
+  return { comments, members }
+}
+```
+
+- [ ] **Step 3: 커밋**
+
+```bash
+git add app/actions/comment/
+git commit -m "feat(comment): CRUD 서버 액션 + 초기 데이터 조회 추가"
+```
+
+---
+
+## Task 4: MentionInput 컴포넌트
+
+**Files:**
+- Create: `components/comment/mention-input.tsx`
+
+- [ ] **Step 1: 컴포넌트 작성**
+
+```typescript
+// components/comment/mention-input.tsx
+"use client"
+
+import { useCallback, useRef, useState } from "react"
+import { Textarea } from "@/components/ui/textarea"
+
+export type MemberOption = { mem_id: string; mem_nm: string }
+
+interface MentionInputProps {
+  value: string
+  onChange: (value: string) => void
+  onMentionsChange: (memIds: string[]) => void
+  members: MemberOption[]
+  placeholder?: string
+  rows?: number
+  className?: string
+}
+
+function parseMentionQuery(text: string, cursorPos: number): { query: string; start: number } | null {
+  const before = text.slice(0, cursorPos)
+  const match = before.match(/@([가-힣a-zA-Z0-9_]*)$/)
+  if (!match) return null
+  return { query: match[1], start: cursorPos - match[0].length }
+}
+
+// @이름 텍스트를 파란색으로 강조 — 공용 유틸
+export function renderMentions(text: string) {
+  const parts = text.split(/(@[가-힣a-zA-Z0-9_]+)/)
+  return parts.map((part, i) =>
+    part.startsWith("@") ? (
+      <span key={i} className="text-primary font-medium">{part}</span>
+    ) : (
+      <span key={i}>{part}</span>
+    )
+  )
+}
+
+export function MentionInput({
+  value,
+  onChange,
+  onMentionsChange,
+  members,
+  placeholder,
+  rows = 3,
+  className,
+}: MentionInputProps) {
+  const textareaRef = useRef<HTMLTextAreaElement>(null)
+  const mentionedIds = useRef<Set<string>>(new Set())
+  const [mentionState, setMentionState] = useState<{
+    query: string
+    start: number
+    filtered: MemberOption[]
+  } | null>(null)
+
+  const handleChange = useCallback(
+    (e: React.ChangeEvent<HTMLTextAreaElement>) => {
+      const text = e.target.value
+      const cursor = e.target.selectionStart ?? text.length
+      onChange(text)
+
+      const parsed = parseMentionQuery(text, cursor)
+      if (parsed) {
+        const filtered = members.filter((m) =>
+          m.mem_nm.toLowerCase().includes(parsed.query.toLowerCase())
+        )
+        setMentionState(filtered.length > 0 ? { ...parsed, filtered } : null)
+      } else {
+        setMentionState(null)
+      }
+    },
+    [members, onChange]
+  )
+
+  const selectMember = useCallback(
+    (member: MemberOption) => {
+      if (!mentionState) return
+      const cursor = textareaRef.current?.selectionStart ?? value.length
+      const before = value.slice(0, mentionState.start)
+      const after = value.slice(cursor)
+      const newText = `${before}@${member.mem_nm} ${after}`
+      onChange(newText)
+      mentionedIds.current.add(member.mem_id)
+      onMentionsChange([...mentionedIds.current])
+      setMentionState(null)
+      // 커서 위치 복귀
+      setTimeout(() => {
+        const pos = before.length + member.mem_nm.length + 2
+        textareaRef.current?.focus()
+        textareaRef.current?.setSelectionRange(pos, pos)
+      }, 0)
+    },
+    [mentionState, value, onChange, onMentionsChange]
+  )
+
+  const handleKeyDown = useCallback(
+    (e: React.KeyboardEvent) => {
+      if (e.key === "Escape" && mentionState) {
+        setMentionState(null)
+        e.preventDefault()
+      }
+    },
+    [mentionState]
+  )
+
+  return (
+    <div className="relative">
+      <Textarea
+        ref={textareaRef}
+        value={value}
+        onChange={handleChange}
+        onKeyDown={handleKeyDown}
+        placeholder={placeholder}
+        rows={rows}
+        className={`resize-none ${className ?? ""}`}
+      />
+      {mentionState && (
+        <div className="absolute bottom-full left-0 z-50 mb-1 w-48 overflow-hidden rounded-lg border border-border bg-background shadow-md">
+          {mentionState.filtered.slice(0, 5).map((m) => (
+            <button
+              key={m.mem_id}
+              type="button"
+              className="w-full px-3 py-2 text-left text-sm hover:bg-muted"
+              onMouseDown={(e) => {
+                e.preventDefault()
+                selectMember(m)
+              }}
+            >
+              @{m.mem_nm}
+            </button>
+          ))}
+        </div>
+      )}
+    </div>
+  )
+}
+```
+
+- [ ] **Step 2: 커밋**
+
+```bash
+git add components/comment/mention-input.tsx
+git commit -m "feat(comment): MentionInput 컴포넌트 추가 (@멘션 자동완성)"
+```
+
+---
+
+## Task 5: CommentItem 컴포넌트
+
+**Files:**
+- Create: `components/comment/comment-item.tsx`
+
+- [ ] **Step 1: 컴포넌트 작성**
+
+```typescript
+// components/comment/comment-item.tsx
+"use client"
+
+import { useState } from "react"
+import { dayjs } from "@/lib/dayjs"
+import { Avatar } from "@/components/common/avatar"
+import { Body, Caption } from "@/components/common/typography"
+import { Button } from "@/components/ui/button"
+import { MentionInput, renderMentions, type MemberOption } from "./mention-input"
+import { updateComment, deleteComment } from "@/app/actions/comment/manage-comment"
+
+export type CmntRow = {
+  cmnt_id: string
+  prnt_id: string | null
+  mem_id: string
+  mem_nm: string
+  avatar_url?: string | null
+  cont_txt: string
+  edit_yn: boolean
+  del_yn: boolean
+  crt_at: string
+  upd_at: string
+  has_replies?: boolean
+}
+
+interface CommentItemProps {
+  comment: CmntRow
+  currentMemberId?: string
+  isAdmin?: boolean
+  members: MemberOption[]
+  onReply?: (cmnt: CmntRow) => void
+  isReply?: boolean
+}
+
+export function CommentItem({
+  comment,
+  currentMemberId,
+  isAdmin,
+  members,
+  onReply,
+  isReply,
+}: CommentItemProps) {
+  const [editing, setEditing] = useState(false)
+  const [editText, setEditText] = useState(comment.cont_txt)
+  const [editMentions, setEditMentions] = useState<string[]>([])
+  const [loading, setLoading] = useState(false)
+
+  const isMine = comment.mem_id === currentMemberId
+  const canEdit = isMine && !comment.del_yn && !comment.has_replies
+  const canDelete = (isMine || isAdmin) && !comment.del_yn && !comment.has_replies
+
+  if (comment.del_yn) {
+    return (
+      <div className={`py-2 ${isReply ? "pl-10" : ""}`}>
+        <Caption className="italic opacity-50">삭제된 댓글입니다.</Caption>
+      </div>
+    )
+  }
+
+  const handleUpdate = async () => {
+    if (!editText.trim()) return
+    setLoading(true)
+    await updateComment({ cmntId: comment.cmnt_id, contTxt: editText.trim(), mentionedMemIds: editMentions })
+    setLoading(false)
+    setEditing(false)
+  }
+
+  const handleDelete = async () => {
+    if (!confirm("댓글을 삭제할까요?")) return
+    setLoading(true)
+    await deleteComment({ cmntId: comment.cmnt_id })
+    setLoading(false)
+  }
+
+  return (
+    <div className={`flex gap-2.5 py-2.5 ${isReply ? "pl-10" : ""}`}>
+      <Avatar src={comment.avatar_url} size="sm" />
+      <div className="flex-1 min-w-0">
+        <div className="flex flex-wrap items-baseline gap-x-2 gap-y-0.5">
+          <Body className="text-sm font-semibold">{comment.mem_nm}</Body>
+          <Caption className="text-xs">{dayjs(comment.crt_at).fromNow()}</Caption>
+          {comment.edit_yn && <Caption className="text-xs opacity-60">(수정됨)</Caption>}
+        </div>
+
+        {editing ? (
+          <div className="mt-1.5 flex flex-col gap-2">
+            <MentionInput
+              value={editText}
+              onChange={setEditText}
+              onMentionsChange={setEditMentions}
+              members={members}
+              rows={2}
+            />
+            <div className="flex gap-2">
+              <Button size="sm" onClick={handleUpdate} disabled={loading || !editText.trim()}>
+                저장
+              </Button>
+              <Button size="sm" variant="ghost" onClick={() => { setEditing(false); setEditText(comment.cont_txt) }}>
+                취소
+              </Button>
+            </div>
+          </div>
+        ) : (
+          <p className="mt-0.5 text-sm leading-relaxed break-words">
+            {renderMentions(comment.cont_txt)}
+          </p>
+        )}
+
+        <div className="mt-1 flex gap-3">
+          {!isReply && onReply && (
+            <button
+              className="text-xs text-muted-foreground hover:text-foreground transition-colors"
+              onClick={() => onReply(comment)}
+            >
+              답글
+            </button>
+          )}
+          {canEdit && !editing && (
+            <button
+              className="text-xs text-muted-foreground hover:text-foreground transition-colors"
+              onClick={() => setEditing(true)}
+            >
+              수정
+            </button>
+          )}
+          {canDelete && !editing && (
+            <button
+              className="text-xs text-muted-foreground hover:text-destructive transition-colors"
+              onClick={handleDelete}
+              disabled={loading}
+            >
+              삭제
+            </button>
+          )}
+        </div>
+      </div>
+    </div>
+  )
+}
+```
+
+- [ ] **Step 2: 커밋**
+
+```bash
+git add components/comment/comment-item.tsx
+git commit -m "feat(comment): CommentItem 컴포넌트 추가 (수정/삭제/수정됨)"
+```
+
+---
+
+## Task 6: CommentSection 컴포넌트 (Realtime)
+
+**Files:**
+- Create: `components/comment/comment-section.tsx`
+
+- [ ] **Step 1: 컴포넌트 작성**
+
+```typescript
+// components/comment/comment-section.tsx
+"use client"
+
+import { useEffect, useState } from "react"
+import { createClient } from "@/lib/supabase/client"
+import { SectionLabel } from "@/components/common/typography"
+import { Button } from "@/components/ui/button"
+import { CommentItem, type CmntRow } from "./comment-item"
+import { MentionInput, type MemberOption } from "./mention-input"
+import { createComment } from "@/app/actions/comment/manage-comment"
+
+interface CommentSectionProps {
+  entityType: "sch_post" | "comp" | "gathering"
+  entityId: string
+  currentMemberId?: string
+  isAdmin?: boolean
+  members: MemberOption[]
+  initialComments: CmntRow[]
+}
+
+type CommentWithReplies = CmntRow & { replies: CmntRow[] }
+
+function buildTree(flat: CmntRow[]): CommentWithReplies[] {
+  const replyParentIds = new Set(
+    flat.filter((c) => c.prnt_id && !c.del_yn).map((c) => c.prnt_id as string)
+  )
+  return flat
+    .filter((c) => !c.prnt_id)
+    .map((c) => ({
+      ...c,
+      has_replies: replyParentIds.has(c.cmnt_id),
+      replies: flat
+        .filter((r) => r.prnt_id === c.cmnt_id)
+        .map((r) => ({ ...r, replies: [] })),
+    }))
+}
+
+export function CommentSection({
+  entityType,
+  entityId,
+  currentMemberId,
+  isAdmin,
+  members,
+  initialComments,
+}: CommentSectionProps) {
+  const [comments, setComments] = useState<CmntRow[]>(initialComments)
+  const [newText, setNewText] = useState("")
+  const [newMentions, setNewMentions] = useState<string[]>([])
+  const [replyTo, setReplyTo] = useState<CmntRow | null>(null)
+  const [loading, setLoading] = useState(false)
+  const supabase = createClient()
+
+  useEffect(() => {
+    const channel = supabase
+      .channel(`cmnt:${entityType}:${entityId}`)
+      .on(
+        "postgres_changes",
+        {
+          event: "*",
+          schema: "public",
+          table: "cmnt_mst",
+          filter: `entity_id=eq.${entityId}`,
+        },
+        (payload) => {
+          if (payload.eventType === "INSERT") {
+            // mem_nm은 Realtime payload에 없으므로 members 목록에서 조회
+            const mem = members.find((m) => m.mem_id === (payload.new as CmntRow).mem_id)
+            setComments((prev) => [
+              ...prev,
+              { ...(payload.new as CmntRow), mem_nm: mem?.mem_nm ?? "멤버" },
+            ])
+          } else if (payload.eventType === "UPDATE") {
+            setComments((prev) =>
+              prev.map((c) =>
+                c.cmnt_id === (payload.new as CmntRow).cmnt_id
+                  ? { ...c, ...(payload.new as CmntRow) }
+                  : c
+              )
+            )
+          }
+        }
+      )
+      .subscribe()
+
+    return () => { supabase.removeChannel(channel) }
+  }, [entityType, entityId, supabase, members])
+
+  const handleSubmit = async () => {
+    if (!newText.trim()) return
+    setLoading(true)
+    await createComment({
+      entityType,
+      entityId,
+      contTxt: newText.trim(),
+      prntId: replyTo?.cmnt_id,
+      mentionedMemIds: newMentions,
+    })
+    setNewText("")
+    setNewMentions([])
+    setReplyTo(null)
+    setLoading(false)
+  }
+
+  const tree = buildTree(comments)
+
+  return (
+    <div className="flex flex-col gap-3">
+      <SectionLabel>COMMENTS {comments.filter((c) => !c.del_yn).length > 0 && `· ${comments.filter((c) => !c.del_yn).length}`}</SectionLabel>
+
+      {tree.length === 0 ? (
+        <p className="text-sm text-muted-foreground py-2">아직 댓글이 없습니다.</p>
+      ) : (
+        <div className="flex flex-col divide-y divide-border">
+          {tree.map((cmnt) => (
+            <div key={cmnt.cmnt_id}>
+              <CommentItem
+                comment={cmnt}
+                currentMemberId={currentMemberId}
+                isAdmin={isAdmin}
+                members={members}
+                onReply={currentMemberId ? setReplyTo : undefined}
+              />
+              {cmnt.replies.map((reply) => (
+                <CommentItem
+                  key={reply.cmnt_id}
+                  comment={reply}
+                  currentMemberId={currentMemberId}
+                  isAdmin={isAdmin}
+                  members={members}
+                  isReply
+                />
+              ))}
+            </div>
+          ))}
+        </div>
+      )}
+
+      {currentMemberId && (
+        <div className="flex flex-col gap-2 pt-1">
+          {replyTo && (
+            <div className="flex items-center gap-2 text-xs text-muted-foreground">
+              <span>↩ @{replyTo.mem_nm}에게 답글</span>
+              <button onClick={() => setReplyTo(null)} className="hover:text-foreground">✕</button>
+            </div>
+          )}
+          <MentionInput
+            value={newText}
+            onChange={setNewText}
+            onMentionsChange={setNewMentions}
+            members={members}
+            placeholder={replyTo ? "답글을 입력하세요..." : "댓글을 입력하세요..."}
+            rows={2}
+          />
+          <Button
+            size="sm"
+            onClick={handleSubmit}
+            disabled={loading || !newText.trim()}
+            className="self-end"
+          >
+            {replyTo ? "답글 달기" : "댓글 달기"}
+          </Button>
+        </div>
+      )}
+    </div>
+  )
+}
+```
+
+- [ ] **Step 2: 커밋**
+
+```bash
+git add components/comment/comment-section.tsx
+git commit -m "feat(comment): CommentSection 컴포넌트 추가 (Realtime 구독)"
+```
+
+---
+
+## Task 7: 소식 상세 팝업 + CommentSection 연결
+
+**Files:**
+- Create: `components/schedule/sch-post-detail-dialog.tsx`
+- Modify: `components/home/schedule-list-view.tsx` (클릭 핸들러 연결)
+- Modify: `components/home/mini-calendar.tsx` (클릭 핸들러 연결)
+
+- [ ] **Step 1: 소식 상세 팝업 작성**
+
+```typescript
+// components/schedule/sch-post-detail-dialog.tsx
+"use client"
+
+import { useEffect, useState } from "react"
+import { dayjs } from "@/lib/dayjs"
+import { ExternalLink } from "lucide-react"
+import { Dialog, DialogContent, DialogHeader, DialogTitle } from "@/components/ui/dialog"
+import { CommentSection } from "@/components/comment/comment-section"
+import { getCommentData } from "@/app/actions/comment/get-comment-data"
+import type { CmntRow } from "@/components/comment/comment-item"
+import type { MemberOption } from "@/components/comment/mention-input"
+import type { CalendarRace } from "@/components/home/mini-calendar"
+
+interface SchPostDetailDialogProps {
+  post: CalendarRace | null
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  currentMemberId?: string
+  isAdmin?: boolean
+}
+
+export function SchPostDetailDialog({
+  post,
+  open,
+  onOpenChange,
+  currentMemberId,
+  isAdmin,
+}: SchPostDetailDialogProps) {
+  const [comments, setComments] = useState<CmntRow[]>([])
+  const [members, setMembers] = useState<MemberOption[]>([])
+  const [loading, setLoading] = useState(false)
+
+  useEffect(() => {
+    if (!open || !post) return
+    setLoading(true)
+    getCommentData("sch_post", post.id).then(({ comments, members }) => {
+      setComments(comments)
+      setMembers(members)
+      setLoading(false)
+    })
+  }, [open, post])
+
+  if (!post) return null
+
+  const startAt = post.evt_stt_at ? dayjs(post.evt_stt_at) : dayjs(post.start_date)
+  const endAt = post.evt_end_at ? dayjs(post.evt_end_at) : null
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="max-w-md max-h-[85vh] overflow-y-auto">
+        <DialogHeader>
+          <DialogTitle className="text-left">{post.title}</DialogTitle>
+        </DialogHeader>
+
+        <div className="flex flex-col gap-4">
+          {/* 일시 */}
+          <p className="text-sm text-muted-foreground">
+            {startAt.format("YYYY년 M월 D일 (ddd) HH:mm")}
+            {endAt && ` ~ ${endAt.format("HH:mm")}`}
+          </p>
+
+          {/* URL */}
+          {post.url && (
+            <a
+              href={post.url}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="flex items-center gap-1 text-sm text-primary underline-offset-4 hover:underline"
+            >
+              <ExternalLink className="size-3.5" />
+              {post.url}
+            </a>
+          )}
+
+          {/* 본문 */}
+          {post.cont_txt && (
+            <p className="text-sm leading-relaxed whitespace-pre-wrap">{post.cont_txt}</p>
+          )}
+
+          <div className="border-t border-border pt-4">
+            {loading ? (
+              <p className="text-sm text-muted-foreground">댓글 불러오는 중...</p>
+            ) : (
+              <CommentSection
+                entityType="sch_post"
+                entityId={post.id}
+                currentMemberId={currentMemberId}
+                isAdmin={isAdmin}
+                members={members}
+                initialComments={comments}
+              />
+            )}
+          </div>
+        </div>
+      </DialogContent>
+    </Dialog>
+  )
+}
+```
+
+- [ ] **Step 2: `MiniCalendar`에 `SchPostDetailDialog` 연결**
+
+`components/home/mini-calendar.tsx`에서 소식 클릭 시 `openEditForm` (작성자/관리자) 또는 `SchPostDetailDialog` (일반 멤버) 열도록 수정. 현재 클릭 핸들러 로직 확인 후 분기 추가:
+
+```typescript
+// mini-calendar.tsx 내부 — 소식(schedule) 클릭 핸들러
+const [detailPost, setDetailPost] = useState<CalendarRace | null>(null)
+const [detailOpen, setDetailOpen] = useState(false)
+
+function handleScheduleClick(race: CalendarRace) {
+  const isAuthorOrAdmin = race.crt_by === memberId || isAdmin
+  if (isAuthorOrAdmin) {
+    openEditForm(race)  // 기존 수정 폼
+  } else {
+    setDetailPost(race)
+    setDetailOpen(true)
+  }
+}
+// JSX에 추가:
+// <SchPostDetailDialog post={detailPost} open={detailOpen} onOpenChange={setDetailOpen} currentMemberId={memberId} isAdmin={isAdmin} />
+```
+
+> `MiniCalendar`의 실제 클릭 핸들러명과 prop명은 파일 읽어서 확인 후 적용.
+
+- [ ] **Step 3: `ScheduleListView`에 동일 분기 적용**
+
+`components/home/schedule-list-view.tsx`의 소식 아이템 클릭 핸들러에 동일 로직 추가.
+
+- [ ] **Step 4: 커밋**
+
+```bash
+git add components/schedule/sch-post-detail-dialog.tsx components/home/mini-calendar.tsx components/home/schedule-list-view.tsx
+git commit -m "feat(comment): 소식 상세 팝업 + CommentSection 연결"
+```
+
+---
+
+## Task 8: 대회 상세 다이얼로그에 CommentSection 추가
+
+**Files:**
+- Modify: `components/races/competition-detail-dialog.tsx`
+
+- [ ] **Step 1: 파일 읽어서 구조 파악**
+
+`components/races/competition-detail-dialog.tsx` 전체 확인 — props, 상태, JSX 구조 파악.
+
+- [ ] **Step 2: CommentSection 추가**
+
+다이얼로그 내부에서 `open` 상태 변경 시 댓글 데이터 로드:
+
+```typescript
+// competition-detail-dialog.tsx 상단에 추가
+import { useEffect, useState } from "react"
+import { CommentSection } from "@/components/comment/comment-section"
+import { getCommentData } from "@/app/actions/comment/get-comment-data"
+import type { CmntRow } from "@/components/comment/comment-item"
+import type { MemberOption } from "@/components/comment/mention-input"
+
+// 컴포넌트 내부 상태 추가
+const [cmntData, setCmntData] = useState<{ comments: CmntRow[]; members: MemberOption[] }>({ comments: [], members: [] })
+
+useEffect(() => {
+  if (!open || !competition) return
+  getCommentData("comp", competition.id).then(setCmntData)
+}, [open, competition])
+
+// JSX 내부 다이얼로그 콘텐츠 하단에 추가 (기존 내용 아래)
+<div className="border-t border-border pt-4 mt-4">
+  <CommentSection
+    entityType="comp"
+    entityId={competition.id}
+    currentMemberId={currentMemberId}
+    isAdmin={isAdmin}
+    members={cmntData.members}
+    initialComments={cmntData.comments}
+  />
+</div>
+```
+
+> 실제 파일의 prop명(`competition.id`, `currentMemberId`, `isAdmin`)은 Step 1에서 확인한 실제 이름으로 교체.
+
+- [ ] **Step 3: 빌드 + 린트 확인**
+
+```bash
+pnpm run build
+```
+Expected: 에러 없음
+
+- [ ] **Step 4: 커밋**
+
+```bash
+git add components/races/competition-detail-dialog.tsx
+git commit -m "feat(comment): 대회 상세 다이얼로그에 CommentSection 추가"
+```
+
+---
+
+## 완료 후 체크리스트
+
+- [ ] 소식 클릭 → 댓글 보임, 달 수 있음
+- [ ] 대회 상세 → 댓글 보임, 달 수 있음
+- [ ] `@이름` 타이핑 시 멤버 드롭다운 표시
+- [ ] 멘션 선택 후 알림 발송 확인
+- [ ] 답글 달기 → 원댓글 작성자에게 알림
+- [ ] 답글 달린 댓글 수정/삭제 버튼 비활성
+- [ ] 삭제된 댓글 → "삭제된 댓글입니다" 표시
+- [ ] 다른 탭에서 댓글 작성 시 Realtime으로 즉시 반영

--- a/docs/superpowers/plans/2026-06-15-comment-system.md
+++ b/docs/superpowers/plans/2026-06-15-comment-system.md
@@ -205,7 +205,7 @@ export async function createComment(input: CreateCommentInput) {
         team_id: teamId,
         mem_id: memId,
         noti_type_enm: "cmnt_mention",
-        noti_nm: `${member.full_name}님이 댓글에서 멘션했습니다`,
+        noti_nm: `${member.full_name}님이 댓글에서 멘션했습니다.`,
         noti_cont: parsed.contTxt.slice(0, 100),
         ref_id: cmnt.cmnt_id,
         ref_type_enm: "cmnt",

--- a/lib/dayjs.ts
+++ b/lib/dayjs.ts
@@ -1,10 +1,10 @@
 // lib/dayjs.ts — KST 기준 날짜 유틸리티 (dayjs 기반)
 
 import dayjs from "dayjs";
-import utc from "dayjs/plugin/utc";
-import timezone from "dayjs/plugin/timezone";
 import duration from "dayjs/plugin/duration";
 import relativeTime from "dayjs/plugin/relativeTime";
+import timezone from "dayjs/plugin/timezone";
+import utc from "dayjs/plugin/utc";
 import "dayjs/locale/ko";
 
 dayjs.extend(utc);

--- a/lib/dayjs.ts
+++ b/lib/dayjs.ts
@@ -4,11 +4,13 @@ import dayjs from "dayjs";
 import utc from "dayjs/plugin/utc";
 import timezone from "dayjs/plugin/timezone";
 import duration from "dayjs/plugin/duration";
+import relativeTime from "dayjs/plugin/relativeTime";
 import "dayjs/locale/ko";
 
 dayjs.extend(utc);
 dayjs.extend(timezone);
 dayjs.extend(duration);
+dayjs.extend(relativeTime);
 dayjs.locale("ko");
 
 const KST = "Asia/Seoul";

--- a/lib/env.ts
+++ b/lib/env.ts
@@ -6,7 +6,7 @@ export const env = createEnv({
     SUPABASE_SERVICE_ROLE_KEY: z.string().min(1),
     REVALIDATE_SECRET: z.string().min(1),
     KAKAO_CHAT_PASSWORD: z.string().optional(),
-    GEMINI_API_KEY: z.string().min(1),
+    GEMINI_API_KEY: z.string().min(1).optional(),
     NODE_ENV: z.enum(["development", "production", "test"]),
   },
   client: {

--- a/lib/queries/notification.ts
+++ b/lib/queries/notification.ts
@@ -55,7 +55,8 @@ export async function getNotifications(
     query = query.lt("crt_at", cursor);
   }
 
-  const { data } = await query;
+  const { data, error } = await query;
+  if (error) throw error;
   return (data ?? []) as Notification[];
 }
 

--- a/lib/supabase/database.types.ts
+++ b/lib/supabase/database.types.ts
@@ -283,6 +283,100 @@ export type Database = {
           },
         ]
       }
+      cmnt_mention_rel: {
+        Row: {
+          cmnt_id: string
+          mem_id: string
+        }
+        Insert: {
+          cmnt_id: string
+          mem_id: string
+        }
+        Update: {
+          cmnt_id?: string
+          mem_id?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "cmnt_mention_rel_cmnt_id_fkey"
+            columns: ["cmnt_id"]
+            isOneToOne: false
+            referencedRelation: "cmnt_mst"
+            referencedColumns: ["cmnt_id"]
+          },
+          {
+            foreignKeyName: "cmnt_mention_rel_mem_id_fkey"
+            columns: ["mem_id"]
+            isOneToOne: false
+            referencedRelation: "mem_mst"
+            referencedColumns: ["mem_id"]
+          },
+        ]
+      }
+      cmnt_mst: {
+        Row: {
+          cmnt_id: string
+          cont_txt: string
+          crt_at: string
+          del_yn: boolean
+          edit_yn: boolean
+          entity_id: string
+          entity_type: string
+          mem_id: string
+          prnt_id: string | null
+          team_id: string
+          upd_at: string
+        }
+        Insert: {
+          cmnt_id?: string
+          cont_txt: string
+          crt_at?: string
+          del_yn?: boolean
+          edit_yn?: boolean
+          entity_id: string
+          entity_type: string
+          mem_id: string
+          prnt_id?: string | null
+          team_id: string
+          upd_at?: string
+        }
+        Update: {
+          cmnt_id?: string
+          cont_txt?: string
+          crt_at?: string
+          del_yn?: boolean
+          edit_yn?: boolean
+          entity_id?: string
+          entity_type?: string
+          mem_id?: string
+          prnt_id?: string | null
+          team_id?: string
+          upd_at?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "cmnt_mst_mem_id_fkey"
+            columns: ["mem_id"]
+            isOneToOne: false
+            referencedRelation: "mem_mst"
+            referencedColumns: ["mem_id"]
+          },
+          {
+            foreignKeyName: "cmnt_mst_prnt_id_fkey"
+            columns: ["prnt_id"]
+            isOneToOne: false
+            referencedRelation: "cmnt_mst"
+            referencedColumns: ["cmnt_id"]
+          },
+          {
+            foreignKeyName: "cmnt_mst_team_id_fkey"
+            columns: ["team_id"]
+            isOneToOne: false
+            referencedRelation: "team_mst"
+            referencedColumns: ["team_id"]
+          },
+        ]
+      }
       comp_evt_cfg: {
         Row: {
           comp_evt_id: string
@@ -1192,6 +1286,53 @@ export type Database = {
           },
         ]
       }
+      feedback_messages: {
+        Row: {
+          admin_note: string | null
+          body: string
+          created_at: string
+          del_yn: boolean
+          id: string
+          responded_at: string | null
+          status: string
+          upd_at: string
+          user_id: string
+          vers: number
+        }
+        Insert: {
+          admin_note?: string | null
+          body: string
+          created_at?: string
+          del_yn?: boolean
+          id?: string
+          responded_at?: string | null
+          status?: string
+          upd_at?: string
+          user_id: string
+          vers?: number
+        }
+        Update: {
+          admin_note?: string | null
+          body?: string
+          created_at?: string
+          del_yn?: boolean
+          id?: string
+          responded_at?: string | null
+          status?: string
+          upd_at?: string
+          user_id?: string
+          vers?: number
+        }
+        Relationships: [
+          {
+            foreignKeyName: "feedback_messages_user_id_fkey"
+            columns: ["user_id"]
+            isOneToOne: false
+            referencedRelation: "mem_mst"
+            referencedColumns: ["mem_id"]
+          },
+        ]
+      }
       mem_mst: {
         Row: {
           avatar_url: string | null
@@ -1531,7 +1672,7 @@ export type Database = {
           },
         ]
       }
-      sch_post: {
+      sch_post_mst: {
         Row: {
           cont_txt: string | null
           crt_at: string
@@ -2099,4 +2240,3 @@ export const Constants = {
     },
   },
 } as const
-

--- a/lib/validations/comment.ts
+++ b/lib/validations/comment.ts
@@ -1,0 +1,23 @@
+import { z } from "zod"
+
+export const createCommentSchema = z.object({
+  entityType: z.enum(["sch_post", "comp", "gathering"]),
+  entityId: z.string().uuid(),
+  contTxt: z.string().min(1, "내용을 입력해주세요").max(1000, "1000자 이내로 입력해주세요"),
+  prntId: z.string().uuid().optional(),
+  mentionedMemIds: z.array(z.string().uuid()).default([]),
+})
+
+export const updateCommentSchema = z.object({
+  cmntId: z.string().uuid(),
+  contTxt: z.string().min(1).max(1000),
+  mentionedMemIds: z.array(z.string().uuid()).default([]),
+})
+
+export const deleteCommentSchema = z.object({
+  cmntId: z.string().uuid(),
+})
+
+export type CreateCommentInput = z.infer<typeof createCommentSchema>
+export type UpdateCommentInput = z.infer<typeof updateCommentSchema>
+export type DeleteCommentInput = z.infer<typeof deleteCommentSchema>

--- a/supabase/migrations/20260615100000_rename_sch_post_to_sch_post_mst.sql
+++ b/supabase/migrations/20260615100000_rename_sch_post_to_sch_post_mst.sql
@@ -1,0 +1,6 @@
+-- sch_post → sch_post_mst 리네임 (_mst 접미사 규칙 통일)
+ALTER TABLE public.sch_post RENAME TO sch_post_mst;
+
+ALTER INDEX sch_post_pkey                RENAME TO sch_post_mst_pkey;
+ALTER INDEX ix_sch_post_team_evt_stt_at  RENAME TO ix_sch_post_mst_team_evt_stt_at;
+ALTER INDEX ix_sch_post_crt_by           RENAME TO ix_sch_post_mst_crt_by;

--- a/supabase/migrations/20260615110000_cmnt_mst.sql
+++ b/supabase/migrations/20260615110000_cmnt_mst.sql
@@ -1,0 +1,92 @@
+-- ============================================================
+-- cmnt_mst — 범용 댓글 테이블
+-- entity_type + entity_id 로 소식(sch_post) / 대회(comp) / 모임(gathering) 공용
+-- ============================================================
+
+CREATE TABLE public.cmnt_mst (
+  cmnt_id      uuid        PRIMARY KEY DEFAULT gen_random_uuid(),
+  team_id      uuid        NOT NULL REFERENCES public.team_mst(team_id),
+  entity_type  text        NOT NULL
+               CHECK (entity_type IN ('sch_post', 'comp', 'gathering')),
+  entity_id    uuid        NOT NULL,
+  prnt_id      uuid        REFERENCES public.cmnt_mst(cmnt_id),  -- null=루트댓글, 있으면 1단계 답글
+  mem_id       uuid        NOT NULL REFERENCES public.mem_mst(mem_id),
+  cont_txt     text        NOT NULL,
+  edit_yn      boolean     NOT NULL DEFAULT false,
+  del_yn       boolean     NOT NULL DEFAULT false,
+  crt_at       timestamptz NOT NULL DEFAULT now(),
+  upd_at       timestamptz NOT NULL DEFAULT now()
+);
+
+COMMENT ON TABLE  public.cmnt_mst              IS '범용 댓글 (소식·대회·모임 공용)';
+COMMENT ON COLUMN public.cmnt_mst.entity_type  IS 'sch_post | comp | gathering';
+COMMENT ON COLUMN public.cmnt_mst.entity_id    IS 'sch_post_id / comp_id / gthr_id';
+COMMENT ON COLUMN public.cmnt_mst.prnt_id      IS '부모 댓글 ID — null=루트, 있으면 1단계 답글';
+COMMENT ON COLUMN public.cmnt_mst.edit_yn      IS '수정됨 표시 — 클라이언트에서 (수정됨) 렌더링';
+COMMENT ON COLUMN public.cmnt_mst.del_yn       IS 'soft delete — 답글 있으면 자리표시자로 표시';
+
+-- 엔티티별 댓글 목록 조회 (삭제됨 포함 — 자리표시자 표시용)
+CREATE INDEX ix_cmnt_mst_entity
+  ON public.cmnt_mst(team_id, entity_type, entity_id, crt_at ASC);
+
+-- 멤버별 댓글 조회
+CREATE INDEX ix_cmnt_mst_mem
+  ON public.cmnt_mst(mem_id)
+  WHERE del_yn = false;
+
+-- ============================================================
+-- cmnt_mention_rel — 댓글 멘션 관계
+-- 알림 발송 대상 추적용 (cont_txt의 @이름 파싱 결과를 구조화)
+-- ============================================================
+
+CREATE TABLE public.cmnt_mention_rel (
+  cmnt_id  uuid NOT NULL REFERENCES public.cmnt_mst(cmnt_id),
+  mem_id   uuid NOT NULL REFERENCES public.mem_mst(mem_id),
+  PRIMARY KEY (cmnt_id, mem_id)
+);
+
+COMMENT ON TABLE public.cmnt_mention_rel IS '댓글 멘션 관계 — 알림 발송 대상';
+
+-- ============================================================
+-- RLS
+-- ============================================================
+
+ALTER TABLE public.cmnt_mst         ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.cmnt_mention_rel  ENABLE ROW LEVEL SECURITY;
+
+-- cmnt_mst SELECT: 팀 멤버 전체 조회 (del_yn=true도 포함 — 자리표시자 표시)
+CREATE POLICY cmnt_mst_select ON public.cmnt_mst
+  FOR SELECT TO authenticated
+  USING (public.v2_rls_auth_in_team(team_id));
+
+-- cmnt_mst INSERT: 팀 멤버가 본인 mem_id로만 작성
+CREATE POLICY cmnt_mst_insert ON public.cmnt_mst
+  FOR INSERT TO authenticated
+  WITH CHECK (
+    mem_id = public.v2_rls_resolve_mem_id()
+    AND public.v2_rls_auth_in_team(team_id)
+    AND del_yn = false
+    AND edit_yn = false
+  );
+
+-- cmnt_mst UPDATE: 본인 수정/삭제 OR 관리자 삭제
+CREATE POLICY cmnt_mst_update ON public.cmnt_mst
+  FOR UPDATE TO authenticated
+  USING (
+    mem_id = public.v2_rls_resolve_mem_id()
+    OR public.v2_rls_auth_team_owner_or_admin(team_id)
+  )
+  WITH CHECK (public.v2_rls_auth_in_team(team_id));
+
+-- cmnt_mention_rel SELECT: 팀 멤버
+CREATE POLICY cmnt_mention_rel_select ON public.cmnt_mention_rel
+  FOR SELECT TO authenticated
+  USING (
+    EXISTS (
+      SELECT 1 FROM public.cmnt_mst c
+      WHERE c.cmnt_id = cmnt_mention_rel.cmnt_id
+        AND public.v2_rls_auth_in_team(c.team_id)
+    )
+  );
+
+-- cmnt_mention_rel INSERT: 서버 액션(service role)에서만 처리

--- a/supabase/migrations/20260615120000_cmnt_noti_types.sql
+++ b/supabase/migrations/20260615120000_cmnt_noti_types.sql
@@ -1,0 +1,10 @@
+-- noti_mst.noti_type_enm 허용값에 cmnt_reply, cmnt_mention 추가
+ALTER TABLE noti_mst
+  DROP CONSTRAINT IF EXISTS noti_mst_noti_type_enm_check;
+
+ALTER TABLE noti_mst
+  ADD CONSTRAINT noti_mst_noti_type_enm_check
+  CHECK (noti_type_enm IN (
+    'ttl_grnt', 'adm_cust', 'dues_check_req', 'dues_notice',
+    'cmnt_reply', 'cmnt_mention'
+  ));

--- a/supabase/migrations/20260615130000_cmnt_mst_realtime.sql
+++ b/supabase/migrations/20260615130000_cmnt_mst_realtime.sql
@@ -1,0 +1,2 @@
+-- cmnt_mst Supabase Realtime publication 등록
+ALTER PUBLICATION supabase_realtime ADD TABLE public.cmnt_mst;

--- a/supabase/migrations/20260616000000_add_sch_post_cmnt_noti_type.sql
+++ b/supabase/migrations/20260616000000_add_sch_post_cmnt_noti_type.sql
@@ -1,0 +1,10 @@
+-- noti_mst.noti_type_enm 허용값에 sch_post_cmnt 추가
+ALTER TABLE noti_mst
+  DROP CONSTRAINT IF EXISTS noti_mst_noti_type_enm_check;
+
+ALTER TABLE noti_mst
+  ADD CONSTRAINT noti_mst_noti_type_enm_check
+  CHECK (noti_type_enm IN (
+    'ttl_grnt', 'adm_cust', 'dues_check_req', 'dues_notice',
+    'cmnt_reply', 'cmnt_mention', 'sch_post_cmnt'
+  ));

--- a/supabase/migrations/20260616010000_noti_mst_realtime.sql
+++ b/supabase/migrations/20260616010000_noti_mst_realtime.sql
@@ -1,0 +1,2 @@
+-- noti_mst Supabase Realtime publication 등록
+ALTER PUBLICATION supabase_realtime ADD TABLE public.noti_mst;

--- a/supabase/migrations/20260616020000_add_sch_post_new_noti_type.sql
+++ b/supabase/migrations/20260616020000_add_sch_post_new_noti_type.sql
@@ -1,0 +1,10 @@
+-- noti_mst.noti_type_enm 허용값에 sch_post_new (피드 등록 알림) 추가
+ALTER TABLE noti_mst
+  DROP CONSTRAINT IF EXISTS noti_mst_noti_type_enm_check;
+
+ALTER TABLE noti_mst
+  ADD CONSTRAINT noti_mst_noti_type_enm_check
+  CHECK (noti_type_enm IN (
+    'ttl_grnt', 'adm_cust', 'dues_check_req', 'dues_notice',
+    'cmnt_reply', 'cmnt_mention', 'sch_post_cmnt', 'sch_post_new'
+  ));


### PR DESCRIPTION
Summary
소식 댓글 알림 시스템 구현 (그룹핑 · 딥링크 · 실시간)
멘션 감지 로직 전면 수정 — 드롭다운 선택 state 의존에서 제출 시점 텍스트 파싱으로 전환
댓글 Realtime 구독 버그 수정 및 알림 UX 개선
Changes
댓글 시스템

MentionInput 드롭다운 선택 후 텍스트 삭제해도 멘션 알림이 가던 버그 수정 — newMentions / replyMentions / editMentions state 제거, 제출 시 텍스트 직접 파싱(parseMentionsFromText)으로 통일
renderMentions: 실제 멤버 이름과 정확히 일치하는 @이름만 파란색 강조 (오타·비멤버 @ 제거)
@이름 파싱 시 부분 문자열 오매칭 방지 — 정규식 word boundary((?=[\s]|$)) 적용
supabase 클라이언트 useMemo 안정화 — 타이핑마다 Realtime 채널이 재구독되던 버그 수정
buildTree · visibleCount useMemo 적용
알림 시스템

noti_mst Realtime publication 등록 마이그레이션 추가
소식 댓글 알림: 게시글 제목 포함, 같은 글 미읽음 알림 그룹핑(카운트 +1), 딥링크(/?post=<id>)로 상세 자동 오픈
멘션 알림: ref_id / ref_type_enm 올바르게 저장 → 소식·대회 상세 딥링크 이동
알림 UPDATE Realtime 핸들러 추가 — 그룹핑된 알림 메시지 실시간 반영
API route 중복 쿼리 제거 (getNotifications 재사용)
Test plan
 소식 댓글 작성 시 작성자에게 알림 도착 확인
 미읽음 상태에서 같은 소식에 댓글 추가 시 기존 알림 카운트 증가 확인
 알림 클릭 → 소식/대회 상세 자동 오픈 확인
 멘션 드롭다운 선택 후 텍스트 삭제 → 제출 시 해당 멤버에게 알림 미발송 확인
 @오타이름 작성 시 파란색 강조 없음 확인

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **New Features**
  * 소식/대회 상세에 댓글·답글·멘션 추가(작성/수정/삭제 가능 조건 반영)
  * 멘션·답글 알림 연동 및 알림 유형/라우팅 표기 강화
  * 댓글을 실시간으로 동기화(추가/수정 반영)
* **UI Improvements**
  * 상세 보기 다이얼로그를 화면 크기별 Drawer/Dialog로 통일(모바일 Drawer)
* **Documentation**
  * 댓글 시스템 설계 문서 및 다이얼로그→드로어 전환 절차 추가
* **Chores**
  * 일정 데이터 조회/저장 구조를 새 테이블 기준으로 정리
<!-- end of auto-generated comment: release notes by coderabbit.ai -->