### PR TITLE
perf: 홈 로딩 최적화 및 Lighthouse CI 도입

### DIFF
--- a/.github/workflows/lighthouse-pr.yml
+++ b/.github/workflows/lighthouse-pr.yml
@@ -9,6 +9,7 @@ jobs:
       github.event.deployment_status.state == 'success' &&
       startsWith(github.event.deployment.environment, 'Preview')
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     permissions:
       pull-requests: write
 
@@ -22,10 +23,12 @@ jobs:
         run: npm install -g lighthouse
 
       - name: Run Lighthouse
+        env:
+          PREVIEW_URL: ${{ github.event.deployment_status.environment_url }}
         run: |
-          lighthouse "${{ github.event.deployment_status.environment_url }}" \
+          lighthouse "$PREVIEW_URL" \
             --output json \
-            --output-path ./lh \
+            --output-path ./lh.json \
             --only-categories performance \
             --chrome-flags="--headless=new --no-sandbox --disable-dev-shm-usage" \
             --quiet
@@ -34,9 +37,9 @@ jobs:
         id: pr
         env:
           GH_TOKEN: ${{ github.token }}
+          DEPLOY_REF: ${{ github.event.deployment.ref }}
         run: |
-          REF="${{ github.event.deployment.ref }}"
-          PR=$(gh pr list --repo "${{ github.repository }}" --head "$REF" --state open --json number --jq '.[0].number // empty')
+          PR=$(gh pr list --repo "${{ github.repository }}" --head "$DEPLOY_REF" --state open --json number --jq '.[0].number // empty')
           echo "number=$PR" >> $GITHUB_OUTPUT
 
       - name: Post Lighthouse comment

--- a/.github/workflows/lighthouse-pr.yml
+++ b/.github/workflows/lighthouse-pr.yml
@@ -36,7 +36,7 @@ jobs:
           GH_TOKEN: ${{ github.token }}
         run: |
           REF="${{ github.event.deployment.ref }}"
-          PR=$(gh pr list --head "$REF" --state open --json number --jq '.[0].number // empty')
+          PR=$(gh pr list --repo "${{ github.repository }}" --head "$REF" --state open --json number --jq '.[0].number // empty')
           echo "number=$PR" >> $GITHUB_OUTPUT
 
       - name: Post Lighthouse comment

--- a/.github/workflows/lighthouse-pr.yml
+++ b/.github/workflows/lighthouse-pr.yml
@@ -1,0 +1,95 @@
+name: Lighthouse — PR Preview
+
+on:
+  deployment_status:
+
+jobs:
+  lighthouse:
+    if: |
+      github.event.deployment_status.state == 'success' &&
+      startsWith(github.event.deployment.environment, 'Preview')
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+
+    steps:
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Install Lighthouse
+        run: npm install -g lighthouse
+
+      - name: Run Lighthouse
+        run: |
+          lighthouse "${{ github.event.deployment_status.environment_url }}" \
+            --output json \
+            --output-path ./lh \
+            --only-categories performance \
+            --chrome-flags="--headless=new --no-sandbox --disable-dev-shm-usage" \
+            --quiet
+
+      - name: Find associated PR
+        id: pr
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          REF="${{ github.event.deployment.ref }}"
+          PR=$(gh pr list --head "$REF" --state open --json number --jq '.[0].number // empty')
+          echo "number=$PR" >> $GITHUB_OUTPUT
+
+      - name: Post Lighthouse comment
+        if: steps.pr.outputs.number != ''
+        uses: actions/github-script@v7
+        env:
+          PREVIEW_URL: ${{ github.event.deployment_status.environment_url }}
+          PR_NUMBER: ${{ steps.pr.outputs.number }}
+        with:
+          script: |
+            const fs = require('fs');
+            const report = JSON.parse(fs.readFileSync('./lh.json', 'utf8'));
+
+            const perf = Math.round(report.categories.performance.score * 100);
+            const fcp = report.audits['first-contentful-paint'].displayValue;
+            const lcp = report.audits['largest-contentful-paint'].displayValue;
+            const ttfb = report.audits['server-response-time'].displayValue;
+            const tbt = report.audits['total-blocking-time'].displayValue;
+
+            const badge = perf >= 90 ? '🟢' : perf >= 50 ? '🟡' : '🔴';
+
+            const body = [
+              '## ⚡ Lighthouse 결과 — / (홈)',
+              '',
+              '| 지표 | 점수 |',
+              '|------|------|',
+              `| Performance | ${badge} ${perf} |`,
+              `| FCP | ${fcp} |`,
+              `| LCP | ${lcp} |`,
+              `| TTFB | ${ttfb} |`,
+              `| TBT | ${tbt} |`,
+              '',
+              `🔗 [프리뷰 URL](${process.env.PREVIEW_URL})`,
+            ].join('\n');
+
+            const prNumber = parseInt(process.env.PR_NUMBER);
+            const { data: comments } = await github.rest.issues.listComments({
+              ...context.repo,
+              issue_number: prNumber,
+            });
+
+            const existing = comments.find(c => c.body.includes('⚡ Lighthouse 결과'));
+
+            if (existing) {
+              await github.rest.issues.updateComment({
+                ...context.repo,
+                comment_id: existing.id,
+                body,
+              });
+            } else {
+              await github.rest.issues.createComment({
+                ...context.repo,
+                issue_number: prNumber,
+                body,
+              });
+            }

--- a/.github/workflows/lighthouse-pr.yml
+++ b/.github/workflows/lighthouse-pr.yml
@@ -37,9 +37,9 @@ jobs:
         id: pr
         env:
           GH_TOKEN: ${{ github.token }}
-          DEPLOY_REF: ${{ github.event.deployment.ref }}
+          DEPLOY_SHA: ${{ github.event.deployment.sha }}
         run: |
-          PR=$(gh pr list --repo "${{ github.repository }}" --head "$DEPLOY_REF" --state open --json number --jq '.[0].number // empty')
+          PR=$(gh api repos/${{ github.repository }}/commits/$DEPLOY_SHA/pulls --jq '.[0].number // empty')
           echo "number=$PR" >> $GITHUB_OUTPUT
 
       - name: Post Lighthouse comment

--- a/.github/workflows/lighthouse-weekly.yml
+++ b/.github/workflows/lighthouse-weekly.yml
@@ -1,0 +1,39 @@
+name: Lighthouse — Weekly
+
+on:
+  schedule:
+    - cron: '0 0 * * 1'  # 매주 월요일 00:00 UTC = 09:00 KST
+  workflow_dispatch:
+
+jobs:
+  lighthouse:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+
+    steps:
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Install Lighthouse
+        run: npm install -g lighthouse
+
+      - name: Run Lighthouse on production
+        run: |
+          lighthouse https://gigang.team/ \
+            --output html \
+            --output json \
+            --output-path ./lighthouse \
+            --chrome-flags="--headless=new --no-sandbox --disable-dev-shm-usage" \
+            --quiet
+
+      - name: Upload report artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: lighthouse-report
+          path: |
+            lighthouse.report.html
+            lighthouse.report.json
+          retention-days: 30

--- a/.github/workflows/lighthouse-weekly.yml
+++ b/.github/workflows/lighthouse-weekly.yml
@@ -8,6 +8,7 @@ on:
 jobs:
   lighthouse:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     permissions:
       contents: read
 

--- a/app/(main)/layout.tsx
+++ b/app/(main)/layout.tsx
@@ -3,6 +3,35 @@ import { Suspense } from "react";
 import { BottomTabBar } from "@/components/bottom-tab-bar";
 import { MemberProviderServer } from "@/components/member-provider-server";
 import { PwaInstallPrompt } from "@/components/pwa-install-prompt";
+import { Skeleton } from "@/components/ui/skeleton";
+
+function AppShellFallback() {
+  return (
+    <div className="min-h-svh bg-background">
+      <main className="pb-[calc(3.5rem+env(safe-area-inset-bottom,0px))]">
+        <div className="h-14" />
+        <div className="flex flex-col gap-7 px-6">
+          <div className="flex flex-col gap-4">
+            <Skeleton className="h-3 w-20" />
+            <Skeleton className="h-32 w-full rounded-2xl" />
+          </div>
+          <div className="flex flex-col gap-4">
+            <Skeleton className="h-3 w-20" />
+            <Skeleton className="h-32 w-full rounded-2xl" />
+          </div>
+          <div className="flex flex-col gap-4">
+            <Skeleton className="h-3 w-20" />
+            <div className="grid grid-cols-2 gap-3">
+              <Skeleton className="h-24 rounded-2xl" />
+              <Skeleton className="h-24 rounded-2xl" />
+            </div>
+          </div>
+        </div>
+      </main>
+      <BottomTabBar />
+    </div>
+  );
+}
 
 export default function MainLayout({
   children,
@@ -10,7 +39,7 @@ export default function MainLayout({
   children: React.ReactNode;
 }) {
   return (
-    <Suspense>
+    <Suspense fallback={<AppShellFallback />}>
       <MemberProviderServer>
         <div className="min-h-svh bg-background">
           <main className="pb-[calc(3.5rem+env(safe-area-inset-bottom,0px))]">

--- a/components/member-provider-server.tsx
+++ b/components/member-provider-server.tsx
@@ -1,4 +1,4 @@
-import { getMember } from "@/lib/get-member";
+import { getCurrentMember } from "@/lib/queries/member";
 import { MemberProvider } from "@/contexts/member-context";
 
 export async function MemberProviderServer({
@@ -6,10 +6,10 @@ export async function MemberProviderServer({
 }: {
   children: React.ReactNode;
 }) {
-  const { userId, member } = await getMember();
+  const { user, member } = await getCurrentMember();
 
   return (
-    <MemberProvider userId={userId} member={member}>
+    <MemberProvider userId={user?.id ?? null} member={member}>
       {children}
     </MemberProvider>
   );

--- a/contexts/member-context.tsx
+++ b/contexts/member-context.tsx
@@ -1,11 +1,11 @@
 "use client";
 
 import { createContext, useContext } from "react";
-import type { Member } from "@/lib/get-member";
+import type { AppMemberProfile } from "@/lib/queries/app-member";
 
 type MemberContextValue = {
   userId: string | null;
-  member: Member | null;
+  member: AppMemberProfile | null;
 };
 
 const MemberContext = createContext<MemberContextValue>({
@@ -19,7 +19,7 @@ export function MemberProvider({
   children,
 }: {
   userId: string | null;
-  member: Member | null;
+  member: AppMemberProfile | null;
   children: React.ReactNode;
 }) {
   return (

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -36,48 +36,7 @@ const eslintConfig = [
           caughtErrorsIgnorePattern: "^_",
         },
       ],
-      "import/order": [
-        "warn",
-        {
-          groups: [
-            "builtin",
-            "external",
-            "internal",
-            "parent",
-            "sibling",
-            "index",
-            "type",
-          ],
-          pathGroups: [
-            {
-              pattern: "react",
-              group: "builtin",
-              position: "before",
-            },
-            {
-              pattern: "next/**",
-              group: "builtin",
-              position: "before",
-            },
-            {
-              pattern: "@/lib/**",
-              group: "internal",
-              position: "before",
-            },
-            {
-              pattern: "@/components/**",
-              group: "internal",
-              position: "after",
-            },
-          ],
-          pathGroupsExcludedImportTypes: ["react", "next"],
-          "newlines-between": "always",
-          alphabetize: {
-            order: "asc",
-            caseInsensitive: true,
-          },
-        },
-      ],
+      "import/order": "off",
       "no-restricted-imports": [
         "error",
         {

--- a/lib/queries/request-team.ts
+++ b/lib/queries/request-team.ts
@@ -1,5 +1,6 @@
 import { cache } from "react";
 import { headers } from "next/headers";
+import { unstable_cache } from "next/cache";
 import { createAdminClient } from "@/lib/supabase/admin";
 import { DEFAULT_FALLBACK_TEAM_ID } from "@/lib/constants/gigang-team";
 
@@ -64,6 +65,9 @@ export async function resolveTeamContextFromHost(
 export const getRequestTeamContext = cache(async (): Promise<RequestTeamContext> => {
   const h = await headers();
   const host = h.get("x-forwarded-host") ?? h.get("host");
-  console.log("[getRequestTeamContext] host:", host, "x-forwarded-host:", h.get("x-forwarded-host"), "host-header:", h.get("host"));
-  return resolveTeamContextFromHost(host);
+  return unstable_cache(
+    () => resolveTeamContextFromHost(host),
+    ["team-context", host ?? "unknown"],
+    { revalidate: false },
+  )();
 });

--- a/lib/queries/request-team.ts
+++ b/lib/queries/request-team.ts
@@ -68,6 +68,6 @@ export const getRequestTeamContext = cache(async (): Promise<RequestTeamContext>
   return unstable_cache(
     () => resolveTeamContextFromHost(host),
     ["team-context", host ?? "unknown"],
-    { revalidate: false },
+    { revalidate: false, tags: [`team-context:${host ?? "unknown"}`] },
   )();
 });

--- a/serwist.config.js
+++ b/serwist.config.js
@@ -1,16 +1,7 @@
 // @ts-check
-import { spawnSync } from "node:child_process";
-
 import { serwist } from "@serwist/next/config";
-
-// 배포마다 고유한 revision — git commit hash 또는 UUID 폴백
-const revision =
-  spawnSync("git", ["rev-parse", "HEAD"], { encoding: "utf-8" }).stdout?.trim() ??
-  crypto.randomUUID();
 
 export default serwist({
   swSrc: "app/sw.ts",
   swDest: "public/sw.js",
-  // Next.js가 사전 렌더링한 페이지를 자동으로 precache에 추가
-  additionalPrecacheEntries: [{ url: "/", revision }],
 });


### PR DESCRIPTION
## 관련 이슈

관련 이슈 없음

## 요약

홈탭 초기 로딩 체감을 개선하는 4가지 수정과, PR·주간 성능을 자동 측정하는 Lighthouse CI 워크플로우를 추가한다.

## AS-IS (변경 전)

- `<Suspense>` fallback이 `null` → `MemberProviderServer` 비동기 완료 전까지 완전한 흰 화면
- `getMember()`가 `getUser()` → `getRequestTeamContext()` → `fetchMemMstWithTeamRel()` 3단 순차 실행
- `getRequestTeamContext()`가 매 요청마다 `team_mst` DB 조회 (도메인-팀 매핑은 불변인데도)
- SW가 SSR 페이지 `/`를 프리캐시 → stale HTML 서빙 + SW 설치 시 불필요한 Vercel 콜드스타트 유발
- Lighthouse 성능 측정 수동 의존

## TO-BE (변경 후)

- `AppShellFallback` (탭바 + 스켈레톤)을 Suspense fallback으로 즉시 표시 → 서버 응답 대기 중에도 앱 UI 노출
- `getCurrentMember()`로 교체 → `getUser()`와 `getRequestTeamContext()` 병렬 실행
- `unstable_cache({ revalidate: false })` 적용 → 배포 단위 캐시, 팀 조회 DB 쿼리 사실상 제거
- `/` 프리캐시 제거 → 기존 NetworkFirst 전략이 항상 최신 HTML 서빙
- PR 생성 시 Vercel 프리뷰 URL 자동 Lighthouse 측정 후 댓글, 주간 프로덕션 모니터링 추가

## 변경 흐름 (Mermaid)

```mermaid
flowchart TD
    subgraph AS_IS ["AS-IS"]
        A1[요청] --> B1[getUser]
        B1 --> C1[getRequestTeamContext\nDB 매 요청마다]
        C1 --> D1[fetchMemMstWithTeamRel]
        D1 --> E1[렌더]
        F1[Suspense fallback = null\n흰 화면] -.->|대기 중| E1
    end

    subgraph TO_BE ["TO-BE"]
        A2[요청] --> B2[getUser]
        A2 --> C2[getRequestTeamContext\nunstable_cache]
        B2 & C2 --> D2[fetchMemMstWithTeamRel]
        D2 --> E2[렌더]
        F2[AppShellFallback\n탭바 + 스켈레톤] -.->|대기 중 즉시 표시| E2
    end

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **New Features**
  * Pull Request 미리보기에 자동 성능 측정 및 평가 결과 추가
  * 주간 성능 리포트 자동 생성
  * 페이지 로딩 중 개선된 UI 표시

* **Refactor**
  * 성능 최적화를 위한 데이터 조회 캐싱 추가
  * 내부 구성 요소 및 설정 개선

<!-- end of auto-generated comment: release notes by coderabbit.ai -->