### PR TITLE
fix(onboarding): details 단계에서 phone undefined로 가입 불가하던 문제 수정

### DIFF
--- a/components/auth/member-onboarding-form.tsx
+++ b/components/auth/member-onboarding-form.tsx
@@ -100,6 +100,7 @@ export function MemberOnboardingForm({
 	>("phone");
 	const [phoneLoading, setPhoneLoading] = useState(false);
 	const phoneInputRef = useRef<HTMLInputElement | null>(null);
+	const verifiedPhoneRef = useRef<string>("");
 
 	// 모바일 브라우저 자동완성(autofill)은 DOM 값만 채우고 React onChange를 발화하지
 	// 않을 수 있어, 제어 컴포넌트인 연락처 입력의 RHF 상태가 빈 채로 남는다.
@@ -126,7 +127,8 @@ export function MemberOnboardingForm({
 			return;
 		}
 
-		form.setValue("phone", phoneValue, { shouldValidate: true });
+		form.setValue("phone", phoneValue, { shouldValidate: false, shouldDirty: true });
+		verifiedPhoneRef.current = phoneValue;
 		form.clearErrors("phone");
 		setPhoneLoading(true);
 		form.clearErrors("root");
@@ -164,7 +166,8 @@ export function MemberOnboardingForm({
 
 	const onSubmit = async (values: MemberOnboardingValues) => {
 		const emailValue = (email ?? values.emailInput.trim()) || null;
-		const phoneValue = formatPhone(values.phone.trim());
+		const rawPhone = values.phone ?? form.getValues("phone") ?? verifiedPhoneRef.current ?? "";
+		const phoneValue = formatPhone(rawPhone.trim());
 		if (!digitsOnly(phoneValue)) {
 			form.setError("phone", { message: "연락처를 입력해 주세요." });
 			return;
@@ -279,7 +282,7 @@ export function MemberOnboardingForm({
 								href="/profile/bank"
 								className="text-center text-xs font-medium text-muted-foreground underline"
 							>
-								계좌는 나중에 등록할게요
+								계좌 정보 지금 등록하기
 							</Link>
 						</div>
 					</CardContent>
@@ -445,7 +448,6 @@ export function MemberOnboardingForm({
 										<FormField
 											control={form.control}
 											name="phone"
-											rules={{ required: "연락처를 입력해 주세요." }}
 											render={({ field }) => (
 												<FormItem>
 													<FormLabel>연락처</FormLabel>


### PR DESCRIPTION
## 관련 이슈

#336 (`fix/onboarding-phone-autofill-uncontrolled`) 의 후속 수정

## 원인

#336이 `phone` 단계 자동완성 버그를 수정했지만, `details` 단계(가입 완료 버튼)에서 동일한 문제가 남아 있었음.

모바일 자동완성으로 `phone` 단계를 진행하면 RHF state가 비어있는 채로 `details` 단계로 넘어오고, `onSubmit`에서 `values.phone`이 `undefined`가 되어 `.trim()` 호출 시 런타임 에러 발생 → 가입 불가.

## AS-IS

- `details` 단계 `onSubmit`에서 `values.phone.trim()` → `TypeError: Cannot read properties of undefined`
- `details` 단계 연락처 `FormField`에 불필요한 `rules={{ required }}` 존재 (disabled 표시용 필드)
- 가입 완료 화면 계좌 링크 문구: "계좌는 나중에 등록할게요" (클릭 시 등록 화면으로 이동해 맥락 불일치)

## TO-BE

- `verifiedPhoneRef`로 `handlePhoneSubmit` 검증 완료 시점에 번호를 별도 보관
- `onSubmit`에서 `values.phone → form.getValues("phone") → verifiedPhoneRef.current` 순으로 폴백
- `details` 연락처 `FormField` `required rules` 제거
- 가입 완료 화면 계좌 링크 문구: "계좌 정보 지금 등록하기"

## 테스트

- [ ] 모바일 자동완성으로 연락처 입력 후 가입 완료까지 진행
- [ ] 수동 입력으로 연락처 입력 후 가입 완료까지 진행

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **버그 수정**
  * 비활성화된 연락처 필드에서 불필요한 검증 오류 제거
  
* **개선사항**
  * 전화번호 입력 및 검증 흐름 개선으로 사용성 향상
  * 가입 완료 화면의 계좌 등록 안내 문구 업데이트 ("계좌 정보 지금 등록하기"로 변경)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->