### PR TITLE
fix(dues): 파일 롤백 후 재업로드 차단 및 거래 재삽입 불가 버그 수정

### DIFF
--- a/app/actions/dues/rollback-xlsx.ts
+++ b/app/actions/dues/rollback-xlsx.ts
@@ -20,7 +20,6 @@ export async function rollbackXlsx(updId: string) {
     .maybeSingle();
 
   if (!upd) return { ok: false as const, message: "업로드 이력을 찾을 수 없습니다." };
-  if (upd.upd_st_cd === "rolled_back") return { ok: false as const, message: "이미 롤백된 업로드입니다." };
 
   // 확정된 거래 있는지 확인
   const { count } = await db

--- a/app/actions/dues/rollback-xlsx.ts
+++ b/app/actions/dues/rollback-xlsx.ts
@@ -41,10 +41,10 @@ export async function rollbackXlsx(updId: string) {
     .eq("upd_id", updId)
     .eq("is_cfm_yn", false);
 
-  // 업로드 상태 rolled_back
+  // 업로드 상태 rolled_back + del_yn=true (재업로드 허용을 위해 vers=0 해제)
   await db
     .from("fee_xlsx_upd_hist")
-    .update({ upd_st_cd: "rolled_back" })
+    .update({ upd_st_cd: "rolled_back", del_yn: true })
     .eq("upd_id", updId);
 
   return { ok: true as const, message: null };

--- a/app/actions/dues/rollback-xlsx.ts
+++ b/app/actions/dues/rollback-xlsx.ts
@@ -34,17 +34,21 @@ export async function rollbackXlsx(updId: string) {
   }
 
   // 미확정 거래 soft-delete
-  await db
+  const { error: txnErr } = await db
     .from("fee_txn_hist")
     .update({ del_yn: true })
     .eq("upd_id", updId)
     .eq("is_cfm_yn", false);
 
+  if (txnErr) return { ok: false as const, message: "거래 롤백 중 오류가 발생했습니다." };
+
   // 업로드 상태 rolled_back + del_yn=true (재업로드 허용을 위해 vers=0 해제)
-  await db
+  const { error: updHistErr } = await db
     .from("fee_xlsx_upd_hist")
     .update({ upd_st_cd: "rolled_back", del_yn: true })
     .eq("upd_id", updId);
+
+  if (updHistErr) return { ok: false as const, message: "업로드 이력 롤백 중 오류가 발생했습니다." };
 
   return { ok: true as const, message: null };
 }

--- a/app/actions/dues/upload-xlsx.ts
+++ b/app/actions/dues/upload-xlsx.ts
@@ -1,6 +1,7 @@
 "use server";
 
 import crypto from "crypto";
+
 import { verifyAdmin } from "@/lib/queries/member";
 import { getRequestTeamContext } from "@/lib/queries/request-team";
 import { createAdminClient } from "@/lib/supabase/admin";
@@ -173,7 +174,11 @@ export async function uploadXlsx(formData: FormData) {
       del_yn: false,
     });
 
-    if (error?.code === "23505") skipped++; // unique conflict
+    if (error?.code === "23505") {
+      skipped++;
+    } else if (error) {
+      console.error("[uploadXlsx] 거래 INSERT 실패:", error.code, error.message, row);
+    }
   }
 
   return {

--- a/app/actions/dues/upload-xlsx.ts
+++ b/app/actions/dues/upload-xlsx.ts
@@ -46,13 +46,14 @@ export async function uploadXlsx(formData: FormData) {
   const buffer = Buffer.from(await file.arrayBuffer());
   const fileHash = crypto.createHash("sha256").update(buffer).digest("hex");
 
-  // 중복 파일 체크
+  // 중복 파일 체크 (rolled_back 제외 — 롤백 후 재업로드 허용)
   const { data: existing } = await db
     .from("fee_xlsx_upd_hist")
     .select("upd_id")
     .eq("team_id", teamId)
     .eq("file_hash", fileHash)
     .eq("vers", 0)
+    .neq("upd_st_cd", "rolled_back")
     .maybeSingle();
 
   if (existing) return { ok: false as const, message: "이미 처리된 파일입니다." };
@@ -61,9 +62,7 @@ export async function uploadXlsx(formData: FormData) {
   let rows: ParsedRow[];
   try {
     const XLSX = await import("xlsx");
-    const password = process.env.KAKAOBANK_XLSX_PASSWORD;
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const wb = XLSX.read(buffer, { type: "buffer", password } as any);
+    const wb = XLSX.read(buffer, { type: "buffer" });
     const ws = wb.Sheets[wb.SheetNames[0]];
     // 9행: 빈행, 10행: 헤더, 11행~: 데이터 (0-indexed range:9 → raw[0]=빈행, raw[1]=헤더)
     const raw: string[][] = XLSX.utils.sheet_to_json(ws, { header: 1, range: 9 });

--- a/app/actions/dues/upload-xlsx.ts
+++ b/app/actions/dues/upload-xlsx.ts
@@ -47,13 +47,14 @@ export async function uploadXlsx(formData: FormData) {
   const buffer = Buffer.from(await file.arrayBuffer());
   const fileHash = crypto.createHash("sha256").update(buffer).digest("hex");
 
-  // 중복 파일 체크 (rolled_back 제외 — 롤백 후 재업로드 허용)
+  // 중복 파일 체크 (del_yn=false + rolled_back 제외 — 롤백 후 재업로드 허용)
   const { data: existing } = await db
     .from("fee_xlsx_upd_hist")
     .select("upd_id")
     .eq("team_id", teamId)
     .eq("file_hash", fileHash)
     .eq("vers", 0)
+    .eq("del_yn", false)
     .neq("upd_st_cd", "rolled_back")
     .maybeSingle();
 
@@ -100,7 +101,7 @@ export async function uploadXlsx(formData: FormData) {
       }];
     });
   } catch {
-    return { ok: false as const, message: "파일 파싱에 실패했습니다. 파일 형식 또는 비밀번호를 확인하세요." };
+    return { ok: false as const, message: "파일 파싱에 실패했습니다. 파일 형식을 확인하세요." };
   }
 
   // 업로드 이력 생성
@@ -177,7 +178,13 @@ export async function uploadXlsx(formData: FormData) {
     if (error?.code === "23505") {
       skipped++;
     } else if (error) {
-      console.error("[uploadXlsx] 거래 INSERT 실패:", error.code, error.message, row);
+      console.error("[uploadXlsx] 거래 INSERT 실패:", error.code, error.message, {
+        txn_dt: row.txn_dt,
+        txn_tm: row.txn_tm,
+        txn_amt: row.txn_amt,
+        fee_item_cd: row.fee_item_cd,
+      });
+      return { ok: false as const, message: `거래 저장 중 오류가 발생했습니다. (${error.code})` };
     }
   }
 

--- a/supabase/migrations/20260617100000_fee_txn_hist_dedup_partial_index.sql
+++ b/supabase/migrations/20260617100000_fee_txn_hist_dedup_partial_index.sql
@@ -1,0 +1,17 @@
+-- fee_txn_hist 중복 방지 제약을 partial index로 교체
+-- del_yn=false 인 살아있는 거래 사이에서만 중복을 막고,
+-- 롤백(del_yn=true)된 거래는 재업로드 시 재삽입 허용
+ALTER TABLE public.fee_txn_hist
+  DROP CONSTRAINT uk_fee_txn_hist_dedup;
+
+CREATE UNIQUE INDEX uk_fee_txn_hist_dedup
+  ON public.fee_txn_hist (team_id, txn_dt, txn_tm, txn_amt, raw_name)
+  WHERE del_yn = false;
+
+-- fee_xlsx_upd_hist 파일 중복 제약도 partial index로 교체
+-- 롤백(del_yn=true)된 업로드 이력은 동일 파일 재업로드 허용
+DROP INDEX public.uk_fee_xlsx_upd_hist_team_hash_vers;
+
+CREATE UNIQUE INDEX uk_fee_xlsx_upd_hist_team_hash_vers
+  ON public.fee_xlsx_upd_hist (team_id, file_hash, vers)
+  WHERE del_yn = false;

--- a/supabase/migrations/20260617100000_fee_txn_hist_dedup_partial_index.sql
+++ b/supabase/migrations/20260617100000_fee_txn_hist_dedup_partial_index.sql
@@ -10,7 +10,8 @@ CREATE UNIQUE INDEX uk_fee_txn_hist_dedup
 
 -- fee_xlsx_upd_hist 파일 중복 제약도 partial index로 교체
 -- 롤백(del_yn=true)된 업로드 이력은 동일 파일 재업로드 허용
-DROP INDEX public.uk_fee_xlsx_upd_hist_team_hash_vers;
+ALTER TABLE public.fee_xlsx_upd_hist
+  DROP CONSTRAINT uk_fee_xlsx_upd_hist_team_hash_vers;
 
 CREATE UNIQUE INDEX uk_fee_xlsx_upd_hist_team_hash_vers
   ON public.fee_xlsx_upd_hist (team_id, file_hash, vers)


### PR DESCRIPTION
## AS-IS (버그)

- 파일 롤백 후 동일 파일 재업로드 시 "이미 처리된 파일입니다." 로 차단됨
  - fee_xlsx_upd_hist 중복 체크에 upd_st_cd != 'rolled_back' 조건 누락
- 롤백된 거래내역이 del_yn=true 소프트딜리트 되어도 UNIQUE 제약이 del_yn 무관하게 걸려 재삽입 불가
  - uk_fee_txn_hist_dedup, uk_fee_xlsx_upd_hist_team_hash_vers 모두 partial index가 아님
- 파일 업로드 시 xlsx 비밀번호 로직이 잔존 (process.env.KAKAOBANK_XLSX_PASSWORD)

## TO-BE (수정)

### 코드
- upload-xlsx.ts: 중복 체크에 .neq("upd_st_cd", "rolled_back") 추가 → 롤백 후 재업로드 허용
- upload-xlsx.ts: xlsx 비밀번호 로직 제거
- upload-xlsx.ts: 거래 INSERT 실패 시 23505 외 에러도 콘솔 로깅 추가
- rollback-xlsx.ts: 롤백 시 fee_xlsx_upd_hist del_yn=true 처리 추가
- rollback-xlsx.ts: dead code 제거

### 마이그레이션
- uk_fee_txn_hist_dedup: 테이블 제약 → WHERE del_yn = false partial index 교체
- uk_fee_xlsx_upd_hist_team_hash_vers: 일반 index → WHERE del_yn = false partial index 교체

### 운영계 핫픽스 (이미 적용)
- rolled_back 상태이나 del_yn=false 로 남아있던 업로드 이력 2건 → del_yn=true 처리 완료


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **버그 수정**
  * 롤백된 업로드 이력 및 미확정 거래 처리 방식이 개선되어, 롤백 후 동일 파일을 다시 업로드할 수 있습니다.
  * 롤백 대상 업로드 이력 조회 결과가 없으면 즉시 실패 처리되도록 변경했습니다.

* **개선 사항**
  * XLSX 파싱 실패 시 메시지가 정리되고, 오류 발생 시 로깅/실패 반환이 더 명확해졌습니다.
  * 중복 제약이 롤백 데이터(del_yn=true)는 제외하도록 조정되어 재삽입이 가능해졌습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->