### PR TITLE
perf(infra): Vercel 함수 리전을 서울(icn1)로 고정

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,4 +1,5 @@
 {
+  "regions": ["icn1"],
   "crons": [
     {
       "path": "/api/cron/keep-alive",


### PR DESCRIPTION
## 관련 이슈

관련 이슈 없음

## 요약

Vercel 함수가 기본 리전(미국 `iad1`)에서 실행되어 한국 사용자 요청이 매번 태평양을 왕복하던 문제를, 함수 리전을 서울(`icn1`)로 고정해 해소합니다. 무료 설정 변경만으로 TTFB를 크게 개선합니다.

## AS-IS (변경 전)

- `vercel.json`에 `regions` 미설정 → 함수가 **기본 리전 `iad1`(미국 워싱턴)** 에서 실행.
- 요청 경로: **한국 사용자 → 미국 함수(iad1) → 서울 Supabase(`ap-northeast-2`) 왕복 N회 → 한국**.
- 페이지마다 DB 조회가 여러 번이라 태평양 왕복이 곱으로 누적 → 홈 TTFB 1초+.
- Supabase·DB 자체는 서울에 있어 빠른데, 함수 위치 때문에 느린 전형적 리전 미스매치.

## TO-BE (변경 후)

- `vercel.json`에 `"regions": ["icn1"]`(Vercel 서울) 추가.
- 사용자·함수·DB가 모두 서울에 co-location → 태평양 왕복 제거.
- 단일 `vercel.json`이 **dev(프리뷰/브랜치) · prd(프로덕션) 배포에 모두 적용**.
- 기존 `keep-alive` cron(`/api/cron/keep-alive`)은 그대로 유지.

## 주요 변경 사항

- `vercel.json`: `regions: ["icn1"]` 추가 (crons 보존)

## 검증 방법

배포 후 응답 헤더 확인:

\`\`\`
curl -sI https://<도메인>/manifest.webmanifest | grep -i x-vercel-id
# 기대값: x-vercel-id: icn1::icn1::...  (이전엔 icn1::iad1::...)
\`\`\`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Chores**
  * 배포 인프라 구성을 최적화하여 서비스 성능을 개선했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->