### PR TITLE
fix: 홈탭 캘린더 UX 개선 및 일정 정보 추가 폼 개선

### DIFF
--- a/components/home/mini-calendar.tsx
+++ b/components/home/mini-calendar.tsx
@@ -94,7 +94,7 @@ export function MiniCalendar({
   // 일정 폼 다이얼로그 상태
   const [formOpen, setFormOpen] = useState(false);
   const [formMode, setFormMode] = useState<"create" | "edit">("create");
-  const [formPostType, setFormPostType] = useState<SchPostType>("general");
+  const [formPostType, setFormPostType] = useState<SchPostType | undefined>(undefined);
   const [editTarget, setEditTarget] = useState<CalendarRace | null>(null);
 
   // 소식 상세 다이얼로그 상태 (일반 멤버용)
@@ -426,7 +426,7 @@ export function MiniCalendar({
     });
   }
 
-  function openCreateForm(defaultDate?: string, postType: SchPostType = "general") {
+  function openCreateForm(defaultDate?: string, postType?: SchPostType) {
     setFormMode("create");
     setFormPostType(postType);
     setEditTarget(defaultDate ? { id: "", title: "", start_date: defaultDate, type: "schedule" } : null);

--- a/components/home/mini-calendar.tsx
+++ b/components/home/mini-calendar.tsx
@@ -203,10 +203,10 @@ export function MiniCalendar({
     const seen = new Set<string>();
     for (const race of allRaces) {
       const endDateStr = race.end_date
-        ? dayjs(race.end_date).format("YYYY-MM-DD")
+        ? dayjs(race.end_date).tz("Asia/Seoul").format("YYYY-MM-DD")
         : race.start_date;
-      let cur = dayjs(race.start_date);
-      const endDay = dayjs(endDateStr);
+      let cur = dayjs(race.start_date).tz("Asia/Seoul");
+      const endDay = dayjs(endDateStr).tz("Asia/Seoul");
       while (!cur.isAfter(endDay)) {
         const dateStr = cur.format("YYYY-MM-DD");
         const key = `${dateStr}:${race.id}`;
@@ -253,12 +253,12 @@ export function MiniCalendar({
       const active = allRaces.filter((race) => {
         if (seen.has(race.id)) return false;
         seen.add(race.id);
-        const endStr = race.end_date ? dayjs(race.end_date).format("YYYY-MM-DD") : race.start_date;
+        const endStr = race.end_date ? dayjs(race.end_date).tz("Asia/Seoul").format("YYYY-MM-DD") : race.start_date;
         return race.start_date <= weekEnd && endStr >= weekStart;
       });
 
       const positioned = active.map((race) => {
-        const endStr = race.end_date ? dayjs(race.end_date).format("YYYY-MM-DD") : race.start_date;
+        const endStr = race.end_date ? dayjs(race.end_date).tz("Asia/Seoul").format("YYYY-MM-DD") : race.start_date;
         let colStart = colDates.findIndex((d) => d !== null && d >= race.start_date);
         if (colStart === -1) colStart = colDates.findIndex((d) => d !== null) ?? 0;
         let colEnd = colStart;
@@ -762,10 +762,10 @@ export function MiniCalendar({
                               {race.evt_stt_at && (
                                 <span>
                                   {(() => {
-                                    const stt = dayjs(race.evt_stt_at);
-                                    const end = race.evt_end_at ? dayjs(race.evt_end_at) : null;
+                                    const stt = dayjs(race.evt_stt_at).tz("Asia/Seoul");
+                                    const end = race.evt_end_at ? dayjs(race.evt_end_at).tz("Asia/Seoul") : null;
                                     const sameDay = !end || stt.format("YYYY-MM-DD") === end.format("YYYY-MM-DD");
-                                    if (sameDay) return `${stt.format("HH:mm")}${end ? `~${end.format("HH:mm")}` : ""}`;
+                                    if (sameDay) return `${stt.format("HH:mm")}${end ? ` ~ ${end.format("HH:mm")}` : ""}`;
                                     const sameMonth = end && stt.month() === end.month() && stt.year() === end.year();
                                     const fmt = sameMonth ? "D일 HH:mm" : "M/D HH:mm";
                                     return `${stt.format(fmt)} ~ ${end!.format(fmt)}`;

--- a/components/home/mini-calendar.tsx
+++ b/components/home/mini-calendar.tsx
@@ -614,26 +614,41 @@ export function MiniCalendar({
                 const lanes = weekEventLanes[weekIdx] ?? [];
                 const visibleLanes = lanes.filter((l) => l.slot < 3);
                 return (
-                  <div key={weekIdx}>
-                    {/* 날짜 숫자 행 */}
-                    <div className="grid grid-cols-7">
+                  <div key={weekIdx} className="relative">
+                    {/* 전체 높이 클릭 오버레이 — 선택 배경 + 날짜 선택 */}
+                    <div className="pointer-events-none absolute inset-0 grid grid-cols-7">
+                      {week.map((day, colIdx) => {
+                        if (day === null) return <div key={`ol-${weekIdx}-${colIdx}`} />;
+                        const dateStr = formatCellDate(day);
+                        const isSelected = selectedDate === dateStr;
+                        return (
+                          <button
+                            key={`ol-${dateStr}`}
+                            onClick={() => setSelectedDate(dateStr)}
+                            className={cn(
+                              "pointer-events-auto h-full w-full transition-colors",
+                              isSelected && "bg-secondary/60",
+                            )}
+                            aria-label={`${day}일 선택`}
+                            aria-pressed={isSelected}
+                          />
+                        );
+                      })}
+                    </div>
+
+                    {/* 날짜 숫자 행 (표시 전용) */}
+                    <div className="relative z-10 grid grid-cols-7" style={{ pointerEvents: "none" }}>
                       {week.map((day, colIdx) => {
                         if (day === null) {
                           return <div key={`e-${weekIdx}-${colIdx}`} className="h-8 border-t border-border/40" />;
                         }
                         const dateStr = formatCellDate(day);
                         const isToday = dateStr === today;
-                        const isSelected = selectedDate === dateStr;
                         const overflowCount = Math.max(0, (eventsByDate.get(dateStr)?.length ?? 0) - 3);
                         return (
-                          <button
-                            key={dateStr}
-                            onClick={() => setSelectedDate(dateStr)}
-                            className={cn(
-                              "flex h-8 flex-col items-center border-t border-border/40 pt-0.5 transition-colors",
-                              isSelected && "bg-secondary/60",
-                            )}
-                            aria-pressed={isSelected}
+                          <div
+                            key={`d-${dateStr}`}
+                            className="flex h-8 flex-col items-center border-t border-border/40 pt-0.5"
                           >
                             <div className="flex items-center gap-0.5">
                               <span
@@ -653,16 +668,16 @@ export function MiniCalendar({
                                 </span>
                               )}
                             </div>
-                          </button>
+                          </div>
                         );
                       })}
                     </div>
 
-                    {/* 이벤트 바 행 — 멀티데이 CSS grid span */}
+                    {/* 이벤트 바 행 — 멀티데이 CSS grid span (표시 전용) */}
                     {visibleLanes.length > 0 ? (
                       <div
-                        className="grid grid-cols-7 pb-1"
-                        style={{ gridAutoRows: "13px", rowGap: "1px" }}
+                        className="relative z-10 grid grid-cols-7 pb-1"
+                        style={{ gridAutoRows: "13px", rowGap: "1px", pointerEvents: "none" }}
                       >
                         {visibleLanes.map((lane) => (
                           <div
@@ -687,7 +702,7 @@ export function MiniCalendar({
                         ))}
                       </div>
                     ) : (
-                      <div className="h-2" />
+                      <div className="relative z-10 h-2" />
                     )}
                   </div>
                 );
@@ -744,7 +759,19 @@ export function MiniCalendar({
                           )}
                           {race.type === "schedule" && (race.evt_stt_at || (race.cmntCount ?? 0) > 0) && (
                             <span className="flex items-center gap-1 text-[9px] text-muted-foreground tabular-nums">
-                              {race.evt_stt_at && <span>{dayjs(race.evt_stt_at).format("HH:mm")}{race.evt_end_at ? `~${dayjs(race.evt_end_at).format("HH:mm")}` : ""}</span>}
+                              {race.evt_stt_at && (
+                                <span>
+                                  {(() => {
+                                    const stt = dayjs(race.evt_stt_at);
+                                    const end = race.evt_end_at ? dayjs(race.evt_end_at) : null;
+                                    const sameDay = !end || stt.format("YYYY-MM-DD") === end.format("YYYY-MM-DD");
+                                    if (sameDay) return `${stt.format("HH:mm")}${end ? `~${end.format("HH:mm")}` : ""}`;
+                                    const sameMonth = end && stt.month() === end.month() && stt.year() === end.year();
+                                    const fmt = sameMonth ? "D일 HH:mm" : "M/D HH:mm";
+                                    return `${stt.format(fmt)} ~ ${end!.format(fmt)}`;
+                                  })()}
+                                </span>
+                              )}
                               {(race.cmntCount ?? 0) > 0 && <span>💬 {race.cmntCount}</span>}
                             </span>
                           )}

--- a/components/home/mini-calendar.tsx
+++ b/components/home/mini-calendar.tsx
@@ -196,18 +196,28 @@ export function MiniCalendar({
   const totalDays = daysInMonth(year, month);
   const firstDayOfWeek = dayjs.tz(`${year}-${String(month).padStart(2, "0")}-01`, "Asia/Seoul").day();
 
-  // 날짜별 이벤트 목록 (mine 우선, schedule, gigang 순)
+  // 날짜별 이벤트 목록 (mine 우선, schedule, gigang 순) — 기간 이벤트는 모든 날짜에 전개
   const eventsByDate = useMemo(() => {
     const map = new Map<string, CalendarRace[]>();
     const allRaces = [...myRaces, ...schPosts, ...gigangRaces];
     const seen = new Set<string>();
     for (const race of allRaces) {
-      const key = `${race.start_date}:${race.id}`;
-      if (seen.has(key)) continue;
-      seen.add(key);
-      const list = map.get(race.start_date) ?? [];
-      list.push(race);
-      map.set(race.start_date, list);
+      const endDateStr = race.end_date
+        ? dayjs(race.end_date).format("YYYY-MM-DD")
+        : race.start_date;
+      let cur = dayjs(race.start_date);
+      const endDay = dayjs(endDateStr);
+      while (!cur.isAfter(endDay)) {
+        const dateStr = cur.format("YYYY-MM-DD");
+        const key = `${dateStr}:${race.id}`;
+        if (!seen.has(key)) {
+          seen.add(key);
+          const list = map.get(dateStr) ?? [];
+          list.push(race);
+          map.set(dateStr, list);
+        }
+        cur = cur.add(1, "day");
+      }
     }
     return map;
   }, [gigangRaces, myRaces, schPosts]);
@@ -225,6 +235,54 @@ export function MiniCalendar({
     return result;
   }, [firstDayOfWeek, totalDays]);
 
+  // 주차별 스패닝 이벤트 레인 계산
+  const weekEventLanes = useMemo(() => {
+    const allRaces = [...myRaces, ...schPosts, ...gigangRaces];
+    return weeks.map((week) => {
+      const colDates = week.map((day) =>
+        day !== null
+          ? `${year}-${String(month).padStart(2, "0")}-${String(day).padStart(2, "0")}`
+          : null
+      );
+      const validDates = colDates.filter((d): d is string => d !== null);
+      if (validDates.length === 0) return [];
+      const weekStart = validDates[0];
+      const weekEnd = validDates[validDates.length - 1];
+
+      const seen = new Set<string>();
+      const active = allRaces.filter((race) => {
+        if (seen.has(race.id)) return false;
+        seen.add(race.id);
+        const endStr = race.end_date ? dayjs(race.end_date).format("YYYY-MM-DD") : race.start_date;
+        return race.start_date <= weekEnd && endStr >= weekStart;
+      });
+
+      const positioned = active.map((race) => {
+        const endStr = race.end_date ? dayjs(race.end_date).format("YYYY-MM-DD") : race.start_date;
+        let colStart = colDates.findIndex((d) => d !== null && d >= race.start_date);
+        if (colStart === -1) colStart = colDates.findIndex((d) => d !== null) ?? 0;
+        let colEnd = colStart;
+        for (let i = colStart + 1; i < 7; i++) {
+          if (colDates[i] !== null && colDates[i]! <= endStr) colEnd = i;
+        }
+        return {
+          race,
+          colStart,
+          colSpan: colEnd - colStart + 1,
+          startsThisWeek: race.start_date >= weekStart,
+          endsThisWeek: endStr <= weekEnd,
+        };
+      });
+
+      const slotEnds: number[] = [];
+      return positioned.map((ep) => {
+        let slot = slotEnds.findIndex((e) => e < ep.colStart);
+        if (slot === -1) { slot = slotEnds.length; slotEnds.push(-1); }
+        slotEnds[slot] = ep.colStart + ep.colSpan - 1;
+        return { ...ep, slot };
+      });
+    });
+  }, [weeks, myRaces, schPosts, gigangRaces, year, month]);
 
   function formatCellDate(day: number): string {
     return `${year}-${String(month).padStart(2, "0")}-${String(day).padStart(2, "0")}`;
@@ -550,68 +608,88 @@ export function MiniCalendar({
               ))}
             </div>
 
-            {/* 바둑판 그리드 — 셀 고정 높이 */}
-            <div className="grid grid-cols-7">
-              {weeks.flat().map((day, idx) => {
-                if (day === null) {
-                  return <div key={`empty-${idx}`} className="h-15 border-t border-border/40" />;
-                }
-                const dateStr = formatCellDate(day);
-                const isToday = dateStr === today;
-                const isSelected = selectedDate === dateStr;
-                const colIndex = idx % 7;
-                const races = eventsByDate.get(dateStr) ?? [];
-
+            {/* 바둑판 그리드 — 주차별 스패닝 이벤트 바 */}
+            <div className="flex flex-col">
+              {weeks.map((week, weekIdx) => {
+                const lanes = weekEventLanes[weekIdx] ?? [];
+                const visibleLanes = lanes.filter((l) => l.slot < 3);
                 return (
-                  <button
-                    key={dateStr}
-                    onClick={() => setSelectedDate(dateStr)}
-                    className={cn(
-                      "flex h-15 flex-col gap-px overflow-hidden border-t border-border/40 px-0.5 pt-0.5 text-left transition-colors",
-                      isSelected && "bg-secondary/60",
-                    )}
-                    aria-pressed={isSelected}
-                  >
-                    {/* 날짜 숫자 + 초과 개수 */}
-                    <div className="flex items-center justify-center gap-0.5">
-                      <span
-                        className={cn(
-                          "flex size-6 items-center justify-center rounded-full text-[12px] font-medium",
-                          isToday && "bg-primary text-primary-foreground font-bold",
-                          !isToday && colIndex === 0 && "text-destructive",
-                          !isToday && colIndex === 6 && "text-primary",
-                          !isToday && colIndex !== 0 && colIndex !== 6 && "text-foreground",
-                        )}
-                      >
-                        {day}
-                      </span>
-                      {races.length > 3 && (
-                        <span className="text-[8px] font-medium text-muted-foreground leading-none">
-                          +{races.length - 3}
-                        </span>
-                      )}
+                  <div key={weekIdx}>
+                    {/* 날짜 숫자 행 */}
+                    <div className="grid grid-cols-7">
+                      {week.map((day, colIdx) => {
+                        if (day === null) {
+                          return <div key={`e-${weekIdx}-${colIdx}`} className="h-8 border-t border-border/40" />;
+                        }
+                        const dateStr = formatCellDate(day);
+                        const isToday = dateStr === today;
+                        const isSelected = selectedDate === dateStr;
+                        const overflowCount = Math.max(0, (eventsByDate.get(dateStr)?.length ?? 0) - 3);
+                        return (
+                          <button
+                            key={dateStr}
+                            onClick={() => setSelectedDate(dateStr)}
+                            className={cn(
+                              "flex h-8 flex-col items-center border-t border-border/40 pt-0.5 transition-colors",
+                              isSelected && "bg-secondary/60",
+                            )}
+                            aria-pressed={isSelected}
+                          >
+                            <div className="flex items-center gap-0.5">
+                              <span
+                                className={cn(
+                                  "flex size-6 items-center justify-center rounded-full text-[12px] font-medium",
+                                  isToday && "bg-primary text-primary-foreground font-bold",
+                                  !isToday && colIdx === 0 && "text-destructive",
+                                  !isToday && colIdx === 6 && "text-primary",
+                                  !isToday && colIdx !== 0 && colIdx !== 6 && "text-foreground",
+                                )}
+                              >
+                                {day}
+                              </span>
+                              {overflowCount > 0 && (
+                                <span className="text-[8px] font-medium leading-none text-muted-foreground">
+                                  +{overflowCount}
+                                </span>
+                              )}
+                            </div>
+                          </button>
+                        );
+                      })}
                     </div>
 
-                    {/* 이벤트 목록 — 최대 3개 */}
-                    <div className="flex flex-col gap-px">
-                      {races.slice(0, 3).map((race) => (
-                        <span
-                          key={race.id}
-                          className={cn(
-                            "w-full overflow-hidden rounded-sm px-0.5 text-left text-[7px] font-medium leading-[1.5]",
-                            race.type === "mine"
-                              ? "bg-success/20 text-success"
-                              : race.type === "schedule"
-                                ? "bg-info/15 text-info"
-                                : "bg-warning/15 text-warning",
-                          )}
-                          style={{ whiteSpace: "nowrap", textOverflow: "clip" }}
-                        >
-                          {race.title}
-                        </span>
-                      ))}
-                    </div>
-                  </button>
+                    {/* 이벤트 바 행 — 멀티데이 CSS grid span */}
+                    {visibleLanes.length > 0 ? (
+                      <div
+                        className="grid grid-cols-7 pb-1"
+                        style={{ gridAutoRows: "13px", rowGap: "1px" }}
+                      >
+                        {visibleLanes.map((lane) => (
+                          <div
+                            key={`${lane.race.id}-w${weekIdx}`}
+                            style={{
+                              gridColumn: `${lane.colStart + 1} / ${lane.colStart + lane.colSpan + 1}`,
+                              gridRow: lane.slot + 1,
+                            }}
+                            className={cn(
+                              "overflow-hidden px-0.5 text-[7px] font-medium leading-[13px]",
+                              lane.startsThisWeek ? "rounded-l-sm" : "",
+                              lane.endsThisWeek ? "rounded-r-sm" : "",
+                              lane.race.type === "mine"
+                                ? "bg-success/20 text-success"
+                                : lane.race.type === "schedule"
+                                  ? "bg-info/15 text-info"
+                                  : "bg-warning/15 text-warning",
+                            )}
+                          >
+                            {lane.startsThisWeek ? lane.race.title : ""}
+                          </div>
+                        ))}
+                      </div>
+                    ) : (
+                      <div className="h-2" />
+                    )}
+                  </div>
                 );
               })}
             </div>

--- a/components/home/schedule-list-view.tsx
+++ b/components/home/schedule-list-view.tsx
@@ -149,9 +149,9 @@ async function fetchMonth(
 
 function formatTimeRange(sttAt: string | null | undefined, endAt: string | null | undefined): string | null {
   if (!sttAt) return null;
-  const stt = dayjs(sttAt);
+  const stt = dayjs(sttAt).tz("Asia/Seoul");
   if (!endAt) return stt.format("HH:mm");
-  const end = dayjs(endAt);
+  const end = dayjs(endAt).tz("Asia/Seoul");
   const sameDay = stt.format("YYYY-MM-DD") === end.format("YYYY-MM-DD");
   if (sameDay) return `${stt.format("HH:mm")} ~ ${end.format("HH:mm")}`;
   const sameMonth = stt.month() === end.month() && stt.year() === end.year();

--- a/components/home/schedule-list-view.tsx
+++ b/components/home/schedule-list-view.tsx
@@ -149,10 +149,14 @@ async function fetchMonth(
 
 function formatTimeRange(sttAt: string | null | undefined, endAt: string | null | undefined): string | null {
   if (!sttAt) return null;
-  const stt = dayjs(sttAt).format("HH:mm");
-  if (!endAt) return stt;
-  const end = dayjs(endAt).format("HH:mm");
-  return `${stt} ~ ${end}`;
+  const stt = dayjs(sttAt);
+  if (!endAt) return stt.format("HH:mm");
+  const end = dayjs(endAt);
+  const sameDay = stt.format("YYYY-MM-DD") === end.format("YYYY-MM-DD");
+  if (sameDay) return `${stt.format("HH:mm")} ~ ${end.format("HH:mm")}`;
+  const sameMonth = stt.month() === end.month() && stt.year() === end.year();
+  const fmt = sameMonth ? "D일 HH:mm" : "M/D HH:mm";
+  return `${stt.format(fmt)} ~ ${end.format(fmt)}`;
 }
 
 // schedule 타입 아이템

--- a/components/notifications/notification-item.tsx
+++ b/components/notifications/notification-item.tsx
@@ -160,7 +160,7 @@ export function NotificationItem({ noti, onDelete, onRead, onClose }: Notificati
           <button
             type="button"
             onClick={handleNavigate}
-            className="shrink-0 text-muted-foreground"
+            className="flex shrink-0 items-center justify-center rounded-md bg-secondary p-2 text-muted-foreground active:bg-muted"
             aria-label="이동"
           >
             <ChevronRight className="size-4" />

--- a/components/schedule/sch-post-form-dialog.tsx
+++ b/components/schedule/sch-post-form-dialog.tsx
@@ -66,7 +66,7 @@ export function SchPostFormDialog({
   open,
   onOpenChange,
   mode,
-  defaultPostType = "general",
+  defaultPostType,
   initialData,
   onSuccess,
 }: SchPostFormDialogProps) {
@@ -81,7 +81,7 @@ export function SchPostFormDialog({
       evt_end_at: null,
       url: null,
       cont_txt: null,
-    },
+    } as FormValues,
   });
 
   const { isSubmitting } = form.formState;
@@ -93,7 +93,7 @@ export function SchPostFormDialog({
     if (mode === "edit" && initialData) {
       form.reset({
         sch_nm: initialData.sch_nm,
-        post_type: initialData.post_type ?? "general",
+        post_type: initialData.post_type ?? "general" as SchPostType,
         evt_stt_at: toDatetimeLocal(initialData.evt_stt_at),
         evt_end_at: initialData.evt_end_at ? toDatetimeLocal(initialData.evt_end_at) : null,
         url: initialData.url ?? null,
@@ -102,7 +102,7 @@ export function SchPostFormDialog({
     } else if (mode === "create") {
       form.reset({
         sch_nm: "",
-        post_type: defaultPostType,
+        post_type: defaultPostType ?? undefined,
         evt_stt_at: initialData?.evt_stt_at ? toDateInput(initialData.evt_stt_at) : "",
         evt_end_at: null,
         url: null,
@@ -159,9 +159,9 @@ export function SchPostFormDialog({
               name="sch_nm"
               render={({ field }) => (
                 <FormItem>
-                  <FormLabel>일정명 <span className="text-destructive">*</span></FormLabel>
+                  <FormLabel>제목 <span className="text-destructive">*</span></FormLabel>
                   <FormControl>
-                    <Input placeholder="일정명을 입력해 주세요." {...field} />
+                    <Input placeholder="예: 동아마라톤 대회접수, 나이키 슈퍼위크 등" {...field} />
                   </FormControl>
                   <FormMessage />
                 </FormItem>
@@ -243,11 +243,11 @@ export function SchPostFormDialog({
                 name="post_type"
                 render={({ field }) => (
                   <FormItem>
-                    <FormLabel>유형</FormLabel>
+                    <FormLabel>유형 <span className="text-destructive">*</span></FormLabel>
                     <FormControl>
-                      <Select value={field.value} onValueChange={field.onChange}>
+                      <Select value={field.value ?? ""} onValueChange={field.onChange}>
                         <SelectTrigger className="text-[13px]">
-                          <SelectValue />
+                          <SelectValue placeholder="유형을 선택해 주세요." />
                         </SelectTrigger>
                         <SelectContent>
                           {SCH_POST_TYPES.map((type) => (

--- a/components/schedule/sch-post-form-dialog.tsx
+++ b/components/schedule/sch-post-form-dialog.tsx
@@ -40,7 +40,7 @@ import {
 import { Separator } from "@/components/ui/separator";
 
 const formSchema = createSchPostSchema.omit({ team_id: true }).extend({
-  post_type: z.enum(SCH_POST_TYPES),
+  post_type: z.enum(SCH_POST_TYPES, { message: "유형을 선택해 주세요." }),
 });
 type FormValues = z.infer<typeof formSchema>;
 
@@ -161,7 +161,7 @@ export function SchPostFormDialog({
                 <FormItem>
                   <FormLabel>제목 <span className="text-destructive">*</span></FormLabel>
                   <FormControl>
-                    <Input placeholder="예: 동아마라톤 대회접수, 나이키 슈퍼위크 등" {...field} />
+                    <Input placeholder="예: 동아마라톤 접수, 나이키 슈퍼위크 등" {...field} />
                   </FormControl>
                   <FormMessage />
                 </FormItem>

--- a/components/settings/settings-client.tsx
+++ b/components/settings/settings-client.tsx
@@ -179,7 +179,7 @@ export function SettingsClient({ isAdmin }: { isAdmin: boolean }) {
               버전 정보
             </span>
           </div>
-          <span className="text-sm text-muted-foreground">{process.env.NEXT_PUBLIC_APP_VERSION ?? "v0.0.0"}</span>
+          <span className="text-sm text-muted-foreground">v1.0.0</span>
         </div>
       </div>
 

--- a/lib/dayjs.ts
+++ b/lib/dayjs.ts
@@ -123,7 +123,7 @@ export function parseDate(dateStr: string): Date {
 
 /** "YYYY-MM-DD" 날짜의 D-Day 문자열 반환 (예: "D-3", "D-DAY", "D+1") */
 export function formatDDay(dateStr: string): string {
-  const today = dayjs().startOf("day");
+  const today = dayjs().tz(KST).startOf("day");
   const target = dayjs(dateStr).startOf("day");
   const diff = target.diff(today, "day");
   if (diff === 0) return "D-DAY";

--- a/lib/dayjs.ts
+++ b/lib/dayjs.ts
@@ -124,7 +124,7 @@ export function parseDate(dateStr: string): Date {
 /** "YYYY-MM-DD" 날짜의 D-Day 문자열 반환 (예: "D-3", "D-DAY", "D+1") */
 export function formatDDay(dateStr: string): string {
   const today = dayjs().tz(KST).startOf("day");
-  const target = dayjs(dateStr).startOf("day");
+  const target = dayjs(dateStr).tz(KST).startOf("day");
   const diff = target.diff(today, "day");
   if (diff === 0) return "D-DAY";
   if (diff > 0) return `D-${diff}`;

--- a/lib/validations/schedule.ts
+++ b/lib/validations/schedule.ts
@@ -1,23 +1,25 @@
 import { z } from "zod";
 
-export const SCH_POST_TYPES = ["general", "race_entry", "event"] as const;
+export const SCH_POST_TYPES = ["race_entry", "sale", "session", "general"] as const;
 export type SchPostType = typeof SCH_POST_TYPES[number];
 
 export const schPostTypeLabels: Record<SchPostType, string> = {
-  general: "일반",
-  race_entry: "대회접수",
-  event: "이벤트",
+  race_entry: "대회접수 정보",
+  sale: "세일 정보",
+  session: "세션 정보",
+  general: "기타",
 };
 
 export const schPostTypeInlineLabel: Partial<Record<SchPostType, string>> = {
   race_entry: "대회접수",
-  event: "이벤트",
+  sale: "세일",
+  session: "세션",
 };
 
 export const createSchPostSchema = z.object({
   team_id: z.string().uuid(),
-  sch_nm: z.string().min(1, "일정명을 입력해 주세요.").max(100, "일정명은 100자 이내로 입력해 주세요."),
-  post_type: z.enum(SCH_POST_TYPES).default("general"),
+  sch_nm: z.string().min(1, "제목을 입력해 주세요.").max(100, "제목은 100자 이내로 입력해 주세요."),
+  post_type: z.enum(SCH_POST_TYPES, { message: "유형을 선택해 주세요." }),
   evt_stt_at: z.string().min(1, "시작 일시를 입력해 주세요."),
   evt_end_at: z.string().nullable().optional(),
   url: z.string().url("올바른 URL 형식으로 입력해 주세요.").nullable().optional().or(z.literal("")),

--- a/lib/validations/schedule.ts
+++ b/lib/validations/schedule.ts
@@ -11,7 +11,7 @@ export const schPostTypeLabels: Record<SchPostType, string> = {
 };
 
 export const schPostTypeInlineLabel: Partial<Record<SchPostType, string>> = {
-  race_entry: "대회접수",
+  race_entry: "접수",
   sale: "세일",
   session: "세션",
 };


### PR DESCRIPTION
## Summary

### 🐛 버그 수정
- **formatDDay KST 타임존 수정**: Vercel(UTC) 서버와 브라우저(KST) 간 D-Day 계산 불일치로 발생하던 hydration error #418 수정
- **캘린더 셀 클릭 범위 복원**: 다중일 이벤트 바 도입 후 클릭 영역이 날짜 숫자 부분으로 축소되던 문제 수정 (오버레이 버튼으로 전체 높이 커버)

### ✨ 기능 개선

**캘린더 — 다중일 이벤트 스패닝 바**
- 기간 일정(evt_stt_at ~ evt_end_at)이 시작일에만 표시되던 버그 수정
- CSS grid span 기반 주차별 스패닝 바로 변경 — 24~27일 등록 시 4일에 걸쳐 연속 바로 표시
- 슬롯 그리디 배치로 여러 이벤트가 같은 행(slot)에 정렬되어 시각적으로 연결됨

**일정 시간 표시 개선** (캘린더뷰 · 리스트뷰 공통)
- 당일 일정: `HH:mm ~ HH:mm` (기존 동일)
- 다일 일정: `25일 09:00 ~ 26일 00:33`
- 월 넘어가는 일정: `6/25 09:00 ~ 7/1 00:33`

**일정 정보 추가 폼**
- 유형 4개로 개편: 대회접수 정보 / 세일 정보 / 세션 정보 / 기타
- 유형 기본값 제거 → 필수 선택 (미선택 시 한국어 오류 메시지)
- 일정명 → 제목, placeholder 예시 문구 개선
- DB CHECK 제약조건에 `sale`, `session` 추가 (dev/prd 동시 적용)

**알림 이동 버튼**
- 아이콘 단독 → `bg-secondary` 배경 + 패딩으로 탭 영역 확대 및 시각화

## Test Plan
- [ ] 홈탭 캘린더에서 24~27일 기간 일정 등록 후 연속 바 확인
- [ ] 다일 일정 선택 시 패널에서 `25일 09:00 ~ 26일 00:33` 형식 확인
- [ ] 리스트뷰에서도 동일한 날짜 표시 형식 확인
- [ ] 일정 추가 폼에서 유형 미선택 시 한국어 오류 메시지 확인
- [ ] 일정 등록 시 sale/session 타입 정상 저장 확인
- [ ] 알림 목록에서 이동 버튼 탭 영역 확인
- [ ] Vercel dev 환경에서 홈탭 hydration 에러 미발생 확인

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 일정 달력에서 여러 날에 걸친 일정이 전체 기간에 걸쳐 표시됩니다

* **개선 사항**
  * 일정 시간 표시 형식이 더 명확하게 개선되었습니다
  * 일정 등록 폼의 필드명과 입력창 안내 문구가 개선되었습니다
  * 일정 유형 선택이 필수 항목으로 강화되었습니다
  * 알림 버튼의 시각적 스타일이 개선되었습니다

* **버그 수정**
  * D-Day 계산이 한국 표준시 기준으로 정확하게 작동합니다

<!-- end of auto-generated comment: release notes by coderabbit.ai -->