### PR TITLE
fix(home): 일정 정보 삭제 권한 개선 및 캘린더 UX 수정

### DIFF
--- a/app/actions/schedule/manage-sch-post.ts
+++ b/app/actions/schedule/manage-sch-post.ts
@@ -4,7 +4,7 @@ import { revalidatePath } from "next/cache";
 import { after } from "next/server";
 
 import { dayjs } from "@/lib/dayjs";
-import { getCurrentMember } from "@/lib/queries/member";
+import { getCurrentMember, verifyAdmin } from "@/lib/queries/member";
 import { getRequestTeamContext } from "@/lib/queries/request-team";
 import { createUntypedAdminClient } from "@/lib/supabase/admin";
 import { createSchPostSchema, updateSchPostSchema } from "@/lib/validations/schedule";
@@ -35,7 +35,7 @@ export async function createSchPost(input: {
       team_id: parsed.team_id,
       sch_nm: parsed.sch_nm,
       post_type: parsed.post_type ?? "general",
-      evt_stt_at: toUtcIso(parsed.evt_stt_at) ?? parsed.evt_stt_at,
+      evt_stt_at: toUtcIso(parsed.evt_stt_at)!,
       evt_end_at: toUtcIso(parsed.evt_end_at),
       url: parsed.url || null,
       cont_txt: parsed.cont_txt ?? null,
@@ -119,7 +119,7 @@ export async function updateSchPost(input: {
     .from("sch_post_mst")
     .update({
       ...fields,
-      evt_stt_at: fields.evt_stt_at ? (toUtcIso(fields.evt_stt_at) ?? fields.evt_stt_at) : undefined,
+      evt_stt_at: fields.evt_stt_at ? toUtcIso(fields.evt_stt_at)! : undefined,
       evt_end_at: fields.evt_end_at !== undefined ? toUtcIso(fields.evt_end_at) : undefined,
       url: fields.url || null,
       upd_at: dayjs().toISOString(),
@@ -146,17 +146,8 @@ export async function deleteSchPost(sch_post_id: string) {
   // 작성자 또는 운영진(owner/admin) 확인
   const isAuthor = post.crt_by === member.id;
   if (!isAuthor) {
-    const { data: rel } = await supabase
-      .from("team_mem_rel")
-      .select("team_role_cd")
-      .eq("team_id", post.team_id)
-      .eq("mem_id", member.id)
-      .eq("vers", 0)
-      .eq("del_yn", false)
-      .single();
-    if (rel?.team_role_cd !== "owner" && rel?.team_role_cd !== "admin") {
-      throw new Error("삭제 권한이 없습니다.");
-    }
+    const adminResult = await verifyAdmin();
+    if (!adminResult) throw new Error("삭제 권한이 없습니다.");
   }
 
   // admin client로 del_yn=true (WITH CHECK RLS 우회)

--- a/components/home/mini-calendar.tsx
+++ b/components/home/mini-calendar.tsx
@@ -673,37 +673,33 @@ export function MiniCalendar({
                       })}
                     </div>
 
-                    {/* 이벤트 바 행 — 멀티데이 CSS grid span (표시 전용) */}
-                    {visibleLanes.length > 0 ? (
-                      <div
-                        className="relative z-10 grid grid-cols-7 pb-1"
-                        style={{ gridAutoRows: "13px", rowGap: "1px", pointerEvents: "none" }}
-                      >
-                        {visibleLanes.map((lane) => (
-                          <div
-                            key={`${lane.race.id}-w${weekIdx}`}
-                            style={{
-                              gridColumn: `${lane.colStart + 1} / ${lane.colStart + lane.colSpan + 1}`,
-                              gridRow: lane.slot + 1,
-                            }}
-                            className={cn(
-                              "overflow-hidden px-0.5 text-[7px] font-medium leading-[13px]",
-                              lane.startsThisWeek ? "rounded-l-sm" : "",
-                              lane.endsThisWeek ? "rounded-r-sm" : "",
-                              lane.race.type === "mine"
-                                ? "bg-success/20 text-success"
-                                : lane.race.type === "schedule"
-                                  ? "bg-info/15 text-info"
-                                  : "bg-warning/15 text-warning",
-                            )}
-                          >
-                            {lane.startsThisWeek ? lane.race.title : ""}
-                          </div>
-                        ))}
-                      </div>
-                    ) : (
-                      <div className="relative z-10 h-2" />
-                    )}
+                    {/* 이벤트 바 행 — 최대 3슬롯 고정 높이 (주 행 높이 일정하게 유지) */}
+                    <div
+                      className="relative z-10 grid grid-cols-7 pb-1"
+                      style={{ gridTemplateRows: "13px 13px 13px", rowGap: "1px", pointerEvents: "none" }}
+                    >
+                      {visibleLanes.map((lane) => (
+                        <div
+                          key={`${lane.race.id}-w${weekIdx}`}
+                          style={{
+                            gridColumn: `${lane.colStart + 1} / ${lane.colStart + lane.colSpan + 1}`,
+                            gridRow: lane.slot + 1,
+                          }}
+                          className={cn(
+                            "overflow-hidden px-0.5 text-[7px] font-medium leading-[13px]",
+                            lane.startsThisWeek ? "rounded-l-sm" : "",
+                            lane.endsThisWeek ? "rounded-r-sm" : "",
+                            lane.race.type === "mine"
+                              ? "bg-success/20 text-success"
+                              : lane.race.type === "schedule"
+                                ? "bg-info/15 text-info"
+                                : "bg-warning/15 text-warning",
+                          )}
+                        >
+                          {lane.startsThisWeek ? lane.race.title : ""}
+                        </div>
+                      ))}
+                    </div>
                   </div>
                 );
               })}

--- a/components/schedule/sch-post-detail-dialog.tsx
+++ b/components/schedule/sch-post-detail-dialog.tsx
@@ -54,6 +54,8 @@ export function SchPostDetailDialog({
       await deleteSchPost(post.id)
       onOpenChange(false)
       onDelete?.()
+    } catch (err) {
+      alert(err instanceof Error ? err.message : "삭제에 실패했습니다.")
     } finally {
       setDeleting(false)
     }


### PR DESCRIPTION
## 관련 이슈

관련 이슈 없음

## 요약

hotfix/home-info-share의 코드 리뷰에서 발견된 개선사항 3건 반영.
기능 버그는 아니지만 에러 처리 누락, 중복 코드, 캘린더 높이 불일치를 수정.

## AS-IS (변경 전)

- `handleDelete`에 catch 블록 없어 삭제 실패 시 사용자에게 아무 피드백 없이 조용히 실패
- `deleteSchPost`의 운영진 권한 체크가 `team_mem_rel` 직접 쿼리로 인라인 구현 → 역할 체계 변경 시 누락 위험
- `toUtcIso()` 호출 시 도달 불가능한 `?? fallback` 데드코드 존재
- 이벤트 없는 주와 있는 주 사이 캘린더 행 높이가 달라져 스크롤 시 덜컹거리는 UX

## TO-BE (변경 후)

- `handleDelete`: catch 블록 추가, 실패 시 에러 메시지 alert 표시
- `deleteSchPost`: 인라인 admin 체크 → `verifyAdmin()` 공용 함수로 교체
- `toUtcIso()` 호출부 non-null assertion(`!`)으로 의도 명시화, 데드코드 제거
- 캘린더 이벤트 바 영역을 `gridTemplateRows: "13px 13px 13px"` 고정 → 모든 주가 동일 높이 유지
