### PR TITLE
perf(home): 홈탭 성능 최적화 및 알림·일정 UX 개선

### DIFF
--- a/app/(main)/page.tsx
+++ b/app/(main)/page.tsx
@@ -7,6 +7,7 @@ import { getCachedCmmCdRows } from "@/lib/queries/cmm-cd-cached";
 import { getCurrentMember } from "@/lib/queries/member";
 import { getNotifications, getUnreadNotificationCount } from "@/lib/queries/notification";
 import { getRequestTeamContext } from "@/lib/queries/request-team";
+
 import { BoardPopoverIcon } from "@/components/board/board-popover-icon";
 import { H1 } from "@/components/common/typography";
 import { MiniCalendar } from "@/components/home/mini-calendar";

--- a/app/(main)/page.tsx
+++ b/app/(main)/page.tsx
@@ -1,66 +1,31 @@
-﻿import { Suspense } from "react";
+import { Suspense } from "react";
 
-import { dayjs, todayKST, currentMonthKST, monthLastDay } from "@/lib/dayjs";
+import { dayjs, currentMonthKST, monthLastDay } from "@/lib/dayjs";
 import { env } from "@/lib/env";
 import { hasUnreadBoardPost } from "@/lib/queries/board";
 import { getCachedCmmCdRows } from "@/lib/queries/cmm-cd-cached";
-import { getCurrentMember, getMyTitleNames } from "@/lib/queries/member";
-import { getUnreadNotificationCount } from "@/lib/queries/notification";
+import { getCurrentMember } from "@/lib/queries/member";
+import { getNotifications, getUnreadNotificationCount } from "@/lib/queries/notification";
 import { getRequestTeamContext } from "@/lib/queries/request-team";
-import { createAdminClient } from "@/lib/supabase/admin";
-
 import { BoardPopoverIcon } from "@/components/board/board-popover-icon";
 import { H1 } from "@/components/common/typography";
 import { MiniCalendar } from "@/components/home/mini-calendar";
 import type { CalendarRace } from "@/components/home/mini-calendar";
-import { RecentJoiners } from "@/components/home/recent-joiners";
-import type { RecentJoiner } from "@/components/home/recent-joiners";
-import { RecentRecordsGrid } from "@/components/home/recent-records-grid";
-import type { RecentRecord, RecordTitleInfo } from "@/components/home/recent-records-grid";
-import { RecentTitles } from "@/components/home/recent-titles";
-import type { RecentTitleGrant } from "@/components/home/recent-titles";
-import { UpcomingRaces } from "@/components/home/upcoming-races";
 import { NotificationBellIcon } from "@/components/notifications/notification-bell-icon";
 import type { CompetitionRegistration, MemberStatus } from "@/components/races/types";
 import { SocialLinksGrid } from "@/components/social-links";
 import { Skeleton } from "@/components/ui/skeleton";
 
 
-type UpcomingRace = {
-  id: string;
-  title: string;
-  start_date: string;
-  location: string | null;
-  sport: string | null;
-  event_types: string[] | null;
-  /** 참가자들이 참가 시 입력한 이벤트 타입 (표시용, 없으면 event_types 사용) */
-  registered_event_types?: string[];
-  regCount?: number;
-  label?: string;
-};
-
-/** 같은 날이거나 같은 주말(토-일)이면 true */
-function isSameSlot(dateA: string, dateB: string) {
-  if (dateA === dateB) return true;
-  const a = new Date(dateA);
-  const b = new Date(dateB);
-  const dayA = a.getDay(); // 0=일, 6=토
-  const dayB = b.getDay();
-  const diff = Math.abs(a.getTime() - b.getTime()) / (1000 * 60 * 60 * 24);
-  // 토-일 or 일-토, 1일 차이
-  return diff <= 1 && ((dayA === 6 && dayB === 0) || (dayA === 0 && dayB === 6));
-}
-
-const SHOW_EXTRA_SECTIONS = false;
-
 async function HomeHeader() {
   const { member: currentMember } = await getCurrentMember();
   const { teamId } = await getRequestTeamContext();
 
-  const [unreadNotiCount, hasUnreadNotice, hasUnreadUpdate] = await Promise.all([
+  const [unreadNotiCount, hasUnreadNotice, hasUnreadUpdate, initialNotifications] = await Promise.all([
     getUnreadNotificationCount(currentMember?.id),
     hasUnreadBoardPost(currentMember?.id, teamId, "notice"),
     hasUnreadBoardPost(currentMember?.id, teamId, "update"),
+    currentMember ? getNotifications(currentMember.id, { limit: 20 }) : Promise.resolve([]),
   ]);
 
   return (
@@ -84,6 +49,7 @@ async function HomeHeader() {
         />
         <NotificationBellIcon
           initialCount={unreadNotiCount}
+          initialNotifications={initialNotifications}
           memberId={currentMember?.id}
           disabled={!currentMember}
         />
@@ -94,101 +60,39 @@ async function HomeHeader() {
 
 async function HomeContent() {
   const { user, member: currentMember, supabase } = await getCurrentMember();
-  const admin = createAdminClient();
   const { teamId } = await getRequestTeamContext();
-  const today = todayKST();
   const monthStart = currentMonthKST();
 
-  // 이번 달 마지막 날 계산
   const [yearStr, monthStr] = monthStart.split("-");
   const monthLastDayStr = monthLastDay(parseInt(yearStr, 10), parseInt(monthStr, 10));
 
   let initialMemberStatus: MemberStatus = { status: "signed-out" };
 
   const [
-    { data: teamComps },
-    { data: recentRecordsRaw },
     { data: calendarComps },
-    { data: recentJoinersRaw },
-    { data: recentTitleGrantsRaw },
     cmmCdRows,
-    myTitleNames,
+    { data: schPostRows },
+    myRegsResult,
   ] = await Promise.all([
-    supabase.rpc("get_public_team_competitions", { p_team_id: teamId, p_start: today }),
-    SHOW_EXTRA_SECTIONS
-      ? supabase.rpc("get_public_team_recent_records", { p_team_id: teamId, p_limit: 12 })
-      : Promise.resolve({ data: null }),
     supabase.rpc("get_public_team_competitions", { p_team_id: teamId, p_start: monthStart, p_end: monthLastDayStr }),
-    SHOW_EXTRA_SECTIONS
-      ? admin
-          .from("team_mem_rel")
-          .select("mem_id, join_dt, mem_mst!inner(mem_nm)")
-          .eq("team_id", teamId)
-          .eq("mem_st_cd", "active")
-          .eq("vers", 0)
-          .eq("del_yn", false)
-          .order("join_dt", { ascending: false })
-          .limit(10)
-      : Promise.resolve({ data: null }),
-    SHOW_EXTRA_SECTIONS
-      ? admin
-          .from("mem_ttl_rel")
-          .select("grnt_at, ttl_mst!inner(ttl_nm, ttl_desc, desc_visibility), team_mem_rel!inner(mem_id, selected_badge_effect, mem_mst!inner(mem_nm))")
-          .eq("team_id", teamId)
-          .eq("vers", 0)
-          .eq("del_yn", false)
-          .order("grnt_at", { ascending: false })
-          .limit(10)
-      : Promise.resolve({ data: null }),
     getCachedCmmCdRows(),
-    getMyTitleNames(),
+    supabase.rpc("get_public_team_sch_posts", {
+      p_team_id: teamId,
+      p_start: monthStart,
+      p_end: monthLastDayStr,
+    }),
+    currentMember
+      ? supabase
+          .from("comp_reg_rel")
+          .select(
+            "comp_reg_id, mem_id, prt_role_cd, crt_at, team_comp_plan_rel!inner(comp_id, comp_mst!inner(comp_id, comp_nm, stt_dt, loc_nm, comp_sprt_cd, comp_evt_cfg(comp_evt_type))), comp_evt_cfg(comp_evt_type)",
+          )
+          .eq("mem_id", currentMember.id)
+          .eq("team_comp_plan_rel.team_id", teamId)
+          .eq("vers", 0)
+          .eq("del_yn", false)
+      : Promise.resolve({ data: null }),
   ]);
-
-  // 기강대회: 등록자 1명 이상, 중복 제거 + 참가자 등록 event_type 수집
-  const seenIds = new Set<string>();
-  const gigangRaces: UpcomingRace[] = (teamComps ?? [])
-    .filter((row) => (row.reg_count ?? 0) > 0)
-    .map((row) => {
-      const regs = (row.reg_evt_types ?? []).map((evt) => ({ evt_cd: evt }));
-      const registered_event_types = [
-        ...new Set(regs.map((re) => re.evt_cd).filter((et): et is string => Boolean(et?.trim()))),
-      ].sort();
-      return {
-        id: row.comp_id,
-        title: row.comp_nm,
-        start_date: row.stt_dt,
-        location: row.loc_nm,
-        sport: row.comp_sprt_cd,
-        event_types: (row.comp_evt_types ?? []).map((e) => e?.toUpperCase()).filter(Boolean),
-        regCount: row.reg_count ?? 0,
-        registered_event_types: registered_event_types.length > 0 ? registered_event_types : undefined,
-      } as UpcomingRace;
-    })
-    .filter((r) => {
-      const regs = r.regCount ?? 0;
-      if (regs === 0) return false;
-      if (seenIds.has(r.id)) return false;
-      seenIds.add(r.id);
-      return true;
-    });
-
-  // 기강대회 1번 카드: 가장 가까운 것 (같은 주말이면 참여 인원 많은 것)
-  let topGigang: UpcomingRace | null = null;
-  if (gigangRaces.length > 0) {
-    const first = gigangRaces[0];
-    const weekendGroup = gigangRaces.filter(
-      (r) => isSameSlot(r.start_date, first.start_date),
-    );
-    weekendGroup.sort((a, b) => (b.regCount ?? 0) - (a.regCount ?? 0));
-    topGigang = weekendGroup[0];
-  }
-
-  // sch_post (이번 달) — 댓글 수 포함 RPC
-  const { data: schPostRows } = await supabase.rpc("get_public_team_sch_posts", {
-    p_team_id: teamId,
-    p_start: monthStart,
-    p_end: monthLastDayStr,
-  });
 
   const calendarSchPosts: CalendarRace[] = (schPostRows ?? []).map((row) => ({
     id: row.sch_post_id,
@@ -206,15 +110,8 @@ async function HomeContent() {
     cmntCount: row.cmnt_count ? Number(row.cmnt_count) : undefined,
   }));
 
-  // 캘린더용 기강 대회 (이번 달)
-  const calendarGigangSeenIds = new Set<string>();
   const calendarGigangRaces: CalendarRace[] = (calendarComps ?? [])
     .filter((row) => (row.reg_count ?? 0) > 0 && row.stt_dt <= monthLastDayStr)
-    .filter((row) => {
-      if (calendarGigangSeenIds.has(row.comp_id)) return false;
-      calendarGigangSeenIds.add(row.comp_id);
-      return true;
-    })
     .map((row) => ({
       id: row.comp_id,
       title: row.comp_nm,
@@ -225,35 +122,26 @@ async function HomeContent() {
       cmntCount: row.cmnt_count ? Number(row.cmnt_count) : undefined,
     }));
 
-  // 내가 참가하는 대회 가져오기
-  let myRaces: UpcomingRace[] = [];
   let myRegistrations: CompetitionRegistration[] = [];
   let isMember = false;
   let calendarMyRaces: CalendarRace[] = [];
 
   if (user) {
     if (currentMember) {
-      const member = currentMember;
       isMember = true;
-      initialMemberStatus = member.status !== "active"
+      initialMemberStatus = currentMember.status !== "active"
         ? { status: "inactive", userId: user.id }
         : {
             status: "ready",
             userId: user.id,
-            memberId: member.id,
-            fullName: member.full_name ?? null,
-            email: member.email ?? null,
-            admin: member.admin ?? false,
+            memberId: currentMember.id,
+            fullName: currentMember.full_name ?? null,
+            email: currentMember.email ?? null,
+            admin: currentMember.admin ?? false,
           };
-      const { data: myRegs } = await supabase
-        .from("comp_reg_rel")
-        .select(
-          "comp_reg_id, mem_id, prt_role_cd, crt_at, team_comp_plan_rel!inner(comp_id, comp_mst!inner(comp_id, comp_nm, stt_dt, loc_nm, comp_sprt_cd, comp_evt_cfg(comp_evt_type))), comp_evt_cfg(comp_evt_type)",
-        )
-        .eq("mem_id", member.id)
-        .eq("team_comp_plan_rel.team_id", teamId)
-        .eq("vers", 0)
-        .eq("del_yn", false);
+
+      const myRegs = myRegsResult?.data ?? null;
+
       myRegistrations = (myRegs ?? []).map((r) => ({
         id: r.comp_reg_id,
         competition_id: (
@@ -269,105 +157,25 @@ async function HomeContent() {
           )?.comp_evt_type?.toUpperCase() ?? null,
         created_at: r.crt_at,
       })) as CompetitionRegistration[];
-      myRaces = (myRegs ?? [])
-        .map((r) => {
-          const plan = Array.isArray(r.team_comp_plan_rel)
-            ? r.team_comp_plan_rel[0]
-            : r.team_comp_plan_rel;
-          const comp = Array.isArray(plan.comp_mst) ? plan.comp_mst[0] : plan.comp_mst;
-          return {
-            id: comp.comp_id,
-            title: comp.comp_nm,
-            start_date: comp.stt_dt,
-            location: comp.loc_nm,
-            sport: comp.comp_sprt_cd,
-            event_types: (comp.comp_evt_cfg ?? [])
-              .map((e: { comp_evt_type: string | null }) => e.comp_evt_type?.toUpperCase())
-              .filter(Boolean),
-          } as UpcomingRace;
-        })
-        .filter((c) => c && c.start_date >= today)
-        .sort((a, b) => a.start_date.localeCompare(b.start_date));
 
-      // 캘린더용 내 대회 (이번 달) — today 필터 없이 myRegs 원본에서 직접 추출
-      const calendarCompsRegCountMap = new Map<string, number>(
-        (calendarComps ?? []).map((row) => [row.comp_id, row.reg_count ?? 0]),
-      );
-      const calendarCompsCmntCountMap = new Map<string, number>(
-        (calendarComps ?? []).map((row) => [row.comp_id, row.cmnt_count ? Number(row.cmnt_count) : 0]),
-      );
+      const calendarCompsMetaMap = new Map<string, { regCount: number; cmntCount: number }>();
+      for (const row of calendarComps ?? []) {
+        calendarCompsMetaMap.set(row.comp_id, {
+          regCount: row.reg_count ?? 0,
+          cmntCount: row.cmnt_count ? Number(row.cmnt_count) : 0,
+        });
+      }
       calendarMyRaces = (myRegs ?? [])
         .flatMap((r) => {
           const plan = Array.isArray(r.team_comp_plan_rel) ? r.team_comp_plan_rel[0] : r.team_comp_plan_rel;
           const comp = Array.isArray(plan.comp_mst) ? plan.comp_mst[0] : plan.comp_mst;
           if (!comp) return [];
-          const cmntCount = calendarCompsCmntCountMap.get(comp.comp_id);
-          const race: CalendarRace = { id: comp.comp_id, title: comp.comp_nm, start_date: comp.stt_dt, type: "mine", location: comp.loc_nm ?? null, regCount: calendarCompsRegCountMap.get(comp.comp_id) ?? 0, cmntCount: cmntCount || undefined };
+          const meta = calendarCompsMetaMap.get(comp.comp_id);
+          const race: CalendarRace = { id: comp.comp_id, title: comp.comp_nm, start_date: comp.stt_dt, type: "mine", location: comp.loc_nm ?? null, regCount: meta?.regCount ?? 0, cmntCount: meta?.cmntCount || undefined };
           return race.start_date >= monthStart && race.start_date <= monthLastDayStr ? [race] : [];
         });
-
-      // 내 대회 각 competition에 대해 참가자들이 등록한 event_type 수집
-      if (myRaces.length > 0) {
-        const { data: regsByComp } = await supabase
-          .from("comp_reg_rel")
-          .select("team_comp_plan_rel!inner(comp_id), comp_evt_cfg(comp_evt_type)")
-          .eq("team_comp_plan_rel.team_id", teamId)
-          .in(
-            "team_comp_plan_rel.comp_id",
-            myRaces.map((r) => r.id),
-          );
-        const byCompId = new Map<string, Set<string>>();
-        (regsByComp ?? []).forEach((row) => {
-          const compId = (
-            Array.isArray(row.team_comp_plan_rel)
-              ? row.team_comp_plan_rel[0]
-              : row.team_comp_plan_rel
-          )?.comp_id;
-          const evtCd = (
-            Array.isArray(row.comp_evt_cfg) ? row.comp_evt_cfg[0] : row.comp_evt_cfg
-          )?.comp_evt_type;
-          if (!compId || !evtCd?.trim()) return;
-          let set = byCompId.get(compId);
-          if (!set) {
-            set = new Set();
-            byCompId.set(compId, set);
-          }
-          set.add(evtCd.trim().toUpperCase());
-        });
-        myRaces = myRaces.map((r) => {
-          const set = byCompId.get(r.id);
-          const registered_event_types = set ? [...set].sort() : undefined;
-          return { ...r, registered_event_types };
-        });
-      }
     } else {
-      // 인증됐지만 member가 없으면 온보딩 필요
       initialMemberStatus = { status: "needs-onboarding", userId: user.id };
-    }
-  }
-
-  // 업커밍 카드 결정 (기존 로직 유지)
-  const upcomingCards: UpcomingRace[] = [];
-
-  if (topGigang) {
-    upcomingCards.push({ ...topGigang, label: "기강 대회" });
-  }
-
-  const isDifferentSlot = (r: UpcomingRace) =>
-    !topGigang || !isSameSlot(r.start_date, topGigang.start_date);
-
-  const myNext = myRaces.find((r) => isDifferentSlot(r));
-  if (myNext) {
-    upcomingCards.push({ ...myNext, label: "내 대회" });
-  } else if (myRaces.length > 0 && !isDifferentSlot(myRaces[0])) {
-    const nextGigang = gigangRaces.find((r) => isDifferentSlot(r));
-    if (nextGigang) {
-      upcomingCards.push({ ...nextGigang, label: "기강 대회" });
-    }
-  } else if (!currentMember) {
-    const nextGigang = gigangRaces.find((r) => isDifferentSlot(r));
-    if (nextGigang) {
-      upcomingCards.push({ ...nextGigang, label: "기강 대회" });
     }
   }
 
@@ -376,134 +184,25 @@ async function HomeContent() {
     initialRegistrationsByCompetitionId[reg.competition_id] = reg;
   });
 
-  const recentRecords: RecentRecord[] = (recentRecordsRaw ?? []).map((r) => ({
-    mem_id: r.mem_id ?? null,
-    mem_nm: r.mem_nm ?? null,
-    race_nm: r.race_nm ?? null,
-    evt_cd: r.evt_cd ?? null,
-    rec_time_sec: r.rec_time_sec ?? null,
-  }));
-
-  // 최근 기록 멤버들의 칭호/프레임 조회
-  const recentMemberIds = recentRecords
-    .map((r) => r.mem_id)
-    .filter((id): id is string => Boolean(id));
-  const titleMap: Record<string, RecordTitleInfo> = {};
-  if (recentMemberIds.length > 0) {
-    const { data: titleData } = await admin
-      .from("mem_ttl_rel")
-      .select(
-        "team_mem_rel!inner(mem_id, selected_badge_effect, selected_frame_cd), ttl_mst!inner(ttl_nm, ttl_desc, desc_visibility)",
-      )
-      .in("team_mem_rel.mem_id", recentMemberIds)
-      .eq("team_mem_rel.team_id", teamId)
-      .eq("is_prmy_yn", true)
-      .eq("vers", 0)
-      .eq("del_yn", false);
-    for (const row of titleData ?? []) {
-      const rel = Array.isArray(row.team_mem_rel) ? row.team_mem_rel[0] : row.team_mem_rel;
-      const ttl = Array.isArray(row.ttl_mst) ? row.ttl_mst[0] : row.ttl_mst;
-      if (rel?.mem_id && ttl?.ttl_nm) {
-        const r = rel as {
-          mem_id: string;
-          selected_badge_effect?: string | null;
-          selected_frame_cd?: string | null;
-        };
-        const t = ttl as {
-          ttl_nm: string;
-          ttl_desc?: string | null;
-          desc_visibility?: string;
-        };
-        titleMap[r.mem_id] = {
-          ttl_nm: t.ttl_nm,
-          ttl_desc: t.ttl_desc ?? null,
-          desc_visibility: (t.desc_visibility ?? "others") as
-            | "always"
-            | "others"
-            | "held"
-            | "never",
-          badge_effect: r.selected_badge_effect ?? "none",
-          frame_cd: r.selected_frame_cd ?? "frame-none",
-        };
-      }
-    }
-  }
-
-  // 최근 가입자 가공
-  const recentJoiners: RecentJoiner[] = (recentJoinersRaw ?? []).map((row) => {
-    const mem = Array.isArray(row.mem_mst) ? row.mem_mst[0] : row.mem_mst;
-    return {
-      mem_id: row.mem_id as string,
-      mem_nm: (mem as { mem_nm: string })?.mem_nm ?? "멤버",
-      join_dt: row.join_dt as string,
-    };
-  });
-
-  // 최근 칭호 획득 가공
-  const recentTitleGrants: RecentTitleGrant[] = (recentTitleGrantsRaw ?? []).map((row) => {
-    const rel = Array.isArray(row.team_mem_rel) ? row.team_mem_rel[0] : row.team_mem_rel;
-    const ttl = Array.isArray(row.ttl_mst) ? row.ttl_mst[0] : row.ttl_mst;
-    const memInfo = rel as { mem_id: string; selected_badge_effect?: string | null; mem_mst: { mem_nm: string } | { mem_nm: string }[] } | null;
-    const memMst = memInfo ? (Array.isArray(memInfo.mem_mst) ? memInfo.mem_mst[0] : memInfo.mem_mst) : null;
-    const ttlInfo = ttl as { ttl_nm: string; ttl_desc?: string | null; desc_visibility?: string } | null;
-    return {
-      mem_id: memInfo?.mem_id ?? "",
-      mem_nm: (memMst as { mem_nm: string } | null)?.mem_nm ?? "멤버",
-      ttl_nm: ttlInfo?.ttl_nm ?? "",
-      ttl_desc: ttlInfo?.ttl_desc ?? null,
-      desc_visibility: (ttlInfo?.desc_visibility ?? "others") as "always" | "others" | "held" | "never",
-      badge_effect: memInfo?.selected_badge_effect ?? "none",
-      grnt_at: row.grnt_at as string,
-    };
-  }).filter((g) => g.mem_id && g.ttl_nm);
-
   return (
     <div className="flex flex-col gap-0">
-
       <div className="flex flex-col gap-7 px-6 pb-6">
-      {/* 2. SCHEDULE 캘린더 */}
-      <Suspense>
-        <MiniCalendar
-          gigangRaces={calendarGigangRaces}
-          myRaces={calendarMyRaces}
-          schPosts={calendarSchPosts}
-          teamId={teamId}
-          memberId={currentMember?.id}
-          cmmCdRows={cmmCdRows}
-          initialMemberStatus={initialMemberStatus}
-          initialRegistrationsByCompetitionId={initialRegistrationsByCompetitionId}
-        />
-      </Suspense>
-
-      {/* 3. UPCOMING RACES 압축 리스트 */}
-      <UpcomingRaces
-        teamId={teamId}
-        cmmCdRows={cmmCdRows}
-        races={upcomingCards}
-        initialMemberStatus={initialMemberStatus}
-        initialRegistrationsByCompetitionId={initialRegistrationsByCompetitionId}
-      />
-
-      {/* 4. RECENT RECORDS + 최근 가입자 + 최근 칭호 (기획 재설계 전까지 비노출) */}
-      {SHOW_EXTRA_SECTIONS && (
-        <>
-          <RecentRecordsGrid
-            records={recentRecords}
-            titleMap={titleMap}
-            myTitleNames={[...myTitleNames]}
-            initialCount={2}
+        <Suspense>
+          <MiniCalendar
+            gigangRaces={calendarGigangRaces}
+            myRaces={calendarMyRaces}
+            schPosts={calendarSchPosts}
+            teamId={teamId}
+            memberId={currentMember?.id}
+            cmmCdRows={cmmCdRows}
+            initialMemberStatus={initialMemberStatus}
+            initialRegistrationsByCompetitionId={initialRegistrationsByCompetitionId}
           />
-          <div className="grid grid-cols-2 gap-4">
-            <RecentJoiners joiners={recentJoiners} initialCount={4} />
-            <RecentTitles grants={recentTitleGrants} initialCount={4} myTitleNames={[...myTitleNames]} />
-          </div>
-        </>
-      )}
+        </Suspense>
 
-      {/* 7. Social Links */}
-      <SocialLinksGrid
-        kakaoChatPassword={isMember ? (env.KAKAO_CHAT_PASSWORD ?? "") : undefined}
-      />
+        <SocialLinksGrid
+          kakaoChatPassword={isMember ? (env.KAKAO_CHAT_PASSWORD ?? "") : undefined}
+        />
       </div>
     </div>
   );
@@ -513,29 +212,21 @@ async function HomeContent() {
 function HomeSkeleton() {
   return (
     <div className="flex flex-col gap-0">
-      {/* 헤더 스켈레톤 */}
-      <div className="flex flex-col gap-2 px-6 pb-6 pt-4">
-        <Skeleton className="h-8 w-16" />
-        <Skeleton className="h-4 w-48" />
-      </div>
       <div className="flex flex-col gap-7 px-6 pb-6">
-      {/* 캘린더 */}
-      <div className="flex flex-col gap-3">
-        <Skeleton className="h-3.5 w-20" />
-        <Skeleton className="h-64 rounded-xl" />
-      </div>
-      {/* Upcoming */}
-      <div className="flex flex-col gap-3">
-        <Skeleton className="h-3.5 w-32" />
-        <Skeleton className="h-10 rounded-lg" />
-        <Skeleton className="h-10 rounded-lg" />
-      </div>
-      {/* Social Links */}
-      <div className="grid grid-cols-4 gap-3">
-        {Array.from({ length: 4 }).map((_, i) => (
-          <Skeleton key={i} className="h-16 rounded-2xl" />
-        ))}
-      </div>
+        {/* MiniCalendar 영역 */}
+        <div className="flex flex-col gap-3">
+          <Skeleton className="h-3.5 w-20" />
+          <Skeleton className="h-64 rounded-xl" />
+        </div>
+        {/* SocialLinksGrid 영역 */}
+        <div className="flex flex-col gap-4">
+          <Skeleton className="h-3 w-12" />
+          <div className="grid grid-cols-4 gap-2.5">
+            {Array.from({ length: 4 }).map((_, i) => (
+              <Skeleton key={i} className="h-[72px] rounded-2xl" />
+            ))}
+          </div>
+        </div>
       </div>
     </div>
   );
@@ -555,7 +246,10 @@ function HomeHeaderSkeleton() {
           No time to be weak
         </p>
       </div>
-      <div className="size-8 shrink-0" />
+      <div className="flex shrink-0 items-center gap-1">
+        <div className="size-8 shrink-0" />
+        <div className="size-8 shrink-0" />
+      </div>
     </div>
   );
 }

--- a/app/api/og/route.ts
+++ b/app/api/og/route.ts
@@ -1,0 +1,29 @@
+import { NextRequest, NextResponse } from "next/server";
+
+export async function GET(req: NextRequest) {
+  const url = req.nextUrl.searchParams.get("url");
+  if (!url) return NextResponse.json({ error: "url required" }, { status: 400 });
+
+  try {
+    const res = await fetch(url, {
+      headers: { "User-Agent": "Mozilla/5.0 (compatible; Googlebot/2.1)" },
+      next: { revalidate: 3600 },
+    });
+    const html = await res.text();
+
+    const get = (prop: string) => {
+      const m = html.match(new RegExp(`<meta[^>]+property=["']og:${prop}["'][^>]+content=["']([^"']+)["']`, "i"))
+        ?? html.match(new RegExp(`<meta[^>]+content=["']([^"']+)["'][^>]+property=["']og:${prop}["']`, "i"));
+      return m?.[1] ?? null;
+    };
+
+    const title = get("title") ?? html.match(/<title[^>]*>([^<]+)<\/title>/i)?.[1] ?? null;
+    const image = get("image");
+    const description = get("description");
+    const hostname = new URL(url).hostname.replace(/^www\./, "");
+
+    return NextResponse.json({ title, image, description, hostname });
+  } catch {
+    return NextResponse.json({ title: null, image: null, description: null, hostname: null });
+  }
+}

--- a/components/comment/comment-item.tsx
+++ b/components/comment/comment-item.tsx
@@ -24,6 +24,8 @@ export type CmntRow = {
   crt_at: string
   upd_at: string
   has_replies?: boolean
+  optimistic?: boolean
+  optimisticFailed?: boolean
 }
 
 interface CommentItemProps {
@@ -75,12 +77,18 @@ export function CommentItem({
   }
 
   return (
-    <div className={`flex gap-2.5 py-2.5 ${isReply ? "pl-10" : ""}`}>
+    <div className={`flex gap-2.5 py-2.5 ${isReply ? "pl-10" : ""} ${comment.optimistic ? "opacity-50" : ""}`}>
       <Avatar src={comment.avatar_url} size="sm" />
       <div className="flex-1 min-w-0">
         <div className="flex items-center gap-x-2">
           <Body className="text-sm font-semibold">{comment.mem_nm}</Body>
-          <Caption className="text-xs">{dayjs(comment.crt_at).fromNow()}</Caption>
+          {comment.optimisticFailed ? (
+            <Caption className="text-xs text-destructive">전송 실패</Caption>
+          ) : comment.optimistic ? (
+            <Caption className="text-xs text-muted-foreground">전송 중...</Caption>
+          ) : (
+            <Caption className="text-xs">{dayjs(comment.crt_at).fromNow()}</Caption>
+          )}
           {comment.edit_yn && <Caption className="text-xs opacity-60">(수정됨)</Caption>}
           {!editing && (
             <div className="ml-auto flex gap-3">

--- a/components/comment/comment-section.tsx
+++ b/components/comment/comment-section.tsx
@@ -21,6 +21,7 @@ interface CommentSectionProps {
   currentMemberId?: string
   isAdmin?: boolean
   members: MemberOption[]
+  initialComments?: CmntRow[]
 }
 
 type CommentWithReplies = CmntRow & { replies: CmntRow[] }
@@ -47,9 +48,18 @@ export function CommentSection({
   currentMemberId,
   isAdmin,
   members,
+  initialComments,
 }: CommentSectionProps) {
-  const [comments, setComments] = useState<CmntRow[]>([])
-  const [loadingComments, setLoadingComments] = useState(!!currentMemberId)
+  const [comments, setComments] = useState<CmntRow[]>(initialComments ?? [])
+  const [loadingComments, setLoadingComments] = useState(!!currentMemberId && !initialComments)
+
+  // entityId 변경 시 (다른 글 열기) 이전 댓글 초기화
+  useEffect(() => {
+    // eslint-disable-next-line react-hooks/set-state-in-effect
+    setComments(initialComments ?? [])
+    // eslint-disable-next-line react-hooks/set-state-in-effect
+    setLoadingComments(!!currentMemberId && !initialComments)
+  }, [entityId])
   const [newText, setNewText] = useState("")
   const [replyTo, setReplyTo] = useState<CmntRow | null>(null)
   const [replyText, setReplyText] = useState("")
@@ -61,7 +71,7 @@ export function CommentSection({
 
   // 댓글 클라이언트 직접 조회
   useEffect(() => {
-    if (!currentMemberId) return
+    if (!currentMemberId || initialComments) return
     let cancelled = false
     // eslint-disable-next-line react-hooks/set-state-in-effect
     setLoadingComments(true)

--- a/components/comment/comment-section.tsx
+++ b/components/comment/comment-section.tsx
@@ -57,7 +57,7 @@ export function CommentSection({
   useEffect(() => {
     // eslint-disable-next-line react-hooks/set-state-in-effect
     setComments(initialComments ?? [])
-    // eslint-disable-next-line react-hooks/set-state-in-effect
+     
     setLoadingComments(!!currentMemberId && !initialComments)
   }, [entityId])
   const [newText, setNewText] = useState("")

--- a/components/comment/comment-section.tsx
+++ b/components/comment/comment-section.tsx
@@ -63,7 +63,6 @@ export function CommentSection({
   const [newText, setNewText] = useState("")
   const [replyTo, setReplyTo] = useState<CmntRow | null>(null)
   const [replyText, setReplyText] = useState("")
-  const [loading, setLoading] = useState(false)
 
   const supabase = useMemo(() => createClient(), [])
   const membersRef = useRef(members)
@@ -126,6 +125,15 @@ export function CommentSection({
             const incoming = payload.new as CmntRow
             setComments((prev) => {
               if (prev.some((c) => c.cmnt_id === incoming.cmnt_id)) return prev
+              // 내가 보낸 optimistic 댓글이 아직 교체 안 된 상태에서 Realtime이 먼저 온 경우 → optimistic 교체
+              const optimisticIdx = prev.findIndex(
+                (c) => c.optimistic && c.mem_id === incoming.mem_id && c.cont_txt === incoming.cont_txt && c.prnt_id === incoming.prnt_id
+              )
+              if (optimisticIdx !== -1) {
+                const next = [...prev]
+                next[optimisticIdx] = { ...incoming, mem_nm: prev[optimisticIdx].mem_nm, avatar_url: prev[optimisticIdx].avatar_url }
+                return next
+              }
               const mem = membersRef.current.find((m) => m.mem_id === incoming.mem_id)
               return [...prev, { ...incoming, mem_nm: mem?.mem_nm ?? "멤버", avatar_url: incoming.avatar_url ?? mem?.avatar_url ?? null }]
             })
@@ -149,71 +157,84 @@ export function CommentSection({
 
   const handleSubmitComment = async () => {
     if (!newText.trim() || !currentMemberId) return
-    setLoading(true)
-    try {
-      const result = await createComment({
-        entityType,
-        entityId,
-        contTxt: newText.trim(),
-        mentionedMemIds: parseMentionsFromText(newText, members),
-      })
-      if (result.ok) {
-        const me = members.find((m) => m.mem_id === currentMemberId)
-        setComments((prev) => [
-          ...prev,
-          {
-            cmnt_id: result.data.cmnt_id,
-            prnt_id: result.data.prnt_id,
-            mem_id: result.data.mem_id,
-            mem_nm: me?.mem_nm ?? "나",
-            avatar_url: me?.avatar_url ?? null,
-            cont_txt: result.data.cont_txt,
-            edit_yn: result.data.edit_yn,
-            del_yn: result.data.del_yn,
-            crt_at: result.data.crt_at,
-            upd_at: result.data.upd_at,
-          },
-        ])
-        setNewText("")
-      }
-    } finally {
-      setLoading(false)
+    const me = members.find((m) => m.mem_id === currentMemberId)
+    const tempId = `optimistic-${Date.now()}`
+    const optimisticComment: CmntRow = {
+      cmnt_id: tempId,
+      prnt_id: null,
+      mem_id: currentMemberId,
+      mem_nm: me?.mem_nm ?? "나",
+      avatar_url: me?.avatar_url ?? null,
+      cont_txt: newText.trim(),
+      edit_yn: false,
+      del_yn: false,
+      crt_at: new Date().toISOString(),
+      upd_at: new Date().toISOString(),
+      optimistic: true,
+    }
+    setComments((prev) => [...prev, optimisticComment])
+    setNewText("")
+
+    const result = await createComment({
+      entityType,
+      entityId,
+      contTxt: optimisticComment.cont_txt,
+      mentionedMemIds: parseMentionsFromText(optimisticComment.cont_txt, members),
+    })
+
+    if (result.ok) {
+      setComments((prev) => prev.map((c) =>
+        c.cmnt_id === tempId
+          ? { ...c, cmnt_id: result.data.cmnt_id, crt_at: result.data.crt_at, upd_at: result.data.upd_at, optimistic: false }
+          : c
+      ))
+    } else {
+      setComments((prev) => prev.map((c) =>
+        c.cmnt_id === tempId ? { ...c, optimistic: false, optimisticFailed: true } : c
+      ))
     }
   }
 
   const handleSubmitReply = async () => {
     if (!replyText.trim() || !currentMemberId || !replyTo) return
-    setLoading(true)
-    try {
-      const result = await createComment({
-        entityType,
-        entityId,
-        contTxt: replyText.trim(),
-        prntId: replyTo.prnt_id ?? replyTo.cmnt_id,
-        mentionedMemIds: parseMentionsFromText(replyText, members),
-      })
-      if (result.ok) {
-        const me = members.find((m) => m.mem_id === currentMemberId)
-        setComments((prev) => [
-          ...prev,
-          {
-            cmnt_id: result.data.cmnt_id,
-            prnt_id: result.data.prnt_id,
-            mem_id: result.data.mem_id,
-            mem_nm: me?.mem_nm ?? "나",
-            avatar_url: me?.avatar_url ?? null,
-            cont_txt: result.data.cont_txt,
-            edit_yn: result.data.edit_yn,
-            del_yn: result.data.del_yn,
-            crt_at: result.data.crt_at,
-            upd_at: result.data.upd_at,
-          },
-        ])
-        setReplyText("")
-        setReplyTo(null)
-      }
-    } finally {
-      setLoading(false)
+    const me = members.find((m) => m.mem_id === currentMemberId)
+    const tempId = `optimistic-${Date.now()}`
+    const prntId = replyTo.prnt_id ?? replyTo.cmnt_id
+    const optimisticReply: CmntRow = {
+      cmnt_id: tempId,
+      prnt_id: prntId,
+      mem_id: currentMemberId,
+      mem_nm: me?.mem_nm ?? "나",
+      avatar_url: me?.avatar_url ?? null,
+      cont_txt: replyText.trim(),
+      edit_yn: false,
+      del_yn: false,
+      crt_at: new Date().toISOString(),
+      upd_at: new Date().toISOString(),
+      optimistic: true,
+    }
+    setComments((prev) => [...prev, optimisticReply])
+    setReplyText("")
+    setReplyTo(null)
+
+    const result = await createComment({
+      entityType,
+      entityId,
+      contTxt: optimisticReply.cont_txt,
+      prntId,
+      mentionedMemIds: parseMentionsFromText(optimisticReply.cont_txt, members),
+    })
+
+    if (result.ok) {
+      setComments((prev) => prev.map((c) =>
+        c.cmnt_id === tempId
+          ? { ...c, cmnt_id: result.data.cmnt_id, crt_at: result.data.crt_at, upd_at: result.data.upd_at, optimistic: false }
+          : c
+      ))
+    } else {
+      setComments((prev) => prev.map((c) =>
+        c.cmnt_id === tempId ? { ...c, optimistic: false, optimisticFailed: true } : c
+      ))
     }
   }
 
@@ -296,7 +317,7 @@ export function CommentSection({
                     <Button
                       size="sm"
                       onClick={handleSubmitReply}
-                      disabled={loading || !replyText.trim()}
+                      disabled={!replyText.trim()}
                     >
                       답글 달기
                     </Button>
@@ -327,7 +348,7 @@ export function CommentSection({
         <Button
           size="sm"
           onClick={handleSubmitComment}
-          disabled={loading || !newText.trim()}
+          disabled={!newText.trim()}
           className="self-end"
         >
           댓글 달기

--- a/components/common/link-preview-card.tsx
+++ b/components/common/link-preview-card.tsx
@@ -1,0 +1,83 @@
+"use client";
+
+import { useEffect, useState } from "react";
+
+import { ExternalLink } from "lucide-react";
+
+type OgData = {
+  title: string | null;
+  image: string | null;
+  description: string | null;
+  hostname: string | null;
+};
+
+export function LinkPreviewCard({ url }: { url: string }) {
+  const [og, setOg] = useState<OgData | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    fetch(`/api/og?url=${encodeURIComponent(url)}`)
+      .then((r) => r.json())
+      .then((data: OgData) => setOg(data))
+      .catch(() => setOg(null))
+      .finally(() => setLoading(false));
+  }, [url]);
+
+  if (loading) {
+    return (
+      <div className="h-14 animate-pulse rounded-xl border border-border bg-muted" />
+    );
+  }
+
+  // OG 이미지 없으면 기존 텍스트 버튼 형태로 폴백
+  if (!og?.image) {
+    return (
+      <a
+        href={url}
+        target="_blank"
+        rel="noopener noreferrer"
+        className="flex items-center justify-center gap-2 rounded-md border border-border py-2 text-sm transition-colors hover:bg-muted"
+      >
+        <ExternalLink className="size-3.5" />
+        {og?.title ?? "링크 바로가기"}
+      </a>
+    );
+  }
+
+  return (
+    <a
+      href={url}
+      target="_blank"
+      rel="noopener noreferrer"
+      className="flex overflow-hidden rounded-xl border border-border transition-colors hover:bg-muted/50 active:bg-muted"
+    >
+      {/* 썸네일 */}
+      <div className="relative h-[72px] w-[72px] shrink-0 bg-muted">
+        {/* eslint-disable-next-line @next/next/no-img-element */}
+        <img
+          src={og.image}
+          alt=""
+          className="h-full w-full object-cover"
+          onError={(e) => { (e.currentTarget as HTMLImageElement).style.display = "none"; }}
+        />
+      </div>
+
+      {/* 텍스트 */}
+      <div className="flex min-w-0 flex-col justify-center gap-0.5 px-3 py-2">
+        {og.title && (
+          <p className="line-clamp-1 text-[13px] font-medium leading-snug">
+            {og.title}
+          </p>
+        )}
+        {og.description && (
+          <p className="line-clamp-1 text-[11px] text-muted-foreground">
+            {og.description}
+          </p>
+        )}
+        {og.hostname && (
+          <p className="text-[10px] text-muted-foreground">{og.hostname}</p>
+        )}
+      </div>
+    </a>
+  );
+}

--- a/components/common/share-sheet.tsx
+++ b/components/common/share-sheet.tsx
@@ -4,7 +4,6 @@ import { useState } from "react";
 
 import { Check, Copy, Link, MessageCircle } from "lucide-react";
 
-import { Button } from "@/components/ui/button";
 import {
   ResponsiveDrawer,
   ResponsiveDrawerContent,
@@ -12,6 +11,7 @@ import {
   ResponsiveDrawerTitle,
   ResponsiveDrawerDescription,
 } from "@/components/common/responsive-drawer";
+import { Button } from "@/components/ui/button";
 
 type ShareSheetProps = {
   open: boolean;
@@ -86,7 +86,7 @@ export function ShareSheet({
             </div>
             <div className="flex flex-col">
               <span className="text-[14px] font-medium">링크 복사</span>
-              <span className="text-[12px] text-muted-foreground">이 게시물 주소를 복사합니다</span>
+              <span className="text-[12px] text-muted-foreground">이 게시물 주소를 복사</span>
             </div>
           </button>
 

--- a/components/common/share-sheet.tsx
+++ b/components/common/share-sheet.tsx
@@ -1,0 +1,136 @@
+"use client";
+
+import { useState } from "react";
+
+import { Check, Copy, Link, MessageCircle } from "lucide-react";
+
+import { Button } from "@/components/ui/button";
+import {
+  ResponsiveDrawer,
+  ResponsiveDrawerContent,
+  ResponsiveDrawerHeader,
+  ResponsiveDrawerTitle,
+  ResponsiveDrawerDescription,
+} from "@/components/common/responsive-drawer";
+
+type ShareSheetProps = {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  title: string;
+  timeLabel: string;
+  contentSnippet?: string;
+  /** 이 게시물 상세보기 딥링크. 없으면 현재 페이지 URL 사용 */
+  pageUrl?: string;
+};
+
+export function ShareSheet({
+  open,
+  onOpenChange,
+  title,
+  timeLabel,
+  contentSnippet,
+  pageUrl,
+}: ShareSheetProps) {
+  const [copiedLink, setCopiedLink] = useState(false);
+  const [copiedText, setCopiedText] = useState(false);
+
+  function getUrl() {
+    return pageUrl ?? (typeof window !== "undefined" ? window.location.href : "");
+  }
+
+  function buildText() {
+    const lines = [`📌 ${title}`, `🕐 ${timeLabel}`];
+    if (contentSnippet) lines.push("", contentSnippet.slice(0, 80) + (contentSnippet.length > 80 ? "…" : ""));
+    lines.push("", getUrl());
+    return lines.join("\n");
+  }
+
+  async function handleCopyLink() {
+    await navigator.clipboard.writeText(getUrl());
+    setCopiedLink(true);
+    setTimeout(() => setCopiedLink(false), 1500);
+  }
+
+  async function handleCopyText() {
+    await navigator.clipboard.writeText(buildText());
+    setCopiedText(true);
+    setTimeout(() => setCopiedText(false), 1500);
+  }
+
+  function handleKakao() {
+    const text = buildText();
+    // 카카오톡 앱 URL 스킴으로 공유 텍스트 전달 (모바일)
+    const kakaoUrl = `kakaotalk://send?text=${encodeURIComponent(text)}`;
+    window.location.href = kakaoUrl;
+  }
+
+  return (
+    <ResponsiveDrawer open={open} onOpenChange={onOpenChange}>
+      <ResponsiveDrawerContent
+        dialogClassName="max-w-sm p-0 gap-0 overflow-hidden"
+        drawerClassName="h-auto"
+      >
+        <ResponsiveDrawerHeader className="border-b border-border px-4 py-4 text-left">
+          <ResponsiveDrawerTitle>공유하기</ResponsiveDrawerTitle>
+          <ResponsiveDrawerDescription className="sr-only">공유 옵션</ResponsiveDrawerDescription>
+        </ResponsiveDrawerHeader>
+
+        <div className="flex flex-col gap-2 p-4">
+          <button
+            type="button"
+            onClick={handleCopyLink}
+            className="flex items-center gap-3 rounded-xl border border-border px-4 py-3 text-left transition-colors active:bg-muted"
+          >
+            <div className="flex size-9 shrink-0 items-center justify-center rounded-full bg-secondary">
+              {copiedLink ? <Check className="size-4 text-success" /> : <Link className="size-4" />}
+            </div>
+            <div className="flex flex-col">
+              <span className="text-[14px] font-medium">링크 복사</span>
+              <span className="text-[12px] text-muted-foreground">이 게시물 주소를 복사합니다</span>
+            </div>
+          </button>
+
+          <button
+            type="button"
+            onClick={handleCopyText}
+            className="flex items-center gap-3 rounded-xl border border-border px-4 py-3 text-left transition-colors active:bg-muted"
+          >
+            <div className="flex size-9 shrink-0 items-center justify-center rounded-full bg-secondary">
+              {copiedText ? <Check className="size-4 text-success" /> : <Copy className="size-4" />}
+            </div>
+            <div className="flex flex-col">
+              <span className="text-[14px] font-medium">텍스트로 복사</span>
+              <span className="text-[12px] text-muted-foreground">제목·시간·내용·링크를 한번에 복사</span>
+            </div>
+          </button>
+
+          <button
+            type="button"
+            onClick={handleKakao}
+            className="flex items-center gap-3 rounded-xl border border-border px-4 py-3 text-left transition-colors active:bg-muted"
+          >
+            <div className="flex size-9 shrink-0 items-center justify-center rounded-full bg-[#FEE500]">
+              <MessageCircle className="size-4 text-[#3C1E1E]" />
+            </div>
+            <div className="flex flex-col">
+              <span className="text-[14px] font-medium">카카오톡으로 공유</span>
+              <span className="text-[12px] text-muted-foreground">카카오톡 앱으로 바로 전송</span>
+            </div>
+          </button>
+        </div>
+
+        <div className="px-4 pb-6">
+          <Button
+            type="button"
+            variant="ghost"
+            size="sm"
+            className="w-full text-muted-foreground"
+            onClick={() => onOpenChange(false)}
+          >
+            닫기
+          </Button>
+        </div>
+      </ResponsiveDrawerContent>
+    </ResponsiveDrawer>
+  );
+}

--- a/components/home/mini-calendar.tsx
+++ b/components/home/mini-calendar.tsx
@@ -139,54 +139,60 @@ export function MiniCalendar({
 
   useEffect(() => {
     if (deepLinkPostId) {
-      supabase
-        .from("sch_post_mst")
-        .select("sch_post_id, sch_nm, post_type, evt_stt_at, evt_end_at, url, cont_txt, crt_by")
-        .eq("sch_post_id", deepLinkPostId)
-        .maybeSingle()
-        .then(({ data }) => {
-          if (!data) return
-          setSchDetailPost({
-            id: data.sch_post_id,
-            title: data.sch_nm,
-            start_date: data.evt_stt_at ? dayjs(data.evt_stt_at).format("YYYY-MM-DD") : dayjs().format("YYYY-MM-DD"),
-            type: "schedule",
-            url: data.url ?? null,
-            cont_txt: data.cont_txt ?? null,
-            crt_by: data.crt_by ?? undefined,
-            post_type: data.post_type ?? null,
-            evt_stt_at: data.evt_stt_at ?? null,
-            evt_end_at: data.evt_end_at ?? null,
-          })
-          setSchDetailOpen(true)
-          router.replace("/")
+      Promise.all([
+        supabase
+          .from("sch_post_mst")
+          .select("sch_post_id, sch_nm, post_type, evt_stt_at, evt_end_at, url, cont_txt, crt_by")
+          .eq("sch_post_id", deepLinkPostId)
+          .maybeSingle(),
+        memberId ? fetchComments("sch_post", deepLinkPostId) : Promise.resolve(undefined),
+      ]).then(([{ data }, comments]) => {
+        if (!data) return
+        setSchDetailPost({
+          id: data.sch_post_id,
+          title: data.sch_nm,
+          start_date: data.evt_stt_at ? dayjs(data.evt_stt_at).format("YYYY-MM-DD") : dayjs().format("YYYY-MM-DD"),
+          type: "schedule",
+          url: data.url ?? null,
+          cont_txt: data.cont_txt ?? null,
+          crt_by: data.crt_by ?? undefined,
+          post_type: data.post_type ?? null,
+          evt_stt_at: data.evt_stt_at ?? null,
+          evt_end_at: data.evt_end_at ?? null,
         })
+        setSchDetailInitialComments(comments)
+        setSchDetailOpen(true)
+        router.replace("/")
+      })
     }
 
     if (deepLinkCompId) {
-      supabase
-        .from("comp_mst")
-        .select("comp_id, comp_nm, comp_sprt_cd, stt_dt, end_dt, loc_nm, src_url, comp_evt_cfg(comp_evt_type)")
-        .eq("comp_id", deepLinkCompId)
-        .single()
-        .then(({ data }) => {
-          if (!data) return
-          setSelectedCompetition({
-            id: data.comp_id,
-            external_id: "",
-            sport: data.comp_sprt_cd ?? null,
-            title: data.comp_nm,
-            start_date: data.stt_dt,
-            end_date: data.end_dt ?? null,
-            location: data.loc_nm ?? null,
-            event_types: (data.comp_evt_cfg as { comp_evt_type: string | null }[])
-              .map((e) => e.comp_evt_type?.toUpperCase())
-              .filter((e): e is string => Boolean(e)),
-            source_url: data.src_url ?? null,
-          })
-          setDetailOpen(true)
-          router.replace("/")
+      Promise.all([
+        supabase
+          .from("comp_mst")
+          .select("comp_id, comp_nm, comp_sprt_cd, stt_dt, end_dt, loc_nm, src_url, comp_evt_cfg(comp_evt_type)")
+          .eq("comp_id", deepLinkCompId)
+          .single(),
+        memberId ? fetchComments("comp", deepLinkCompId) : Promise.resolve(undefined),
+      ]).then(([{ data }, comments]) => {
+        if (!data) return
+        setSelectedCompetition({
+          id: data.comp_id,
+          external_id: "",
+          sport: data.comp_sprt_cd ?? null,
+          title: data.comp_nm,
+          start_date: data.stt_dt,
+          end_date: data.end_dt ?? null,
+          location: data.loc_nm ?? null,
+          event_types: (data.comp_evt_cfg as { comp_evt_type: string | null }[])
+            .map((e) => e.comp_evt_type?.toUpperCase())
+            .filter((e): e is string => Boolean(e)),
+          source_url: data.src_url ?? null,
         })
+        setCompDetailInitialComments(comments)
+        setDetailOpen(true)
+        router.replace("/")
+      })
     }
   // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [deepLinkPostId, deepLinkCompId])

--- a/components/home/mini-calendar.tsx
+++ b/components/home/mini-calendar.tsx
@@ -20,6 +20,7 @@ import { getOrCreateCompEvtIdForParticipation } from "@/app/actions/get-or-creat
 import { revalidateCompetitions } from "@/app/actions/revalidate-competitions";
 
 
+import type { CmntRow } from "@/components/comment/comment-item";
 import type { MemberOption } from "@/components/comment/mention-input";
 import { Micro, SectionLabel } from "@/components/common/typography";
 import { AddScheduleDropdown } from "@/components/home/add-schedule-dropdown";
@@ -100,6 +101,7 @@ export function MiniCalendar({
   // 소식 상세 다이얼로그 상태 (일반 멤버용)
   const [schDetailPost, setSchDetailPost] = useState<CalendarRace | null>(null);
   const [schDetailOpen, setSchDetailOpen] = useState(false);
+  const [schDetailInitialComments, setSchDetailInitialComments] = useState<CmntRow[] | undefined>(undefined);
 
   // 대회 선택 다이얼로그 상태
   const [pickerOpen, setPickerOpen] = useState(false);
@@ -109,6 +111,7 @@ export function MiniCalendar({
   const [selectedDate, setSelectedDate] = useState<string>(() => todayKST());
   const [selectedCompetition, setSelectedCompetition] = useState<Competition | null>(null);
   const [detailOpen, setDetailOpen] = useState(false);
+  const [compDetailInitialComments, setCompDetailInitialComments] = useState<CmntRow[] | undefined>(undefined);
   const [registrationsByCompetitionId, setRegistrationsByCompetitionId] =
     useState<Record<string, CompetitionRegistration>>(initialRegistrationsByCompetitionId);
 
@@ -140,7 +143,7 @@ export function MiniCalendar({
         .from("sch_post_mst")
         .select("sch_post_id, sch_nm, post_type, evt_stt_at, evt_end_at, url, cont_txt, crt_by")
         .eq("sch_post_id", deepLinkPostId)
-        .single()
+        .maybeSingle()
         .then(({ data }) => {
           if (!data) return
           setSchDetailPost({
@@ -196,10 +199,11 @@ export function MiniCalendar({
   const totalDays = daysInMonth(year, month);
   const firstDayOfWeek = dayjs.tz(`${year}-${String(month).padStart(2, "0")}-01`, "Asia/Seoul").day();
 
+  const allRaces = useMemo(() => [...myRaces, ...schPosts, ...gigangRaces], [myRaces, schPosts, gigangRaces]);
+
   // 날짜별 이벤트 목록 (mine 우선, schedule, gigang 순) — 기간 이벤트는 모든 날짜에 전개
   const eventsByDate = useMemo(() => {
     const map = new Map<string, CalendarRace[]>();
-    const allRaces = [...myRaces, ...schPosts, ...gigangRaces];
     const seen = new Set<string>();
     for (const race of allRaces) {
       const endDateStr = race.end_date
@@ -220,7 +224,7 @@ export function MiniCalendar({
       }
     }
     return map;
-  }, [gigangRaces, myRaces, schPosts]);
+  }, [allRaces]);
 
   // 주차별로 날짜 그룹핑
   const weeks = useMemo(() => {
@@ -237,7 +241,6 @@ export function MiniCalendar({
 
   // 주차별 스패닝 이벤트 레인 계산
   const weekEventLanes = useMemo(() => {
-    const allRaces = [...myRaces, ...schPosts, ...gigangRaces];
     return weeks.map((week) => {
       const colDates = week.map((day) =>
         day !== null
@@ -282,18 +285,46 @@ export function MiniCalendar({
         return { ...ep, slot };
       });
     });
-  }, [weeks, myRaces, schPosts, gigangRaces, year, month]);
+  }, [weeks, allRaces, year, month]);
 
   function formatCellDate(day: number): string {
     return `${year}-${String(month).padStart(2, "0")}-${String(day).padStart(2, "0")}`;
   }
 
-  async function handleRaceClick(race: CalendarRace) {
+  async function fetchComments(entityType: "sch_post" | "comp", entityId: string): Promise<CmntRow[]> {
     const { data } = await supabase
-      .from("comp_mst")
-      .select("comp_id, comp_nm, comp_sprt_cd, stt_dt, end_dt, loc_nm, src_url, comp_evt_cfg(comp_evt_type)")
-      .eq("comp_id", race.id)
-      .single();
+      .from("cmnt_mst")
+      .select("cmnt_id, prnt_id, mem_id, cont_txt, edit_yn, del_yn, crt_at, upd_at, mem_mst!cmnt_mst_mem_id_fkey(mem_nm, avatar_url)")
+      .eq("entity_type", entityType)
+      .eq("entity_id", entityId)
+      .eq("team_id", teamId)
+      .order("crt_at", { ascending: true })
+    return (data ?? []).map((row) => {
+      const mem = Array.isArray(row.mem_mst) ? row.mem_mst[0] : row.mem_mst
+      return {
+        cmnt_id: row.cmnt_id,
+        prnt_id: row.prnt_id,
+        mem_id: row.mem_id,
+        mem_nm: (mem as { mem_nm: string } | null)?.mem_nm ?? "멤버",
+        avatar_url: (mem as { avatar_url?: string | null } | null)?.avatar_url ?? null,
+        cont_txt: row.cont_txt,
+        edit_yn: row.edit_yn,
+        del_yn: row.del_yn,
+        crt_at: row.crt_at,
+        upd_at: row.upd_at,
+      }
+    })
+  }
+
+  async function handleRaceClick(race: CalendarRace) {
+    const [{ data }, comments] = await Promise.all([
+      supabase
+        .from("comp_mst")
+        .select("comp_id, comp_nm, comp_sprt_cd, stt_dt, end_dt, loc_nm, src_url, comp_evt_cfg(comp_evt_type)")
+        .eq("comp_id", race.id)
+        .single(),
+      memberId ? fetchComments("comp", race.id) : Promise.resolve(undefined),
+    ]);
 
     const comp: Competition = data
       ? {
@@ -321,7 +352,9 @@ export function MiniCalendar({
           source_url: null,
         };
 
+    // fetch 완료 후 한 번에 설정 — 이전 댓글이 남는 버그 방지
     setSelectedCompetition(comp);
+    setCompDetailInitialComments(comments);
     setDetailOpen(true);
   }
 
@@ -410,48 +443,42 @@ export function MiniCalendar({
     const m = parseInt(mStr, 10);
     const lastDay = monthLastDayStr(y, m);
 
-    const { data: teamComps } = await supabase.rpc("get_public_team_competitions", {
-      p_team_id: teamId,
-      p_start: newMonth,
-      p_end: lastDay,
-    });
+    const [
+      { data: teamComps },
+      myRegsResult,
+      { data: schPostRows },
+    ] = await Promise.all([
+      supabase.rpc("get_public_team_competitions", { p_team_id: teamId, p_start: newMonth, p_end: lastDay }),
+      memberId
+        ? supabase
+            .from("comp_reg_rel")
+            .select("team_comp_plan_rel!inner(comp_id, comp_mst!inner(comp_id, comp_nm, stt_dt, loc_nm))")
+            .eq("mem_id", memberId)
+            .eq("team_comp_plan_rel.team_id", teamId)
+            .eq("vers", 0)
+            .eq("del_yn", false)
+        : Promise.resolve({ data: null }),
+      supabase.rpc("get_public_team_sch_posts", { p_team_id: teamId, p_start: newMonth, p_end: lastDay }),
+    ]);
 
-    const seenIds = new Set<string>();
     const newGigang: CalendarRace[] = (teamComps ?? [])
       .filter((row) => (row.reg_count ?? 0) > 0)
-      .filter((row) => { if (seenIds.has(row.comp_id)) return false; seenIds.add(row.comp_id); return true; })
       .map((row) => ({ id: row.comp_id, title: row.comp_nm, start_date: row.stt_dt, type: "gigang" as const, location: row.loc_nm ?? null, regCount: row.reg_count ?? 0, cmntCount: row.cmnt_count ? Number(row.cmnt_count) : undefined }));
 
-    let newMine: CalendarRace[] = [];
-    if (memberId) {
-      const { data: myRegs } = await supabase
-        .from("comp_reg_rel")
-        .select("team_comp_plan_rel!inner(comp_id, comp_mst!inner(comp_id, comp_nm, stt_dt, loc_nm))")
-        .eq("mem_id", memberId)
-        .eq("team_comp_plan_rel.team_id", teamId)
-        .eq("vers", 0)
-        .eq("del_yn", false);
+    const calendarMetaMap = new Map(
+      (teamComps ?? []).map((row) => [row.comp_id, { regCount: row.reg_count ?? 0, cmntCount: row.cmnt_count ? Number(row.cmnt_count) : undefined }]),
+    );
 
-      const regCountMap = new Map<string, number>(
-        (teamComps ?? []).map((row) => [row.comp_id, row.reg_count ?? 0]),
-      );
-
-      newMine = (myRegs ?? []).flatMap((r) => {
-        const plan = Array.isArray(r.team_comp_plan_rel) ? r.team_comp_plan_rel[0] : r.team_comp_plan_rel;
-        const comp = Array.isArray(plan?.comp_mst) ? plan.comp_mst[0] : plan?.comp_mst;
-        if (!comp) return [];
-        const compRow = (teamComps ?? []).find((r) => r.comp_id === comp.comp_id);
-        const race: CalendarRace = { id: comp.comp_id, title: comp.comp_nm, start_date: comp.stt_dt, type: "mine", location: comp.loc_nm ?? null, regCount: regCountMap.get(comp.comp_id) ?? 0, cmntCount: compRow?.cmnt_count ? Number(compRow.cmnt_count) : undefined };
-        return race.start_date >= newMonth && race.start_date <= lastDay ? [race] : [];
-      });
-    }
-
-    // sch_post RPC 조회 (cmnt_count 포함)
-    const { data: schPostRows } = await supabase.rpc("get_public_team_sch_posts", {
-      p_team_id: teamId,
-      p_start: newMonth,
-      p_end: lastDay,
-    });
+    const newMine: CalendarRace[] = memberId
+      ? (myRegsResult.data ?? []).flatMap((r) => {
+          const plan = Array.isArray(r.team_comp_plan_rel) ? r.team_comp_plan_rel[0] : r.team_comp_plan_rel;
+          const comp = Array.isArray(plan?.comp_mst) ? plan.comp_mst[0] : plan?.comp_mst;
+          if (!comp) return [];
+          const meta = calendarMetaMap.get(comp.comp_id);
+          const race: CalendarRace = { id: comp.comp_id, title: comp.comp_nm, start_date: comp.stt_dt, type: "mine", location: comp.loc_nm ?? null, regCount: meta?.regCount ?? 0, cmntCount: meta?.cmntCount };
+          return race.start_date >= newMonth && race.start_date <= lastDay ? [race] : [];
+        })
+      : [];
 
     const newSchPosts: CalendarRace[] = (schPostRows ?? []).map((row) => ({
       id: row.sch_post_id,
@@ -496,24 +523,29 @@ export function MiniCalendar({
     setPickerOpen(true);
   }
 
-  function handlePickedCompetition(competition: Competition) {
+  async function handlePickedCompetition(competition: Competition) {
+    const comments = memberId ? await fetchComments("comp", competition.id) : undefined;
     setSelectedCompetition(competition);
+    setCompDetailInitialComments(comments);
     setDetailOpen(true);
   }
 
   async function handleCompetitionCreated(competition: Competition) {
+    setCompDetailInitialComments([]);
     setSelectedCompetition(competition);
     setDetailOpen(true);
     await handleSchPostSuccess();
   }
 
-  function openEditForm(race: CalendarRace) {
+  async function openSchPostDetail(race: CalendarRace) {
+    const comments = memberId ? await fetchComments("sch_post", race.id) : undefined;
+    // fetch 완료 후 한 번에 설정 — 이전 댓글이 남는 버그 방지
     setSchDetailPost(race);
+    setSchDetailInitialComments(comments);
     setSchDetailOpen(true);
   }
 
   async function handleSchPostSuccess() {
-    router.refresh();
     const { gigang, mine, schPosts: newSch } = await fetchMonthData(viewMonth);
     setGigangRaces(gigang);
     setMyRaces(mine);
@@ -731,7 +763,7 @@ export function MiniCalendar({
                     return (
                       <button
                         key={race.id}
-                        onClick={() => race.type === "schedule" ? openEditForm(race) : handleRaceClick(race)}
+                        onClick={() => race.type === "schedule" ? openSchPostDetail(race) : handleRaceClick(race)}
                         className="flex w-full items-center gap-1.5 rounded-lg px-1 py-0.5 text-left transition-all active:scale-[0.98] active:bg-secondary hover:bg-secondary/60"
                       >
                         <span
@@ -810,7 +842,7 @@ export function MiniCalendar({
             memberId={memberId}
             initialMonthKey={initialMonth.slice(0, 7)}
             initialRaces={[...initMine, ...initSchPosts, ...initGigang]}
-            onClickSchedule={openEditForm}
+            onClickSchedule={openSchPostDetail}
             onClickCompetition={handleRaceClick}
           />
         </div>
@@ -844,6 +876,7 @@ export function MiniCalendar({
         currentMemberId={memberStatus.status === "ready" ? memberStatus.memberId : undefined}
         isAdmin={memberStatus.status === "ready" ? memberStatus.admin : false}
         members={membersCache ?? []}
+        initialComments={schDetailInitialComments}
         onEdit={() => {
           if (!schDetailPost) return;
           setSchDetailOpen(false);
@@ -892,6 +925,7 @@ export function MiniCalendar({
         onCreate={createRegistration}
         onUpdate={updateRegistration}
         onDelete={deleteRegistration}
+        initialComments={compDetailInitialComments}
         onCompetitionUpdated={async () => {
           await revalidateCompetitions();
           window.location.reload();

--- a/components/home/mini-calendar.tsx
+++ b/components/home/mini-calendar.tsx
@@ -90,6 +90,7 @@ export function MiniCalendar({
   const [gigangRaces, setGigangRaces] = useState(initGigang);
   const [myRaces, setMyRaces] = useState(initMine);
   const [schPosts, setSchPosts] = useState(initSchPosts);
+  const [listViewKey, setListViewKey] = useState(0);
   const [isPending, startTransition] = useTransition();
 
   // 일정 폼 다이얼로그 상태
@@ -283,13 +284,21 @@ export function MiniCalendar({
         };
       });
 
+      // colSpan 내림차순 → colStart 오름차순 정렬: 긴 이벤트가 낮은 슬롯 선점
+      const sorted = [...positioned].sort((a, b) =>
+        b.colSpan - a.colSpan || a.colStart - b.colStart
+      );
+
       const slotEnds: number[] = [];
-      return positioned.map((ep) => {
+      const withSlot = sorted.map((ep) => {
         let slot = slotEnds.findIndex((e) => e < ep.colStart);
         if (slot === -1) { slot = slotEnds.length; slotEnds.push(-1); }
         slotEnds[slot] = ep.colStart + ep.colSpan - 1;
         return { ...ep, slot };
       });
+
+      // 원래 순서(colStart → id)로 돌려서 반환
+      return withSlot.sort((a, b) => a.colStart - b.colStart || a.race.id.localeCompare(b.race.id));
     });
   }, [weeks, allRaces, year, month]);
 
@@ -556,6 +565,7 @@ export function MiniCalendar({
     setGigangRaces(gigang);
     setMyRaces(mine);
     setSchPosts(newSch);
+    setListViewKey((k) => k + 1);
   }
 
   return (
@@ -844,10 +854,11 @@ export function MiniCalendar({
         /* 리스트뷰 */
         <div className="flex flex-col">
           <ScheduleListView
+            key={listViewKey}
             teamId={teamId}
             memberId={memberId}
-            initialMonthKey={initialMonth.slice(0, 7)}
-            initialRaces={[...initMine, ...initSchPosts, ...initGigang]}
+            initialMonthKey={viewMonth.slice(0, 7)}
+            initialRaces={[...myRaces, ...schPosts, ...gigangRaces]}
             onClickSchedule={openSchPostDetail}
             onClickCompetition={handleRaceClick}
           />

--- a/components/notifications/notification-bell-icon.tsx
+++ b/components/notifications/notification-bell-icon.tsx
@@ -22,6 +22,7 @@ import { NotificationItem } from "./notification-item";
 
 type NotificationBellIconProps = {
   initialCount: number;
+  initialNotifications?: Notification[];
   memberId?: string;
   disabled?: boolean;
 };
@@ -33,15 +34,17 @@ const NOTI_TYPE_LABELS: Record<string, string> = {
 
 type ViewType = "list" | "settings";
 
-export function NotificationBellIcon({ initialCount, memberId, disabled }: NotificationBellIconProps) {
+export function NotificationBellIcon({ initialCount, initialNotifications = [], memberId, disabled }: NotificationBellIconProps) {
   const [open, setOpen] = useState(false);
   const [view, setView] = useState<ViewType>("list");
   const [unreadCount, setUnreadCount] = useState(initialCount);
-  const [notifications, setNotifications] = useState<Notification[]>([]);
+  const [notifications, setNotifications] = useState<Notification[]>(initialNotifications);
   const [prefs, setPrefs] = useState<NotificationPref[]>([]);
   const [loading, setLoading] = useState(false);
-  const [hasMore, setHasMore] = useState(true);
-  const [cursor, setCursor] = useState<string | null>(null);
+  const [hasMore, setHasMore] = useState(initialNotifications.length === 20);
+  const [cursor, setCursor] = useState<string | null>(
+    initialNotifications.length > 0 ? initialNotifications[initialNotifications.length - 1].crt_at : null,
+  );
   const [deleteAllOpen, setDeleteAllOpen] = useState(false);
   const sentinelRef = useRef<HTMLDivElement>(null);
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -79,11 +82,12 @@ export function NotificationBellIcon({ initialCount, memberId, disabled }: Notif
   useEffect(() => {
     if (!open || !memberId) return;
 
-    // eslint-disable-next-line react-hooks/set-state-in-effect
-    setCursor(null);
-     
-    setHasMore(true);
-    fetchNotifications(true, null);
+    if (notifications.length === 0) {
+      // eslint-disable-next-line react-hooks/set-state-in-effect
+      setCursor(null);
+      setHasMore(true);
+      fetchNotifications(true, null);
+    }
 
     const supabase = createClient();
     const channel = supabase

--- a/components/notifications/notification-item.tsx
+++ b/components/notifications/notification-item.tsx
@@ -4,7 +4,7 @@ import { useState, useRef, useEffect } from "react";
 
 import { useRouter } from "next/navigation";
 
-import { Bell, Coins, MessageCircle, Trophy, Trash2, ChevronRight, FileText } from "lucide-react";
+import { Bell, Coins, MessageCircle, Trophy, Trash2, FileText } from "lucide-react";
 
 import { dayjs } from "@/lib/dayjs";
 import type { Notification } from "@/lib/queries/notification";
@@ -71,17 +71,17 @@ export function NotificationItem({ noti, onDelete, onRead, onClose }: Notificati
   const Icon = NOTI_ICON[noti.noti_type_enm] ?? Bell;
   const route = NOTI_ROUTE[noti.noti_type_enm]?.(noti.ref_id, noti.ref_type_enm) ?? null;
 
-  async function handleRead() {
+  function handleRead() {
     if (!isRead) {
       setIsRead(true);
       onRead(noti.noti_id);
-      await markNotificationRead(noti.noti_id);
+      markNotificationRead(noti.noti_id); // fire-and-forget: UI 블로킹 없이 백그라운드 처리
     }
   }
 
-  async function handleNavigate() {
+  function handleNavigate() {
     if (!route) return;
-    await handleRead();
+    handleRead();
     onClose();
     router.push(route);
   }
@@ -124,28 +124,26 @@ export function NotificationItem({ noti, onDelete, onRead, onClose }: Notificati
         <Trash2 className="size-5" />
       </button>
 
-      {/* 알림 본문 */}
-      <div
-        className="relative flex items-center gap-3 bg-background px-4 py-3 transition-transform"
+      {/* 알림 본문 — 로우 전체가 클릭 영역 */}
+      <button
+        type="button"
+        onClick={route ? handleNavigate : handleRead}
+        className="relative flex w-full items-center gap-3 bg-background px-4 py-3 text-left transition-transform active:bg-muted/50"
         style={{ transform: `translateX(${swipeX}px)` }}
         onTouchStart={onTouchStart}
         onTouchMove={onTouchMove}
         onTouchEnd={onTouchEnd}
       >
-        {/* 미읽음 dot */}
-        <div className="flex w-3 shrink-0 items-center justify-center">
-          {!isRead && <span className="size-2 rounded-full bg-destructive" />}
+        {/* 아이콘 + 미읽음 dot */}
+        <div className="relative flex shrink-0 items-center justify-center">
+          <Icon className={cn("size-5", isRead ? "text-muted-foreground" : "text-foreground")} />
+          {!isRead && (
+            <span className="absolute -right-1 -top-1 size-2 rounded-full bg-destructive" />
+          )}
         </div>
 
-        {/* 아이콘 */}
-        <Icon className={cn("size-5 shrink-0", isRead ? "text-muted-foreground" : "text-foreground")} />
-
         {/* 내용 */}
-        <button
-          type="button"
-          onClick={handleRead}
-          className="flex min-w-0 flex-1 flex-col gap-0.5 text-left"
-        >
+        <div className="flex min-w-0 flex-1 flex-col gap-0.5">
           <Body className={cn("text-[13px] leading-snug", isRead && "text-muted-foreground")}>
             {noti.noti_nm}
           </Body>
@@ -153,20 +151,8 @@ export function NotificationItem({ noti, onDelete, onRead, onClose }: Notificati
             <Caption className="line-clamp-1">{noti.noti_cont}</Caption>
           )}
           <Caption className="text-[11px]">{formatRelative(noti.crt_at)}</Caption>
-        </button>
-
-        {/* 이동 버튼 */}
-        {route && (
-          <button
-            type="button"
-            onClick={handleNavigate}
-            className="flex shrink-0 items-center justify-center rounded-md bg-secondary p-2 text-muted-foreground active:bg-muted"
-            aria-label="이동"
-          >
-            <ChevronRight className="size-4" />
-          </button>
-        )}
-      </div>
+        </div>
+      </button>
     </div>
   );
 }

--- a/components/races/competition-detail-dialog.tsx
+++ b/components/races/competition-detail-dialog.tsx
@@ -31,6 +31,7 @@ import { updateCompetition } from "@/app/actions/admin/manage-competition";
 import { getPublicTeamCompRegDisplayCounts } from "@/app/actions/get-public-team-comp-reg-display-counts";
 import { revalidateCompetitions } from "@/app/actions/revalidate-competitions";
 
+import type { CmntRow } from "@/components/comment/comment-item";
 import { CommentSection } from "@/components/comment/comment-section";
 import type { MemberOption } from "@/components/comment/mention-input";
 import {
@@ -79,6 +80,7 @@ interface CompetitionDetailDialogProps {
   members: MemberOption[];
   open: boolean;
   onOpenChange: (open: boolean) => void;
+  initialComments?: CmntRow[];
   onCreate: (
     competitionId: string,
     payload: { role: "participant" | "cheering" | "volunteer"; eventType: string },
@@ -104,6 +106,7 @@ export function CompetitionDetailDialog({
   members,
   open,
   onOpenChange,
+  initialComments,
   onCreate,
   onUpdate,
   onDelete,
@@ -702,6 +705,7 @@ export function CompetitionDetailDialog({
               currentMemberId={memberStatus.status === "ready" ? memberStatus.memberId : undefined}
               isAdmin={isAdmin}
               members={members}
+              initialComments={initialComments}
             />
           </div>
 

--- a/components/schedule/sch-post-detail-dialog.tsx
+++ b/components/schedule/sch-post-detail-dialog.tsx
@@ -2,14 +2,16 @@
 
 import { useState } from "react"
 
-import { ExternalLink, Pencil, Trash2 } from "lucide-react"
+import { Pencil, Share2, Trash2 } from "lucide-react"
 
 import { dayjs } from "@/lib/dayjs"
 
 import { deleteSchPost } from "@/app/actions/schedule/manage-sch-post"
 
+import type { CmntRow } from "@/components/comment/comment-item"
 import { CommentSection } from "@/components/comment/comment-section"
 import type { MemberOption } from "@/components/comment/mention-input"
+import { LinkPreviewCard } from "@/components/common/link-preview-card"
 import {
   ResponsiveDrawer,
   ResponsiveDrawerClose,
@@ -18,6 +20,7 @@ import {
   ResponsiveDrawerHeader,
   ResponsiveDrawerTitle,
 } from "@/components/common/responsive-drawer"
+import { ShareSheet } from "@/components/common/share-sheet"
 import type { CalendarRace } from "@/components/home/mini-calendar"
 import { Button } from "@/components/ui/button"
 
@@ -29,6 +32,7 @@ interface SchPostDetailDialogProps {
   currentMemberId?: string
   isAdmin?: boolean
   members: MemberOption[]
+  initialComments?: CmntRow[]
   onEdit?: () => void
   onDelete?: () => void
 }
@@ -41,10 +45,12 @@ export function SchPostDetailDialog({
   currentMemberId,
   isAdmin,
   members,
+  initialComments,
   onEdit,
   onDelete,
 }: SchPostDetailDialogProps) {
   const [deleting, setDeleting] = useState(false)
+  const [shareOpen, setShareOpen] = useState(false)
 
   async function handleDelete() {
     if (!post) return
@@ -67,85 +73,104 @@ export function SchPostDetailDialog({
   const endAt = post.evt_end_at ? dayjs(post.evt_end_at) : null
   const isAuthor = currentMemberId === post.crt_by
 
+  const timeLabel =
+    startAt.format("YYYY년 M월 D일 (ddd) HH:mm") +
+    (endAt ? ` ~ ${endAt.format("HH:mm")}` : "")
+
+  const pageUrl =
+    typeof window !== "undefined"
+      ? `${window.location.origin}/?post=${post.id}`
+      : `/?post=${post.id}`
+
   return (
-    <ResponsiveDrawer open={open} onOpenChange={onOpenChange}>
-      <ResponsiveDrawerContent
-        dialogClassName="max-w-md max-h-[85dvh] flex flex-col gap-0 p-0 overflow-hidden"
-        drawerClassName="h-[85dvh] max-h-[85dvh]"
-      >
-        <ResponsiveDrawerHeader className="shrink-0 border-b border-border px-4 py-4 text-left">
-          <ResponsiveDrawerTitle>{post.title}</ResponsiveDrawerTitle>
-          <ResponsiveDrawerDescription className="sr-only">일정 상세 정보</ResponsiveDrawerDescription>
-        </ResponsiveDrawerHeader>
+    <>
+      <ResponsiveDrawer open={open} onOpenChange={onOpenChange}>
+        <ResponsiveDrawerContent
+          dialogClassName="max-w-md max-h-[85dvh] flex flex-col gap-0 p-0 overflow-hidden"
+          drawerClassName="h-[85dvh] max-h-[85dvh]"
+        >
+          <ResponsiveDrawerHeader className="shrink-0 border-b border-border px-4 py-4 text-left">
+            <ResponsiveDrawerTitle>{post.title}</ResponsiveDrawerTitle>
+            <ResponsiveDrawerDescription className="sr-only">일정 상세 정보</ResponsiveDrawerDescription>
+          </ResponsiveDrawerHeader>
 
-        <div className="flex-1 overflow-y-auto px-4 pb-6 pt-4">
-          <div className="flex flex-col gap-4">
-            <div className="flex items-center justify-between gap-2">
-              <p className="text-sm text-muted-foreground">
-                {startAt.format("YYYY년 M월 D일 (ddd) HH:mm")}
-                {endAt && ` ~ ${endAt.format("HH:mm")}`}
-              </p>
-              {post.crt_by_nm && (
-                <p className="shrink-0 text-xs text-muted-foreground">{post.crt_by_nm}</p>
+          <div className="flex-1 overflow-y-auto px-4 pb-6 pt-4">
+            <div className="flex flex-col gap-4">
+              <div className="flex items-center justify-between gap-2">
+                <p className="text-sm text-muted-foreground">{timeLabel}</p>
+                {post.crt_by_nm && (
+                  <p className="shrink-0 text-xs text-muted-foreground">{post.crt_by_nm}</p>
+                )}
+              </div>
+
+              {post.url && <LinkPreviewCard url={post.url} />}
+
+              {post.cont_txt && (
+                <p className="text-sm leading-relaxed whitespace-pre-wrap">{post.cont_txt}</p>
               )}
-            </div>
 
-            {post.url && (
-              <a
-                href={post.url}
-                target="_blank"
-                rel="noopener noreferrer"
-                className="flex items-center justify-center gap-2 rounded-md border border-border py-2 text-sm transition-colors hover:bg-muted"
-              >
-                <ExternalLink className="size-3.5" />
-                링크 바로가기
-              </a>
-            )}
-
-            {post.cont_txt && (
-              <p className="text-sm leading-relaxed whitespace-pre-wrap">{post.cont_txt}</p>
-            )}
-
-            {(isAuthor || isAdmin) && (
-              <div className="flex gap-2 self-end">
-                <Button variant="outline" size="sm" onClick={onEdit} disabled={deleting}>
-                  <Pencil className="size-3.5" />
-                  수정
-                </Button>
+              <div className="flex items-center justify-between gap-2">
                 <Button
                   variant="outline"
                   size="sm"
-                  className="border-destructive/30 text-destructive hover:bg-destructive/5 hover:text-destructive"
-                  onClick={handleDelete}
-                  disabled={deleting}
+                  onClick={(e) => { (e.currentTarget as HTMLElement).blur(); setShareOpen(true); }}
                 >
-                  <Trash2 className="size-3.5" />
-                  {deleting ? "삭제 중..." : "삭제"}
+                  <Share2 className="size-3.5" />
+                  공유하기
                 </Button>
+
+                {(isAuthor || isAdmin) && (
+                  <div className="flex gap-2">
+                    <Button variant="outline" size="sm" onClick={onEdit} disabled={deleting}>
+                      <Pencil className="size-3.5" />
+                      수정
+                    </Button>
+                    <Button
+                      variant="outline"
+                      size="sm"
+                      className="border-destructive/30 text-destructive hover:bg-destructive/5 hover:text-destructive"
+                      onClick={handleDelete}
+                      disabled={deleting}
+                    >
+                      <Trash2 className="size-3.5" />
+                      {deleting ? "삭제 중..." : "삭제"}
+                    </Button>
+                  </div>
+                )}
               </div>
-            )}
 
-            <div className="border-t border-border pt-4">
-              <CommentSection
-                entityType="sch_post"
-                entityId={post.id}
-                teamId={teamId}
-                currentMemberId={currentMemberId}
-                isAdmin={isAdmin}
-                members={members}
-              />
-            </div>
+              <div className="border-t border-border pt-4">
+                <CommentSection
+                  entityType="sch_post"
+                  entityId={post.id}
+                  teamId={teamId}
+                  currentMemberId={currentMemberId}
+                  isAdmin={isAdmin}
+                  members={members}
+                  initialComments={initialComments}
+                />
+              </div>
 
-            <div className="mt-4 flex justify-center">
-              <ResponsiveDrawerClose asChild>
-                <Button type="button" variant="ghost" size="sm" className="text-muted-foreground">
-                  닫기
-                </Button>
-              </ResponsiveDrawerClose>
+              <div className="mt-4 flex justify-center">
+                <ResponsiveDrawerClose asChild>
+                  <Button type="button" variant="ghost" size="sm" className="text-muted-foreground">
+                    닫기
+                  </Button>
+                </ResponsiveDrawerClose>
+              </div>
             </div>
           </div>
-        </div>
-      </ResponsiveDrawerContent>
-    </ResponsiveDrawer>
+        </ResponsiveDrawerContent>
+      </ResponsiveDrawer>
+
+      <ShareSheet
+        open={shareOpen}
+        onOpenChange={setShareOpen}
+        title={post.title}
+        timeLabel={timeLabel}
+        contentSnippet={post.cont_txt ?? undefined}
+        pageUrl={pageUrl}
+      />
+    </>
   )
 }


### PR DESCRIPTION
## Summary

### 홈탭 성능 최적화
- `HomeContent` DB 쿼리 병렬화 (`Promise.all`) — 초기 로딩 쿼리 직렬 3회 → 동시 실행
- `UpcomingRaces` 섹션 제거 — 중복 콘텐츠 + 불필요 쿼리 2개 제거
- `fetchMonthData` (월 이동 시) 쿼리 병렬화 — 직렬 3회 → 동시 실행
- `router.refresh()` 제거 — 일정 변경 후 서버 왕복 + 클라이언트 쿼리 이중 실행 제거
- `HomeSkeleton` 실제 레이아웃과 구조 일치 (CLS 개선)
- 미사용 dead code 제거: `seenIds` Set, `getMyTitleNames` import, `member` alias, `SHOW_EXTRA_SECTIONS` 등
- `allRaces` useMemo 추출 — 동일 배열 2회 생성 → 공유

### 알림 UX 개선
- 알림 로우 전체를 클릭 영역으로 변경 (인스타그램 스타일)
- 우측 ChevronRight 버튼 제거
- 미읽음 dot을 아이콘에 absolute badge로 이동 (왼쪽 여백 정렬 개선)

### 일정 상세보기 기능 강화
- 링크 OG 태그 썸네일 프리뷰 카드 (`LinkPreviewCard`) 추가
- 공유하기 기능 추가 (`ShareSheet`): 링크 복사 / 텍스트 복사 / 카카오톡 공유

## Test plan
- [ ] 홈탭 초기 로딩 속도 체감 확인
- [ ] 월 이동 (캘린더 `<`, `>` 버튼) 속도 확인
- [ ] 알림 로우 클릭 → 이동 또는 읽음 처리 동작 확인
- [ ] 미읽음 dot 위치 (아이콘 우상단) 확인
- [ ] 일정 상세보기 링크 썸네일 표시 확인
- [ ] 공유하기 → 링크 복사 / 텍스트 복사 / 카카오톡 각각 동작 확인
- [ ] 일정 등록·수정·삭제 후 캘린더 정상 갱신 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)
