### PR TITLE
fix(auth,admin,dues): 로그인 단계 표시 조건 수정 및 회비 관리 UX 개선

### DIFF
--- a/app/(info)/admin/dues/transactions/dues-transactions-client.tsx
+++ b/app/(info)/admin/dues/transactions/dues-transactions-client.tsx
@@ -668,6 +668,7 @@ function BalanceTab({
   const [memberQuery, setMemberQuery] = useState("");
   const [sortKey, setSortKey] = useState<"mem_nm" | "join_dt" | "bal_amt" | "last_calc_dt" | "last_calc_at">("mem_nm");
   const [sortDir, setSortDir] = useState<"asc" | "desc">("asc");
+  const [showInactive, setShowInactive] = useState(true);
 
   function handleSort(key: typeof sortKey) {
     if (sortKey === key) setSortDir((d) => (d === "asc" ? "desc" : "asc"));
@@ -680,8 +681,9 @@ function BalanceTab({
   }
 
   const mq = memberQuery.trim().toLowerCase();
-  const unpaidMembers = members.filter((m) => m.snap && m.snap.bal_amt < 0);
-  const baseMembers = (filter === "unpaid" ? unpaidMembers : members).filter(
+  const activeFilteredMembers = showInactive ? members : members.filter((m) => m.mem_st_cd !== "inactive");
+  const unpaidMembers = activeFilteredMembers.filter((m) => m.snap && m.snap.bal_amt < 0);
+  const baseMembers = (filter === "unpaid" ? unpaidMembers : activeFilteredMembers).filter(
     (m) => !mq || m.mem_nm.toLowerCase().includes(mq)
   );
 
@@ -776,6 +778,16 @@ function BalanceTab({
         >
           미납 {unpaidMembers.length}명
         </Button>
+        <div className="flex items-center gap-1.5">
+          <Checkbox
+            id="show-inactive"
+            checked={showInactive}
+            onCheckedChange={(v) => setShowInactive(!!v)}
+          />
+          <Label htmlFor="show-inactive" className="text-xs text-muted-foreground cursor-pointer select-none">
+            비활성 포함
+          </Label>
+        </div>
         <MemberSearchInput value={memberQuery} onChange={setMemberQuery} />
         {selectedIds.size > 0 && (
           <Button size="sm" onClick={handleSendNoti}>
@@ -829,7 +841,7 @@ function BalanceTab({
       </div>
 
       <div className="flex flex-col gap-2">
-        <SectionLabel>회원별 잔액 ({displayedMembers.length}명{filter === "unpaid" ? " · 미납 필터" : ""})</SectionLabel>
+        <SectionLabel>회원별 잔액 ({displayedMembers.length}명{filter === "unpaid" ? " · 미납 필터" : ""}{!showInactive ? " · 비활성 제외" : ""})</SectionLabel>
         <div className="overflow-x-auto rounded-2xl border border-border">
           <Table>
             <TableHeader>

--- a/app/(info)/admin/page.tsx
+++ b/app/(info)/admin/page.tsx
@@ -51,7 +51,8 @@ const generalCards: Card[] = [
     label: "회비 관리",
     href: "/admin/dues",
     icon: Wallet,
-    getValue: () => "",
+    getValue: (s) => s.unpaidMemberCount,
+    getAccentValue: (s) => s.unpaidMemberCount,
   },
   {
     key: "competitions",

--- a/app/actions/admin/get-admin-stats.ts
+++ b/app/actions/admin/get-admin-stats.ts
@@ -12,6 +12,7 @@ export type AdminStats = {
   recentRecordCount: number;
   activeProjectCount: number;
   pendingParticipationCount: number;
+  unpaidMemberCount: number;
   _debug?: Record<string, unknown>;
 };
 
@@ -27,7 +28,7 @@ export async function getAdminStats(): Promise<AdminStats> {
   const keyPrefix = env.SUPABASE_SERVICE_ROLE_KEY.slice(0, 20);
   console.log("[getAdminStats] teamId:", teamId, "keyPrefix:", keyPrefix, "noFilterCount:", noFilter.count, "noFilterError:", noFilter.error);
 
-  const [total, competitions, records, activeProjects, pendingPrt] = await Promise.all([
+  const [total, competitions, records, activeProjects, pendingPrt, unpaidSnaps] = await Promise.all([
     admin
       .from("team_mem_rel")
       .select("*", { count: "exact", head: true })
@@ -64,6 +65,13 @@ export async function getAdminStats(): Promise<AdminStats> {
       .select("evt_id, evt_team_mst!inner(team_id)", { count: "exact", head: true })
       .eq("aprv_yn", false)
       .eq("evt_team_mst.team_id", teamId),
+    admin
+      .from("fee_mem_bal_snap")
+      .select("*", { count: "exact", head: true })
+      .eq("team_id", teamId)
+      .eq("vers", 0)
+      .eq("del_yn", false)
+      .lt("bal_amt", 0),
   ]);
 
   const result: AdminStats = {
@@ -72,6 +80,7 @@ export async function getAdminStats(): Promise<AdminStats> {
     recentRecordCount: records.count ?? 0,
     activeProjectCount: activeProjects.count ?? 0,
     pendingParticipationCount: pendingPrt.count ?? 0,
+    unpaidMemberCount: unpaidSnaps.count ?? 0,
     _debug: {
       teamId,
       teamCd,

--- a/app/auth/login/page.tsx
+++ b/app/auth/login/page.tsx
@@ -4,10 +4,16 @@ import { LoginForm } from "@/components/auth/login-form";
 import { SignupProgress } from "@/components/auth/signup-progress";
 import { InAppBrowserGate } from "@/components/in-app-browser-gate";
 
-export default function Page() {
+export default async function Page({
+  searchParams,
+}: {
+  searchParams: Promise<{ next?: string }>;
+}) {
+  const { next } = await searchParams;
+  const isSignupFlow = next === "/onboarding";
   return (
     <InAppBrowserGate>
-      <SignupProgress step={2} />
+      {isSignupFlow && <SignupProgress step={2} />}
       <Suspense
         fallback={
           <div className="flex min-h-svh w-full items-center justify-center">


### PR DESCRIPTION
## Summary

- 로그인 화면에서 일반 유저에게 가입 진행 단계 바(SignupProgress)가 노출되는 문제 수정 — `next=/onboarding` 파라미터가 있을 때(뉴비 가입 플로우)만 표시
- 관리페이지 메인 회비 관리 카드에 미납회원 수 표시 추가 (1명 이상 시 빨간색 강조)
- 회비관리 잔액탭에 비활성회원 포함/제외 체크박스 추가 (기본값: 포함, 해제 시 비활성 회원 제외)

## Test plan

- [ ] 일반 유저가 `/auth/login` 직접 접근 시 단계 바 미노출 확인
- [ ] 뉴비가 `/newbie` → 시작하기 버튼 → `/auth/login?next=/onboarding` 경로에서 단계 바 노출 확인
- [ ] 관리페이지 메인에서 회비 관리 카드에 미납회원 수 표시 확인 (미납자 없으면 숫자 미표시)
- [ ] 회비관리 잔액탭에서 "비활성 포함" 체크박스 해제 시 비활성 회원 제외되는지 확인
