### PR TITLE
fix: 미납 통계 비활성 제외·공유 텍스트·인앱브라우저 게이트 개선

### DIFF
--- a/app/(protected)/onboarding/page.tsx
+++ b/app/(protected)/onboarding/page.tsx
@@ -6,7 +6,6 @@ import { env } from "@/lib/env";
 import { getCurrentMember } from "@/lib/queries/member";
 
 import { MemberOnboardingForm } from "@/components/auth/member-onboarding-form";
-import { InAppBrowserGate } from "@/components/in-app-browser-gate";
 
 async function OnboardingContent({
   searchParams,
@@ -47,20 +46,18 @@ async function OnboardingContent({
     : "";
 
   return (
-    <InAppBrowserGate>
-      <div className="flex min-h-svh w-full items-center justify-center bg-background px-6">
-        <div className="w-full max-w-sm">
-          <MemberOnboardingForm
-            userId={user.id}
-            provider={user.app_metadata?.provider as "kakao" | "google"}
-            email={user.email}
-            initialAvatarUrl={initialAvatarUrl}
-            initialFullName={initialFullName}
-            kakaoChatPassword={env.KAKAO_CHAT_PASSWORD ?? ""}
-          />
-        </div>
+    <div className="flex min-h-svh w-full items-center justify-center bg-background px-6">
+      <div className="w-full max-w-sm">
+        <MemberOnboardingForm
+          userId={user.id}
+          provider={user.app_metadata?.provider as "kakao" | "google"}
+          email={user.email}
+          initialAvatarUrl={initialAvatarUrl}
+          initialFullName={initialFullName}
+          kakaoChatPassword={env.KAKAO_CHAT_PASSWORD ?? ""}
+        />
       </div>
-    </InAppBrowserGate>
+    </div>
   );
 }
 

--- a/app/actions/admin/get-admin-stats.ts
+++ b/app/actions/admin/get-admin-stats.ts
@@ -68,7 +68,7 @@ export async function getAdminStats(): Promise<AdminStats> {
       .eq("evt_team_mst.team_id", teamId),
     admin
       .from("fee_mem_bal_snap")
-      .select("*", { count: "exact", head: true })
+      .select("mem_id")
       .eq("team_id", teamId)
       .eq("vers", 0)
       .eq("del_yn", false)
@@ -81,13 +81,28 @@ export async function getAdminStats(): Promise<AdminStats> {
       .eq("del_yn", false),
   ]);
 
+  // 미납 회원 중 active 상태인 인원만 카운트
+  const unpaidMemIds = (unpaidSnaps.data ?? []).map((s) => s.mem_id);
+  let unpaidMemberCount = 0;
+  if (unpaidMemIds.length > 0) {
+    const { count } = await admin
+      .from("team_mem_rel")
+      .select("mem_id", { count: "exact", head: true })
+      .eq("team_id", teamId)
+      .in("mem_id", unpaidMemIds)
+      .eq("mem_st_cd", "active")
+      .eq("vers", 0)
+      .eq("del_yn", false);
+    unpaidMemberCount = count ?? 0;
+  }
+
   const result: AdminStats = {
     totalCount: total.count ?? 0,
     monthlyCompetitionCount: competitions.count ?? 0,
     recentRecordCount: records.count ?? 0,
     activeProjectCount: activeProjects.count ?? 0,
     pendingParticipationCount: pendingPrt.count ?? 0,
-    unpaidMemberCount: unpaidSnaps.count ?? 0,
+    unpaidMemberCount,
     openFeedbackCount: openFeedback.count ?? 0,
     _debug: {
       teamId,

--- a/app/actions/admin/get-admin-stats.ts
+++ b/app/actions/admin/get-admin-stats.ts
@@ -29,7 +29,7 @@ export async function getAdminStats(): Promise<AdminStats> {
   const keyPrefix = env.SUPABASE_SERVICE_ROLE_KEY.slice(0, 20);
   console.log("[getAdminStats] teamId:", teamId, "keyPrefix:", keyPrefix, "noFilterCount:", noFilter.count, "noFilterError:", noFilter.error);
 
-  const [total, competitions, records, activeProjects, pendingPrt, unpaidSnaps, openFeedback] = await Promise.all([
+  const [total, competitions, records, activeProjects, pendingPrt, unpaidResult, openFeedback] = await Promise.all([
     admin
       .from("team_mem_rel")
       .select("*", { count: "exact", head: true })
@@ -66,13 +66,7 @@ export async function getAdminStats(): Promise<AdminStats> {
       .select("evt_id, evt_team_mst!inner(team_id)", { count: "exact", head: true })
       .eq("aprv_yn", false)
       .eq("evt_team_mst.team_id", teamId),
-    admin
-      .from("fee_mem_bal_snap")
-      .select("mem_id")
-      .eq("team_id", teamId)
-      .eq("vers", 0)
-      .eq("del_yn", false)
-      .lt("bal_amt", 0),
+    admin.rpc("get_admin_unpaid_active_count", { p_team_id: teamId }),
     admin
       .from("fdbk_mst")
       .select("*", { count: "exact", head: true })
@@ -81,20 +75,10 @@ export async function getAdminStats(): Promise<AdminStats> {
       .eq("del_yn", false),
   ]);
 
-  // 미납 회원 중 active 상태인 인원만 카운트
-  const unpaidMemIds = (unpaidSnaps.data ?? []).map((s) => s.mem_id);
-  let unpaidMemberCount = 0;
-  if (unpaidMemIds.length > 0) {
-    const { count } = await admin
-      .from("team_mem_rel")
-      .select("mem_id", { count: "exact", head: true })
-      .eq("team_id", teamId)
-      .in("mem_id", unpaidMemIds)
-      .eq("mem_st_cd", "active")
-      .eq("vers", 0)
-      .eq("del_yn", false);
-    unpaidMemberCount = count ?? 0;
+  if (unpaidResult.error) {
+    console.error("[getAdminStats] unpaid count error:", unpaidResult.error);
   }
+  const unpaidMemberCount = (unpaidResult.data as number | null) ?? 0;
 
   const result: AdminStats = {
     totalCount: total.count ?? 0,

--- a/app/auth/login/page.tsx
+++ b/app/auth/login/page.tsx
@@ -2,7 +2,6 @@ import { Suspense } from "react";
 
 import { LoginForm } from "@/components/auth/login-form";
 import { SignupProgress } from "@/components/auth/signup-progress";
-import { InAppBrowserGate } from "@/components/in-app-browser-gate";
 
 export default async function Page({
   searchParams,
@@ -12,7 +11,7 @@ export default async function Page({
   const { next } = await searchParams;
   const isSignupFlow = next === "/onboarding";
   return (
-    <InAppBrowserGate>
+    <>
       {isSignupFlow && <SignupProgress step={2} />}
       <Suspense
         fallback={
@@ -23,6 +22,6 @@ export default async function Page({
       >
         <LoginForm />
       </Suspense>
-    </InAppBrowserGate>
+    </>
   );
 }

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,3 +1,5 @@
+import { Suspense } from "react";
+
 import type { Metadata, Viewport } from "next";
 
 import { Inter } from "next/font/google";
@@ -5,6 +7,7 @@ import { Inter } from "next/font/google";
 import { GoogleAnalytics } from "@next/third-parties/google";
 import { NuqsAdapter } from "nuqs/adapters/next/app";
 
+import { InAppBrowserGate } from "@/components/in-app-browser-gate";
 import { Providers } from "@/components/providers";
 
 import "./globals.css";
@@ -67,7 +70,11 @@ export default function RootLayout({
     <html lang="ko" suppressHydrationWarning>
       <body className={`${inter.className} antialiased`}>
         <Providers>
-          <NuqsAdapter>{children}</NuqsAdapter>
+          <NuqsAdapter>
+            <Suspense fallback={null}>
+              <InAppBrowserGate>{children}</InAppBrowserGate>
+            </Suspense>
+          </NuqsAdapter>
         </Providers>
       </body>
       <GoogleAnalytics gaId="G-H9LXJH97CZ" />

--- a/app/newbie/page.tsx
+++ b/app/newbie/page.tsx
@@ -4,7 +4,6 @@ import { Check } from "lucide-react";
 
 import { SignupProgress } from "@/components/auth/signup-progress";
 import { H1, H2, Body, Caption } from "@/components/common/typography";
-
 import { Button } from "@/components/ui/button";
 import { CardItem } from "@/components/ui/card";
 

--- a/app/newbie/page.tsx
+++ b/app/newbie/page.tsx
@@ -4,7 +4,7 @@ import { Check } from "lucide-react";
 
 import { SignupProgress } from "@/components/auth/signup-progress";
 import { H1, H2, Body, Caption } from "@/components/common/typography";
-import { InAppBrowserGate } from "@/components/in-app-browser-gate";
+
 import { Button } from "@/components/ui/button";
 import { CardItem } from "@/components/ui/card";
 
@@ -122,7 +122,7 @@ function Toggle({
 
 export default function NewbiePage() {
   return (
-    <InAppBrowserGate>
+    <>
       <SignupProgress step={1} />
       <div className="mx-auto max-w-md px-6 pb-44 pt-[calc(env(safe-area-inset-top,0px)+5rem)]">
         {/* 1. 히어로 */}
@@ -335,6 +335,6 @@ export default function NewbiePage() {
           </div>
         </div>
       </div>
-    </InAppBrowserGate>
+    </>
   );
 }

--- a/components/common/share-sheet.tsx
+++ b/components/common/share-sheet.tsx
@@ -38,8 +38,18 @@ export function ShareSheet({
   }
 
   function buildText() {
-    const lines = [title, timeLabel];
-    if (contentSnippet) lines.push("", contentSnippet.slice(0, 100) + (contentSnippet.length > 100 ? ".." : ""));
+    const urlRegex = /https?:\/\/[^\s]+/g;
+    const lines = [`${title} - ${timeLabel}`];
+
+    if (contentSnippet) {
+      const contentUrls = contentSnippet.match(urlRegex) ?? [];
+      const textOnly = contentSnippet.replace(urlRegex, "").replace(/\s+/g, " ").trim();
+
+      lines.push("");
+      contentUrls.forEach((url) => lines.push(url));
+      if (textOnly) lines.push(textOnly.slice(0, 100) + (textOnly.length > 100 ? ".." : ""));
+    }
+
     lines.push("", getUrl());
     return lines.join("\n");
   }
@@ -55,11 +65,8 @@ export function ShareSheet({
       await handleCopyText();
       return;
     }
-    const text = contentSnippet
-      ? contentSnippet.slice(0, 80) + (contentSnippet.length > 80 ? "..." : "")
-      : undefined;
     try {
-      await navigator.share({ title: `${title} - ${timeLabel}`, text, url: getUrl() });
+      await navigator.share({ text: buildText() });
     } catch (e) {
       if (e instanceof Error && e.name !== "AbortError") throw e;
     }

--- a/components/common/share-sheet.tsx
+++ b/components/common/share-sheet.tsx
@@ -18,7 +18,10 @@ type ShareSheetProps = {
   onOpenChange: (open: boolean) => void;
   title: string;
   timeLabel: string;
+  /** 본문 텍스트 */
   contentSnippet?: string;
+  /** 본문에 첨부된 외부 링크 */
+  contentUrl?: string;
   /** 이 게시물 상세보기 딥링크. 없으면 현재 페이지 URL 사용 */
   pageUrl?: string;
 };
@@ -29,6 +32,7 @@ export function ShareSheet({
   title,
   timeLabel,
   contentSnippet,
+  contentUrl,
   pageUrl,
 }: ShareSheetProps) {
   const [copiedText, setCopiedText] = useState(false);
@@ -38,16 +42,12 @@ export function ShareSheet({
   }
 
   function buildText() {
-    const urlRegex = /https?:\/\/[^\s]+/g;
-    const lines = [`${title} - ${timeLabel}`];
+    const lines = [`[${title}]`, timeLabel];
 
+    if (contentUrl) lines.push(contentUrl);
     if (contentSnippet) {
-      const contentUrls = contentSnippet.match(urlRegex) ?? [];
-      const textOnly = contentSnippet.replace(urlRegex, "").replace(/\s+/g, " ").trim();
-
-      lines.push("");
-      contentUrls.forEach((url) => lines.push(url));
-      if (textOnly) lines.push(textOnly.slice(0, 100) + (textOnly.length > 100 ? ".." : ""));
+      const text = contentSnippet.trim();
+      lines.push(text.slice(0, 100) + (text.length > 100 ? ".." : ""));
     }
 
     lines.push("", getUrl());

--- a/components/home/schedule-list-view.tsx
+++ b/components/home/schedule-list-view.tsx
@@ -28,116 +28,76 @@ type Props = {
   onClickCompetition: (race: CalendarRace) => void;
 };
 
-function nextMonthKey(key: string) {
-  return dayjs(key + "-01").add(1, "month").format("YYYY-MM");
-}
 
-function monthBounds(monthKey: string): { start: string; end: string } {
-  const d = dayjs(monthKey + "-01");
-  return { start: d.format("YYYY-MM-01"), end: d.endOf("month").format("YYYY-MM-DD") };
-}
+type SchedulePagedRow = {
+  item_type: string;
+  item_id: string;
+  item_nm: string;
+  post_type: string | null;
+  start_date: string;
+  end_date: string | null;
+  loc_nm: string | null;
+  url: string | null;
+  cont_txt: string | null;
+  evt_stt_at: string | null;
+  evt_end_at: string | null;
+  crt_by: string | null;
+  crt_by_nm: string | null;
+  reg_count: number | null;
+  cmnt_count: number;
+};
 
-async function fetchRange(
+async function fetchAdjacent(
   supabase: ReturnType<typeof createClient>,
   teamId: string,
   memberId: string | undefined,
-  start: string,
-  end: string,
+  direction: "prev" | "next",
+  cursorDate: string,
+  monthLimit: number,
 ): Promise<CalendarRace[]> {
+  const { data, error } = await supabase.rpc("get_schedule_paged", {
+    p_team_id: teamId,
+    p_direction: direction,
+    p_cursor_date: cursorDate,
+    p_mem_id: memberId ?? null,
+    p_month_limit: monthLimit,
+  });
+  if (error || !data) return [];
 
-  const [{ data: schRows }, { data: gigangRows }, myRows] = await Promise.all([
-    supabase.rpc("get_public_team_sch_posts", {
-      p_team_id: teamId,
-      p_start: start,
-      p_end: end,
-    }),
-    supabase.rpc("get_public_team_competitions", {
-      p_team_id: teamId,
-      p_start: start,
-      p_end: end,
-    }),
-    memberId
-      ? supabase
-          .from("comp_reg_rel")
-          .select("team_comp_plan_rel!inner(comp_id, comp_mst!inner(comp_id, comp_nm, stt_dt, loc_nm))")
-          .eq("mem_id", memberId)
-          .eq("team_comp_plan_rel.team_id", teamId)
-          .eq("vers", 0)
-          .eq("del_yn", false)
-      : Promise.resolve({ data: null }),
-  ]);
-
-  const results: CalendarRace[] = [];
   const seen = new Set<string>();
-  const regCountMap = new Map<string, number>(
-    (gigangRows ?? []).map((row) => [row.comp_id, row.reg_count ?? 0]),
-  );
-
-  // 내 대회
-  if (myRows.data) {
-    for (const r of myRows.data) {
-      const plan = Array.isArray(r.team_comp_plan_rel) ? r.team_comp_plan_rel[0] : r.team_comp_plan_rel;
-      const comp = Array.isArray(plan?.comp_mst) ? plan.comp_mst[0] : plan?.comp_mst;
-      if (!comp || comp.stt_dt < start || comp.stt_dt > end) continue;
-      const key = `mine:${comp.comp_id}`;
-      if (seen.has(key)) continue;
-      seen.add(key);
-      const compRow = (gigangRows ?? []).find((r) => r.comp_id === comp.comp_id);
+  const results: CalendarRace[] = [];
+  for (const row of data as SchedulePagedRow[]) {
+    const key = `${row.item_type}:${row.item_id}`;
+    if (seen.has(key)) continue;
+    seen.add(key);
+    if (row.item_type === "sch_post") {
       results.push({
-        id: comp.comp_id,
-        title: comp.comp_nm,
-        start_date: comp.stt_dt,
-        type: "mine",
-        location: comp.loc_nm ?? null,
-        regCount: regCountMap.get(comp.comp_id) ?? 0,
-        cmntCount: compRow?.cmnt_count ? Number(compRow.cmnt_count) : undefined,
+        id: row.item_id,
+        title: row.item_nm,
+        start_date: row.start_date,
+        type: "schedule",
+        post_type: row.post_type ?? null,
+        end_date: row.end_date ?? null,
+        evt_stt_at: row.evt_stt_at ?? null,
+        evt_end_at: row.evt_end_at ?? null,
+        url: row.url ?? null,
+        cont_txt: row.cont_txt ?? null,
+        crt_by: row.crt_by ?? undefined,
+        crt_by_nm: row.crt_by_nm ?? null,
+        cmntCount: row.cmnt_count ? Number(row.cmnt_count) : undefined,
+      });
+    } else {
+      results.push({
+        id: row.item_id,
+        title: row.item_nm,
+        start_date: row.start_date,
+        type: row.item_type === "mine" ? "mine" : "gigang",
+        location: row.loc_nm ?? null,
+        regCount: row.reg_count ? Number(row.reg_count) : 0,
+        cmntCount: row.cmnt_count ? Number(row.cmnt_count) : undefined,
       });
     }
   }
-
-  // 공유 일정
-  for (const row of schRows ?? []) {
-    const key = `sch:${row.sch_post_id}`;
-    if (seen.has(key)) continue;
-    seen.add(key);
-    results.push({
-      id: row.sch_post_id,
-      short_id: row.short_id ?? null,
-      title: row.sch_nm,
-      start_date: dayjs(row.evt_stt_at).tz("Asia/Seoul").format("YYYY-MM-DD"),
-      type: "schedule",
-      post_type: row.post_type,
-      end_date: row.evt_end_at,
-      evt_stt_at: row.evt_stt_at,
-      evt_end_at: row.evt_end_at,
-      url: row.url,
-      cont_txt: row.cont_txt,
-      crt_by: row.crt_by,
-      crt_by_nm: row.crt_by_nm ?? null,
-      cmntCount: row.cmnt_count ? Number(row.cmnt_count) : undefined,
-    });
-  }
-
-  // 기강 대회 (참가자 1명 이상)
-  const gigangSeen = new Set<string>();
-  for (const row of gigangRows ?? []) {
-    if ((row.reg_count ?? 0) === 0) continue;
-    if (gigangSeen.has(row.comp_id)) continue;
-    gigangSeen.add(row.comp_id);
-    const key = `gigang:${row.comp_id}`;
-    if (seen.has(key)) continue;
-    seen.add(key);
-    results.push({
-      id: row.comp_id,
-      title: row.comp_nm,
-      start_date: row.stt_dt,
-      type: "gigang",
-      location: row.loc_nm ?? null,
-      regCount: row.reg_count ?? 0,
-    });
-  }
-
-  results.sort((a, b) => a.start_date.localeCompare(b.start_date));
   return results;
 }
 
@@ -289,14 +249,12 @@ export function ScheduleListView({
     if (loadingPrev || !canLoadPrev) return;
     setLoadingPrev(true);
     try {
-      const end = dayjs(oldestMonth + "-01").subtract(1, "day").format("YYYY-MM-DD");
-      const start = "2000-01-01";
-      const races = await fetchRange(supabase, teamId, memberId, start, end);
+      const cursorDate = dayjs(oldestMonth + "-01").format("YYYY-MM-DD");
+      const races = await fetchAdjacent(supabase, teamId, memberId, "prev", cursorDate, 2);
       if (races.length === 0) {
         setCanLoadPrev(false);
         return;
       }
-      // 결과에서 최신 2달만 추출
       const buckets = new Map<string, CalendarRace[]>();
       for (const race of races) {
         const key = race.start_date.slice(0, 7);
@@ -305,9 +263,7 @@ export function ScheduleListView({
         buckets.set(key, list);
       }
       const newMonths = Array.from(buckets.entries())
-        .sort(([a], [b]) => b.localeCompare(a)) // 내림차순
-        .slice(0, 2)
-        .reverse() // 오름차순으로 복원
+        .sort(([a], [b]) => a.localeCompare(b))
         .map(([key, r]) => ({ monthKey: key, races: r }));
       prevScrollHeightRef.current = containerRef.current?.scrollHeight ?? 0;
       setMonths((prev) => [...newMonths, ...prev]);
@@ -321,14 +277,22 @@ export function ScheduleListView({
     if (loadingNext || !canLoadNext) return;
     setLoadingNext(true);
     try {
-      const key = nextMonthKey(newestMonth);
-      const { start, end } = monthBounds(key);
-      const races = await fetchRange(supabase, teamId, memberId, start, end);
+      const cursorDate = dayjs(newestMonth + "-01").endOf("month").format("YYYY-MM-DD");
+      const races = await fetchAdjacent(supabase, teamId, memberId, "next", cursorDate, 1);
       if (races.length === 0) {
         setCanLoadNext(false);
         return;
       }
-      setMonths((prev) => [...prev, { monthKey: key, races }]);
+      const buckets = new Map<string, CalendarRace[]>();
+      for (const race of races) {
+        const key = race.start_date.slice(0, 7);
+        const list = buckets.get(key) ?? [];
+        list.push(race);
+        buckets.set(key, list);
+      }
+      const [firstKey, firstRaces] = Array.from(buckets.entries())
+        .sort(([a], [b]) => a.localeCompare(b))[0];
+      setMonths((prev) => [...prev, { monthKey: firstKey, races: firstRaces }]);
     } finally {
       setLoadingNext(false);
     }

--- a/components/home/schedule-list-view.tsx
+++ b/components/home/schedule-list-view.tsx
@@ -59,7 +59,7 @@ async function fetchAdjacent(
     p_team_id: teamId,
     p_direction: direction,
     p_cursor_date: cursorDate,
-    p_mem_id: memberId ?? null,
+    p_mem_id: memberId ?? undefined,
     p_month_limit: monthLimit,
   });
   if (error || !data) return [];

--- a/components/home/schedule-list-view.tsx
+++ b/components/home/schedule-list-view.tsx
@@ -28,29 +28,22 @@ type Props = {
   onClickCompetition: (race: CalendarRace) => void;
 };
 
-function monthBounds(monthKey: string): { start: string; end: string } {
-  const d = dayjs(monthKey + "-01");
-  return {
-    start: d.format("YYYY-MM-01"),
-    end: d.endOf("month").format("YYYY-MM-DD"),
-  };
-}
-
-function prevMonthKey(key: string) {
-  return dayjs(key + "-01").subtract(1, "month").format("YYYY-MM");
-}
-
 function nextMonthKey(key: string) {
   return dayjs(key + "-01").add(1, "month").format("YYYY-MM");
 }
 
-async function fetchMonth(
+function monthBounds(monthKey: string): { start: string; end: string } {
+  const d = dayjs(monthKey + "-01");
+  return { start: d.format("YYYY-MM-01"), end: d.endOf("month").format("YYYY-MM-DD") };
+}
+
+async function fetchRange(
   supabase: ReturnType<typeof createClient>,
   teamId: string,
   memberId: string | undefined,
-  monthKey: string,
+  start: string,
+  end: string,
 ): Promise<CalendarRace[]> {
-  const { start, end } = monthBounds(monthKey);
 
   const [{ data: schRows }, { data: gigangRows }, myRows] = await Promise.all([
     supabase.rpc("get_public_team_sch_posts", {
@@ -296,14 +289,28 @@ export function ScheduleListView({
     if (loadingPrev || !canLoadPrev) return;
     setLoadingPrev(true);
     try {
-      const key = prevMonthKey(oldestMonth);
-      const races = await fetchMonth(supabase, teamId, memberId, key);
+      const end = dayjs(oldestMonth + "-01").subtract(1, "day").format("YYYY-MM-DD");
+      const start = "2000-01-01";
+      const races = await fetchRange(supabase, teamId, memberId, start, end);
       if (races.length === 0) {
         setCanLoadPrev(false);
         return;
       }
+      // 결과에서 최신 2달만 추출
+      const buckets = new Map<string, CalendarRace[]>();
+      for (const race of races) {
+        const key = race.start_date.slice(0, 7);
+        const list = buckets.get(key) ?? [];
+        list.push(race);
+        buckets.set(key, list);
+      }
+      const newMonths = Array.from(buckets.entries())
+        .sort(([a], [b]) => b.localeCompare(a)) // 내림차순
+        .slice(0, 2)
+        .reverse() // 오름차순으로 복원
+        .map(([key, r]) => ({ monthKey: key, races: r }));
       prevScrollHeightRef.current = containerRef.current?.scrollHeight ?? 0;
-      setMonths((prev) => [{ monthKey: key, races }, ...prev]);
+      setMonths((prev) => [...newMonths, ...prev]);
     } finally {
       setLoadingPrev(false);
     }
@@ -315,7 +322,8 @@ export function ScheduleListView({
     setLoadingNext(true);
     try {
       const key = nextMonthKey(newestMonth);
-      const races = await fetchMonth(supabase, teamId, memberId, key);
+      const { start, end } = monthBounds(key);
+      const races = await fetchRange(supabase, teamId, memberId, start, end);
       if (races.length === 0) {
         setCanLoadNext(false);
         return;

--- a/components/in-app-browser-gate.tsx
+++ b/components/in-app-browser-gate.tsx
@@ -1,6 +1,10 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useState, useSyncExternalStore } from "react";
+
+import { usePathname } from "next/navigation";
+
+import { X } from "lucide-react";
 
 import { Button } from "@/components/ui/button";
 
@@ -25,9 +29,7 @@ export function detectInAppBrowser(): InAppEnv {
   if (ua.includes("naver(inapp")) return "naver";
   if (ua.includes("band")) return "band";
   if (ua.includes("daumapps")) return "daum";
-  // Android WebView 힌트 (소모임 등 시스템 WebView 기반 인앱 브라우저 포함)
   if (/wv\)/.test(ua) && !ua.includes("chrome")) return "other";
-  // iOS 비-Safari WebView: iOS인데 Safari/Chrome/Firefox 토큰이 없으면 인앱으로 간주
   const isIOSDevice = /iphone|ipad|ipod/.test(ua);
   const looksLikeRealBrowser =
     ua.includes("safari") || ua.includes("crios") || ua.includes("fxios");
@@ -40,21 +42,17 @@ export function isIOS(): boolean {
   return /iphone|ipad|ipod/i.test(navigator.userAgent);
 }
 
-/** PWA로 홈 화면에서 실행 중(이미 설치)인지 */
 export function isStandalone(): boolean {
   if (typeof window === "undefined") return false;
   const mql = window.matchMedia?.("(display-mode: standalone)").matches;
-  // iOS Safari 전용 navigator.standalone
   const iosStandalone = (navigator as { standalone?: boolean }).standalone;
   return Boolean(mql || iosStandalone);
 }
 
 function openExternalBrowser(url: string) {
   if (isIOS()) {
-    // iOS: Safari로 열기 시도
     window.location.href = url;
   } else {
-    // Android: intent:// 로 Chrome 열기
     const intentUrl =
       `intent://${url.replace(/^https?:\/\//, "")}#Intent;scheme=https;package=com.android.chrome;end`;
     window.location.href = intentUrl;
@@ -72,37 +70,25 @@ const APP_LABELS: Record<string, string> = {
   other: "앱",
 };
 
-export function InAppBrowserGate({ children }: { children: React.ReactNode }) {
-  const [inApp, setInApp] = useState<InAppEnv>(null);
-  const [checked, setChecked] = useState(false);
-
-  useEffect(() => {
-    setInApp(detectInAppBrowser());
-    setChecked(true);
-  }, []);
-
-  // 아직 체크 안 됨 → 깜빡임 방지를 위해 children 렌더
-  if (!checked) return <>{children}</>;
-
-  // 인앱 브라우저가 아님 → 정상 렌더
-  if (!inApp) return <>{children}</>;
-
-  const appName = APP_LABELS[inApp] ?? "앱";
+/** 전체 화면 차단 — 로그인/가입 페이지용 */
+function FullScreenGate({ inApp, isAuth }: { inApp: InAppEnv; isAuth: boolean }) {
+  const appName = APP_LABELS[inApp ?? "other"] ?? "앱";
   const currentUrl = typeof window !== "undefined" ? window.location.href : "";
+
+  const title = isAuth
+    ? `${appName}에서는 로그인할 수 없어요`
+    : `${appName} 안에서는 가입할 수 없어요`;
 
   return (
     <div className="flex min-h-svh flex-col items-center justify-center bg-background px-6">
       <div className="w-full max-w-sm text-center">
         <div className="text-5xl">🌐</div>
-        <h1 className="mt-4 text-xl font-bold text-foreground">
-          {appName}에선 가입할 수 없어요
-        </h1>
+        <h1 className="mt-4 text-xl font-bold text-foreground">{title}</h1>
         <p className="mt-3 text-sm leading-relaxed text-muted-foreground">
           크롬 또는 사파리로 열면
-          <br />1분이면 가입이 끝나요.
+          <br />1분이면 완료돼요.
         </p>
 
-        {/* Android: 자동 열기 버튼 */}
         {!isIOS() && (
           <Button
             type="button"
@@ -114,12 +100,9 @@ export function InAppBrowserGate({ children }: { children: React.ReactNode }) {
           </Button>
         )}
 
-        {/* iOS: 안내 */}
         {isIOS() && (
           <div className="mt-6 rounded-xl border border-border bg-secondary/50 p-4 text-left">
-            <p className="text-sm font-bold text-foreground">
-              Safari에서 여는 방법
-            </p>
+            <p className="text-sm font-bold text-foreground">Safari에서 여는 방법</p>
             <ol className="mt-2 space-y-1.5 text-xs leading-relaxed text-muted-foreground">
               {inApp === "kakao" ? (
                 <>
@@ -136,7 +119,6 @@ export function InAppBrowserGate({ children }: { children: React.ReactNode }) {
           </div>
         )}
 
-        {/* URL 복사 폴백 */}
         <Button
           type="button"
           variant="outline"
@@ -152,4 +134,78 @@ export function InAppBrowserGate({ children }: { children: React.ReactNode }) {
       </div>
     </div>
   );
+}
+
+/** 상단 배너 — 일반 콘텐츠 페이지용 */
+function BannerGate({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  const [dismissed, setDismissed] = useState(false);
+  const currentUrl = typeof window !== "undefined" ? window.location.href : "";
+
+  if (dismissed) return <>{children}</>;
+
+  return (
+    <>
+      <div className="sticky top-0 z-50 flex items-center gap-2 bg-primary px-4 py-2.5 text-primary-foreground">
+        <span className="flex-1 text-xs leading-snug">
+          {isIOS()
+            ? "Safari에서 열면 모든 기능을 사용할 수 있어요"
+            : "Chrome에서 열면 모든 기능을 사용할 수 있어요"}
+        </span>
+        {!isIOS() && (
+          <button
+            type="button"
+            onClick={() => openExternalBrowser(currentUrl)}
+            className="shrink-0 rounded-md bg-primary-foreground px-2.5 py-1 text-xs font-bold text-primary"
+          >
+            열기
+          </button>
+        )}
+        <button
+          type="button"
+          onClick={() => setDismissed(true)}
+          className="shrink-0 opacity-70"
+          aria-label="닫기"
+        >
+          <X className="size-4" />
+        </button>
+      </div>
+      {children}
+    </>
+  );
+}
+
+const noop = () => () => {};
+
+/** 루트 레이아웃에 단 하나만 배치 */
+export function InAppBrowserGate({ children }: { children: React.ReactNode }) {
+  const inApp = useSyncExternalStore(
+    noop,
+    () => detectInAppBrowser(),
+    () => null,
+  );
+  const pathname = usePathname();
+
+  if (!inApp) return <>{children}</>;
+
+  // 로그인·가입·온보딩 → 전체 차단
+  const isBlockPage =
+    pathname.startsWith("/auth") ||
+    pathname.startsWith("/newbie") ||
+    pathname === "/onboarding";
+
+  if (isBlockPage) {
+    return (
+      <FullScreenGate
+        inApp={inApp}
+        isAuth={pathname.startsWith("/auth")}
+      />
+    );
+  }
+
+  // 나머지 → 배너만
+  return <BannerGate>{children}</BannerGate>;
 }

--- a/components/in-app-browser-gate.tsx
+++ b/components/in-app-browser-gate.tsx
@@ -70,14 +70,11 @@ const APP_LABELS: Record<string, string> = {
   other: "앱",
 };
 
-/** 전체 화면 차단 — 로그인/가입 페이지용 */
-function FullScreenGate({ inApp, isAuth }: { inApp: InAppEnv; isAuth: boolean }) {
+/** 전체 화면 차단 — 가입 페이지용 */
+function FullScreenGate({ inApp }: { inApp: InAppEnv }) {
   const appName = APP_LABELS[inApp ?? "other"] ?? "앱";
   const currentUrl = typeof window !== "undefined" ? window.location.href : "";
-
-  const title = isAuth
-    ? `${appName}에서는 로그인할 수 없어요`
-    : `${appName} 안에서는 가입할 수 없어요`;
+  const title = `${appName} 안에서는 가입할 수 없어요`;
 
   return (
     <div className="flex min-h-svh flex-col items-center justify-center bg-background px-6">
@@ -150,7 +147,7 @@ function BannerGate({
   return (
     <>
       {children}
-      <div className="fixed bottom-0 left-0 right-0 z-50 flex items-center gap-2 bg-primary px-4 py-3 text-primary-foreground" style={{ paddingBottom: "calc(0.75rem + env(safe-area-inset-bottom, 0px))" }}>
+      <div className="fixed bottom-0 left-0 right-0 z-[60] flex items-center gap-2 bg-primary px-4 py-3 text-primary-foreground" style={{ paddingBottom: "calc(0.75rem + env(safe-area-inset-bottom, 0px))" }}>
         <span className="flex-1 text-xs leading-snug">
           {isIOS()
             ? "Safari에서 열면 모든 기능을 사용할 수 있어요"
@@ -197,7 +194,7 @@ export function InAppBrowserGate({ children }: { children: React.ReactNode }) {
     pathname === "/onboarding";
 
   if (isBlockPage) {
-    return <FullScreenGate inApp={inApp} isAuth={false} />;
+    return <FullScreenGate inApp={inApp} />;
   }
 
   // 나머지 → 배너만

--- a/components/in-app-browser-gate.tsx
+++ b/components/in-app-browser-gate.tsx
@@ -136,7 +136,7 @@ function FullScreenGate({ inApp, isAuth }: { inApp: InAppEnv; isAuth: boolean })
   );
 }
 
-/** 상단 배너 — 일반 콘텐츠 페이지용 */
+/** 하단 배너 — 일반 콘텐츠 페이지 및 로그인 페이지용 */
 function BannerGate({
   children,
 }: {
@@ -149,7 +149,8 @@ function BannerGate({
 
   return (
     <>
-      <div className="sticky top-0 z-50 flex items-center gap-2 bg-primary px-4 py-2.5 text-primary-foreground">
+      {children}
+      <div className="fixed bottom-0 left-0 right-0 z-50 flex items-center gap-2 bg-primary px-4 py-3 text-primary-foreground" style={{ paddingBottom: "calc(0.75rem + env(safe-area-inset-bottom, 0px))" }}>
         <span className="flex-1 text-xs leading-snug">
           {isIOS()
             ? "Safari에서 열면 모든 기능을 사용할 수 있어요"
@@ -173,7 +174,6 @@ function BannerGate({
           <X className="size-4" />
         </button>
       </div>
-      {children}
     </>
   );
 }
@@ -191,19 +191,13 @@ export function InAppBrowserGate({ children }: { children: React.ReactNode }) {
 
   if (!inApp) return <>{children}</>;
 
-  // 로그인·가입·온보딩 → 전체 차단
+  // 가입·온보딩만 전체 차단 (로그인은 테스트 가능하도록 배너)
   const isBlockPage =
-    pathname.startsWith("/auth") ||
     pathname.startsWith("/newbie") ||
     pathname === "/onboarding";
 
   if (isBlockPage) {
-    return (
-      <FullScreenGate
-        inApp={inApp}
-        isAuth={pathname.startsWith("/auth")}
-      />
-    );
+    return <FullScreenGate inApp={inApp} isAuth={false} />;
   }
 
   // 나머지 → 배너만

--- a/components/schedule/sch-post-detail-dialog.tsx
+++ b/components/schedule/sch-post-detail-dialog.tsx
@@ -169,6 +169,7 @@ export function SchPostDetailDialog({
         onOpenChange={setShareOpen}
         title={post.title}
         timeLabel={timeLabel}
+        contentUrl={post.url ?? undefined}
         contentSnippet={post.cont_txt ?? undefined}
         pageUrl={pageUrl}
       />

--- a/lib/supabase/database.types.ts
+++ b/lib/supabase/database.types.ts
@@ -2003,6 +2003,10 @@ export type Database = {
             Returns: undefined
           }
       generate_nanoid: { Args: { size?: number }; Returns: string }
+      get_admin_unpaid_active_count: {
+        Args: { p_team_id: string }
+        Returns: number
+      }
       get_public_member_card: {
         Args: { p_mem_id: string; p_team_id: string }
         Returns: Json
@@ -2085,6 +2089,32 @@ export type Database = {
           rct_race_rec: string
           utmb_idx: number
           utmb_prf_url: string
+        }[]
+      }
+      get_schedule_paged: {
+        Args: {
+          p_cursor_date: string
+          p_direction: string
+          p_mem_id?: string
+          p_month_limit?: number
+          p_team_id: string
+        }
+        Returns: {
+          cmnt_count: number
+          cont_txt: string
+          crt_by: string
+          crt_by_nm: string
+          end_date: string
+          evt_end_at: string
+          evt_stt_at: string
+          item_id: string
+          item_nm: string
+          item_type: string
+          loc_nm: string
+          post_type: string
+          reg_count: number
+          start_date: string
+          url: string
         }[]
       }
       is_legacy_platform_admin: { Args: never; Returns: boolean }
@@ -2273,4 +2303,3 @@ export const Constants = {
     },
   },
 } as const
-

--- a/supabase/migrations/20260618100000_get_schedule_paged.sql
+++ b/supabase/migrations/20260618100000_get_schedule_paged.sql
@@ -1,0 +1,174 @@
+-- get_schedule_paged: 방향 기반 스크롤 페이지네이션
+-- 이벤트가 있는 가장 가까운 N달의 일정을 한 번의 쿼리로 반환
+-- 빈 달을 건너뛰는 청크 탐색 없이 DB 내부에서 CTE로 처리
+
+CREATE OR REPLACE FUNCTION public.get_schedule_paged(
+  p_team_id     uuid,
+  p_direction   text,         -- 'prev' | 'next'
+  p_cursor_date date,         -- prev: 가장 오래된 달의 1일, next: 가장 최근 달의 말일
+  p_mem_id      uuid DEFAULT NULL,
+  p_month_limit int  DEFAULT 2
+)
+RETURNS TABLE (
+  item_type  text,
+  item_id    uuid,
+  item_nm    text,
+  post_type  text,
+  start_date date,
+  end_date   date,
+  loc_nm     text,
+  url        text,
+  cont_txt   text,
+  evt_stt_at timestamptz,
+  evt_end_at timestamptz,
+  crt_by     uuid,
+  crt_by_nm  text,
+  reg_count  bigint,
+  cmnt_count bigint
+)
+LANGUAGE sql
+STABLE
+SECURITY DEFINER
+SET search_path = public
+AS $$
+WITH
+-- 멤버 본인 등록 대회 목록
+my_regs AS (
+  SELECT DISTINCT team_comp_id
+  FROM public.comp_reg_rel
+  WHERE mem_id = p_mem_id
+    AND vers = 0
+    AND del_yn = false
+),
+
+-- 공유 일정 날짜 (방향 기준 필터)
+sch_dates AS (
+  SELECT (s.evt_stt_at AT TIME ZONE 'Asia/Seoul')::date AS event_date
+  FROM public.sch_post_mst s
+  WHERE s.team_id = p_team_id
+    AND s.del_yn = false
+    AND (
+      (p_direction = 'prev' AND (s.evt_stt_at AT TIME ZONE 'Asia/Seoul')::date < p_cursor_date) OR
+      (p_direction = 'next' AND (s.evt_stt_at AT TIME ZONE 'Asia/Seoul')::date > p_cursor_date)
+    )
+),
+
+-- 대회 날짜 (참가자 있거나 본인 등록)
+comp_dates AS (
+  SELECT DISTINCT c.stt_dt AS event_date
+  FROM public.team_comp_plan_rel tcp
+  JOIN public.comp_mst c ON c.comp_id = tcp.comp_id AND c.vers = 0 AND c.del_yn = false
+  WHERE tcp.team_id = p_team_id
+    AND tcp.vers = 0
+    AND tcp.del_yn = false
+    AND (
+      (p_direction = 'prev' AND c.stt_dt < p_cursor_date) OR
+      (p_direction = 'next' AND c.stt_dt > p_cursor_date)
+    )
+    AND (
+      EXISTS (
+        SELECT 1 FROM public.comp_reg_rel cr
+        WHERE cr.team_comp_id = tcp.team_comp_id AND cr.vers = 0 AND cr.del_yn = false
+      )
+      OR EXISTS (
+        SELECT 1 FROM my_regs mr WHERE mr.team_comp_id = tcp.team_comp_id
+      )
+    )
+),
+
+-- 이벤트가 있는 달 후보 (두 소스 합산)
+month_candidates AS (
+  SELECT DISTINCT DATE_TRUNC('month', event_date)::date AS month_start
+  FROM (
+    SELECT event_date FROM sch_dates
+    UNION
+    SELECT event_date FROM comp_dates
+  ) all_dates
+),
+
+-- 방향에 따라 N달 선택 (prev: 최근순 DESC, next: 오래된순 ASC)
+target_months AS (
+  ( SELECT month_start FROM month_candidates WHERE p_direction = 'prev' ORDER BY month_start DESC LIMIT p_month_limit )
+  UNION ALL
+  ( SELECT month_start FROM month_candidates WHERE p_direction = 'next' ORDER BY month_start ASC  LIMIT p_month_limit )
+),
+
+-- 선택된 달들의 실제 조회 범위
+date_range AS (
+  SELECT
+    MIN(month_start)                                                  AS range_start,
+    (MAX(month_start) + interval '1 month' - interval '1 day')::date AS range_end
+  FROM target_months
+)
+
+-- 공유 일정
+SELECT
+  'sch_post'::text                                AS item_type,
+  s.sch_post_id                                  AS item_id,
+  s.sch_nm                                       AS item_nm,
+  s.post_type,
+  (s.evt_stt_at AT TIME ZONE 'Asia/Seoul')::date AS start_date,
+  NULL::date                                     AS end_date,
+  NULL::text                                     AS loc_nm,
+  s.url,
+  s.cont_txt,
+  s.evt_stt_at,
+  s.evt_end_at,
+  s.crt_by,
+  m.mem_nm                                       AS crt_by_nm,
+  NULL::bigint                                   AS reg_count,
+  COALESCE((
+    SELECT count(*) FROM public.cmnt_mst cm
+    WHERE cm.entity_type = 'sch_post' AND cm.entity_id = s.sch_post_id AND cm.del_yn = false
+  ), 0)                                          AS cmnt_count
+FROM public.sch_post_mst s
+CROSS JOIN date_range
+LEFT JOIN public.mem_mst m ON m.mem_id = s.crt_by
+WHERE s.team_id = p_team_id
+  AND s.del_yn = false
+  AND date_range.range_start IS NOT NULL
+  AND (s.evt_stt_at AT TIME ZONE 'Asia/Seoul')::date BETWEEN date_range.range_start AND date_range.range_end
+
+UNION ALL
+
+-- 대회 (참가자 있거나 본인 등록, 중복 없이)
+SELECT
+  CASE WHEN mr.team_comp_id IS NOT NULL THEN 'mine' ELSE 'comp' END AS item_type,
+  c.comp_id                                                          AS item_id,
+  c.comp_nm                                                          AS item_nm,
+  NULL::text                                                         AS post_type,
+  c.stt_dt                                                           AS start_date,
+  c.end_dt                                                           AS end_date,
+  c.loc_nm,
+  c.src_url                                                          AS url,
+  NULL::text                                                         AS cont_txt,
+  NULL::timestamptz                                                  AS evt_stt_at,
+  NULL::timestamptz                                                  AS evt_end_at,
+  NULL::uuid                                                         AS crt_by,
+  NULL::text                                                         AS crt_by_nm,
+  count(DISTINCT cr.comp_reg_id)                                     AS reg_count,
+  COALESCE((
+    SELECT count(*) FROM public.cmnt_mst cm
+    WHERE cm.entity_type = 'comp' AND cm.entity_id = c.comp_id AND cm.del_yn = false
+  ), 0)                                                              AS cmnt_count
+FROM public.team_comp_plan_rel tcp
+JOIN public.comp_mst c
+  ON c.comp_id = tcp.comp_id AND c.vers = 0 AND c.del_yn = false
+CROSS JOIN date_range
+LEFT JOIN public.comp_reg_rel cr
+  ON cr.team_comp_id = tcp.team_comp_id AND cr.vers = 0 AND cr.del_yn = false
+LEFT JOIN my_regs mr
+  ON mr.team_comp_id = tcp.team_comp_id
+WHERE tcp.team_id = p_team_id
+  AND tcp.vers = 0
+  AND tcp.del_yn = false
+  AND date_range.range_start IS NOT NULL
+  AND c.stt_dt BETWEEN date_range.range_start AND date_range.range_end
+GROUP BY c.comp_id, c.comp_nm, c.stt_dt, c.end_dt, c.loc_nm, c.src_url, mr.team_comp_id
+HAVING count(DISTINCT cr.comp_reg_id) > 0 OR mr.team_comp_id IS NOT NULL
+
+ORDER BY start_date ASC;
+$$;
+
+GRANT EXECUTE ON FUNCTION public.get_schedule_paged(uuid, text, date, uuid, int)
+  TO anon, authenticated, service_role;

--- a/supabase/migrations/20260618110000_get_admin_unpaid_active_count.sql
+++ b/supabase/migrations/20260618110000_get_admin_unpaid_active_count.sql
@@ -1,0 +1,27 @@
+-- get_admin_unpaid_active_count: 미납 활성 멤버 수 단일 쿼리
+-- fee_mem_bal_snap과 team_mem_rel을 DB 내부에서 직접 JOIN하여
+-- max_rows 1000 제한과 2-step 쿼리 문제를 동시에 해결
+
+CREATE OR REPLACE FUNCTION public.get_admin_unpaid_active_count(p_team_id uuid)
+RETURNS bigint
+LANGUAGE sql
+STABLE
+SECURITY DEFINER
+SET search_path = public
+AS $$
+  SELECT count(DISTINCT tmr.mem_id)
+  FROM public.team_mem_rel tmr
+  JOIN public.fee_mem_bal_snap fbs
+    ON fbs.mem_id  = tmr.mem_id
+   AND fbs.team_id = tmr.team_id
+   AND fbs.vers    = 0
+   AND fbs.del_yn  = false
+   AND fbs.bal_amt < 0
+  WHERE tmr.team_id   = p_team_id
+    AND tmr.mem_st_cd = 'active'
+    AND tmr.vers      = 0
+    AND tmr.del_yn    = false;
+$$;
+
+-- 관리자 전용 — service_role만 호출 가능
+GRANT EXECUTE ON FUNCTION public.get_admin_unpaid_active_count(uuid) TO service_role;


### PR DESCRIPTION
## 변경 요약

### 1. 미납 회원 수에서 비활성 인원 제외
- AS-IS: 비활성 멤버도 미납 카운트에 포함
- TO-BE: 활성 멤버 기준으로만 미납 집계

### 2. 공유하기 텍스트 포맷 개선
- 공유 형식: [제목] / 시간 / 본문링크(있으면) / 본문내용 / 원글링크
- 본문 URL을 regex 추출 대신 post.url 필드로 직접 전달
- 다른 앱으로 공유·텍스트 복사 동일 포맷 통일

### 3. 인앱브라우저 게이트 전체 페이지 확장
- 루트 레이아웃에 단일 배치 → 모든 페이지 커버
- 가입·온보딩: 전체 화면 차단 ("가입할 수 없어요")
- 로그인·일반 콘텐츠: 하단 배너만 표시 (닫기 가능, 내용 열람 가능)
- Android: Chrome에서 열기 / iOS: Safari 안내
- 배너 z-[60]으로 하단 탭바 위에 표시

### 4. 홈 리스트뷰 이전달 스크롤 빈 달 건너뛰기
- 빈 달이 끼어도 데이터 있는 달을 정확히 찾아 로드

## 테스트
- [x] 관리자 통계 — 비활성 멤버 미납 카운트 제외 확인
- [x] 공유 텍스트 포맷 확인
- [x] 카카오톡 인앱 → 콘텐츠: 하단 배너
- [x] 카카오톡 인앱 → /newbie: 전체 차단
- [ ] Android Chrome 열기 / iOS Safari 안내
