### PR TITLE
fix(gate): 다이얼로그 위 배너 버튼 클릭 불가 버그 수정

### DIFF
--- a/components/in-app-browser-gate.tsx
+++ b/components/in-app-browser-gate.tsx
@@ -160,7 +160,7 @@ function BannerGate({
     <>
       {children}
       {createPortal(
-      <div className="fixed bottom-0 left-0 right-0 z-[9999] flex items-center gap-2 bg-primary px-4 py-3 text-primary-foreground" style={{ paddingBottom: "calc(0.75rem + env(safe-area-inset-bottom, 0px))" }}>
+      <div className="pointer-events-auto fixed bottom-0 left-0 right-0 z-[9999] flex items-center gap-2 bg-primary px-4 py-3 text-primary-foreground" style={{ paddingBottom: "calc(0.75rem + env(safe-area-inset-bottom, 0px))" }}>
         <span className="flex-1 text-xs leading-snug">
           {isIOS()
             ? "Safari에서 열면 모든 기능을 사용할 수 있어요"


### PR DESCRIPTION
Radix UI Dialog(modal=true)는 DismissableLayer가 document.body에 pointer-events: none을 설정하여 외부 요소 클릭을 차단한다.
배너 Portal도 body 하위에 있어 동일하게 영향을 받았으므로
pointer-events-auto를 명시적으로 추가해 override한다.