### PR TITLE
feat(gathering): 모임 일정 기능 추가 및 홈 캘린더 통합

### DIFF
--- a/.claude/docs/push-notification-design.md
+++ b/.claude/docs/push-notification-design.md
@@ -1,0 +1,172 @@
+# PWA 푸시 알림 설계 문서
+
+> 작성일: 2026-06-21 | 상태: 설계 단계 (미구현)
+
+---
+
+## 1. 현재 인앱 알림 구조
+
+### 핵심 테이블: `noti_mst`
+
+| 컬럼 | 설명 |
+|------|------|
+| `noti_id` | UUID PK |
+| `mem_id` | 수신 멤버 |
+| `team_id` | 팀 |
+| `noti_type_enm` | 알림 종류 (아래 목록 참고) |
+| `noti_nm` | 알림 제목 |
+| `noti_cont` | 알림 본문 |
+| `ref_id` | 딥링크 대상 UUID (게더링 ID, 일정 ID 등) |
+| `ref_type_enm` | 딥링크 대상 타입 (`gathering`, `comp`, `sch_post`) |
+| `read_yn` | 읽음 여부 |
+| `del_yn` | 삭제 여부 |
+| `crt_at` | 생성일시 |
+
+### 현재 알림 타입 (`noti_type_enm`)
+
+| 타입 | 설명 | 딥링크 |
+|------|------|--------|
+| `adm_cust` | 관리자 공지 | 없음 |
+| `dues_notice` | 회비 안내 | `/profile/dues` |
+| `dues_check_req` | 회비 확인 요청 | 없음 |
+| `ttl_grnt` | 타이틀 획득 | `/profile` |
+| `sch_post_new` | 정보 일정 등록 | `/?post={ref_id}` |
+| `sch_post_cmnt` | 정보 일정 댓글 | `/?post={ref_id}` |
+| `cmnt_mention` | 댓글 멘션 | ref_type에 따라 분기 |
+| `cmnt_reply` | 댓글 답글 | ref_type에 따라 분기 |
+| `gthr_new` | 모임 등록 | `/?gthr={ref_id}` |
+| `gthr_upd` | 모임 수정 | `/?gthr={ref_id}` |
+| `gthr_del` | 모임 삭제 | `/` |
+| `gthr_cmnt` | 모임 댓글 | `/?gthr={ref_id}` |
+| `gthr_reply` | 모임 답글 | `/?gthr={ref_id}` |
+| `gthr_mention` | 모임 멘션 | `/?gthr={ref_id}` |
+
+### 인앱 알림 흐름
+
+```
+서버 액션 실행 (댓글 작성, 모임 등록 등)
+  └→ noti_mst INSERT (대상 멤버 수만큼 row)
+       └→ 알림 탭에서 read_yn=false인 row 카운트 → 빨간 뱃지
+            └→ 멤버가 알림 탭 진입 또는 알림 클릭 → read_yn=true
+```
+
+### 알림 설정: `noti_pref_cfg`
+- 멤버별로 `noti_type_enm` + `enabled_yn` 저장
+- enabled_yn=false면 해당 타입 알림 INSERT 안 함
+
+---
+
+## 2. PWA 푸시 알림 설계 (미구현)
+
+### 인앱 알림과의 관계
+
+**푸시 알림과 인앱 알림은 완전히 독립적.**
+
+- 푸시 알림 = 기기 OS가 띄우는 알림. 앱이 꺼져 있어도 도착.
+- 인앱 알림 = 앱 열었을 때 알림 탭 빨간 뱃지.
+
+푸시를 껐다고 `noti_mst` INSERT가 멈추는 게 아님.
+푸시를 탭해서 앱을 열었다고 `read_yn`이 자동으로 true가 되지 않음.
+→ 푸시로 내용 확인해도 인앱 알림 탭에 빨간 뱃지는 그대로 남음.
+
+이는 대부분의 앱(카카오톡, 인스타 등)과 동일한 UX.
+
+### 구현에 필요한 것
+
+**추가 테이블: `push_sub_rel`**
+```sql
+push_sub_rel (
+  sub_id      uuid PK,
+  mem_id      uuid FK,
+  team_id     uuid FK,
+  endpoint    text,       -- PushSubscription endpoint
+  p256dh      text,       -- 암호화 키
+  auth        text,       -- 암호화 키
+  user_agent  text,       -- 기기/브라우저 구분용
+  crt_at      timestamptz
+)
+```
+한 멤버가 여러 기기(폰+PC 등) 구독 가능 → 멤버당 여러 row.
+
+**서버: `web-push` 라이브러리 + VAPID 키**
+```
+VAPID_PUBLIC_KEY   → 클라이언트에서 구독 시 사용
+VAPID_PRIVATE_KEY  → 서버에서 푸시 발송 시 사용
+```
+
+**Service Worker: `public/sw.js`**
+- `push` 이벤트 수신 → `showNotification()`
+- `notificationclick` 이벤트 → 딥링크 URL로 이동
+
+### 발송 흐름
+
+```
+서버 액션 실행
+  ├→ noti_mst INSERT (인앱 알림, 기존과 동일)
+  └→ push_sub_rel 조회 (대상 멤버의 구독 목록)
+       └→ web-push로 각 endpoint에 발송
+            └→ Service Worker push 이벤트 수신
+                 └→ showNotification() 표시
+```
+
+기존 서버 액션에 `sendPush(memberIds, { title, body, url })` 한 줄 추가하는 방식.
+기존 코드 변경 최소화.
+
+### 알림 그룹핑 전략
+
+**목표: 폰 알림창에서 기강 앱 알림이 항상 1줄로만 보임. 탭하거나 펼치면 개별 알림 확인 가능.**
+
+#### Android
+`isGroupSummary`로 완전히 제어 가능.
+
+```js
+// Service Worker에서 개별 알림 표시
+showNotification("새 모임이 등록됐습니다", {
+  body: "양재천 자유러닝",
+  tag: `noti-${notiId}`,
+  group: "gigang",
+  data: { url: "/?gthr=xxx" },
+})
+
+// 그룹 요약 (접혔을 때 보이는 1줄)
+const existing = await self.registration.getNotifications({ tag: "gigang-summary" })
+showNotification("기강", {
+  body: `새 알림 ${existing.length + 1}개`,
+  tag: "gigang-summary",
+  group: "gigang",
+  isGroupSummary: true,
+})
+```
+
+결과:
+- 접힌 상태: "기강 — 새 알림 N개" 1줄
+- 펼친 상태: 개별 알림 목록 (인앱 알림 탭과 동일한 내용)
+
+#### iOS (iOS 16.4+)
+`group`/`isGroupSummary` 미지원. OS가 앱별로 자동 그룹핑.
+- 접힌 상태: "기강 N개의 알림" (OS 기본 표현)
+- 펼친 상태: 개별 알림 목록
+
+커스텀 요약 텍스트는 불가능하지만 그룹핑 자체는 자동으로 됨.
+
+### 알림 권한 요청 시점
+- 가입 완료 직후 (온보딩 마지막 단계)
+- 또는 첫 알림 발생 시점에 배너로 유도
+- 거부해도 인앱 알림은 정상 동작
+
+### `noti_pref_cfg` 연동
+기존 인앱 알림 설정(`enabled_yn`)을 푸시에도 그대로 적용.
+특정 타입 알림을 껐으면 `noti_mst` INSERT도, 푸시 발송도 둘 다 안 함.
+푸시 전용 on/off 설정을 별도로 추가할 수도 있음 (선택).
+
+---
+
+## 3. 구현 순서 (나중에 진행할 때 참고)
+
+1. VAPID 키 생성 + `lib/env.ts`에 환경변수 추가
+2. `push_sub_rel` 테이블 마이그레이션
+3. `public/sw.js` Service Worker 작성 (push + notificationclick)
+4. 클라이언트 구독 등록 UI (설정 페이지 또는 온보딩)
+5. `lib/push/send-push.ts` 유틸 작성
+6. 기존 서버 액션에 `sendPush()` 연동
+7. Android 그룹핑 적용

--- a/app/(info)/gatherings/[id]/gathering-attend-button.tsx
+++ b/app/(info)/gatherings/[id]/gathering-attend-button.tsx
@@ -1,0 +1,54 @@
+"use client";
+
+import { useState, useTransition } from "react";
+
+import { cn } from "@/lib/utils";
+
+import { toggleGatheringAttendance } from "@/app/actions/gathering/toggle-attendance";
+
+import { Button } from "@/components/ui/button";
+
+type Props = {
+  gthrId: string;
+  initialAttending: boolean;
+  maxPrtCnt: number | null;
+  currentAttdCount: number;
+};
+
+export function GatheringAttendButton({ gthrId, initialAttending, maxPrtCnt, currentAttdCount }: Props) {
+  const [attending, setAttending] = useState(initialAttending);
+  const [attdCount, setAttdCount] = useState(currentAttdCount);
+  const [isPending, startTransition] = useTransition();
+
+  const isFull = !attending && maxPrtCnt !== null && attdCount >= maxPrtCnt;
+
+  function handleToggle() {
+    if (isFull) return;
+    startTransition(async () => {
+      const prev = attending;
+      setAttending(!prev);
+      setAttdCount((c) => (!prev ? c + 1 : c - 1));
+      try {
+        const result = await toggleGatheringAttendance(gthrId);
+        setAttending(result.attending);
+      } catch {
+        setAttending(prev);
+        setAttdCount((c) => (prev ? c + 1 : c - 1));
+      }
+    });
+  }
+
+  return (
+    <Button
+      onClick={handleToggle}
+      disabled={isPending || isFull}
+      variant={attending ? "default" : "outline"}
+      className={cn(
+        "w-full",
+        attending && "bg-success hover:bg-success/90 border-success",
+      )}
+    >
+      {isFull ? "인원 마감" : attending ? "✅ 참석" : "참석하기"}
+    </Button>
+  );
+}

--- a/app/(info)/gatherings/[id]/gathering-attend-button.tsx
+++ b/app/(info)/gatherings/[id]/gathering-attend-button.tsx
@@ -33,7 +33,7 @@ export function GatheringAttendButton({ gthrId, initialAttending, maxPrtCnt, cur
         setAttending(result.attending);
       } catch {
         setAttending(prev);
-        setAttdCount((c) => (prev ? c + 1 : c - 1));
+        setAttdCount((c) => (prev ? c - 1 : c + 1));
       }
     });
   }

--- a/app/(info)/gatherings/[id]/gathering-menu-button.tsx
+++ b/app/(info)/gatherings/[id]/gathering-menu-button.tsx
@@ -53,7 +53,7 @@ export function GatheringMenuButton({ gthrId, isAuthor, isAdmin, gthrData }: Pro
       await deleteGathering(gthrId);
       router.replace("/");
     } catch (e) {
-      console.error(e);
+      alert(e instanceof Error ? e.message : "삭제에 실패했습니다.");
       setIsDeleting(false);
     }
   }

--- a/app/(info)/gatherings/[id]/gathering-menu-button.tsx
+++ b/app/(info)/gatherings/[id]/gathering-menu-button.tsx
@@ -1,0 +1,116 @@
+"use client";
+
+import { useState } from "react";
+
+import { useRouter } from "next/navigation";
+
+import { MoreHorizontal } from "lucide-react";
+
+import { deleteGathering } from "@/app/actions/gathering/manage-gathering";
+
+import { GatheringFormDialog } from "@/components/schedule/gathering-form-dialog";
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+
+type Props = {
+  gthrId: string;
+  isAuthor: boolean;
+  isAdmin: boolean;
+  gthrData: {
+    gthr_nm: string;
+    gthr_type_enm: string;
+    sprt_cd?: string | null;
+    stt_at: string;
+    end_at: string | null;
+    loc_txt: string | null;
+    desc_txt: string | null;
+    max_prt_cnt: number | null;
+  };
+};
+
+export function GatheringMenuButton({ gthrId, isAuthor, isAdmin, gthrData }: Props) {
+  const router = useRouter();
+  const [editOpen, setEditOpen] = useState(false);
+  const [deleteOpen, setDeleteOpen] = useState(false);
+  const [isDeleting, setIsDeleting] = useState(false);
+
+  async function handleDelete() {
+    setIsDeleting(true);
+    try {
+      await deleteGathering(gthrId);
+      router.replace("/");
+    } catch (e) {
+      console.error(e);
+      setIsDeleting(false);
+    }
+  }
+
+  return (
+    <>
+      <DropdownMenu>
+        <DropdownMenuTrigger asChild>
+          <Button variant="ghost" size="icon-sm">
+            <MoreHorizontal className="size-5" />
+          </Button>
+        </DropdownMenuTrigger>
+        <DropdownMenuContent align="end">
+          {isAuthor && (
+            <DropdownMenuItem onClick={() => setEditOpen(true)}>
+              수정
+            </DropdownMenuItem>
+          )}
+          {(isAuthor || isAdmin) && (
+            <DropdownMenuItem
+              onClick={() => setDeleteOpen(true)}
+              className="text-destructive focus:text-destructive"
+            >
+              삭제
+            </DropdownMenuItem>
+          )}
+        </DropdownMenuContent>
+      </DropdownMenu>
+
+      {/* 수정 다이얼로그 */}
+      <GatheringFormDialog
+        open={editOpen}
+        onOpenChange={setEditOpen}
+        mode="edit"
+        initialData={{ gthr_id: gthrId, ...gthrData }}
+        onSuccess={() => router.refresh()}
+      />
+
+      {/* 삭제 확인 다이얼로그 */}
+      <Dialog open={deleteOpen} onOpenChange={setDeleteOpen}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>모임 삭제</DialogTitle>
+            <DialogDescription>
+              &apos;{gthrData.gthr_nm}&apos;을 삭제하시겠습니까? 참석자들에게 알림이 발송됩니다.
+            </DialogDescription>
+          </DialogHeader>
+          <DialogFooter>
+            <Button variant="outline" onClick={() => setDeleteOpen(false)}>
+              취소
+            </Button>
+            <Button variant="destructive" onClick={handleDelete} disabled={isDeleting}>
+              {isDeleting ? "삭제 중..." : "삭제"}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </>
+  );
+}

--- a/app/(info)/gatherings/[id]/page.tsx
+++ b/app/(info)/gatherings/[id]/page.tsx
@@ -1,0 +1,203 @@
+import { notFound } from "next/navigation";
+
+import { dayjs } from "@/lib/dayjs";
+import { getCurrentMember } from "@/lib/queries/member";
+import { getRequestTeamContext } from "@/lib/queries/request-team";
+import { createUntypedAdminClient } from "@/lib/supabase/admin";
+import { gthrTypeLabels } from "@/lib/validations/gathering";
+
+import { getMentionMembers } from "@/app/actions/comment/get-mention-members";
+
+import { CommentSection } from "@/components/comment/comment-section";
+import { Avatar } from "@/components/common/avatar";
+import { H2, Caption, Micro, SectionLabel } from "@/components/common/typography";
+import { Badge } from "@/components/ui/badge";
+
+import { GatheringAttendButton } from "./gathering-attend-button";
+import { GatheringMenuButton } from "./gathering-menu-button";
+
+export default async function GatheringDetailPage({
+  params,
+}: {
+  params: Promise<{ id: string }>;
+}) {
+  const { id } = await params;
+  const { member, supabase } = await getCurrentMember();
+  const { teamId } = await getRequestTeamContext();
+
+  const [{ data: gthr }, membersForComment] = await Promise.all([
+    supabase
+      .from("gthr_mst")
+      .select("gthr_id, gthr_nm, gthr_type_enm, sprt_cd, stt_at, end_at, loc_txt, desc_txt, max_prt_cnt, crt_by, team_id")
+      .eq("gthr_id", id)
+      .eq("del_yn", false)
+      .single(),
+    member ? getMentionMembers() : Promise.resolve([]),
+  ]);
+
+  if (!gthr || gthr.team_id !== teamId) notFound();
+
+  const admin = createUntypedAdminClient();
+  const [{ data: attendees }, myAttd, { data: comments }] = await Promise.all([
+    // 참석자 목록: RLS 없이 공개 노출 (팀 멤버 확인은 gthr_mst SELECT RLS가 보장)
+    admin
+      .from("gthr_attd_rel")
+      .select("mem_id, mem_mst(mem_id, mem_nm, avatar_url)")
+      .eq("gthr_id", id),
+    member
+      ? supabase
+          .from("gthr_attd_rel")
+          .select("attd_id")
+          .eq("gthr_id", id)
+          .eq("mem_id", member.id)
+          .maybeSingle()
+      : Promise.resolve({ data: null }),
+    // cmnt_mst는 RLS 있는 supabase 클라이언트 사용 — del_yn=true 댓글 RLS가 필터
+    supabase
+      .from("cmnt_mst")
+      .select("cmnt_id, prnt_id, mem_id, cont_txt, edit_yn, del_yn, crt_at, upd_at, mem_mst(mem_nm, avatar_url)")
+      .eq("entity_type", "gathering")
+      .eq("entity_id", id)
+      .order("crt_at", { ascending: true }),
+  ]);
+
+  const isAttending = !!myAttd?.data;
+  const isAuthor = member?.id === gthr.crt_by;
+
+  const stt = dayjs(gthr.stt_at).tz("Asia/Seoul");
+  const end = gthr.end_at ? dayjs(gthr.end_at).tz("Asia/Seoul") : null;
+  const dateStr = stt.format("YYYY년 M월 D일 (ddd)");
+  const timeStr = end
+    ? `${stt.format("HH:mm")} ~ ${end.format("HH:mm")}`
+    : stt.format("HH:mm");
+
+  return (
+    <div className="relative flex min-h-svh flex-col bg-background">
+      {/* (info) 레이아웃 BackHeader 위에 title + 메뉴를 absolute로 오버레이 */}
+      <div className="pointer-events-none absolute inset-x-0 top-0 z-50 flex h-12 items-center px-4">
+        <h1 className="absolute left-1/2 -translate-x-1/2 text-base font-semibold text-foreground pointer-events-auto">
+          {gthr.gthr_nm}
+        </h1>
+        {(isAuthor || member?.admin) && (
+          <div className="absolute right-4 pointer-events-auto">
+            <GatheringMenuButton
+              gthrId={id}
+              isAuthor={isAuthor}
+              isAdmin={member?.admin ?? false}
+              gthrData={{
+                gthr_nm: gthr.gthr_nm,
+                gthr_type_enm: gthr.gthr_type_enm,
+                sprt_cd: gthr.sprt_cd ?? null,
+                stt_at: gthr.stt_at,
+                end_at: gthr.end_at ?? null,
+                loc_txt: gthr.loc_txt ?? null,
+                desc_txt: gthr.desc_txt ?? null,
+                max_prt_cnt: gthr.max_prt_cnt ?? null,
+              }}
+            />
+          </div>
+        )}
+      </div>
+
+      <div className="flex flex-col gap-5 px-6 py-5">
+        {/* 모임 정보 */}
+        <div className="flex flex-col gap-3">
+          <div className="flex items-center gap-2">
+            <Badge variant="secondary">
+              {gthrTypeLabels[gthr.gthr_type_enm as keyof typeof gthrTypeLabels] ?? gthr.gthr_type_enm}
+            </Badge>
+          </div>
+
+          <H2>{gthr.gthr_nm}</H2>
+
+          <div className="flex flex-col gap-1.5">
+            <div className="flex items-center gap-2">
+              <Caption className="text-muted-foreground w-4">📅</Caption>
+              <Caption>{dateStr}</Caption>
+            </div>
+            <div className="flex items-center gap-2">
+              <Caption className="text-muted-foreground w-4">⏰</Caption>
+              <Caption>{timeStr}</Caption>
+            </div>
+            {gthr.loc_txt && (
+              <div className="flex items-center gap-2">
+                <Caption className="text-muted-foreground w-4">📍</Caption>
+                <Caption>{gthr.loc_txt}</Caption>
+              </div>
+            )}
+            <div className="flex items-center gap-2">
+              <Caption className="text-muted-foreground w-4">👥</Caption>
+              <Caption>
+                참석 {attendees?.length ?? 0}명
+                {gthr.max_prt_cnt && ` / 최대 ${gthr.max_prt_cnt}명`}
+              </Caption>
+            </div>
+          </div>
+
+          {gthr.desc_txt && (
+            <div className="rounded-xl bg-secondary/50 px-4 py-3">
+              <Caption className="whitespace-pre-wrap text-foreground">{gthr.desc_txt}</Caption>
+            </div>
+          )}
+        </div>
+
+        {/* 참석 버튼 */}
+        {member && (
+          <GatheringAttendButton
+            gthrId={id}
+            initialAttending={isAttending}
+            maxPrtCnt={gthr.max_prt_cnt ?? null}
+            currentAttdCount={attendees?.length ?? 0}
+          />
+        )}
+
+        {/* 참석자 목록 */}
+        {(attendees?.length ?? 0) > 0 && (
+          <div className="flex flex-col gap-3">
+            <SectionLabel>참석자</SectionLabel>
+            <div className="flex flex-wrap gap-3">
+              {(attendees ?? []).map((a) => {
+                const mem = Array.isArray(a.mem_mst) ? a.mem_mst[0] : a.mem_mst;
+                return (
+                  <div key={a.mem_id} className="flex flex-col items-center gap-1">
+                    <Avatar src={mem?.avatar_url} alt={mem?.mem_nm ?? ""} size="sm" />
+                    <Micro className="text-muted-foreground">{mem?.mem_nm ?? ""}</Micro>
+                  </div>
+                );
+              })}
+            </div>
+          </div>
+        )}
+
+        {/* 댓글 */}
+        <div className="flex flex-col gap-3 pb-20">
+          <SectionLabel>댓글</SectionLabel>
+          <CommentSection
+            entityType="gathering"
+            entityId={id}
+            teamId={teamId}
+            currentMemberId={member?.id}
+            isAdmin={member?.admin ?? false}
+            members={membersForComment}
+            initialComments={(comments ?? []).map((c) => {
+              const m = Array.isArray(c.mem_mst) ? c.mem_mst[0] : c.mem_mst;
+              return {
+                cmnt_id: c.cmnt_id,
+                prnt_id: c.prnt_id ?? null,
+                mem_id: c.mem_id,
+                cont_txt: c.cont_txt,
+                edit_yn: c.edit_yn,
+                del_yn: c.del_yn,
+                crt_at: c.crt_at,
+                upd_at: c.upd_at,
+                mem_nm: m?.mem_nm ?? null,
+                avatar_url: m?.avatar_url ?? null,
+              };
+            })}
+            loginReturnPath={`/gatherings/${id}`}
+          />
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/app/(info)/gatherings/[id]/page.tsx
+++ b/app/(info)/gatherings/[id]/page.tsx
@@ -129,7 +129,7 @@ export default async function GatheringDetailPage({
               <Caption className="text-muted-foreground w-4">👥</Caption>
               <Caption>
                 참석 {attendees?.length ?? 0}명
-                {gthr.max_prt_cnt && ` / 최대 ${gthr.max_prt_cnt}명`}
+                {gthr.max_prt_cnt != null && ` / 최대 ${gthr.max_prt_cnt}명`}
               </Caption>
             </div>
           </div>

--- a/app/(info)/gatherings/new/gathering-form.tsx
+++ b/app/(info)/gatherings/new/gathering-form.tsx
@@ -1,0 +1,306 @@
+"use client";
+
+import { useEffect, useState } from "react";
+
+import { useRouter } from "next/navigation";
+
+import { zodResolver } from "@hookform/resolvers/zod";
+import { useForm } from "react-hook-form";
+import { z } from "zod";
+
+import { dayjs } from "@/lib/dayjs";
+import { GTHR_TYPES, gthrTypeLabels, createGthrSchema, type CreateGthrInput } from "@/lib/validations/gathering";
+
+import { createGathering, updateGathering } from "@/app/actions/gathering/manage-gathering";
+
+import { Button } from "@/components/ui/button";
+import {
+  Form,
+  FormControl,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from "@/components/ui/form";
+import { Input } from "@/components/ui/input";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+
+const formSchema = createGthrSchema.omit({ team_id: true });
+type FormValues = z.infer<typeof formSchema>;
+
+type Props = {
+  mode: "create";
+} | {
+  mode: "edit";
+  initialData: {
+    gthr_id: string;
+    gthr_nm: string;
+    gthr_type_enm: string;
+    stt_at: string;
+    end_at?: string | null;
+    loc_txt?: string | null;
+    desc_txt?: string | null;
+    max_prt_cnt?: number | null;
+  };
+  onSuccess?: () => void;
+};
+
+function toDatetimeLocal(utcIso: string) {
+  return dayjs(utcIso).tz("Asia/Seoul").format("YYYY-MM-DDTHH:mm");
+}
+
+export function GatheringForm(props: Props) {
+  const router = useRouter();
+  const [rootError, setRootError] = useState<string | null>(null);
+
+  const form = useForm<FormValues>({
+    resolver: zodResolver(formSchema),
+    defaultValues:
+      props.mode === "edit"
+        ? {
+            gthr_nm: props.initialData.gthr_nm,
+            gthr_type_enm: props.initialData.gthr_type_enm as CreateGthrInput["gthr_type_enm"],
+            stt_at: toDatetimeLocal(props.initialData.stt_at),
+            end_at: props.initialData.end_at ? toDatetimeLocal(props.initialData.end_at) : null,
+            loc_txt: props.initialData.loc_txt ?? "",
+            desc_txt: props.initialData.desc_txt ?? "",
+            max_prt_cnt: props.initialData.max_prt_cnt ?? undefined,
+          }
+        : {
+            gthr_type_enm: "general",
+            gthr_nm: "",
+            stt_at: dayjs().tz("Asia/Seoul").add(1, "hour").startOf("hour").format("YYYY-MM-DDTHH:mm"),
+            end_at: null,
+            loc_txt: "",
+            desc_txt: "",
+          },
+  });
+
+  const { isSubmitting } = form.formState;
+
+  useEffect(() => {
+    if (props.mode !== "edit") return;
+    form.reset({
+      gthr_nm: props.initialData.gthr_nm,
+      gthr_type_enm: props.initialData.gthr_type_enm as CreateGthrInput["gthr_type_enm"],
+      stt_at: toDatetimeLocal(props.initialData.stt_at),
+      end_at: props.initialData.end_at ? toDatetimeLocal(props.initialData.end_at) : null,
+      loc_txt: props.initialData.loc_txt ?? "",
+      desc_txt: props.initialData.desc_txt ?? "",
+      max_prt_cnt: props.initialData.max_prt_cnt ?? undefined,
+    });
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [props.mode === "edit" && props.initialData.gthr_id]);
+
+  async function onSubmit(values: FormValues) {
+    setRootError(null);
+    try {
+      if (props.mode === "edit") {
+        await updateGathering({ gthr_id: props.initialData.gthr_id, ...values });
+        props.onSuccess?.();
+      } else {
+        const result = await createGathering(values);
+        if ("gthr_id" in result) {
+          router.push(`/gatherings/${result.gthr_id}`);
+        }
+      }
+    } catch (e) {
+      setRootError(e instanceof Error ? e.message : "오류가 발생했습니다. 다시 시도해 주세요.");
+    }
+  }
+
+  return (
+    <Form {...form}>
+      <form onSubmit={form.handleSubmit(onSubmit)} className="flex flex-col gap-4">
+
+        {/* 제목 */}
+        <FormField
+          control={form.control}
+          name="gthr_nm"
+          render={({ field }) => (
+            <FormItem>
+              <FormLabel>제목 <span className="text-destructive">*</span></FormLabel>
+              <FormControl>
+                <Input placeholder="예: 양재천 자유러닝" {...field} />
+              </FormControl>
+              <FormMessage />
+            </FormItem>
+          )}
+        />
+
+        {/* 시작/종료일시 */}
+        <div className="grid grid-cols-2 gap-3">
+          <FormField
+            control={form.control}
+            name="stt_at"
+            render={({ field }) => (
+              <FormItem>
+                <FormLabel>시작일시 <span className="text-destructive">*</span></FormLabel>
+                <FormControl>
+                  <div className="relative">
+                    <Input
+                      type="text"
+                      readOnly
+                      value={field.value ? dayjs(field.value).format("YYYY-MM-DD HH:mm") : ""}
+                      placeholder="연도-월-일 --:--"
+                      className="cursor-pointer text-[13px]"
+                      onClick={(e) => {
+                        const hidden = (e.target as HTMLElement).nextElementSibling as HTMLInputElement;
+                        hidden?.showPicker?.();
+                        hidden?.focus();
+                      }}
+                    />
+                    <input
+                      type="datetime-local"
+                      value={field.value ?? ""}
+                      onChange={(e) => field.onChange(e.target.value)}
+                      className="sr-only"
+                      tabIndex={-1}
+                    />
+                  </div>
+                </FormControl>
+                <FormMessage />
+              </FormItem>
+            )}
+          />
+          <FormField
+            control={form.control}
+            name="end_at"
+            render={({ field }) => (
+              <FormItem>
+                <FormLabel>종료일시</FormLabel>
+                <FormControl>
+                  <div className="relative">
+                    <Input
+                      type="text"
+                      readOnly
+                      value={field.value ? dayjs(field.value).format("YYYY-MM-DD HH:mm") : ""}
+                      placeholder="연도-월-일 --:--"
+                      className="cursor-pointer text-[13px]"
+                      onClick={(e) => {
+                        const hidden = (e.target as HTMLElement).nextElementSibling as HTMLInputElement;
+                        hidden?.showPicker?.();
+                        hidden?.focus();
+                      }}
+                    />
+                    <input
+                      type="datetime-local"
+                      value={field.value ?? ""}
+                      onChange={(e) => field.onChange(e.target.value || null)}
+                      className="sr-only"
+                      tabIndex={-1}
+                    />
+                  </div>
+                </FormControl>
+                <FormMessage />
+              </FormItem>
+            )}
+          />
+        </div>
+
+        {/* 장소 */}
+        <FormField
+          control={form.control}
+          name="loc_txt"
+          render={({ field }) => (
+            <FormItem>
+              <FormLabel>장소</FormLabel>
+              <FormControl>
+                <Input placeholder="예: 여의도역 9호선 B1 클룸보관함" {...field} value={field.value ?? ""} />
+              </FormControl>
+              <FormMessage />
+            </FormItem>
+          )}
+        />
+
+        {/* 유형 / 최대 인원 */}
+        <div className="grid grid-cols-2 gap-3">
+          <FormField
+            control={form.control}
+            name="gthr_type_enm"
+            render={({ field }) => (
+              <FormItem>
+                <FormLabel>유형 <span className="text-destructive">*</span></FormLabel>
+                <FormControl>
+                  <Select onValueChange={field.onChange} value={field.value ?? "general"}>
+                    <SelectTrigger className="text-[13px]">
+                      <SelectValue placeholder="유형 선택" />
+                    </SelectTrigger>
+                    <SelectContent>
+                      {GTHR_TYPES.map((t) => (
+                        <SelectItem key={t} value={t}>
+                          {gthrTypeLabels[t]}
+                        </SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
+                </FormControl>
+                <FormMessage />
+              </FormItem>
+            )}
+          />
+          <FormField
+            control={form.control}
+            name="max_prt_cnt"
+            render={({ field }) => (
+              <FormItem>
+                <FormLabel>최대 인원</FormLabel>
+                <FormControl>
+                  <Input
+                    type="number"
+                    placeholder="제한 없음"
+                    className="text-[13px]"
+                    {...field}
+                    value={field.value ?? ""}
+                    onChange={(e) => field.onChange(e.target.value ? parseInt(e.target.value, 10) : null)}
+                  />
+                </FormControl>
+                <FormMessage />
+              </FormItem>
+            )}
+          />
+        </div>
+
+        {/* 비고 */}
+        <FormField
+          control={form.control}
+          name="desc_txt"
+          render={({ field }) => (
+            <FormItem>
+              <FormLabel>비고</FormLabel>
+              <FormControl>
+                <textarea
+                  rows={4}
+                  placeholder="공지, 준비물, 링크 등 자유롭게 입력"
+                  className="flex w-full resize-none rounded-md border border-input bg-transparent px-3 py-2 text-[13px] shadow-sm placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-50"
+                  {...field}
+                  value={field.value ?? ""}
+                  onChange={(e) => field.onChange(e.target.value || null)}
+                />
+              </FormControl>
+              <FormMessage />
+            </FormItem>
+          )}
+        />
+
+        {rootError && (
+          <p className="text-[12px] font-medium text-destructive">{rootError}</p>
+        )}
+
+        <div className="flex justify-end gap-2 pb-1">
+          <Button type="submit" disabled={isSubmitting} className="w-full">
+            {isSubmitting
+              ? (props.mode === "edit" ? "저장 중..." : "등록 중...")
+              : (props.mode === "edit" ? "저장" : "모임 만들기")}
+          </Button>
+        </div>
+      </form>
+    </Form>
+  );
+}

--- a/app/(info)/gatherings/new/page.tsx
+++ b/app/(info)/gatherings/new/page.tsx
@@ -1,0 +1,6 @@
+import { redirect } from "next/navigation";
+
+// FAB 다이얼로그로 전환됨 — 직접 접근 시 홈으로 리다이렉트
+export default function GatheringNewPage() {
+  redirect("/");
+}

--- a/app/(main)/page.tsx
+++ b/app/(main)/page.tsx
@@ -72,6 +72,7 @@ async function HomeContent() {
     { data: calendarComps },
     cmmCdRows,
     { data: schPostRows },
+    { data: gthrRows },
     myRegsResult,
   ] = await Promise.all([
     supabase.rpc("get_public_team_competitions", { p_team_id: teamId, p_start: monthStart, p_end: monthLastDayStr }),
@@ -80,6 +81,12 @@ async function HomeContent() {
       p_team_id: teamId,
       p_start: monthStart,
       p_end: monthLastDayStr,
+    }),
+    supabase.rpc("get_public_team_gatherings", {
+      p_team_id: teamId,
+      p_start: monthStart,
+      p_end: monthLastDayStr,
+      ...(currentMember ? { p_mem_id: currentMember.id } : {}),
     }),
     currentMember
       ? supabase
@@ -93,6 +100,24 @@ async function HomeContent() {
           .eq("del_yn", false)
       : Promise.resolve({ data: null }),
   ]);
+
+  const calendarGatherings: CalendarRace[] = (gthrRows ?? []).map((row) => ({
+    id: row.gthr_id,
+    short_id: row.short_id ?? null,
+    title: row.gthr_nm,
+    start_date: dayjs(row.stt_at).tz("Asia/Seoul").format("YYYY-MM-DD"),
+    end_date: row.end_at ? dayjs(row.end_at).tz("Asia/Seoul").format("YYYY-MM-DD") : null,
+    type: (currentMember && ("is_attending" in row ? row.is_attending : false) ? "gathering_mine" : "gathering") as CalendarRace["type"],
+    post_type: row.gthr_type_enm,
+    location: row.loc_txt ?? null,
+    cont_txt: row.desc_txt ?? null,
+    evt_stt_at: row.stt_at,
+    evt_end_at: row.end_at ?? null,
+    crt_by: row.crt_by,
+    crt_by_nm: row.crt_by_nm ?? null,
+    regCount: row.attd_count ? Number(row.attd_count) : 0,
+    cmntCount: row.cmnt_count ? Number(row.cmnt_count) : undefined,
+  }));
 
   const calendarSchPosts: CalendarRace[] = (schPostRows ?? []).map((row) => ({
     id: row.sch_post_id,
@@ -193,6 +218,7 @@ async function HomeContent() {
             gigangRaces={calendarGigangRaces}
             myRaces={calendarMyRaces}
             schPosts={calendarSchPosts}
+            gatherings={calendarGatherings}
             teamId={teamId}
             memberId={currentMember?.id}
             cmmCdRows={cmmCdRows}

--- a/app/actions/comment/manage-comment.ts
+++ b/app/actions/comment/manage-comment.ts
@@ -81,7 +81,7 @@ export async function createComment(input: CreateCommentInput) {
       }
     }
 
-    if (parsed.entityType === "gathering" && (uniqueMentions.length > 0 || !parsed.prntId)) {
+    if (parsed.entityType === "gathering") {
       const { data: gthrMeta } = await admin
         .from("gthr_mst")
         .select("gthr_id, short_id, crt_by, gthr_nm")

--- a/app/actions/comment/manage-comment.ts
+++ b/app/actions/comment/manage-comment.ts
@@ -45,12 +45,12 @@ export async function createComment(input: CreateCommentInput) {
         .from("sch_post_mst")
         .select("sch_post_id, short_id, crt_by, sch_nm")
         .eq("sch_post_id", parsed.entityId)
-        .single()
+        .maybeSingle()
       if (postMeta) {
         entityShortId = postMeta.short_id ?? null
 
         if (!parsed.prntId && postMeta.crt_by !== member.id && !uniqueMentions.includes(postMeta.crt_by)) {
-          const notiRefId = postMeta.short_id ?? parsed.entityId
+          const notiRefId = parsed.entityId
           const { data: existingNoti } = await admin
             .from("noti_mst")
             .select("noti_id, noti_nm")
@@ -81,13 +81,54 @@ export async function createComment(input: CreateCommentInput) {
       }
     }
 
+    if (parsed.entityType === "gathering" && (uniqueMentions.length > 0 || !parsed.prntId)) {
+      const { data: gthrMeta } = await admin
+        .from("gthr_mst")
+        .select("gthr_id, short_id, crt_by, gthr_nm")
+        .eq("gthr_id", parsed.entityId)
+        .maybeSingle()
+      if (gthrMeta) {
+        entityShortId = gthrMeta.short_id ?? null
+
+        if (!parsed.prntId && gthrMeta.crt_by !== member.id && !uniqueMentions.includes(gthrMeta.crt_by)) {
+          const notiRefId = parsed.entityId
+          const { data: existingNoti } = await admin
+            .from("noti_mst")
+            .select("noti_id, noti_nm")
+            .eq("mem_id", gthrMeta.crt_by)
+            .eq("ref_id", notiRefId)
+            .eq("noti_type_enm", "gthr_cmnt")
+            .eq("read_yn", false)
+            .eq("del_yn", false)
+            .maybeSingle()
+
+          if (existingNoti) {
+            const match = existingNoti.noti_nm.match(/새 댓글 (\d+)개/)
+            const prevCount = match ? parseInt(match[1], 10) : 1
+            const count = prevCount + 1
+            await admin.from("noti_mst").update({
+              noti_nm: `'${gthrMeta.gthr_nm}'에 새 댓글 ${count}개가 달렸습니다.`,
+              noti_cont: parsed.contTxt.slice(0, 100),
+            }).eq("noti_id", existingNoti.noti_id)
+          } else {
+            await admin.from("noti_mst").insert({
+              team_id: teamId, mem_id: gthrMeta.crt_by, noti_type_enm: "gthr_cmnt",
+              noti_nm: `'${gthrMeta.gthr_nm}'에 새 댓글이 달렸습니다.`,
+              noti_cont: parsed.contTxt.slice(0, 100),
+              ref_id: notiRefId, ref_type_enm: "gathering",
+            })
+          }
+        }
+      }
+    }
+
     if (uniqueMentions.length > 0) {
       await admin.from("cmnt_mention_rel").insert(uniqueMentions.map((memId) => ({ cmnt_id: cmnt.cmnt_id, mem_id: memId })))
       if (parsed.entityType === "comp" && !entityShortId) {
         const { data: compMeta } = await admin.from("comp_mst").select("short_id").eq("comp_id", parsed.entityId).single()
         entityShortId = compMeta?.short_id ?? null
       }
-      const mentionRefId = entityShortId ?? parsed.entityId
+      const mentionRefId = parsed.entityId
       await admin.from("noti_mst").insert(
         uniqueMentions.map((memId) => ({
           team_id: teamId, mem_id: memId, noti_type_enm: "cmnt_mention",

--- a/app/actions/comment/manage-comment.ts
+++ b/app/actions/comment/manage-comment.ts
@@ -63,10 +63,10 @@ export async function createComment(input: CreateCommentInput) {
 
           if (existingNoti) {
             const match = existingNoti.noti_nm.match(/새 댓글 (\d+)개/)
+            // "새 댓글이 달렸습니다" (첫 번째) → count=1, "새 댓글 N개" → count=N
             const prevCount = match ? parseInt(match[1], 10) : 1
-            const count = prevCount + 1
             await admin.from("noti_mst").update({
-              noti_nm: `'${postMeta.sch_nm}'에 새 댓글 ${count}개가 달렸습니다.`,
+              noti_nm: `'${postMeta.sch_nm}'에 새 댓글 ${prevCount + 1}개가 달렸습니다.`,
               noti_cont: parsed.contTxt.slice(0, 100),
             }).eq("noti_id", existingNoti.noti_id)
           } else {
@@ -89,9 +89,28 @@ export async function createComment(input: CreateCommentInput) {
         .maybeSingle()
       if (gthrMeta) {
         entityShortId = gthrMeta.short_id ?? null
+        const notiRefId = parsed.entityId
 
+        // 답글 알림 (gthr_reply): 부모 댓글 작성자에게 발송
+        if (parsed.prntId) {
+          const { data: parentCmnt } = await admin
+            .from("cmnt_mst")
+            .select("mem_id")
+            .eq("cmnt_id", parsed.prntId)
+            .maybeSingle()
+          const parentAuthorId = parentCmnt?.mem_id
+          if (parentAuthorId && parentAuthorId !== member.id && !uniqueMentions.includes(parentAuthorId)) {
+            await admin.from("noti_mst").insert({
+              team_id: teamId, mem_id: parentAuthorId, noti_type_enm: "gthr_reply",
+              noti_nm: `${member.full_name}님이 모임 댓글에 답글을 달았습니다.`,
+              noti_cont: parsed.contTxt.slice(0, 100),
+              ref_id: notiRefId, ref_type_enm: "gathering",
+            })
+          }
+        }
+
+        // 개설자 댓글 알림 (gthr_cmnt): 최상위 댓글이고 개설자 본인이 아닌 경우
         if (!parsed.prntId && gthrMeta.crt_by !== member.id && !uniqueMentions.includes(gthrMeta.crt_by)) {
-          const notiRefId = parsed.entityId
           const { data: existingNoti } = await admin
             .from("noti_mst")
             .select("noti_id, noti_nm")
@@ -104,10 +123,10 @@ export async function createComment(input: CreateCommentInput) {
 
           if (existingNoti) {
             const match = existingNoti.noti_nm.match(/새 댓글 (\d+)개/)
+            // "새 댓글이 달렸습니다" (첫 번째) → count=1, "새 댓글 N개" → count=N
             const prevCount = match ? parseInt(match[1], 10) : 1
-            const count = prevCount + 1
             await admin.from("noti_mst").update({
-              noti_nm: `'${gthrMeta.gthr_nm}'에 새 댓글 ${count}개가 달렸습니다.`,
+              noti_nm: `'${gthrMeta.gthr_nm}'에 새 댓글 ${prevCount + 1}개가 달렸습니다.`,
               noti_cont: parsed.contTxt.slice(0, 100),
             }).eq("noti_id", existingNoti.noti_id)
           } else {

--- a/app/actions/gathering/manage-gathering.ts
+++ b/app/actions/gathering/manage-gathering.ts
@@ -51,7 +51,8 @@ export async function createGathering(input: {
     const gthrId = data.gthr_id;
 
     // 작성자 자동 참석 등록
-    await supabase.from("gthr_attd_rel").insert({ gthr_id: gthrId, mem_id: member.id });
+    const { error: attdError } = await supabase.from("gthr_attd_rel").insert({ gthr_id: gthrId, mem_id: member.id });
+    if (attdError) throw new Error("자동 참석 등록에 실패했습니다.");
     const authorId = member.id;
     const gthrNm = parsed.gthr_nm;
     const gthrType = parsed.gthr_type_enm;
@@ -134,7 +135,12 @@ export async function updateGathering(input: {
     if (error) throw new Error("모임 수정에 실패했습니다.");
 
     const { teamId } = await getRequestTeamContext();
-    const gthrNm = parsed.gthr_nm ?? "";
+    // gthr_nm이 생략됐을 때 빈 문자열로 알림이 발송되지 않도록 기존 모임명 조회
+    let gthrNm = parsed.gthr_nm;
+    if (!gthrNm) {
+      const { data: existing } = await supabase.from("gthr_mst").select("gthr_nm").eq("gthr_id", gthr_id).single();
+      gthrNm = existing?.gthr_nm ?? "";
+    }
 
     after(async () => {
       try {

--- a/app/actions/gathering/manage-gathering.ts
+++ b/app/actions/gathering/manage-gathering.ts
@@ -1,0 +1,220 @@
+"use server";
+
+import { revalidatePath } from "next/cache";
+import { after } from "next/server";
+
+import { dayjs } from "@/lib/dayjs";
+import { withMember } from "@/lib/actions/auth";
+import { getRequestTeamContext } from "@/lib/queries/request-team";
+import { createUntypedAdminClient } from "@/lib/supabase/admin";
+import { createGthrSchema, updateGthrSchema } from "@/lib/validations/gathering";
+
+function toUtcIso(localDt: string | null | undefined): string | null {
+  if (!localDt) return null;
+  return dayjs.tz(localDt, "Asia/Seoul").toISOString();
+}
+
+export async function createGathering(input: {
+  gthr_nm: string;
+  gthr_type_enm: string;
+  sprt_cd?: string | null;
+  stt_at: string;
+  end_at?: string | null;
+  loc_txt?: string | null;
+  desc_txt?: string | null;
+  max_prt_cnt?: number | null;
+}) {
+  return withMember(async ({ member, supabase }) => {
+    const { teamId } = await getRequestTeamContext();
+    const parsed = createGthrSchema.parse({ ...input, team_id: teamId });
+
+    const { data, error } = await supabase
+      .from("gthr_mst")
+      .insert({
+        team_id: parsed.team_id,
+        gthr_nm: parsed.gthr_nm,
+        gthr_type_enm: parsed.gthr_type_enm,
+        sprt_cd: parsed.sprt_cd ?? null,
+        stt_at: toUtcIso(parsed.stt_at)!,
+        end_at: toUtcIso(parsed.end_at),
+        loc_txt: parsed.loc_txt ?? null,
+        desc_txt: parsed.desc_txt ?? null,
+        max_prt_cnt: parsed.max_prt_cnt ?? null,
+        crt_by: member.id,
+        del_yn: false,
+      })
+      .select("gthr_id")
+      .single();
+
+    if (error || !data) throw new Error("모임 개설에 실패했습니다.");
+
+    const gthrId = data.gthr_id;
+
+    // 작성자 자동 참석 등록
+    await supabase.from("gthr_attd_rel").insert({ gthr_id: gthrId, mem_id: member.id });
+    const authorId = member.id;
+    const gthrNm = parsed.gthr_nm;
+    const gthrType = parsed.gthr_type_enm;
+    const notiTypeMap: Record<string, string> = {
+      general: "gthr_new", regular: "gthr_new", event: "gthr_new",
+    };
+
+    after(async () => {
+      try {
+        const admin = createUntypedAdminClient();
+
+        const { data: members } = await admin
+          .from("team_mem_rel")
+          .select("mem_id")
+          .eq("team_id", teamId)
+          .eq("vers", 0)
+          .eq("del_yn", false)
+          .neq("mem_id", authorId);
+
+        if (!members?.length) return;
+
+        const notiType = notiTypeMap[gthrType] ?? "gthr_new";
+        const { data: disabledPrefs } = await admin
+          .from("noti_pref_cfg")
+          .select("mem_id")
+          .in("mem_id", members.map((m) => m.mem_id))
+          .eq("noti_type_enm", notiType)
+          .eq("enabled_yn", false);
+
+        const disabledSet = new Set((disabledPrefs ?? []).map((p) => p.mem_id));
+        const targets = members.filter((m) => !disabledSet.has(m.mem_id));
+        if (!targets.length) return;
+
+        const dateStr = dayjs(toUtcIso(parsed.stt_at)!).tz("Asia/Seoul").format("M월 D일");
+        await admin.from("noti_mst").insert(
+          targets.map((m) => ({
+            team_id: teamId,
+            mem_id: m.mem_id,
+            noti_type_enm: notiType,
+            noti_nm: `${dateStr} 새 모임이 등록됐습니다.`,
+            noti_cont: gthrNm,
+            ref_id: gthrId,
+            ref_type_enm: "gathering",
+          })),
+        );
+      } catch (e) {
+        console.error("[gthr_new] 알림 발송 실패", e);
+      }
+    });
+
+    revalidatePath("/");
+    return { gthr_id: gthrId };
+  });
+}
+
+export async function updateGathering(input: {
+  gthr_id: string;
+  gthr_nm?: string;
+  gthr_type_enm?: string;
+  stt_at?: string;
+  end_at?: string | null;
+  loc_txt?: string | null;
+  desc_txt?: string | null;
+  max_prt_cnt?: number | null;
+}) {
+  return withMember(async ({ member, supabase }) => {
+    const parsed = updateGthrSchema.parse(input);
+    const { gthr_id, stt_at, end_at, ...rest } = parsed;
+
+    const { error } = await supabase
+      .from("gthr_mst")
+      .update({
+        ...rest,
+        ...(stt_at !== undefined && { stt_at: toUtcIso(stt_at)! }),
+        ...(end_at !== undefined && { end_at: toUtcIso(end_at) }),
+        upd_at: dayjs().toISOString(),
+      })
+      .eq("gthr_id", gthr_id);
+
+    if (error) throw new Error("모임 수정에 실패했습니다.");
+
+    const { teamId } = await getRequestTeamContext();
+    const gthrNm = parsed.gthr_nm ?? "";
+
+    after(async () => {
+      try {
+        const admin = createUntypedAdminClient();
+
+        const { data: attendees } = await admin
+          .from("gthr_attd_rel")
+          .select("mem_id")
+          .eq("gthr_id", gthr_id)
+          .neq("mem_id", member.id);
+
+        if (!attendees?.length) return;
+
+        await admin.from("noti_mst").insert(
+          attendees.map((a) => ({
+            team_id: teamId,
+            mem_id: a.mem_id,
+            noti_type_enm: "gthr_upd",
+            noti_nm: `'${gthrNm}' 모임 정보가 변경됐습니다.`,
+            noti_cont: gthrNm,
+            ref_id: gthr_id,
+            ref_type_enm: "gathering",
+          })),
+        );
+      } catch (e) {
+        console.error("[gthr_upd] 알림 발송 실패", e);
+      }
+    });
+
+    revalidatePath("/");
+    revalidatePath(`/gatherings/${input.gthr_id}`);
+  });
+}
+
+export async function deleteGathering(gthr_id: string) {
+  return withMember(async ({ member, supabase }) => {
+    const { data: gthr } = await supabase
+      .from("gthr_mst")
+      .select("crt_by, team_id, gthr_nm")
+      .eq("gthr_id", gthr_id)
+      .single();
+    if (!gthr) throw new Error("모임을 찾을 수 없습니다.");
+
+    const isAuthor = gthr.crt_by === member.id;
+    if (!isAuthor && !member.admin) throw new Error("삭제 권한이 없습니다.");
+
+    const admin = createUntypedAdminClient();
+    const { error } = await admin
+      .from("gthr_mst")
+      .update({ del_yn: true, upd_at: dayjs().toISOString() })
+      .eq("gthr_id", gthr_id);
+
+    if (error) throw new Error("모임 삭제에 실패했습니다.");
+
+    after(async () => {
+      try {
+        const { data: attendees } = await admin
+          .from("gthr_attd_rel")
+          .select("mem_id")
+          .eq("gthr_id", gthr_id)
+          .neq("mem_id", member.id);
+
+        if (!attendees?.length) return;
+
+        await admin.from("noti_mst").insert(
+          attendees.map((a) => ({
+            team_id: gthr.team_id,
+            mem_id: a.mem_id,
+            noti_type_enm: "gthr_del",
+            noti_nm: `'${gthr.gthr_nm}' 모임이 취소됐습니다.`,
+            noti_cont: gthr.gthr_nm,
+            ref_id: gthr_id,
+            ref_type_enm: "gathering",
+          })),
+        );
+      } catch (e) {
+        console.error("[gthr_del] 알림 발송 실패", e);
+      }
+    });
+
+    revalidatePath("/");
+  });
+}

--- a/app/actions/gathering/toggle-attendance.ts
+++ b/app/actions/gathering/toggle-attendance.ts
@@ -15,7 +15,8 @@ export async function toggleGatheringAttendance(gthr_id: string): Promise<{ atte
       .maybeSingle();
 
     if (existing) {
-      await supabase.from("gthr_attd_rel").delete().eq("attd_id", existing.attd_id);
+      const { error: deleteError } = await supabase.from("gthr_attd_rel").delete().eq("attd_id", existing.attd_id);
+      if (deleteError) throw new Error("참석 취소에 실패했습니다.");
       revalidatePath("/");
       revalidatePath(`/gatherings/${gthr_id}`);
       return { attending: false };

--- a/app/actions/gathering/toggle-attendance.ts
+++ b/app/actions/gathering/toggle-attendance.ts
@@ -1,0 +1,55 @@
+"use server";
+
+import { revalidatePath } from "next/cache";
+
+import { withMember } from "@/lib/actions/auth";
+import { createUntypedAdminClient } from "@/lib/supabase/admin";
+
+export async function toggleGatheringAttendance(gthr_id: string): Promise<{ attending: boolean }> {
+  return withMember(async ({ member, supabase }) => {
+    const { data: existing } = await supabase
+      .from("gthr_attd_rel")
+      .select("attd_id")
+      .eq("gthr_id", gthr_id)
+      .eq("mem_id", member.id)
+      .maybeSingle();
+
+    if (existing) {
+      await supabase.from("gthr_attd_rel").delete().eq("attd_id", existing.attd_id);
+      revalidatePath("/");
+      revalidatePath(`/gatherings/${gthr_id}`);
+      return { attending: false };
+    }
+
+    // 최대 인원 초과 여부 서버에서 검증
+    const admin = createUntypedAdminClient();
+    const { data: gthr } = await admin
+      .from("gthr_mst")
+      .select("max_prt_cnt")
+      .eq("gthr_id", gthr_id)
+      .eq("del_yn", false)
+      .single();
+
+    if (!gthr) throw new Error("모임을 찾을 수 없습니다.");
+
+    if (gthr.max_prt_cnt !== null) {
+      const { count } = await admin
+        .from("gthr_attd_rel")
+        .select("attd_id", { count: "exact", head: true })
+        .eq("gthr_id", gthr_id);
+
+      if ((count ?? 0) >= gthr.max_prt_cnt) throw new Error("인원이 마감됐습니다.");
+    }
+
+    // UNIQUE(gthr_id, mem_id) 제약이 있으므로 upsert로 중복 충돌 방지
+    const { error } = await supabase
+      .from("gthr_attd_rel")
+      .upsert({ gthr_id, mem_id: member.id }, { onConflict: "gthr_id,mem_id", ignoreDuplicates: true });
+
+    if (error) throw new Error("참석 등록에 실패했습니다.");
+
+    revalidatePath("/");
+    revalidatePath(`/gatherings/${gthr_id}`);
+    return { attending: true };
+  });
+}

--- a/components/comment/comment-item.tsx
+++ b/components/comment/comment-item.tsx
@@ -87,7 +87,14 @@ export function CommentItem({
           ) : comment.optimistic ? (
             <Caption className="text-xs text-muted-foreground">전송 중...</Caption>
           ) : (
-            <Caption className="text-xs">{dayjs(comment.crt_at).fromNow()}</Caption>
+            <Caption className="text-xs">
+              {(() => {
+                const d = dayjs(comment.crt_at).tz("Asia/Seoul");
+                return dayjs().tz("Asia/Seoul").diff(d, "hour") < 24
+                  ? d.fromNow()
+                  : d.format("YY.MM.DD");
+              })()}
+            </Caption>
           )}
           {comment.edit_yn && <Caption className="text-xs opacity-60">(수정됨)</Caption>}
           {!editing && (

--- a/components/comment/mention-input.tsx
+++ b/components/comment/mention-input.tsx
@@ -35,6 +35,11 @@ function parseMentionQuery(text: string, cursorPos: number): { query: string; st
 
 const URL_PATTERN = /https?:\/\/[^\s]+|www\.[^\s]+|[^\s]+\.(?:com|net|org|io|co|kr|team|app|dev|me|ai|gg|tv|club|shop|store|link|site|web|page|blog|info|biz|xyz|tech|run|live|news|cloud|world|online|space|studio)[^\s]*/g
 
+/** URL 끝에 붙은 문장부호(., , ! ? ) ; 등)를 제거 */
+function stripTrailingPunctuation(url: string): string {
+  return url.replace(/[.,!?;:)'"]+$/, "")
+}
+
 function normalizeUrl(url: string): string {
   return /^https?:\/\//i.test(url) ? url : `https://${url}`
 }
@@ -43,9 +48,13 @@ function renderTextWithLinks(text: string, keyPrefix: string) {
   const segments: { text: string; isUrl: boolean }[] = []
   let last = 0
   for (const m of text.matchAll(URL_PATTERN)) {
+    const rawUrl = m[0]
+    const cleanUrl = stripTrailingPunctuation(rawUrl)
+    const trailingPunct = rawUrl.slice(cleanUrl.length)
     if (m.index > last) segments.push({ text: text.slice(last, m.index), isUrl: false })
-    segments.push({ text: m[0], isUrl: true })
-    last = m.index + m[0].length
+    segments.push({ text: cleanUrl, isUrl: true })
+    if (trailingPunct) segments.push({ text: trailingPunct, isUrl: false })
+    last = m.index + rawUrl.length
   }
   if (last < text.length) segments.push({ text: text.slice(last), isUrl: false })
   return segments.map((seg, i) =>

--- a/components/comment/mention-input.tsx
+++ b/components/comment/mention-input.tsx
@@ -33,14 +33,40 @@ function parseMentionQuery(text: string, cursorPos: number): { query: string; st
   return { query: match[1], start: cursorPos - match[0].length }
 }
 
+const URL_PATTERN = /https?:\/\/[^\s]+|www\.[^\s]+|[^\s]+\.(?:com|net|org|io|co|kr|team|app|dev|me|ai|gg|tv|club|shop|store|link|site|web|page|blog|info|biz|xyz|tech|run|live|news|cloud|world|online|space|studio)[^\s]*/g
+
+function normalizeUrl(url: string): string {
+  return /^https?:\/\//i.test(url) ? url : `https://${url}`
+}
+
+function renderTextWithLinks(text: string, keyPrefix: string) {
+  const segments: { text: string; isUrl: boolean }[] = []
+  let last = 0
+  for (const m of text.matchAll(URL_PATTERN)) {
+    if (m.index > last) segments.push({ text: text.slice(last, m.index), isUrl: false })
+    segments.push({ text: m[0], isUrl: true })
+    last = m.index + m[0].length
+  }
+  if (last < text.length) segments.push({ text: text.slice(last), isUrl: false })
+  return segments.map((seg, i) =>
+    seg.isUrl ? (
+      <a key={`${keyPrefix}-${i}`} href={normalizeUrl(seg.text)} target="_blank" rel="noopener noreferrer" className="text-primary underline break-all">
+        {seg.text}
+      </a>
+    ) : (
+      <span key={`${keyPrefix}-${i}`}>{seg.text}</span>
+    )
+  )
+}
+
 export function renderMentions(text: string, members: MemberOption[]) {
   const memberNames = new Set(members.map((m) => m.mem_nm))
   const parts = text.split(/(@[가-힣a-zA-Z0-9_]+)/)
-  return parts.map((part, i) =>
+  return parts.flatMap((part, i) =>
     part.startsWith("@") && memberNames.has(part.slice(1)) ? (
-      <span key={i} className="text-primary font-medium">{part}</span>
+      [<span key={i} className="text-primary font-medium">{part}</span>]
     ) : (
-      <span key={i}>{part}</span>
+      renderTextWithLinks(part, String(i))
     )
   )
 }

--- a/components/common/share-sheet.tsx
+++ b/components/common/share-sheet.tsx
@@ -18,6 +18,8 @@ type ShareSheetProps = {
   onOpenChange: (open: boolean) => void;
   title: string;
   timeLabel: string;
+  /** 장소 (모임 등) */
+  locationText?: string;
   /** 본문 텍스트 */
   contentSnippet?: string;
   /** 본문에 첨부된 외부 링크 */
@@ -31,6 +33,7 @@ export function ShareSheet({
   onOpenChange,
   title,
   timeLabel,
+  locationText,
   contentSnippet,
   contentUrl,
   pageUrl,
@@ -42,13 +45,14 @@ export function ShareSheet({
   }
 
   function buildText() {
-    const lines = [`[${title}]`, timeLabel];
+    const lines = [title, timeLabel];
 
-    if (contentUrl) lines.push(contentUrl);
+    if (locationText) lines.push(locationText);
     if (contentSnippet) {
       const text = contentSnippet.trim();
-      lines.push(text.slice(0, 100) + (text.length > 100 ? ".." : ""));
+      lines.push("", text.slice(0, 100) + (text.length > 100 ? ".." : ""));
     }
+    if (contentUrl) lines.push(contentUrl);
 
     lines.push("", getUrl());
     return lines.join("\n");

--- a/components/home/add-schedule-dropdown.tsx
+++ b/components/home/add-schedule-dropdown.tsx
@@ -9,6 +9,7 @@ import { cn } from "@/lib/utils";
 type Props = {
   onAddSchedule: () => void;
   onAddCompetition: () => void;
+  onAddGathering: () => void;
   defaultDate?: string;
 };
 
@@ -32,14 +33,14 @@ const items = [
   {
     key: "gathering",
     label: "모임",
-    sub: "준비 중",
+    sub: "일반, 정기런, 이벤트",
     icon: Users,
-    color: "text-muted-foreground",
-    disabled: true,
+    color: "text-violet-400",
+    disabled: false,
   },
 ] as const;
 
-export function AddScheduleDropdown({ onAddSchedule, onAddCompetition }: Props) {
+export function AddScheduleDropdown({ onAddSchedule, onAddCompetition, onAddGathering }: Props) {
   const [open, setOpen] = useState(false);
   const containerRef = useRef<HTMLDivElement>(null);
 
@@ -58,6 +59,7 @@ export function AddScheduleDropdown({ onAddSchedule, onAddCompetition }: Props) 
     setOpen(false);
     if (key === "competition") onAddCompetition();
     if (key === "schedule") onAddSchedule();
+    if (key === "gathering") onAddGathering();
   }
 
   return (

--- a/components/home/mini-calendar.tsx
+++ b/components/home/mini-calendar.tsx
@@ -65,6 +65,24 @@ const SchPostFormDialog = dynamic<SchPostFormDialogProps>(
   { ssr: false }
 );
 
+import type { GatheringFormDialogProps } from "@/components/schedule/gathering-form-dialog";
+const GatheringFormDialog = dynamic<GatheringFormDialogProps>(
+  () =>
+    import("@/components/schedule/gathering-form-dialog").then(
+      (m) => m.GatheringFormDialog
+    ),
+  { ssr: false }
+);
+
+import type { GatheringDetailDialogProps, GatheringAttendee } from "@/components/schedule/gathering-detail-dialog";
+const GatheringDetailDialog = dynamic<GatheringDetailDialogProps>(
+  () =>
+    import("@/components/schedule/gathering-detail-dialog").then(
+      (m) => m.GatheringDetailDialog
+    ),
+  { ssr: false }
+);
+
 
 
 
@@ -73,12 +91,12 @@ export type CalendarRace = {
   short_id?: string | null;
   title: string;
   start_date: string;
-  type: "gigang" | "mine" | "schedule";
+  type: "gigang" | "mine" | "schedule" | "gathering" | "gathering_mine";
   // 공통 선택 필드
   end_date?: string | null;
   location?: string | null;
   regCount?: number;
-  // schedule 전용
+  // schedule / gathering 전용
   url?: string | null;
   cont_txt?: string | null;
   crt_by?: string;
@@ -94,6 +112,7 @@ type MiniCalendarProps = {
   gigangRaces: CalendarRace[];
   myRaces: CalendarRace[];
   schPosts: CalendarRace[];
+  gatherings: CalendarRace[];
   teamId: string;
   memberId?: string;
   cmmCdRows: CachedCmmCdRow[];
@@ -112,6 +131,7 @@ export function MiniCalendar({
   gigangRaces: initGigang,
   myRaces: initMine,
   schPosts: initSchPosts,
+  gatherings: initGatherings,
   teamId,
   memberId,
   cmmCdRows,
@@ -125,6 +145,7 @@ export function MiniCalendar({
   const [gigangRaces, setGigangRaces] = useState(initGigang);
   const [myRaces, setMyRaces] = useState(initMine);
   const [schPosts, setSchPosts] = useState(initSchPosts);
+  const [gatherings, setGatherings] = useState(initGatherings);
   const [listViewKey, setListViewKey] = useState(0);
   const [isPending, startTransition] = useTransition();
 
@@ -138,6 +159,17 @@ export function MiniCalendar({
   const [schDetailPost, setSchDetailPost] = useState<CalendarRace | null>(null);
   const [schDetailOpen, setSchDetailOpen] = useState(false);
   const [schDetailInitialComments, setSchDetailInitialComments] = useState<CmntRow[] | undefined>(undefined);
+
+  // 모임 폼 다이얼로그 상태
+  const [gthrFormOpen, setGthrFormOpen] = useState(false);
+  const [gthrDefaultDate, setGthrDefaultDate] = useState<string | undefined>(undefined);
+
+  // 모임 상세 다이얼로그 상태
+  const [gthrDetailOpen, setGthrDetailOpen] = useState(false);
+  const [gthrDetailRace, setGthrDetailRace] = useState<(CalendarRace & { maxPrtCnt?: number | null; attendees?: GatheringAttendee[]; sprt_cd?: string | null }) | null>(null);
+  const [gthrDetailAttending, setGthrDetailAttending] = useState(false);
+  const [gthrDetailComments, setGthrDetailComments] = useState<CmntRow[] | undefined>(undefined);
+  const [gthrEditTarget, setGthrEditTarget] = useState<CalendarRace | null>(null);
 
   // 대회 선택 다이얼로그 상태
   const [pickerOpen, setPickerOpen] = useState(false);
@@ -160,18 +192,49 @@ export function MiniCalendar({
   useEffect(() => {
     if (memberStatus.status !== "ready") return
     if (membersCache !== null || membersFetchingRef.current) return
-    const isAnyDialogOpen = schDetailOpen || detailOpen
+    const isAnyDialogOpen = schDetailOpen || detailOpen || gthrDetailOpen
     if (!isAnyDialogOpen) return
     membersFetchingRef.current = true
     getMentionMembers()
       .then(setMembersCache)
       .catch(() => { membersFetchingRef.current = false })
-  }, [schDetailOpen, detailOpen, membersCache, memberStatus.status])
+  }, [schDetailOpen, detailOpen, gthrDetailOpen, membersCache, memberStatus.status])
 
   // 알림 딥링크: /?post=<id> 또는 /?comp=<id>로 진입 시 해당 상세 자동 오픈
   const searchParams = useSearchParams()
   const deepLinkPostId = searchParams.get("post")
   const deepLinkCompId = searchParams.get("comp")
+  const deepLinkGthrId = searchParams.get("gthr")
+
+  useEffect(() => {
+    if (deepLinkGthrId) {
+      const isUuid = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i.test(deepLinkGthrId)
+      const query = isUuid
+        ? supabase.from("gthr_mst").select("gthr_id, short_id, gthr_nm, gthr_type_enm, stt_at, end_at, loc_txt, desc_txt, crt_by").eq("gthr_id", deepLinkGthrId).maybeSingle()
+        : supabase.from("gthr_mst").select("gthr_id, short_id, gthr_nm, gthr_type_enm, stt_at, end_at, loc_txt, desc_txt, crt_by").eq("short_id", deepLinkGthrId).maybeSingle()
+
+      query.then(({ data }) => {
+        if (!data) return
+        const race: CalendarRace = {
+          id: data.gthr_id,
+          short_id: data.short_id ?? null,
+          title: data.gthr_nm,
+          start_date: dayjs(data.stt_at).tz("Asia/Seoul").format("YYYY-MM-DD"),
+          type: "gathering",
+          post_type: data.gthr_type_enm,
+          location: data.loc_txt ?? null,
+          cont_txt: data.desc_txt ?? null,
+          evt_stt_at: data.stt_at,
+          evt_end_at: data.end_at ?? null,
+          crt_by: data.crt_by,
+        }
+        openGatheringDetail(race).then(() => {
+          router.replace("/")
+        })
+      })
+    }
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [deepLinkGthrId])
 
   useEffect(() => {
     if (deepLinkPostId) {
@@ -210,20 +273,16 @@ export function MiniCalendar({
     if (deepLinkCompId) {
       const isUuid = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i.test(deepLinkCompId)
       const query = isUuid
-        ? supabase.from("comp_mst").select("comp_id, comp_nm, comp_sprt_cd, stt_dt, end_dt, loc_nm, src_url, comp_evt_cfg(comp_evt_type)").eq("comp_id", deepLinkCompId).maybeSingle()
-        : supabase.from("comp_mst").select("comp_id, comp_nm, comp_sprt_cd, stt_dt, end_dt, loc_nm, src_url, comp_evt_cfg(comp_evt_type)").eq("short_id", deepLinkCompId).maybeSingle()
+        ? supabase.from("comp_mst").select("comp_id, short_id, comp_nm, comp_sprt_cd, stt_dt, end_dt, loc_nm, src_url, comp_evt_cfg(comp_evt_type)").eq("comp_id", deepLinkCompId).maybeSingle()
+        : supabase.from("comp_mst").select("comp_id, short_id, comp_nm, comp_sprt_cd, stt_dt, end_dt, loc_nm, src_url, comp_evt_cfg(comp_evt_type)").eq("short_id", deepLinkCompId).maybeSingle()
 
-      Promise.all([
-        query,
-        memberId ? fetchComments("comp", deepLinkCompId) : Promise.resolve(undefined),
-      ]).then(([{ data }, commentsResult]) => {
+      query.then(({ data }) => {
         if (!data) return
-        const commentPromise = isUuid
-          ? Promise.resolve(commentsResult)
-          : memberId ? fetchComments("comp", data.comp_id) : Promise.resolve(undefined)
+        const commentPromise = memberId ? fetchComments("comp", data.comp_id) : Promise.resolve(undefined)
         commentPromise.then((finalComments) => {
           setSelectedCompetition({
             id: data.comp_id,
+            short_id: data.short_id ?? null,
             external_id: "",
             sport: data.comp_sprt_cd ?? null,
             title: data.comp_nm,
@@ -252,7 +311,7 @@ export function MiniCalendar({
   const totalDays = daysInMonth(year, month);
   const firstDayOfWeek = dayjs.tz(`${year}-${String(month).padStart(2, "0")}-01`, "Asia/Seoul").day();
 
-  const allRaces = useMemo(() => [...myRaces, ...schPosts, ...gigangRaces], [myRaces, schPosts, gigangRaces]);
+  const allRaces = useMemo(() => [...myRaces, ...schPosts, ...gigangRaces, ...gatherings], [myRaces, schPosts, gigangRaces, gatherings]);
 
   // 날짜별 이벤트 목록 (mine 우선, schedule, gigang 순) — 기간 이벤트는 모든 날짜에 전개
   const eventsByDate = useMemo(() => {
@@ -352,7 +411,7 @@ export function MiniCalendar({
     return `${year}-${String(month).padStart(2, "0")}-${String(day).padStart(2, "0")}`;
   }
 
-  async function fetchComments(entityType: "sch_post" | "comp", entityId: string): Promise<CmntRow[]> {
+  async function fetchComments(entityType: "sch_post" | "comp" | "gathering", entityId: string): Promise<CmntRow[]> {
     const { data } = await supabase
       .from("cmnt_mst")
       .select("cmnt_id, prnt_id, mem_id, cont_txt, edit_yn, del_yn, crt_at, upd_at, mem_mst!cmnt_mst_mem_id_fkey(mem_nm, avatar_url)")
@@ -381,7 +440,7 @@ export function MiniCalendar({
     const [{ data }, comments] = await Promise.all([
       supabase
         .from("comp_mst")
-        .select("comp_id, comp_nm, comp_sprt_cd, stt_dt, end_dt, loc_nm, src_url, comp_evt_cfg(comp_evt_type)")
+        .select("comp_id, short_id, comp_nm, comp_sprt_cd, stt_dt, end_dt, loc_nm, src_url, comp_evt_cfg(comp_evt_type)")
         .eq("comp_id", race.id)
         .single(),
       memberId ? fetchComments("comp", race.id) : Promise.resolve(undefined),
@@ -390,6 +449,7 @@ export function MiniCalendar({
     const comp: Competition = data
       ? {
           id: data.comp_id,
+          short_id: data.short_id ?? null,
           external_id: "",
           sport: data.comp_sprt_cd ?? null,
           title: data.comp_nm,
@@ -403,6 +463,7 @@ export function MiniCalendar({
         }
       : {
           id: race.id,
+          short_id: null,
           external_id: "",
           sport: null,
           title: race.title,
@@ -508,6 +569,7 @@ export function MiniCalendar({
       { data: teamComps },
       myRegsResult,
       { data: schPostRows },
+      { data: gthrRows },
     ] = await Promise.all([
       supabase.rpc("get_public_team_competitions", { p_team_id: teamId, p_start: newMonth, p_end: lastDay }),
       memberId
@@ -520,6 +582,9 @@ export function MiniCalendar({
             .eq("del_yn", false)
         : Promise.resolve({ data: null }),
       supabase.rpc("get_public_team_sch_posts", { p_team_id: teamId, p_start: newMonth, p_end: lastDay }),
+      memberId
+        ? supabase.rpc("get_public_team_gatherings", { p_team_id: teamId, p_start: newMonth, p_end: lastDay, p_mem_id: memberId })
+        : supabase.rpc("get_public_team_gatherings", { p_team_id: teamId, p_start: newMonth, p_end: lastDay }),
     ]);
 
     const newGigang: CalendarRace[] = (teamComps ?? [])
@@ -558,18 +623,37 @@ export function MiniCalendar({
       cmntCount: row.cmnt_count ? Number(row.cmnt_count) : undefined,
     }));
 
-    return { gigang: newGigang, mine: newMine, schPosts: newSchPosts };
+    const newGatherings: CalendarRace[] = (gthrRows ?? []).map((row) => ({
+      id: row.gthr_id,
+      short_id: row.short_id ?? null,
+      title: row.gthr_nm,
+      start_date: dayjs(row.stt_at).tz("Asia/Seoul").format("YYYY-MM-DD"),
+      end_date: row.end_at ? dayjs(row.end_at).tz("Asia/Seoul").format("YYYY-MM-DD") : null,
+      type: (memberId && ("is_attending" in row ? row.is_attending : false) ? "gathering_mine" : "gathering") as CalendarRace["type"],
+      post_type: row.gthr_type_enm,
+      location: row.loc_txt ?? null,
+      cont_txt: row.desc_txt ?? null,
+      evt_stt_at: row.stt_at,
+      evt_end_at: row.end_at ?? null,
+      crt_by: row.crt_by,
+      crt_by_nm: row.crt_by_nm ?? null,
+      regCount: row.attd_count ? Number(row.attd_count) : 0,
+      cmntCount: row.cmnt_count ? Number(row.cmnt_count) : undefined,
+    }));
+
+    return { gigang: newGigang, mine: newMine, schPosts: newSchPosts, gatherings: newGatherings };
   }
 
   function navigate(dir: -1 | 1) {
     startTransition(async () => {
       const newMonthDayjs = dayjs(viewMonth).add(dir, "month");
       const newMonth = newMonthDayjs.format("YYYY-MM-01");
-      const { gigang, mine, schPosts: newSch } = await fetchMonthData(newMonth);
+      const { gigang, mine, schPosts: newSch, gatherings: newGthr } = await fetchMonthData(newMonth);
       setViewMonth(newMonth);
       setGigangRaces(gigang);
       setMyRaces(mine);
       setSchPosts(newSch);
+      setGatherings(newGthr);
     });
   }
 
@@ -607,11 +691,30 @@ export function MiniCalendar({
     setSchDetailOpen(true);
   }
 
+  async function openGatheringDetail(race: CalendarRace) {
+    const [comments, attdResult, gthrResult] = await Promise.all([
+      memberId ? fetchComments("gathering", race.id) : Promise.resolve(undefined),
+      memberId
+        ? supabase.from("gthr_attd_rel").select("attd_id").eq("gthr_id", race.id).eq("mem_id", memberId).maybeSingle()
+        : Promise.resolve({ data: null }),
+      supabase.from("gthr_mst").select("max_prt_cnt, sprt_cd, gthr_attd_rel(mem_id, mem_mst(mem_nm, avatar_url))").eq("gthr_id", race.id).single(),
+    ]);
+    const attendees: GatheringAttendee[] = (gthrResult.data?.gthr_attd_rel ?? []).map((a) => {
+      const mem = Array.isArray(a.mem_mst) ? a.mem_mst[0] : a.mem_mst;
+      return { mem_id: a.mem_id, mem_nm: (mem as { mem_nm?: string | null } | null)?.mem_nm ?? null, avatar_url: (mem as { avatar_url?: string | null } | null)?.avatar_url ?? null };
+    });
+    setGthrDetailRace({ ...race, regCount: attendees.length, maxPrtCnt: gthrResult.data?.max_prt_cnt ?? null, attendees, sprt_cd: gthrResult.data?.sprt_cd ?? null });
+    setGthrDetailAttending(!!attdResult.data);
+    setGthrDetailComments(comments);
+    setGthrDetailOpen(true);
+  }
+
   async function handleSchPostSuccess() {
-    const { gigang, mine, schPosts: newSch } = await fetchMonthData(viewMonth);
+    const { gigang, mine, schPosts: newSch, gatherings: newGthr } = await fetchMonthData(viewMonth);
     setGigangRaces(gigang);
     setMyRaces(mine);
     setSchPosts(newSch);
+    setGatherings(newGthr);
     setListViewKey((k) => k + 1);
   }
 
@@ -788,7 +891,11 @@ export function MiniCalendar({
                               ? "bg-success/20 text-success"
                               : lane.race.type === "schedule"
                                 ? "bg-info/15 text-info"
-                                : "bg-warning/15 text-warning",
+                                : lane.race.type === "gathering_mine"
+                                  ? "bg-success/20 text-success"
+                                  : lane.race.type === "gathering"
+                                  ? "bg-violet-400/20 text-violet-500"
+                                  : "bg-warning/15 text-warning",
                           )}
                         >
                           {lane.startsThisWeek ? lane.race.title : ""}
@@ -823,16 +930,28 @@ export function MiniCalendar({
                   {panelRaces.map((race) => {
                     const isMine = race.type === "mine";
                     const isComp = race.type === "gigang" || race.type === "mine";
+                    const isGathering = race.type === "gathering" || race.type === "gathering_mine";
+                    const isGatheringMine = race.type === "gathering_mine";
                     return (
                       <button
                         key={race.id}
-                        onClick={() => race.type === "schedule" ? openSchPostDetail(race) : handleRaceClick(race)}
+                        onClick={() =>
+                          race.type === "schedule"
+                            ? openSchPostDetail(race)
+                            : isGathering
+                              ? openGatheringDetail(race)
+                              : handleRaceClick(race)
+                        }
                         className="flex w-full items-center gap-1.5 rounded-lg px-1 py-0.5 text-left transition-all active:scale-[0.98] active:bg-secondary hover:bg-secondary/60"
                       >
                         <span
                           className={cn(
                             "w-0.5 shrink-0 self-stretch rounded-full",
-                            isMine ? "bg-success" : race.type === "schedule" ? "bg-info" : "bg-warning",
+                            isMine ? "bg-success"
+                              : race.type === "schedule" ? "bg-info"
+                              : isGatheringMine ? "bg-success"
+                              : isGathering ? "bg-violet-400"
+                              : "bg-warning",
                           )}
                         />
                         <span className="flex min-w-0 flex-1 flex-col gap-0.5">
@@ -848,8 +967,9 @@ export function MiniCalendar({
                               {(race.cmntCount ?? 0) > 0 && <span>💬 {race.cmntCount}</span>}
                             </span>
                           )}
-                          {race.type === "schedule" && (race.evt_stt_at || (race.cmntCount ?? 0) > 0) && (
+                          {(race.type === "schedule" || isGathering) && (race.evt_stt_at || race.location || (race.cmntCount ?? 0) > 0) && (
                             <span className="flex items-center gap-1 text-[9px] text-muted-foreground tabular-nums">
+                              {isGathering && race.location && <span className="truncate">{race.location}</span>}
                               {race.evt_stt_at && (
                                 <span>
                                   {(() => {
@@ -870,6 +990,9 @@ export function MiniCalendar({
                         {isComp && (race.regCount ?? 0) > 0 && (
                           <span className="shrink-0 text-[10px] tabular-nums text-muted-foreground">{race.regCount}명</span>
                         )}
+                        {isGathering && (race.regCount ?? 0) > 0 && (
+                          <span className="shrink-0 text-[10px] tabular-nums text-muted-foreground">{race.regCount}명</span>
+                        )}
                         {isComp && (
                           <span
                             className={cn(
@@ -880,6 +1003,18 @@ export function MiniCalendar({
                             )}
                           >
                             참가
+                          </span>
+                        )}
+                        {isGathering && (
+                          <span
+                            className={cn(
+                              "shrink-0 rounded-md border px-2 py-0.5 text-[10px] font-medium",
+                              isGatheringMine
+                                ? "border-success/40 bg-success/10 text-success"
+                                : "border-violet-300/60 bg-violet-50 text-violet-500",
+                            )}
+                          >
+                            {isGatheringMine ? "참석" : "모임"}
                           </span>
                         )}
                         {race.type === "schedule" && race.url && (
@@ -905,9 +1040,10 @@ export function MiniCalendar({
             teamId={teamId}
             memberId={memberId}
             initialMonthKey={viewMonth.slice(0, 7)}
-            initialRaces={[...myRaces, ...schPosts, ...gigangRaces]}
+            initialRaces={[...myRaces, ...schPosts, ...gigangRaces, ...gatherings]}
             onClickSchedule={openSchPostDetail}
             onClickCompetition={handleRaceClick}
+            onClickGathering={openGatheringDetail}
           />
         </div>
       )}
@@ -917,8 +1053,71 @@ export function MiniCalendar({
         <AddScheduleDropdown
           onAddSchedule={() => openCreateForm(view === "calendar" ? selectedDate : today)}
           onAddCompetition={() => openCompetitionPicker(view === "calendar" ? selectedDate : today)}
+          onAddGathering={() => {
+            setGthrDefaultDate(view === "calendar" ? selectedDate : today);
+            setGthrFormOpen(true);
+          }}
         />
       )}
+
+      {/* 모임 폼 다이얼로그 (등록 + 수정 겸용) */}
+      <GatheringFormDialog
+        open={gthrFormOpen}
+        onOpenChange={(v) => { setGthrFormOpen(v); if (!v) setGthrEditTarget(null); }}
+        mode={gthrEditTarget ? "edit" : "create"}
+        defaultDate={!gthrEditTarget ? gthrDefaultDate : undefined}
+        initialData={gthrEditTarget ? {
+          gthr_id: gthrEditTarget.id,
+          gthr_nm: gthrEditTarget.title,
+          gthr_type_enm: gthrEditTarget.post_type ?? "general",
+          sprt_cd: (gthrDetailRace?.sprt_cd) ?? null,
+          stt_at: gthrEditTarget.evt_stt_at ?? gthrEditTarget.start_date,
+          end_at: gthrEditTarget.evt_end_at ?? null,
+          loc_txt: gthrEditTarget.location ?? null,
+          desc_txt: gthrEditTarget.cont_txt ?? null,
+          max_prt_cnt: gthrDetailRace?.maxPrtCnt ?? null,
+        } : undefined}
+        onSuccess={async () => {
+          const { gigang, mine, schPosts: newSch, gatherings: newGthr } = await fetchMonthData(viewMonth);
+          setGigangRaces(gigang);
+          setMyRaces(mine);
+          setSchPosts(newSch);
+          setGatherings(newGthr);
+          setListViewKey((k) => k + 1);
+          setGthrEditTarget(null);
+        }}
+      />
+
+      {/* 모임 상세 다이얼로그 */}
+      <GatheringDetailDialog
+        gathering={gthrDetailRace}
+        open={gthrDetailOpen}
+        onOpenChange={setGthrDetailOpen}
+        teamId={teamId}
+        currentMemberId={memberStatus.status === "ready" ? memberStatus.memberId : undefined}
+        isAdmin={memberStatus.status === "ready" ? memberStatus.admin : false}
+        isAttending={gthrDetailAttending}
+        members={membersCache ?? []}
+        initialComments={gthrDetailComments}
+        onEdit={() => {
+          if (!gthrDetailRace) return;
+          setGthrDetailOpen(false);
+          setGthrEditTarget(gthrDetailRace);
+          setGthrFormOpen(true);
+        }}
+        onDelete={async () => {
+          const { gigang, mine, schPosts: newSch, gatherings: newGthr } = await fetchMonthData(viewMonth);
+          setGigangRaces(gigang);
+          setMyRaces(mine);
+          setSchPosts(newSch);
+          setGatherings(newGthr);
+          setListViewKey((k) => k + 1);
+        }}
+        onAttendanceChange={async () => {
+          const { gatherings: newGthr } = await fetchMonthData(viewMonth);
+          setGatherings(newGthr);
+        }}
+      />
 
       {/* 대회 선택 다이얼로그 */}
       <CompetitionPickerDialog

--- a/components/home/mini-calendar.tsx
+++ b/components/home/mini-calendar.tsx
@@ -1095,6 +1095,7 @@ export function MiniCalendar({
         onOpenChange={setGthrDetailOpen}
         teamId={teamId}
         currentMemberId={memberStatus.status === "ready" ? memberStatus.memberId : undefined}
+        currentMemberName={memberStatus.status === "ready" ? memberStatus.fullName : undefined}
         isAdmin={memberStatus.status === "ready" ? memberStatus.admin : false}
         isAttending={gthrDetailAttending}
         members={membersCache ?? []}

--- a/components/home/schedule-list-view.tsx
+++ b/components/home/schedule-list-view.tsx
@@ -26,6 +26,7 @@ type Props = {
   initialRaces: CalendarRace[];
   onClickSchedule: (race: CalendarRace) => void;
   onClickCompetition: (race: CalendarRace) => void;
+  onClickGathering: (race: CalendarRace) => void;
 };
 
 
@@ -45,6 +46,7 @@ type SchedulePagedRow = {
   crt_by_nm: string | null;
   reg_count: number | null;
   cmnt_count: number;
+  short_id: string | null;
 };
 
 async function fetchAdjacent(
@@ -84,6 +86,23 @@ async function fetchAdjacent(
         cont_txt: row.cont_txt ?? null,
         crt_by: row.crt_by ?? undefined,
         crt_by_nm: row.crt_by_nm ?? null,
+        cmntCount: row.cmnt_count ? Number(row.cmnt_count) : undefined,
+      });
+    } else if (row.item_type === "gathering" || row.item_type === "gathering_mine") {
+      results.push({
+        id: row.item_id,
+        short_id: row.short_id ?? null,
+        title: row.item_nm,
+        start_date: row.start_date,
+        type: row.item_type as "gathering" | "gathering_mine",
+        post_type: row.post_type ?? null,
+        location: row.loc_nm ?? null,
+        cont_txt: row.cont_txt ?? null,
+        evt_stt_at: row.evt_stt_at ?? null,
+        evt_end_at: row.evt_end_at ?? null,
+        crt_by: row.crt_by ?? undefined,
+        crt_by_nm: row.crt_by_nm ?? null,
+        regCount: row.reg_count ? Number(row.reg_count) : 0,
         cmntCount: row.cmnt_count ? Number(row.cmnt_count) : undefined,
       });
     } else {
@@ -203,6 +222,45 @@ function CompetitionItem({
   );
 }
 
+function GatheringItem({ race, onClick }: { race: CalendarRace; onClick: () => void }) {
+  const isMine = race.type === "gathering_mine";
+  const timeRange = formatTimeRange(race.evt_stt_at, race.evt_end_at);
+
+  return (
+    <button
+      onClick={onClick}
+      className="flex w-full items-stretch gap-2.5 rounded-lg px-2 py-0.5 text-left transition-all active:scale-[0.98] active:bg-secondary hover:bg-secondary/60"
+    >
+      <span className={cn("w-0.5 shrink-0 rounded-full", isMine ? "bg-success" : "bg-violet-400")} />
+      <span className="flex min-w-0 flex-1 flex-col gap-0.5">
+        <Caption className="truncate font-medium text-foreground">{race.title}</Caption>
+        {(timeRange || race.location || (race.cmntCount ?? 0) > 0) && (
+          <Micro className="flex items-center gap-1.5 tabular-nums text-muted-foreground">
+            {race.location && <span className="truncate">{race.location}</span>}
+            {timeRange && <span>{timeRange}</span>}
+            {(race.cmntCount ?? 0) > 0 && <span>💬 {race.cmntCount}</span>}
+          </Micro>
+        )}
+      </span>
+      <span className="flex w-20 shrink-0 items-center justify-end gap-1.5 self-center">
+        {(race.regCount ?? 0) > 0 && (
+          <Micro className="text-muted-foreground tabular-nums">{race.regCount}명</Micro>
+        )}
+        <span
+          className={cn(
+            "shrink-0 rounded-md border px-2.5 py-1 text-[11px] font-medium",
+            isMine
+              ? "border-success/40 bg-success/10 text-success"
+              : "border-violet-300/60 bg-violet-50 text-violet-500",
+          )}
+        >
+          {isMine ? "참석" : "모임"}
+        </span>
+      </span>
+    </button>
+  );
+}
+
 export function ScheduleListView({
   teamId,
   memberId,
@@ -210,6 +268,7 @@ export function ScheduleListView({
   initialRaces,
   onClickSchedule,
   onClickCompetition,
+  onClickGathering,
 }: Props) {
   const supabase = createClient();
   const today = todayKST();
@@ -404,6 +463,12 @@ export function ScheduleListView({
                                 key={race.id}
                                 race={race}
                                 onClick={() => onClickSchedule(race)}
+                              />
+                            ) : race.type === "gathering" || race.type === "gathering_mine" ? (
+                              <GatheringItem
+                                key={race.id}
+                                race={race}
+                                onClick={() => onClickGathering(race)}
                               />
                             ) : (
                               <CompetitionItem

--- a/components/home/schedule-list-view.tsx
+++ b/components/home/schedule-list-view.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 
 import { MapPin } from "lucide-react";
 
@@ -270,7 +270,7 @@ export function ScheduleListView({
   onClickCompetition,
   onClickGathering,
 }: Props) {
-  const supabase = createClient();
+  const supabase = useMemo(() => createClient(), []);
   const today = todayKST();
 
   const [months, setMonths] = useState<MonthData[]>(() => {

--- a/components/notifications/notification-item.tsx
+++ b/components/notifications/notification-item.tsx
@@ -4,7 +4,7 @@ import { useState, useRef, useEffect } from "react";
 
 import { useRouter } from "next/navigation";
 
-import { Bell, Coins, MessageCircle, Trophy, Trash2, FileText } from "lucide-react";
+import { Bell, Coins, MessageCircle, Trophy, Trash2, FileText, Users } from "lucide-react";
 
 import { dayjs } from "@/lib/dayjs";
 import type { Notification } from "@/lib/queries/notification";
@@ -25,6 +25,12 @@ const NOTI_ICON: Record<string, React.ElementType> = {
   cmnt_reply: MessageCircle,
   sch_post_cmnt: MessageCircle,
   sch_post_new: FileText,
+  gthr_new: Users,
+  gthr_upd: Users,
+  gthr_del: Users,
+  gthr_cmnt: MessageCircle,
+  gthr_reply: MessageCircle,
+  gthr_mention: MessageCircle,
 };
 
 const NOTI_ROUTE: Record<string, (refId: string | null, refType: string | null) => string | null> = {
@@ -34,8 +40,14 @@ const NOTI_ROUTE: Record<string, (refId: string | null, refType: string | null) 
   dues_check_req: () => null,
   sch_post_cmnt: (refId) => refId ? `/?post=${refId}` : "/",
   sch_post_new: (refId) => refId ? `/?post=${refId}` : "/",
-  cmnt_mention: (refId, refType) => refType === "comp" ? `/?comp=${refId}` : refId ? `/?post=${refId}` : "/",
-  cmnt_reply: (refId, refType) => refType === "comp" ? `/?comp=${refId}` : refId ? `/?post=${refId}` : "/",
+  cmnt_mention: (refId, refType) => refType === "comp" ? `/?comp=${refId}` : refType === "gathering" ? (refId ? `/?gthr=${refId}` : "/") : refId ? `/?post=${refId}` : "/",
+  cmnt_reply: (refId, refType) => refType === "comp" ? `/?comp=${refId}` : refType === "gathering" ? (refId ? `/?gthr=${refId}` : "/") : refId ? `/?post=${refId}` : "/",
+  gthr_new: (refId) => refId ? `/?gthr=${refId}` : "/",
+  gthr_upd: (refId) => refId ? `/?gthr=${refId}` : "/",
+  gthr_del: () => "/",
+  gthr_cmnt: (refId) => refId ? `/?gthr=${refId}` : "/",
+  gthr_reply: (refId) => refId ? `/?gthr=${refId}` : "/",
+  gthr_mention: (refId) => refId ? `/?gthr=${refId}` : "/",
 };
 
 function formatRelative(crtAt: string) {

--- a/components/races/competition-detail-dialog.tsx
+++ b/components/races/competition-detail-dialog.tsx
@@ -4,7 +4,7 @@ import { useEffect, useMemo, useState, useCallback } from "react";
 
 
 import { zodResolver } from "@hookform/resolvers/zod";
-import { Calendar, ExternalLink, MapPin, Pencil, Users } from "lucide-react";
+import { Calendar, ExternalLink, MapPin, Pencil, Share2, Users } from "lucide-react";
 import { useForm } from "react-hook-form";
 
 import {
@@ -41,6 +41,7 @@ import {
   ResponsiveDrawerHeader,
   ResponsiveDrawerTitle,
 } from "@/components/common/responsive-drawer";
+import { ShareSheet } from "@/components/common/share-sheet";
 import { detectInAppBrowser, openExternalBrowser } from "@/components/in-app-browser-gate";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
@@ -129,6 +130,7 @@ export function CompetitionDetailDialog({
   const [publicDisplayCounts, setPublicDisplayCounts] = useState<
     { display_key: string; cnt: number }[]
   >([]);
+  const [shareOpen, setShareOpen] = useState(false);
 
   // 관리자 수정 모드
   const isAdmin = memberStatus.status === "ready" && memberStatus.admin;
@@ -340,7 +342,13 @@ export function CompetitionDetailDialog({
     if (result.ok) loadParticipants(competition.id);
   }
 
+  const compRef = competition.short_id ?? competition.id;
+  const sharePageUrl = typeof window !== "undefined"
+    ? `${window.location.origin}/?comp=${compRef}`
+    : `/?comp=${compRef}`;
+
   return (
+    <>
     <ResponsiveDrawer
       open={open}
       onOpenChange={(v) => { if (!v) setEditing(false); onOpenChange(v); }}
@@ -471,16 +479,27 @@ export function CompetitionDetailDialog({
             </div>
           )}
 
-          {isAdmin && !editing && (
-            <Button
-              variant="outline"
-              size="sm"
-              onClick={startEditing}
-              className="mt-3 self-start"
-            >
-              <Pencil className="size-3.5 mr-1.5" />
-              대회 정보 수정
-            </Button>
+          {!editing && (
+            <div className="mt-3 flex items-center gap-2">
+              <Button
+                variant="outline"
+                size="sm"
+                onClick={(e) => { (e.currentTarget as HTMLElement).blur(); setShareOpen(true); }}
+              >
+                <Share2 className="size-3.5" />
+                공유하기
+              </Button>
+              {isAdmin && (
+                <Button
+                  variant="outline"
+                  size="sm"
+                  onClick={startEditing}
+                >
+                  <Pencil className="size-3.5 mr-1.5" />
+                  대회 정보 수정
+                </Button>
+              )}
+            </div>
           )}
 
           {/* 참가 현황 */}
@@ -606,7 +625,7 @@ export function CompetitionDetailDialog({
                 <Button
                   className="w-full"
                   onClick={() => {
-                    const returnPath = `/?comp=${competition.id}`;
+                    const returnPath = `/?comp=${competition.short_id ?? competition.id}`;
                     const href =
                       memberStatus.status === "signed-out"
                         ? `/auth/login?next=${encodeURIComponent(returnPath)}`
@@ -713,7 +732,7 @@ export function CompetitionDetailDialog({
               isAdmin={isAdmin}
               members={members}
               initialComments={initialComments}
-              loginReturnPath={`/?comp=${competition.id}`}
+              loginReturnPath={`/?comp=${competition.short_id ?? competition.id}`}
             />
           </div>
 
@@ -727,5 +746,15 @@ export function CompetitionDetailDialog({
         </div>
       </ResponsiveDrawerContent>
     </ResponsiveDrawer>
+
+    <ShareSheet
+      open={shareOpen}
+      onOpenChange={setShareOpen}
+      title={`[${competition.title}]`}
+      timeLabel={formattedDate}
+      locationText={competition.location ?? undefined}
+      pageUrl={sharePageUrl}
+    />
+    </>
   );
 }

--- a/components/races/types.ts
+++ b/components/races/types.ts
@@ -1,5 +1,6 @@
 export type Competition = {
   id: string;
+  short_id?: string | null;
   external_id: string;
   sport: string | null;
   title: string;

--- a/components/schedule/gathering-detail-dialog.tsx
+++ b/components/schedule/gathering-detail-dialog.tsx
@@ -100,8 +100,8 @@ export function GatheringDetailDialog({
 
   // 공유 텍스트용
   const shareTitle = gathering.maxPrtCnt != null
-    ? `${gathering.title} - ${gathering.maxPrtCnt}명`
-    : gathering.title;
+    ? `[${gathering.title}] - ${gathering.maxPrtCnt}명`
+    : `[${gathering.title}]`;
   const shareTimeLabel = end
     ? `${stt.format("YYYY년 M월 D일 (ddd) HH:mm")} ~ ${stt.format("YYYY-MM-DD") === end.format("YYYY-MM-DD") ? end.format("HH:mm") : end.format("YYYY년 M월 D일 (ddd) HH:mm")}`
     : stt.format("YYYY년 M월 D일 (ddd) HH:mm");

--- a/components/schedule/gathering-detail-dialog.tsx
+++ b/components/schedule/gathering-detail-dialog.tsx
@@ -1,0 +1,298 @@
+"use client";
+
+import { useState } from "react";
+
+import { Pencil, Share2, Trash2 } from "lucide-react";
+
+import { dayjs } from "@/lib/dayjs";
+import { gthrTypeLabels, gthrSprtLabels, type GthrType, type GthrSprtType } from "@/lib/validations/gathering";
+
+import { deleteGathering } from "@/app/actions/gathering/manage-gathering";
+import { toggleGatheringAttendance } from "@/app/actions/gathering/toggle-attendance";
+
+
+import type { CmntRow } from "@/components/comment/comment-item";
+import { CommentSection } from "@/components/comment/comment-section";
+import { renderMentions, type MemberOption } from "@/components/comment/mention-input";
+import { Avatar } from "@/components/common/avatar";
+import { ShareSheet } from "@/components/common/share-sheet";
+import {
+  ResponsiveDrawer,
+  ResponsiveDrawerClose,
+  ResponsiveDrawerContent,
+  ResponsiveDrawerDescription,
+  ResponsiveDrawerHeader,
+  ResponsiveDrawerTitle,
+} from "@/components/common/responsive-drawer";
+import { Caption } from "@/components/common/typography";
+import type { CalendarRace } from "@/components/home/mini-calendar";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+
+export type GatheringAttendee = {
+  mem_id: string;
+  mem_nm: string | null;
+  avatar_url: string | null;
+};
+
+export interface GatheringDetailDialogProps {
+  gathering: (CalendarRace & {
+    maxPrtCnt?: number | null;
+    attendees?: GatheringAttendee[];
+    sprt_cd?: string | null;
+  }) | null;
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  teamId: string;
+  currentMemberId?: string;
+  isAdmin?: boolean;
+  isAttending?: boolean;
+  members: MemberOption[];
+  initialComments?: CmntRow[];
+  onEdit?: () => void;
+  onDelete?: () => void;
+  onAttendanceChange?: () => void;
+}
+
+export function GatheringDetailDialog({
+  gathering,
+  open,
+  onOpenChange,
+  teamId,
+  currentMemberId,
+  isAdmin,
+  isAttending: initialIsAttending,
+  members,
+  initialComments,
+  onEdit,
+  onDelete,
+  onAttendanceChange,
+}: GatheringDetailDialogProps) {
+  const [attending, setAttending] = useState(initialIsAttending ?? false);
+  const [attdCount, setAttdCount] = useState(gathering?.regCount ?? 0);
+  const [isToggling, setIsToggling] = useState(false);
+  const [isDeleting, setIsDeleting] = useState(false);
+  const [shareOpen, setShareOpen] = useState(false);
+
+  // gathering이 바뀌면 상태 동기화
+  const gKey = gathering?.id;
+  const [lastGKey, setLastGKey] = useState(gKey);
+  if (gKey !== lastGKey) {
+    setLastGKey(gKey);
+    setAttending(initialIsAttending ?? false);
+    setAttdCount(gathering?.regCount ?? 0);
+  }
+
+  if (!gathering) return null;
+
+  const isAuthor = currentMemberId === gathering.crt_by;
+  const isFull = !attending && gathering.maxPrtCnt != null && attdCount >= gathering.maxPrtCnt;
+
+  const stt = gathering.evt_stt_at ? dayjs(gathering.evt_stt_at).tz("Asia/Seoul") : dayjs(gathering.start_date);
+  const end = gathering.evt_end_at ? dayjs(gathering.evt_end_at).tz("Asia/Seoul") : null;
+  const dateStr = stt.format("YYYY년 M월 D일 (ddd)");
+  const timeStr = end ? `${stt.format("HH:mm")} ~ ${end.format("HH:mm")}` : stt.format("HH:mm");
+
+  const typeLabel = gthrTypeLabels[gathering.post_type as GthrType] ?? gathering.post_type;
+  const sprtLabel = gathering.sprt_cd ? (gthrSprtLabels[gathering.sprt_cd as GthrSprtType] ?? gathering.sprt_cd) : null;
+
+  // 공유 텍스트용
+  const shareTitle = gathering.maxPrtCnt != null
+    ? `[${gathering.title}] - ${gathering.maxPrtCnt}명`
+    : `[${gathering.title}]`;
+  const shareTimeLabel = end
+    ? `${stt.format("YYYY년 M월 D일 (ddd) HH:mm")} ~ ${stt.format("YYYY-MM-DD") === end.format("YYYY-MM-DD") ? end.format("HH:mm") : end.format("YYYY년 M월 D일 (ddd) HH:mm")}`
+    : stt.format("YYYY년 M월 D일 (ddd) HH:mm");
+  const gthrRef = gathering.short_id ?? gathering.id;
+  const sharePageUrl = typeof window !== "undefined"
+    ? `${window.location.origin}/?gthr=${gthrRef}`
+    : `/?gthr=${gthrRef}`;
+
+  async function handleToggleAttendance() {
+    if (!currentMemberId || isFull || isToggling) return;
+    setIsToggling(true);
+    const prev = attending;
+    setAttending(!prev);
+    setAttdCount((c) => (!prev ? c + 1 : c - 1));
+    try {
+      const result = await toggleGatheringAttendance(gathering!.id);
+      setAttending(result.attending);
+      onAttendanceChange?.();
+    } catch {
+      setAttending(prev);
+      setAttdCount((c) => (prev ? c + 1 : c - 1));
+    } finally {
+      setIsToggling(false);
+    }
+  }
+
+  async function handleDelete() {
+    if (!gathering) return;
+    if (!window.confirm(`'${gathering.title}'을 삭제하시겠습니까? 참석자들에게 알림이 발송됩니다.`)) return;
+    setIsDeleting(true);
+    try {
+      await deleteGathering(gathering.id);
+      onOpenChange(false);
+      onDelete?.();
+    } catch (err) {
+      alert(err instanceof Error ? err.message : "삭제에 실패했습니다.");
+    } finally {
+      setIsDeleting(false);
+    }
+  }
+
+  return (
+    <>
+    <ResponsiveDrawer open={open} onOpenChange={onOpenChange}>
+      <ResponsiveDrawerContent
+        dialogClassName="max-w-md max-h-[85dvh] flex flex-col gap-0 p-0 overflow-hidden"
+        drawerClassName="h-[85dvh] max-h-[85dvh]"
+      >
+        <ResponsiveDrawerHeader className="shrink-0 border-b border-border px-4 py-4 text-left">
+          <ResponsiveDrawerTitle>{gathering.title}</ResponsiveDrawerTitle>
+          <ResponsiveDrawerDescription className="sr-only">모임 상세 정보</ResponsiveDrawerDescription>
+        </ResponsiveDrawerHeader>
+
+        <div className="flex-1 overflow-y-auto px-4 pb-6 pt-4">
+          <div className="flex flex-col gap-4">
+            {/* 뱃지 */}
+            <div className="flex items-center gap-2">
+              {typeLabel && <Badge variant="secondary">{typeLabel}</Badge>}
+              {sprtLabel && <Badge variant="outline">{sprtLabel}</Badge>}
+            </div>
+
+            {/* 날짜/시간/장소/인원 */}
+            <div className="flex flex-col gap-1.5">
+              <div className="flex items-center gap-2">
+                <Caption className="w-4 text-muted-foreground">📅</Caption>
+                <Caption>{dateStr}</Caption>
+              </div>
+              <div className="flex items-center gap-2">
+                <Caption className="w-4 text-muted-foreground">⏰</Caption>
+                <Caption>{timeStr}</Caption>
+              </div>
+              {gathering.location && (
+                <div className="flex items-center gap-2">
+                  <Caption className="w-4 text-muted-foreground">📍</Caption>
+                  <Caption>{gathering.location}</Caption>
+                </div>
+              )}
+              <div className="flex items-center gap-2">
+                <Caption className="w-4 text-muted-foreground">👥</Caption>
+                <Caption>
+                  참석 {attdCount}명
+                  {gathering.maxPrtCnt != null && ` / 최대 ${gathering.maxPrtCnt}명`}
+                </Caption>
+              </div>
+              {gathering.crt_by_nm && (
+                <div className="flex items-center gap-2">
+                  <Caption className="w-4 text-muted-foreground">✍️</Caption>
+                  <Caption>{gathering.crt_by_nm}</Caption>
+                </div>
+              )}
+            </div>
+
+            {/* 비고 */}
+            {gathering.cont_txt && (
+              <div className="rounded-xl bg-secondary/50 px-4 py-3">
+                <Caption className="whitespace-pre-wrap text-foreground">
+                  {renderMentions(gathering.cont_txt, members)}
+                </Caption>
+              </div>
+            )}
+
+            {/* 참석 버튼 */}
+            {currentMemberId && (
+              <Button
+                onClick={handleToggleAttendance}
+                disabled={isToggling || isFull}
+                variant={attending ? "default" : "outline"}
+                className={attending ? "w-full bg-success hover:bg-success/90 border-success" : "w-full"}
+              >
+                {isFull ? "인원 마감" : attending ? "✅ 참석" : "참석하기"}
+              </Button>
+            )}
+
+            {/* 참석자 목록 */}
+            {(gathering.attendees?.length ?? 0) > 0 && (
+              <div className="flex flex-wrap gap-2">
+                {(gathering.attendees ?? []).map((a) => (
+                  <div key={a.mem_id} className="flex flex-col items-center gap-0.5">
+                    <Avatar src={a.avatar_url} alt={a.mem_nm ?? ""} size="sm" className="size-4" />
+                    <span className="text-[9px] text-muted-foreground leading-tight">{a.mem_nm ?? ""}</span>
+                  </div>
+                ))}
+              </div>
+            )}
+
+            {/* 공유/수정/삭제 */}
+            <div className="flex items-center justify-between gap-2">
+              <Button
+                variant="outline"
+                size="sm"
+                onClick={(e) => { (e.currentTarget as HTMLElement).blur(); setShareOpen(true); }}
+              >
+                <Share2 className="size-3.5" />
+                공유하기
+              </Button>
+
+              {(isAuthor || isAdmin) && (
+                <div className="flex gap-2">
+                  {isAuthor && (
+                    <Button variant="outline" size="sm" onClick={onEdit} disabled={isDeleting}>
+                      <Pencil className="size-3.5" />
+                      수정
+                    </Button>
+                  )}
+                  <Button
+                    variant="outline"
+                    size="sm"
+                    className="border-destructive/30 text-destructive hover:bg-destructive/5 hover:text-destructive"
+                    onClick={handleDelete}
+                    disabled={isDeleting}
+                  >
+                    <Trash2 className="size-3.5" />
+                    {isDeleting ? "삭제 중..." : "삭제"}
+                  </Button>
+                </div>
+              )}
+            </div>
+
+            {/* 댓글 */}
+            <div className="border-t border-border pt-4">
+              <CommentSection
+                entityType="gathering"
+                entityId={gathering.id}
+                teamId={teamId}
+                currentMemberId={currentMemberId}
+                isAdmin={isAdmin}
+                members={members}
+                initialComments={initialComments}
+                loginReturnPath={`/?gthr=${gathering.short_id ?? gathering.id}`}
+              />
+            </div>
+
+            <div className="mt-4 flex justify-center">
+              <ResponsiveDrawerClose asChild>
+                <Button type="button" variant="ghost" size="sm" className="text-muted-foreground">
+                  닫기
+                </Button>
+              </ResponsiveDrawerClose>
+            </div>
+          </div>
+        </div>
+      </ResponsiveDrawerContent>
+    </ResponsiveDrawer>
+
+    <ShareSheet
+      open={shareOpen}
+      onOpenChange={setShareOpen}
+      title={shareTitle}
+      timeLabel={shareTimeLabel}
+      locationText={gathering.location ?? undefined}
+      contentSnippet={gathering.cont_txt ?? undefined}
+      pageUrl={sharePageUrl}
+    />
+    </>
+  );
+}

--- a/components/schedule/gathering-detail-dialog.tsx
+++ b/components/schedule/gathering-detail-dialog.tsx
@@ -45,6 +45,7 @@ export interface GatheringDetailDialogProps {
   onOpenChange: (open: boolean) => void;
   teamId: string;
   currentMemberId?: string;
+  currentMemberName?: string | null;
   isAdmin?: boolean;
   isAttending?: boolean;
   members: MemberOption[];
@@ -60,6 +61,7 @@ export function GatheringDetailDialog({
   onOpenChange,
   teamId,
   currentMemberId,
+  currentMemberName,
   isAdmin,
   isAttending: initialIsAttending,
   members,
@@ -114,7 +116,7 @@ export function GatheringDetailDialog({
     if (!currentMemberId || isFull || isToggling) return;
     setIsToggling(true);
     const prev = attending;
-    const myEntry = { mem_id: currentMemberId, mem_nm: gathering!.crt_by_nm ?? null, avatar_url: null };
+    const myEntry = { mem_id: currentMemberId, mem_nm: currentMemberName ?? null, avatar_url: null };
     setAttending(!prev);
     setAttdCount((c) => (!prev ? c + 1 : c - 1));
     setAttendees((list) => !prev ? [...list, myEntry] : list.filter((a) => a.mem_id !== currentMemberId));

--- a/components/schedule/gathering-detail-dialog.tsx
+++ b/components/schedule/gathering-detail-dialog.tsx
@@ -70,6 +70,7 @@ export function GatheringDetailDialog({
 }: GatheringDetailDialogProps) {
   const [attending, setAttending] = useState(initialIsAttending ?? false);
   const [attdCount, setAttdCount] = useState(gathering?.regCount ?? 0);
+  const [attendees, setAttendees] = useState(gathering?.attendees ?? []);
   const [isToggling, setIsToggling] = useState(false);
   const [isDeleting, setIsDeleting] = useState(false);
   const [shareOpen, setShareOpen] = useState(false);
@@ -81,6 +82,7 @@ export function GatheringDetailDialog({
     setLastGKey(gKey);
     setAttending(initialIsAttending ?? false);
     setAttdCount(gathering?.regCount ?? 0);
+    setAttendees(gathering?.attendees ?? []);
   }
 
   if (!gathering) return null;
@@ -98,8 +100,8 @@ export function GatheringDetailDialog({
 
   // 공유 텍스트용
   const shareTitle = gathering.maxPrtCnt != null
-    ? `[${gathering.title}] - ${gathering.maxPrtCnt}명`
-    : `[${gathering.title}]`;
+    ? `${gathering.title} - ${gathering.maxPrtCnt}명`
+    : gathering.title;
   const shareTimeLabel = end
     ? `${stt.format("YYYY년 M월 D일 (ddd) HH:mm")} ~ ${stt.format("YYYY-MM-DD") === end.format("YYYY-MM-DD") ? end.format("HH:mm") : end.format("YYYY년 M월 D일 (ddd) HH:mm")}`
     : stt.format("YYYY년 M월 D일 (ddd) HH:mm");
@@ -112,8 +114,10 @@ export function GatheringDetailDialog({
     if (!currentMemberId || isFull || isToggling) return;
     setIsToggling(true);
     const prev = attending;
+    const myEntry = { mem_id: currentMemberId, mem_nm: gathering!.crt_by_nm ?? null, avatar_url: null };
     setAttending(!prev);
     setAttdCount((c) => (!prev ? c + 1 : c - 1));
+    setAttendees((list) => !prev ? [...list, myEntry] : list.filter((a) => a.mem_id !== currentMemberId));
     try {
       const result = await toggleGatheringAttendance(gathering!.id);
       setAttending(result.attending);
@@ -121,6 +125,7 @@ export function GatheringDetailDialog({
     } catch {
       setAttending(prev);
       setAttdCount((c) => (prev ? c + 1 : c - 1));
+      setAttendees(gathering!.attendees ?? []);
     } finally {
       setIsToggling(false);
     }
@@ -214,9 +219,9 @@ export function GatheringDetailDialog({
             )}
 
             {/* 참석자 목록 */}
-            {(gathering.attendees?.length ?? 0) > 0 && (
+            {attendees.length > 0 && (
               <div className="flex flex-wrap gap-2">
-                {(gathering.attendees ?? []).map((a) => (
+                {attendees.map((a) => (
                   <div key={a.mem_id} className="flex flex-col items-center gap-0.5">
                     <Avatar src={a.avatar_url} alt={a.mem_nm ?? ""} size="sm" className="size-4" />
                     <span className="text-[9px] text-muted-foreground leading-tight">{a.mem_nm ?? ""}</span>

--- a/components/schedule/gathering-detail-dialog.tsx
+++ b/components/schedule/gathering-detail-dialog.tsx
@@ -77,7 +77,8 @@ export function GatheringDetailDialog({
   const [isDeleting, setIsDeleting] = useState(false);
   const [shareOpen, setShareOpen] = useState(false);
 
-  // gathering이 바뀌면 상태 동기화
+  // gathering prop이 바뀌면 로컬 상태 동기화
+  // (렌더 중 파생 state 업데이트 — React 공식 패턴: https://react.dev/learn/you-might-not-need-an-effect#adjusting-some-state-when-a-prop-changes)
   const gKey = gathering?.id;
   const [lastGKey, setLastGKey] = useState(gKey);
   if (gKey !== lastGKey) {

--- a/components/schedule/gathering-form-dialog.tsx
+++ b/components/schedule/gathering-form-dialog.tsx
@@ -9,12 +9,16 @@ import { useFormPersist } from "@/lib/hooks/use-form-persist";
 import { z } from "zod";
 
 import { dayjs } from "@/lib/dayjs";
-import { createSchPostSchema, SCH_POST_TYPES, schPostTypeLabels, type SchPostType } from "@/lib/validations/schedule";
-
 import {
-  createSchPost,
-  updateSchPost,
-} from "@/app/actions/schedule/manage-sch-post";
+  GTHR_TYPES,
+  GTHR_SPRT_TYPES,
+  gthrTypeLabels,
+  gthrSprtLabels,
+  createGthrSchema,
+  type CreateGthrInput,
+} from "@/lib/validations/gathering";
+
+import { createGathering, updateGathering } from "@/app/actions/gathering/manage-gathering";
 
 import { Button } from "@/components/ui/button";
 import {
@@ -41,54 +45,58 @@ import {
 } from "@/components/ui/select";
 import { Separator } from "@/components/ui/separator";
 
-const formSchema = createSchPostSchema.omit({ team_id: true }).extend({
-  post_type: z.enum(SCH_POST_TYPES, { message: "유형을 선택해 주세요." }),
-});
+const formSchema = createGthrSchema.omit({ team_id: true });
 type FormValues = z.infer<typeof formSchema>;
 
-export type SchPostFormDialogProps = {
+export type GatheringFormDialogProps = {
   open: boolean;
   onOpenChange: (open: boolean) => void;
   mode: "create" | "edit";
-  defaultPostType?: SchPostType;
+  defaultDate?: string;
   initialData?: {
-    sch_post_id: string;
-    sch_nm: string;
-    post_type?: SchPostType;
-    evt_stt_at: string;
-    evt_end_at?: string | null;
-    url?: string | null;
-    cont_txt?: string | null;
-    crt_by?: string | null;
+    gthr_id: string;
+    gthr_nm: string;
+    gthr_type_enm: string;
+    sprt_cd?: string | null;
+    stt_at: string;
+    end_at?: string | null;
+    loc_txt?: string | null;
+    desc_txt?: string | null;
+    max_prt_cnt?: number | null;
   };
   onSuccess?: () => void;
 };
 
-export function SchPostFormDialog({
+function toDatetimeLocal(utcIso: string) {
+  return dayjs(utcIso).tz("Asia/Seoul").format("YYYY-MM-DDTHH:mm");
+}
+
+export function GatheringFormDialog({
   open,
   onOpenChange,
   mode,
-  defaultPostType,
+  defaultDate,
   initialData,
   onSuccess,
-}: SchPostFormDialogProps) {
+}: GatheringFormDialogProps) {
   const [rootError, setRootError] = useState<string | null>(null);
 
   const form = useForm<FormValues>({
     resolver: zodResolver(formSchema),
     defaultValues: {
-      sch_nm: "",
-      post_type: defaultPostType,
-      evt_stt_at: "",
-      evt_end_at: null,
-      url: null,
-      cont_txt: null,
+      gthr_nm: "",
+      gthr_type_enm: "general",
+      sprt_cd: "running",
+      stt_at: "",
+      end_at: null,
+      loc_txt: null,
+      desc_txt: null,
     } as FormValues,
   });
 
   const { isSubmitting } = form.formState;
 
-  const persistKey = "sch-post-form-draft";
+  const persistKey = "gathering-form-draft";
   const { clear: clearDraft } = useFormPersist(persistKey, form, open && mode === "create");
 
   useEffect(() => {
@@ -97,91 +105,83 @@ export function SchPostFormDialog({
     setRootError(null);
     if (mode === "edit" && initialData) {
       form.reset({
-        sch_nm: initialData.sch_nm,
-        post_type: initialData.post_type ?? "general" as SchPostType,
-        evt_stt_at: toDatetimeLocal(initialData.evt_stt_at),
-        evt_end_at: initialData.evt_end_at ? toDatetimeLocal(initialData.evt_end_at) : null,
-        url: initialData.url ?? null,
-        cont_txt: initialData.cont_txt ?? null,
+        gthr_nm: initialData.gthr_nm,
+        gthr_type_enm: initialData.gthr_type_enm as CreateGthrInput["gthr_type_enm"],
+        sprt_cd: (initialData.sprt_cd ?? "running") as CreateGthrInput["sprt_cd"],
+        stt_at: toDatetimeLocal(initialData.stt_at),
+        end_at: initialData.end_at ? toDatetimeLocal(initialData.end_at) : null,
+        loc_txt: initialData.loc_txt ?? null,
+        desc_txt: initialData.desc_txt ?? null,
+        max_prt_cnt: initialData.max_prt_cnt ?? undefined,
       });
-    } else if (mode === "create") {
+    } else {
       // sessionStorage 저장값이 없을 때만 기본값으로 초기화 (useFormPersist가 복원 처리)
       const hasDraft = (() => { try { return !!sessionStorage.getItem(persistKey); } catch { return false; } })();
       if (!hasDraft) {
+        const defaultSttAt = defaultDate
+          ? `${defaultDate}T${dayjs().tz("Asia/Seoul").add(1, "hour").startOf("hour").format("HH:mm")}`
+          : dayjs().tz("Asia/Seoul").add(1, "hour").startOf("hour").format("YYYY-MM-DDTHH:mm");
         form.reset({
-          sch_nm: "",
-          post_type: defaultPostType ?? undefined,
-          evt_stt_at: initialData?.evt_stt_at ? toDateInput(initialData.evt_stt_at) : "",
-          evt_end_at: null,
-          url: null,
-          cont_txt: null,
+          gthr_nm: "",
+          gthr_type_enm: "general",
+          sprt_cd: "running",
+          stt_at: defaultSttAt,
+          end_at: null,
+          loc_txt: null,
+          desc_txt: null,
         });
       }
     }
-  }, [open, mode, initialData, defaultPostType, form, persistKey]);
+  }, [open, mode, initialData, defaultDate, form, persistKey]);
 
   async function onSubmit(values: FormValues) {
     setRootError(null);
     try {
-      if (mode === "create") {
-        await createSchPost({
-          sch_nm: values.sch_nm,
-          post_type: values.post_type,
-          evt_stt_at: values.evt_stt_at,
-          evt_end_at: values.evt_end_at ?? null,
-          url: values.url ?? null,
-          cont_txt: values.cont_txt ?? null,
-        });
+      if (mode === "edit" && initialData) {
+        await updateGathering({ gthr_id: initialData.gthr_id, ...values });
       } else {
-        if (!initialData?.sch_post_id) return;
-        await updateSchPost({
-          sch_post_id: initialData.sch_post_id,
-          sch_nm: values.sch_nm,
-          post_type: values.post_type,
-          evt_stt_at: values.evt_stt_at,
-          evt_end_at: values.evt_end_at ?? null,
-          url: values.url ?? null,
-          cont_txt: values.cont_txt ?? null,
-        });
+        await createGathering(values);
       }
       clearDraft();
       onOpenChange(false);
       onSuccess?.();
-    } catch (err) {
-      setRootError(err instanceof Error ? err.message : "오류가 발생했습니다. 다시 시도해 주세요.");
+    } catch (e) {
+      setRootError(e instanceof Error ? e.message : "오류가 발생했습니다. 다시 시도해 주세요.");
     }
   }
 
   return (
     <Dialog open={open} onOpenChange={(v) => { if (!v) { setRootError(null); clearDraft(); } onOpenChange(v); }}>
       <DialogContent className="flex max-h-[85dvh] flex-col gap-0 p-0">
-
         <DialogHeader className="px-5 pb-3 pt-5">
-          <DialogTitle>{mode === "create" ? "정보 추가" : "정보 수정"}</DialogTitle>
+          <DialogTitle>{mode === "create" ? "모임 추가" : "모임 수정"}</DialogTitle>
         </DialogHeader>
 
         <Separator />
 
         <Form {...form}>
           <form onSubmit={form.handleSubmit(onSubmit)} className="flex flex-col gap-4 overflow-y-auto px-5 py-4">
+
+            {/* 제목 */}
             <FormField
               control={form.control}
-              name="sch_nm"
+              name="gthr_nm"
               render={({ field }) => (
                 <FormItem>
                   <FormLabel>제목 <span className="text-destructive">*</span></FormLabel>
                   <FormControl>
-                    <Input placeholder="예: 동아마라톤 접수, 나이키 슈퍼위크 등" {...field} />
+                    <Input placeholder="예: 양재천 자유러닝" {...field} />
                   </FormControl>
                   <FormMessage />
                 </FormItem>
               )}
             />
 
+            {/* 시작/종료일시 */}
             <div className="grid grid-cols-2 gap-3">
               <FormField
                 control={form.control}
-                name="evt_stt_at"
+                name="stt_at"
                 render={({ field }) => (
                   <FormItem>
                     <FormLabel>시작일시 <span className="text-destructive">*</span></FormLabel>
@@ -214,7 +214,7 @@ export function SchPostFormDialog({
               />
               <FormField
                 control={form.control}
-                name="evt_end_at"
+                name="end_at"
                 render={({ field }) => (
                   <FormItem>
                     <FormLabel>종료일시</FormLabel>
@@ -247,22 +247,43 @@ export function SchPostFormDialog({
               />
             </div>
 
-            <div className="grid grid-cols-2 gap-3">
+            {/* 장소 */}
+            <FormField
+              control={form.control}
+              name="loc_txt"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>장소</FormLabel>
+                  <FormControl>
+                    <Input
+                      placeholder="예: 여의도역 9호선 B1 클룸보관함"
+                      {...field}
+                      value={field.value ?? ""}
+                      onChange={(e) => field.onChange(e.target.value || null)}
+                    />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+
+            {/* 유형 / 종목 / 최대 인원 */}
+            <div className="grid grid-cols-3 gap-3">
               <FormField
                 control={form.control}
-                name="post_type"
+                name="gthr_type_enm"
                 render={({ field }) => (
                   <FormItem>
                     <FormLabel>유형 <span className="text-destructive">*</span></FormLabel>
                     <FormControl>
-                      <Select value={field.value ?? ""} onValueChange={field.onChange}>
+                      <Select value={field.value ?? "general"} onValueChange={field.onChange}>
                         <SelectTrigger className="text-[13px]">
-                          <SelectValue placeholder="유형 선택" />
+                          <SelectValue placeholder="유형" />
                         </SelectTrigger>
                         <SelectContent>
-                          {SCH_POST_TYPES.map((type) => (
-                            <SelectItem key={type} value={type}>
-                              {schPostTypeLabels[type]}
+                          {GTHR_TYPES.map((t) => (
+                            <SelectItem key={t} value={t}>
+                              {gthrTypeLabels[t]}
                             </SelectItem>
                           ))}
                         </SelectContent>
@@ -274,18 +295,42 @@ export function SchPostFormDialog({
               />
               <FormField
                 control={form.control}
-                name="url"
+                name="sprt_cd"
                 render={({ field }) => (
                   <FormItem>
-                    <FormLabel>링크</FormLabel>
+                    <FormLabel>종목 <span className="text-destructive">*</span></FormLabel>
+                    <FormControl>
+                      <Select value={field.value ?? ""} onValueChange={field.onChange}>
+                        <SelectTrigger className="text-[13px]">
+                          <SelectValue placeholder="종목" />
+                        </SelectTrigger>
+                        <SelectContent>
+                          {GTHR_SPRT_TYPES.map((t) => (
+                            <SelectItem key={t} value={t}>
+                              {gthrSprtLabels[t]}
+                            </SelectItem>
+                          ))}
+                        </SelectContent>
+                      </Select>
+                    </FormControl>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+              <FormField
+                control={form.control}
+                name="max_prt_cnt"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>최대 인원</FormLabel>
                     <FormControl>
                       <Input
-                        type="url"
-                        placeholder="https://"
+                        type="number"
+                        placeholder="제한 없음"
                         className="text-[13px]"
                         {...field}
                         value={field.value ?? ""}
-                        onChange={(e) => field.onChange(e.target.value || null)}
+                        onChange={(e) => field.onChange(e.target.value ? parseInt(e.target.value, 10) : null)}
                       />
                     </FormControl>
                     <FormMessage />
@@ -294,16 +339,17 @@ export function SchPostFormDialog({
               />
             </div>
 
+            {/* 비고 */}
             <FormField
               control={form.control}
-              name="cont_txt"
+              name="desc_txt"
               render={({ field }) => (
                 <FormItem>
-                  <FormLabel>내용</FormLabel>
+                  <FormLabel>비고</FormLabel>
                   <FormControl>
                     <textarea
                       rows={4}
-                      placeholder="내용을 입력해 주세요."
+                      placeholder="공지, 준비물, 링크 등 자유롭게 입력"
                       className="flex w-full resize-none rounded-md border border-input bg-transparent px-3 py-2 text-[13px] shadow-sm placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-50"
                       {...field}
                       value={field.value ?? ""}
@@ -334,13 +380,4 @@ export function SchPostFormDialog({
       </DialogContent>
     </Dialog>
   );
-}
-
-function toDatetimeLocal(isoString: string): string {
-  return dayjs(isoString).format("YYYY-MM-DDTHH:mm");
-}
-
-function toDateInput(value: string): string {
-  if (value.length === 10) return `${value}T00:00`;
-  return toDatetimeLocal(value);
 }

--- a/components/schedule/sch-post-detail-dialog.tsx
+++ b/components/schedule/sch-post-detail-dialog.tsx
@@ -168,7 +168,7 @@ export function SchPostDetailDialog({
       <ShareSheet
         open={shareOpen}
         onOpenChange={setShareOpen}
-        title={post.title}
+        title={`[${post.title}]`}
         timeLabel={timeLabel}
         contentUrl={post.url ?? undefined}
         contentSnippet={post.cont_txt ?? undefined}

--- a/lib/hooks/use-form-persist.ts
+++ b/lib/hooks/use-form-persist.ts
@@ -35,17 +35,21 @@ export function useFormPersist<T extends FieldValues>(
   // 값 변경 시 저장 (300ms debounce)
   useEffect(() => {
     if (!open) return
+    let timer: ReturnType<typeof setTimeout> | null = null
     const sub = form.watch((values) => {
-      const timer = setTimeout(() => {
+      if (timer) clearTimeout(timer)
+      timer = setTimeout(() => {
         try {
           sessionStorage.setItem(key, JSON.stringify(values))
         } catch {
           // 저장 실패 시 무시
         }
       }, 300)
-      return () => clearTimeout(timer)
     })
-    return () => sub.unsubscribe()
+    return () => {
+      sub.unsubscribe()
+      if (timer) clearTimeout(timer)
+    }
   }, [key, open, form])
 
   return {

--- a/lib/hooks/use-form-persist.ts
+++ b/lib/hooks/use-form-persist.ts
@@ -1,0 +1,56 @@
+"use client"
+
+import { useEffect } from "react"
+import type { UseFormReturn, FieldValues, DefaultValues } from "react-hook-form"
+
+/**
+ * 폼 값을 sessionStorage에 자동 저장/복원합니다.
+ * iOS PWA 백그라운드 전환 시 탭 언로드로 폼이 초기화되는 문제를 방지합니다.
+ *
+ * - open=true 시: sessionStorage에 저장된 값이 있으면 복원
+ * - 값 변경 시: 300ms debounce로 sessionStorage에 저장
+ * - clear(): 제출 성공 또는 닫기 시 저장값 삭제
+ */
+export function useFormPersist<T extends FieldValues>(
+  key: string,
+  form: UseFormReturn<T>,
+  open: boolean,
+) {
+  // open 시 복원
+  useEffect(() => {
+    if (!open) return
+    try {
+      const saved = sessionStorage.getItem(key)
+      if (saved) {
+        const parsed = JSON.parse(saved) as DefaultValues<T>
+        form.reset(parsed)
+      }
+    } catch {
+      // sessionStorage 파싱 실패 시 무시
+    }
+  // form.reset은 안정적인 참조가 아니므로 의존성에서 제외
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [key, open])
+
+  // 값 변경 시 저장 (300ms debounce)
+  useEffect(() => {
+    if (!open) return
+    const sub = form.watch((values) => {
+      const timer = setTimeout(() => {
+        try {
+          sessionStorage.setItem(key, JSON.stringify(values))
+        } catch {
+          // 저장 실패 시 무시
+        }
+      }, 300)
+      return () => clearTimeout(timer)
+    })
+    return () => sub.unsubscribe()
+  }, [key, open, form])
+
+  return {
+    clear: () => {
+      try { sessionStorage.removeItem(key) } catch { /* 무시 */ }
+    },
+  }
+}

--- a/lib/supabase/database.types.ts
+++ b/lib/supabase/database.types.ts
@@ -1336,6 +1336,111 @@ export type Database = {
           },
         ]
       }
+      gthr_attd_rel: {
+        Row: {
+          attd_id: string
+          crt_at: string
+          gthr_id: string
+          mem_id: string
+        }
+        Insert: {
+          attd_id?: string
+          crt_at?: string
+          gthr_id: string
+          mem_id: string
+        }
+        Update: {
+          attd_id?: string
+          crt_at?: string
+          gthr_id?: string
+          mem_id?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "gthr_attd_rel_gthr_id_fkey"
+            columns: ["gthr_id"]
+            isOneToOne: false
+            referencedRelation: "gthr_mst"
+            referencedColumns: ["gthr_id"]
+          },
+          {
+            foreignKeyName: "gthr_attd_rel_mem_id_fkey"
+            columns: ["mem_id"]
+            isOneToOne: false
+            referencedRelation: "mem_mst"
+            referencedColumns: ["mem_id"]
+          },
+        ]
+      }
+      gthr_mst: {
+        Row: {
+          crt_at: string
+          crt_by: string
+          del_yn: boolean
+          desc_txt: string | null
+          end_at: string | null
+          gthr_id: string
+          gthr_nm: string
+          gthr_type_enm: string
+          loc_txt: string | null
+          max_prt_cnt: number | null
+          short_id: string
+          sprt_cd: string | null
+          stt_at: string
+          team_id: string
+          upd_at: string
+        }
+        Insert: {
+          crt_at?: string
+          crt_by: string
+          del_yn?: boolean
+          desc_txt?: string | null
+          end_at?: string | null
+          gthr_id?: string
+          gthr_nm: string
+          gthr_type_enm: string
+          loc_txt?: string | null
+          max_prt_cnt?: number | null
+          short_id?: string
+          sprt_cd?: string | null
+          stt_at: string
+          team_id: string
+          upd_at?: string
+        }
+        Update: {
+          crt_at?: string
+          crt_by?: string
+          del_yn?: boolean
+          desc_txt?: string | null
+          end_at?: string | null
+          gthr_id?: string
+          gthr_nm?: string
+          gthr_type_enm?: string
+          loc_txt?: string | null
+          max_prt_cnt?: number | null
+          short_id?: string
+          sprt_cd?: string | null
+          stt_at?: string
+          team_id?: string
+          upd_at?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "gthr_mst_crt_by_fkey"
+            columns: ["crt_by"]
+            isOneToOne: false
+            referencedRelation: "mem_mst"
+            referencedColumns: ["mem_id"]
+          },
+          {
+            foreignKeyName: "gthr_mst_team_id_fkey"
+            columns: ["team_id"]
+            isOneToOne: false
+            referencedRelation: "team_mst"
+            referencedColumns: ["team_id"]
+          },
+        ]
+      }
       mem_mst: {
         Row: {
           avatar_url: string | null
@@ -2035,6 +2140,47 @@ export type Database = {
           stt_dt: string
         }[]
       }
+      get_public_team_gatherings:
+        | {
+            Args: { p_end?: string; p_start?: string; p_team_id: string }
+            Returns: {
+              attd_count: number
+              cmnt_count: number
+              crt_by: string
+              crt_by_nm: string
+              desc_txt: string
+              end_at: string
+              gthr_id: string
+              gthr_nm: string
+              gthr_type_enm: string
+              loc_txt: string
+              short_id: string
+              stt_at: string
+            }[]
+          }
+        | {
+            Args: {
+              p_end?: string
+              p_mem_id?: string
+              p_start?: string
+              p_team_id: string
+            }
+            Returns: {
+              attd_count: number
+              cmnt_count: number
+              crt_by: string
+              crt_by_nm: string
+              desc_txt: string
+              end_at: string
+              gthr_id: string
+              gthr_nm: string
+              gthr_type_enm: string
+              is_attending: boolean
+              loc_txt: string
+              short_id: string
+              stt_at: string
+            }[]
+          }
       get_public_team_member_stats: {
         Args: { p_team_id: string }
         Returns: {
@@ -2113,6 +2259,7 @@ export type Database = {
           loc_nm: string
           post_type: string
           reg_count: number
+          short_id: string
           start_date: string
           url: string
         }[]

--- a/lib/validations/gathering.ts
+++ b/lib/validations/gathering.ts
@@ -1,0 +1,39 @@
+import { z } from "zod";
+
+export const GTHR_TYPES = ["general", "regular", "event"] as const;
+export type GthrType = (typeof GTHR_TYPES)[number];
+
+export const gthrTypeLabels: Record<GthrType, string> = {
+  general: "일반",
+  regular: "정기",
+  event: "이벤트",
+};
+
+export const GTHR_SPRT_TYPES = ["running", "trail_run", "swimming", "cycling"] as const;
+export type GthrSprtType = (typeof GTHR_SPRT_TYPES)[number];
+
+export const gthrSprtLabels: Record<GthrSprtType, string> = {
+  running: "러닝",
+  trail_run: "트레일러닝",
+  swimming: "수영",
+  cycling: "자전거",
+};
+
+export const createGthrSchema = z.object({
+  team_id: z.string().uuid(),
+  gthr_nm: z.string().min(1, "제목을 입력해 주세요.").max(100, "제목은 100자 이내로 입력해 주세요."),
+  gthr_type_enm: z.enum(GTHR_TYPES, { message: "유형을 선택해 주세요." }),
+  sprt_cd: z.enum(GTHR_SPRT_TYPES, { message: "종목을 선택해 주세요." }),
+  stt_at: z.string().min(1, "시작 일시를 입력해 주세요."),
+  end_at: z.string().nullable().optional(),
+  loc_txt: z.string().max(200).nullable().optional(),
+  desc_txt: z.string().max(2000).nullable().optional(),
+  max_prt_cnt: z.number().int().min(1, "최대 인원은 1명 이상이어야 합니다.").nullable().optional(),
+});
+
+export const updateGthrSchema = createGthrSchema.omit({ team_id: true }).partial().extend({
+  gthr_id: z.string().uuid(),
+});
+
+export type CreateGthrInput = z.infer<typeof createGthrSchema>;
+export type UpdateGthrInput = z.infer<typeof updateGthrSchema>;

--- a/supabase/migrations/20260620100000_gthr_mst.sql
+++ b/supabase/migrations/20260620100000_gthr_mst.sql
@@ -1,0 +1,82 @@
+-- ============================================================
+-- gthr_mst — 모임 마스터
+-- 팀 멤버 누구나 개설할 수 있는 러닝 모임 (일반/정기/이벤트)
+-- 댓글: cmnt_mst entity_type='gathering' 공용 테이블 사용
+-- ============================================================
+
+CREATE TABLE public.gthr_mst (
+  gthr_id      uuid        PRIMARY KEY DEFAULT gen_random_uuid(),
+  team_id      uuid        NOT NULL REFERENCES public.team_mst(team_id),
+  gthr_type_enm text       NOT NULL CHECK (gthr_type_enm IN ('general', 'regular', 'event')),
+  gthr_nm      text        NOT NULL,
+  desc_txt     text,
+  loc_txt      text,
+  stt_at       timestamptz NOT NULL,
+  end_at       timestamptz,
+  max_prt_cnt  int,
+  crt_by       uuid        NOT NULL REFERENCES public.mem_mst(mem_id),
+  del_yn       boolean     NOT NULL DEFAULT false,
+  crt_at       timestamptz NOT NULL DEFAULT now(),
+  upd_at       timestamptz NOT NULL DEFAULT now()
+);
+
+COMMENT ON TABLE  public.gthr_mst              IS '모임 마스터 (팀 멤버 누구나 개설)';
+COMMENT ON COLUMN public.gthr_mst.gthr_id      IS 'PK';
+COMMENT ON COLUMN public.gthr_mst.team_id      IS '소속 팀 (team_mst FK)';
+COMMENT ON COLUMN public.gthr_mst.gthr_type_enm IS '모임 유형: general(일반) | regular(정기) | event(이벤트)';
+COMMENT ON COLUMN public.gthr_mst.gthr_nm      IS '모임명 (필수)';
+COMMENT ON COLUMN public.gthr_mst.desc_txt     IS '모임 설명 (선택)';
+COMMENT ON COLUMN public.gthr_mst.loc_txt      IS '장소 (선택)';
+COMMENT ON COLUMN public.gthr_mst.stt_at       IS '모임 시작 일시 (필수)';
+COMMENT ON COLUMN public.gthr_mst.end_at       IS '모임 종료 일시 (선택)';
+COMMENT ON COLUMN public.gthr_mst.max_prt_cnt  IS '최대 참석 인원 (null=제한없음)';
+COMMENT ON COLUMN public.gthr_mst.crt_by       IS '개설자 mem_id (mem_mst FK)';
+COMMENT ON COLUMN public.gthr_mst.del_yn       IS '삭제여부 (soft delete)';
+COMMENT ON COLUMN public.gthr_mst.crt_at       IS '생성 일시';
+COMMENT ON COLUMN public.gthr_mst.upd_at       IS '수정 일시';
+
+-- 홈 탭 캘린더 조회용: 팀 + 날짜 기준 활성 모임 목록
+CREATE INDEX ix_gthr_mst_team_stt_at
+  ON public.gthr_mst(team_id, stt_at ASC)
+  WHERE del_yn = false;
+
+-- 개설자 기준 내 모임 조회
+CREATE INDEX ix_gthr_mst_crt_by
+  ON public.gthr_mst(crt_by)
+  WHERE del_yn = false;
+
+-- ============================================================
+-- RLS
+-- ============================================================
+
+ALTER TABLE public.gthr_mst ENABLE ROW LEVEL SECURITY;
+
+-- SELECT: 팀 멤버 전체 조회 (del_yn=false만)
+CREATE POLICY gthr_mst_select ON public.gthr_mst
+  FOR SELECT TO authenticated
+  USING (del_yn = false AND public.v2_rls_auth_in_team(team_id));
+
+-- INSERT: 팀 멤버 누구나 개설 (본인 crt_by로만)
+CREATE POLICY gthr_mst_insert ON public.gthr_mst
+  FOR INSERT TO authenticated
+  WITH CHECK (
+    crt_by = public.v2_rls_resolve_mem_id()
+    AND del_yn = false
+    AND public.v2_rls_auth_in_team(team_id)
+  );
+
+-- UPDATE: 개설자 본인 또는 팀 owner/admin (수정 및 soft delete 포함)
+CREATE POLICY gthr_mst_update ON public.gthr_mst
+  FOR UPDATE TO authenticated
+  USING (
+    crt_by = public.v2_rls_resolve_mem_id()
+    OR public.v2_rls_auth_team_owner_or_admin(team_id)
+  )
+  WITH CHECK (
+    crt_by = public.v2_rls_resolve_mem_id()
+    OR public.v2_rls_auth_team_owner_or_admin(team_id)
+  );
+
+COMMENT ON POLICY gthr_mst_select ON public.gthr_mst IS '팀 멤버만 조회 (삭제된 모임 제외)';
+COMMENT ON POLICY gthr_mst_insert ON public.gthr_mst IS '팀 멤버 누구나 모임 개설 가능';
+COMMENT ON POLICY gthr_mst_update ON public.gthr_mst IS '개설자 본인 또는 팀 owner/admin만 수정·soft delete 가능';

--- a/supabase/migrations/20260620110000_gthr_attd_rel.sql
+++ b/supabase/migrations/20260620110000_gthr_attd_rel.sql
@@ -1,0 +1,66 @@
+-- ============================================================
+-- gthr_attd_rel — 모임 참석 관계
+-- 팀 멤버가 모임에 참석 등록/취소하는 M:N 관계 테이블
+-- ============================================================
+
+CREATE TABLE public.gthr_attd_rel (
+  attd_id  uuid        PRIMARY KEY DEFAULT gen_random_uuid(),
+  gthr_id  uuid        NOT NULL REFERENCES public.gthr_mst(gthr_id),
+  mem_id   uuid        NOT NULL REFERENCES public.mem_mst(mem_id),
+  crt_at   timestamptz NOT NULL DEFAULT now(),
+  UNIQUE (gthr_id, mem_id)
+);
+
+COMMENT ON TABLE  public.gthr_attd_rel         IS '모임 참석 관계 (참석 등록/취소)';
+COMMENT ON COLUMN public.gthr_attd_rel.attd_id IS 'PK';
+COMMENT ON COLUMN public.gthr_attd_rel.gthr_id IS '모임 ID (gthr_mst FK)';
+COMMENT ON COLUMN public.gthr_attd_rel.mem_id  IS '참석자 mem_id (mem_mst FK)';
+COMMENT ON COLUMN public.gthr_attd_rel.crt_at  IS '참석 등록 일시';
+
+-- 참석자 목록 조회용
+CREATE INDEX ix_gthr_attd_rel_gthr
+  ON public.gthr_attd_rel(gthr_id);
+
+-- 내 참석 목록 조회용
+CREATE INDEX ix_gthr_attd_rel_mem
+  ON public.gthr_attd_rel(mem_id);
+
+-- ============================================================
+-- RLS
+-- ============================================================
+
+ALTER TABLE public.gthr_attd_rel ENABLE ROW LEVEL SECURITY;
+
+-- SELECT: 팀 멤버 (gthr_mst 통해 team_id 확인)
+CREATE POLICY gthr_attd_rel_select ON public.gthr_attd_rel
+  FOR SELECT TO authenticated
+  USING (
+    EXISTS (
+      SELECT 1 FROM public.gthr_mst g
+      WHERE g.gthr_id = gthr_attd_rel.gthr_id
+        AND g.del_yn = false
+        AND public.v2_rls_auth_in_team(g.team_id)
+    )
+  );
+
+-- INSERT: 본인만 참석 등록 (같은 팀 모임에만)
+CREATE POLICY gthr_attd_rel_insert ON public.gthr_attd_rel
+  FOR INSERT TO authenticated
+  WITH CHECK (
+    mem_id = public.v2_rls_resolve_mem_id()
+    AND EXISTS (
+      SELECT 1 FROM public.gthr_mst g
+      WHERE g.gthr_id = gthr_attd_rel.gthr_id
+        AND g.del_yn = false
+        AND public.v2_rls_auth_in_team(g.team_id)
+    )
+  );
+
+-- DELETE: 본인 참석 취소
+CREATE POLICY gthr_attd_rel_delete ON public.gthr_attd_rel
+  FOR DELETE TO authenticated
+  USING (mem_id = public.v2_rls_resolve_mem_id());
+
+COMMENT ON POLICY gthr_attd_rel_select ON public.gthr_attd_rel IS '팀 멤버만 참석 목록 조회';
+COMMENT ON POLICY gthr_attd_rel_insert ON public.gthr_attd_rel IS '본인만 같은 팀 모임에 참석 등록';
+COMMENT ON POLICY gthr_attd_rel_delete ON public.gthr_attd_rel IS '본인만 참석 취소';

--- a/supabase/migrations/20260620120000_gthr_noti_types.sql
+++ b/supabase/migrations/20260620120000_gthr_noti_types.sql
@@ -1,0 +1,24 @@
+-- ============================================================
+-- gthr_noti_types — 모임(gathering) 관련 알림 타입 추가
+-- 기존 noti_mst.noti_type_enm CHECK 제약에 gathering 타입 6개 추가
+--
+-- 추가 타입:
+--   gthr_new     — 신규 모임 생성 알림 (팀 전체 멤버)
+--   gthr_upd     — 모임 정보 수정 알림 (참석자)
+--   gthr_del     — 모임 삭제 알림 (참석자)
+--   gthr_cmnt    — 개설자 모임 댓글 알림 (참석자)
+--   gthr_reply   — 내 댓글에 답글 알림 (원댓글 작성자)
+--   gthr_mention — 댓글 멘션 알림 (멘션된 멤버)
+-- ============================================================
+
+ALTER TABLE public.noti_mst
+  DROP CONSTRAINT IF EXISTS noti_mst_noti_type_enm_check;
+
+ALTER TABLE public.noti_mst
+  ADD CONSTRAINT noti_mst_noti_type_enm_check
+  CHECK (noti_type_enm IN (
+    'ttl_grnt', 'adm_cust', 'dues_check_req', 'dues_notice',
+    'cmnt_reply', 'cmnt_mention', 'sch_post_cmnt', 'sch_post_new',
+    'gthr_new', 'gthr_upd', 'gthr_del',
+    'gthr_cmnt', 'gthr_reply', 'gthr_mention'
+  ));

--- a/supabase/migrations/20260620130000_gthr_schedule_paged.sql
+++ b/supabase/migrations/20260620130000_gthr_schedule_paged.sql
@@ -1,0 +1,318 @@
+-- ============================================================
+-- gthr_schedule_paged — 모임(gathering)을 일정 스케줄에 통합
+--
+-- 1. get_schedule_paged: gthr_mst UNION ALL 추가
+--    - item_type = 'gathering' (미참석) | 'gathering_mine' (참석)
+--    - month_candidates CTE에 gathering 날짜 포함 (빈 달 스킵 정확성)
+--    - gthr_agg CTE: 모임별 참석자/댓글 수 사전 집계 (서브쿼리 N+1 제거)
+--
+-- 2. get_public_team_gatherings: 달력 마크용 모임 조회 RPC
+--    - LEFT JOIN 집계로 서브쿼리 N+1 제거
+--    - stt_at BETWEEN 범위 비교로 ix_gthr_mst_team_stt_at 인덱스 활용
+-- ============================================================
+
+-- ── 1. get_schedule_paged: gathering 소스 추가 ──────────────
+
+CREATE OR REPLACE FUNCTION public.get_schedule_paged(
+  p_team_id     uuid,
+  p_direction   text,         -- 'prev' | 'next'
+  p_cursor_date date,         -- prev: 가장 오래된 달의 1일, next: 가장 최근 달의 말일
+  p_mem_id      uuid DEFAULT NULL,
+  p_month_limit int  DEFAULT 2
+)
+RETURNS TABLE (
+  item_type  text,
+  item_id    uuid,
+  item_nm    text,
+  post_type  text,
+  start_date date,
+  end_date   date,
+  loc_nm     text,
+  url        text,
+  cont_txt   text,
+  evt_stt_at timestamptz,
+  evt_end_at timestamptz,
+  crt_by     uuid,
+  crt_by_nm  text,
+  reg_count  bigint,
+  cmnt_count bigint
+)
+LANGUAGE sql
+STABLE
+SECURITY DEFINER
+SET search_path = public
+AS $$
+WITH
+-- 멤버 본인 등록 대회 목록
+my_regs AS (
+  SELECT DISTINCT team_comp_id
+  FROM public.comp_reg_rel
+  WHERE mem_id = p_mem_id
+    AND vers = 0
+    AND del_yn = false
+),
+
+-- 멤버 본인 참석 모임 목록
+my_attd AS (
+  SELECT DISTINCT gthr_id
+  FROM public.gthr_attd_rel
+  WHERE mem_id = p_mem_id
+),
+
+-- 공유 일정 날짜 (방향 기준 필터)
+sch_dates AS (
+  SELECT (s.evt_stt_at AT TIME ZONE 'Asia/Seoul')::date AS event_date
+  FROM public.sch_post_mst s
+  WHERE s.team_id = p_team_id
+    AND s.del_yn = false
+    AND (
+      (p_direction = 'prev' AND (s.evt_stt_at AT TIME ZONE 'Asia/Seoul')::date < p_cursor_date) OR
+      (p_direction = 'next' AND (s.evt_stt_at AT TIME ZONE 'Asia/Seoul')::date > p_cursor_date)
+    )
+),
+
+-- 대회 날짜 (참가자 있거나 본인 등록)
+comp_dates AS (
+  SELECT DISTINCT c.stt_dt AS event_date
+  FROM public.team_comp_plan_rel tcp
+  JOIN public.comp_mst c ON c.comp_id = tcp.comp_id AND c.vers = 0 AND c.del_yn = false
+  WHERE tcp.team_id = p_team_id
+    AND tcp.vers = 0
+    AND tcp.del_yn = false
+    AND (
+      (p_direction = 'prev' AND c.stt_dt < p_cursor_date) OR
+      (p_direction = 'next' AND c.stt_dt > p_cursor_date)
+    )
+    AND (
+      EXISTS (
+        SELECT 1 FROM public.comp_reg_rel cr
+        WHERE cr.team_comp_id = tcp.team_comp_id AND cr.vers = 0 AND cr.del_yn = false
+      )
+      OR EXISTS (
+        SELECT 1 FROM my_regs mr WHERE mr.team_comp_id = tcp.team_comp_id
+      )
+    )
+),
+
+-- 모임 날짜 (방향 기준 필터)
+gthr_dates AS (
+  SELECT (g.stt_at AT TIME ZONE 'Asia/Seoul')::date AS event_date
+  FROM public.gthr_mst g
+  WHERE g.team_id = p_team_id
+    AND g.del_yn = false
+    AND (
+      (p_direction = 'prev' AND (g.stt_at AT TIME ZONE 'Asia/Seoul')::date < p_cursor_date) OR
+      (p_direction = 'next' AND (g.stt_at AT TIME ZONE 'Asia/Seoul')::date > p_cursor_date)
+    )
+),
+
+-- 이벤트가 있는 달 후보 (세 소스 합산)
+month_candidates AS (
+  SELECT DISTINCT DATE_TRUNC('month', event_date)::date AS month_start
+  FROM (
+    SELECT event_date FROM sch_dates
+    UNION
+    SELECT event_date FROM comp_dates
+    UNION
+    SELECT event_date FROM gthr_dates
+  ) all_dates
+),
+
+-- 방향에 따라 N달 선택 (prev: 최근순 DESC, next: 오래된순 ASC)
+target_months AS (
+  ( SELECT month_start FROM month_candidates WHERE p_direction = 'prev' ORDER BY month_start DESC LIMIT p_month_limit )
+  UNION ALL
+  ( SELECT month_start FROM month_candidates WHERE p_direction = 'next' ORDER BY month_start ASC  LIMIT p_month_limit )
+),
+
+-- 선택된 달들의 실제 조회 범위
+date_range AS (
+  SELECT
+    MIN(month_start)                                                  AS range_start,
+    (MAX(month_start) + interval '1 month' - interval '1 day')::date AS range_end
+  FROM target_months
+),
+
+-- 모임별 참석자 수·댓글 수 사전 집계 (서브쿼리 N+1 제거)
+gthr_agg AS (
+  SELECT
+    g.gthr_id,
+    COUNT(DISTINCT ar.attd_id) AS attd_count,
+    COUNT(DISTINCT cm.cmnt_id) AS cmnt_count
+  FROM public.gthr_mst g
+  CROSS JOIN date_range
+  LEFT JOIN public.gthr_attd_rel ar ON ar.gthr_id = g.gthr_id
+  LEFT JOIN public.cmnt_mst cm
+    ON cm.entity_type = 'gathering'
+   AND cm.entity_id   = g.gthr_id
+   AND cm.del_yn      = false
+  WHERE g.team_id = p_team_id
+    AND g.del_yn  = false
+    AND date_range.range_start IS NOT NULL
+    AND g.stt_at >= (date_range.range_start::timestamptz AT TIME ZONE 'Asia/Seoul')
+    AND g.stt_at <  ((date_range.range_end::timestamptz + interval '1 day') AT TIME ZONE 'Asia/Seoul')
+  GROUP BY g.gthr_id
+)
+
+-- 공유 일정
+SELECT
+  'sch_post'::text                                AS item_type,
+  s.sch_post_id                                  AS item_id,
+  s.sch_nm                                       AS item_nm,
+  s.post_type,
+  (s.evt_stt_at AT TIME ZONE 'Asia/Seoul')::date AS start_date,
+  NULL::date                                     AS end_date,
+  NULL::text                                     AS loc_nm,
+  s.url,
+  s.cont_txt,
+  s.evt_stt_at,
+  s.evt_end_at,
+  s.crt_by,
+  m.mem_nm                                       AS crt_by_nm,
+  NULL::bigint                                   AS reg_count,
+  COALESCE((
+    SELECT count(*) FROM public.cmnt_mst cm
+    WHERE cm.entity_type = 'sch_post' AND cm.entity_id = s.sch_post_id AND cm.del_yn = false
+  ), 0)                                          AS cmnt_count
+FROM public.sch_post_mst s
+CROSS JOIN date_range
+LEFT JOIN public.mem_mst m ON m.mem_id = s.crt_by
+WHERE s.team_id = p_team_id
+  AND s.del_yn = false
+  AND date_range.range_start IS NOT NULL
+  AND (s.evt_stt_at AT TIME ZONE 'Asia/Seoul')::date BETWEEN date_range.range_start AND date_range.range_end
+
+UNION ALL
+
+-- 대회 (참가자 있거나 본인 등록, 중복 없이)
+SELECT
+  CASE WHEN mr.team_comp_id IS NOT NULL THEN 'mine' ELSE 'comp' END AS item_type,
+  c.comp_id                                                          AS item_id,
+  c.comp_nm                                                          AS item_nm,
+  NULL::text                                                         AS post_type,
+  c.stt_dt                                                           AS start_date,
+  c.end_dt                                                           AS end_date,
+  c.loc_nm,
+  c.src_url                                                          AS url,
+  NULL::text                                                         AS cont_txt,
+  NULL::timestamptz                                                  AS evt_stt_at,
+  NULL::timestamptz                                                  AS evt_end_at,
+  NULL::uuid                                                         AS crt_by,
+  NULL::text                                                         AS crt_by_nm,
+  count(DISTINCT cr.comp_reg_id)                                     AS reg_count,
+  COALESCE((
+    SELECT count(*) FROM public.cmnt_mst cm
+    WHERE cm.entity_type = 'comp' AND cm.entity_id = c.comp_id AND cm.del_yn = false
+  ), 0)                                                              AS cmnt_count
+FROM public.team_comp_plan_rel tcp
+JOIN public.comp_mst c
+  ON c.comp_id = tcp.comp_id AND c.vers = 0 AND c.del_yn = false
+CROSS JOIN date_range
+LEFT JOIN public.comp_reg_rel cr
+  ON cr.team_comp_id = tcp.team_comp_id AND cr.vers = 0 AND cr.del_yn = false
+LEFT JOIN my_regs mr
+  ON mr.team_comp_id = tcp.team_comp_id
+WHERE tcp.team_id = p_team_id
+  AND tcp.vers = 0
+  AND tcp.del_yn = false
+  AND date_range.range_start IS NOT NULL
+  AND c.stt_dt BETWEEN date_range.range_start AND date_range.range_end
+GROUP BY c.comp_id, c.comp_nm, c.stt_dt, c.end_dt, c.loc_nm, c.src_url, mr.team_comp_id
+HAVING count(DISTINCT cr.comp_reg_id) > 0 OR mr.team_comp_id IS NOT NULL
+
+UNION ALL
+
+-- 모임 (사전 집계 CTE 활용, 본인 참석 여부에 따라 gathering_mine / gathering 구분)
+SELECT
+  CASE WHEN ma.gthr_id IS NOT NULL THEN 'gathering_mine' ELSE 'gathering' END AS item_type,
+  g.gthr_id                                                                    AS item_id,
+  g.gthr_nm                                                                    AS item_nm,
+  g.gthr_type_enm                                                              AS post_type,
+  (g.stt_at AT TIME ZONE 'Asia/Seoul')::date                                  AS start_date,
+  NULL::date                                                                   AS end_date,
+  g.loc_txt                                                                    AS loc_nm,
+  NULL::text                                                                   AS url,
+  g.desc_txt                                                                   AS cont_txt,
+  g.stt_at                                                                     AS evt_stt_at,
+  g.end_at                                                                     AS evt_end_at,
+  g.crt_by,
+  m.mem_nm                                                                     AS crt_by_nm,
+  COALESCE(ga.attd_count, 0)                                                   AS reg_count,
+  COALESCE(ga.cmnt_count, 0)                                                   AS cmnt_count
+FROM public.gthr_mst g
+CROSS JOIN date_range
+LEFT JOIN public.mem_mst m   ON m.mem_id   = g.crt_by
+LEFT JOIN my_attd ma          ON ma.gthr_id  = g.gthr_id
+LEFT JOIN gthr_agg ga         ON ga.gthr_id  = g.gthr_id
+WHERE g.team_id = p_team_id
+  AND g.del_yn  = false
+  AND date_range.range_start IS NOT NULL
+  AND g.stt_at >= (date_range.range_start::timestamptz AT TIME ZONE 'Asia/Seoul')
+  AND g.stt_at <  ((date_range.range_end::timestamptz + interval '1 day') AT TIME ZONE 'Asia/Seoul')
+
+ORDER BY start_date ASC;
+$$;
+
+GRANT EXECUTE ON FUNCTION public.get_schedule_paged(uuid, text, date, uuid, int)
+  TO anon, authenticated, service_role;
+
+
+-- ── 2. get_public_team_gatherings: 달력 마크용 모임 조회 RPC ──
+
+CREATE OR REPLACE FUNCTION public.get_public_team_gatherings(
+  p_team_id uuid,
+  p_start   date DEFAULT NULL,
+  p_end     date DEFAULT NULL
+)
+RETURNS TABLE (
+  gthr_id       uuid,
+  gthr_nm       text,
+  gthr_type_enm text,
+  stt_at        timestamptz,
+  end_at        timestamptz,
+  loc_txt       text,
+  desc_txt      text,
+  crt_by        uuid,
+  crt_by_nm     text,
+  attd_count    bigint,
+  cmnt_count    bigint
+)
+LANGUAGE sql
+STABLE
+SECURITY DEFINER
+SET search_path = public
+AS $$
+  SELECT
+    g.gthr_id,
+    g.gthr_nm,
+    g.gthr_type_enm,
+    g.stt_at,
+    g.end_at,
+    g.loc_txt,
+    g.desc_txt,
+    g.crt_by,
+    m.mem_nm                              AS crt_by_nm,
+    COUNT(DISTINCT ar.attd_id)            AS attd_count,
+    COUNT(DISTINCT cm.cmnt_id)            AS cmnt_count
+  FROM public.gthr_mst g
+  LEFT JOIN public.mem_mst m
+    ON m.mem_id = g.crt_by
+  LEFT JOIN public.gthr_attd_rel ar
+    ON ar.gthr_id = g.gthr_id
+  LEFT JOIN public.cmnt_mst cm
+    ON cm.entity_type = 'gathering'
+   AND cm.entity_id   = g.gthr_id
+   AND cm.del_yn      = false
+  WHERE g.team_id  = p_team_id
+    AND g.del_yn   = false
+    AND (p_start IS NULL OR g.stt_at >= (p_start::timestamptz AT TIME ZONE 'Asia/Seoul'))
+    AND (p_end   IS NULL OR g.stt_at <  ((p_end::timestamptz + interval '1 day') AT TIME ZONE 'Asia/Seoul'))
+  GROUP BY
+    g.gthr_id, g.gthr_nm, g.gthr_type_enm,
+    g.stt_at, g.end_at, g.loc_txt, g.desc_txt, g.crt_by,
+    m.mem_nm
+  ORDER BY g.stt_at ASC;
+$$;
+
+GRANT EXECUTE ON FUNCTION public.get_public_team_gatherings(uuid, date, date)
+  TO anon, authenticated, service_role;

--- a/supabase/migrations/20260620140000_gthr_mst_add_sprt_cd.sql
+++ b/supabase/migrations/20260620140000_gthr_mst_add_sprt_cd.sql
@@ -1,0 +1,5 @@
+-- gthr_mst에 종목 컬럼 추가
+ALTER TABLE public.gthr_mst
+  ADD COLUMN IF NOT EXISTS sprt_cd text DEFAULT NULL;
+
+COMMENT ON COLUMN public.gthr_mst.sprt_cd IS '모임 종목 (running, trail_run, swimming, cycling 등 자유값, NULL=미지정)';

--- a/supabase/migrations/20260620150000_gthr_mst_add_short_id.sql
+++ b/supabase/migrations/20260620150000_gthr_mst_add_short_id.sql
@@ -1,0 +1,7 @@
+-- gthr_mst에 short_id 컬럼 추가 (nanoid 기반 딥링크용)
+ALTER TABLE public.gthr_mst
+  ADD COLUMN IF NOT EXISTS short_id text NOT NULL DEFAULT generate_nanoid();
+
+CREATE UNIQUE INDEX IF NOT EXISTS uq_gthr_mst_short_id ON public.gthr_mst(short_id);
+
+COMMENT ON COLUMN public.gthr_mst.short_id IS 'nanoid 기반 공유/딥링크용 단축 ID';

--- a/supabase/migrations/20260620160000_gthr_gatherings_rpc_add_mem_id.sql
+++ b/supabase/migrations/20260620160000_gthr_gatherings_rpc_add_mem_id.sql
@@ -1,0 +1,58 @@
+-- get_public_team_gatherings에 p_mem_id 오버로드 추가
+-- is_attending, short_id 반환 포함
+-- fan-out 방지: scalar subquery로 attd_count, cmnt_count 집계
+
+CREATE OR REPLACE FUNCTION public.get_public_team_gatherings(
+  p_team_id uuid,
+  p_start   date DEFAULT NULL,
+  p_end     date DEFAULT NULL,
+  p_mem_id  uuid DEFAULT NULL
+)
+RETURNS TABLE (
+  gthr_id       uuid,
+  short_id      text,
+  gthr_nm       text,
+  gthr_type_enm text,
+  stt_at        timestamptz,
+  end_at        timestamptz,
+  loc_txt       text,
+  desc_txt      text,
+  crt_by        uuid,
+  crt_by_nm     text,
+  attd_count    bigint,
+  cmnt_count    bigint,
+  is_attending  boolean
+)
+LANGUAGE sql
+STABLE
+SECURITY DEFINER
+SET search_path = public
+AS $$
+  SELECT
+    g.gthr_id,
+    g.short_id,
+    g.gthr_nm,
+    g.gthr_type_enm,
+    g.stt_at,
+    g.end_at,
+    g.loc_txt,
+    g.desc_txt,
+    g.crt_by,
+    m.mem_nm AS crt_by_nm,
+    (SELECT COUNT(*) FROM public.gthr_attd_rel ar WHERE ar.gthr_id = g.gthr_id) AS attd_count,
+    (SELECT COUNT(*) FROM public.cmnt_mst cm
+      WHERE cm.entity_type = 'gathering' AND cm.entity_id = g.gthr_id AND cm.del_yn = false) AS cmnt_count,
+    CASE WHEN p_mem_id IS NULL THEN false
+         ELSE EXISTS (SELECT 1 FROM public.gthr_attd_rel ar WHERE ar.gthr_id = g.gthr_id AND ar.mem_id = p_mem_id)
+    END AS is_attending
+  FROM public.gthr_mst g
+  LEFT JOIN public.mem_mst m ON m.mem_id = g.crt_by
+  WHERE g.team_id = p_team_id
+    AND g.del_yn  = false
+    AND (p_start IS NULL OR g.stt_at >= (p_start::timestamptz AT TIME ZONE 'Asia/Seoul'))
+    AND (p_end   IS NULL OR g.stt_at <  ((p_end::timestamptz + interval '1 day') AT TIME ZONE 'Asia/Seoul'))
+  ORDER BY g.stt_at ASC;
+$$;
+
+GRANT EXECUTE ON FUNCTION public.get_public_team_gatherings(uuid, date, date, uuid)
+  TO anon, authenticated, service_role;

--- a/supabase/migrations/20260621100000_fix_kst_date_boundary.sql
+++ b/supabase/migrations/20260621100000_fix_kst_date_boundary.sql
@@ -1,0 +1,277 @@
+-- ============================================================
+-- fix_kst_date_boundary
+--
+-- date를 ::timestamptz로 캐스팅하면 UTC 기준(00:00 UTC)으로 해석되어
+-- KST 경계(00:00 KST = 전날 15:00 UTC)가 어긋남.
+-- ::timestamp AT TIME ZONE 'Asia/Seoul' 패턴으로 교정.
+--
+-- 영향 함수:
+--   1. get_schedule_paged (gthr_agg CTE + gathering SELECT)
+--   2. get_public_team_gatherings (p_start/p_end 경계 비교)
+-- ============================================================
+
+-- ── 1. get_schedule_paged 재정의 ─────────────────────────────
+
+CREATE OR REPLACE FUNCTION public.get_schedule_paged(
+  p_team_id     uuid,
+  p_direction   text,
+  p_cursor_date date,
+  p_mem_id      uuid DEFAULT NULL,
+  p_month_limit int  DEFAULT 2
+)
+RETURNS TABLE (
+  item_type  text,
+  item_id    uuid,
+  item_nm    text,
+  post_type  text,
+  start_date date,
+  end_date   date,
+  loc_nm     text,
+  url        text,
+  cont_txt   text,
+  evt_stt_at timestamptz,
+  evt_end_at timestamptz,
+  crt_by     uuid,
+  crt_by_nm  text,
+  reg_count  bigint,
+  cmnt_count bigint,
+  short_id   text
+)
+LANGUAGE sql
+STABLE
+SECURITY DEFINER
+SET search_path = public
+AS $$
+WITH
+my_regs AS (
+  SELECT DISTINCT team_comp_id
+  FROM public.comp_reg_rel
+  WHERE mem_id = p_mem_id AND vers = 0 AND del_yn = false
+),
+my_attd AS (
+  SELECT DISTINCT gthr_id
+  FROM public.gthr_attd_rel
+  WHERE mem_id = p_mem_id
+),
+sch_dates AS (
+  SELECT (s.evt_stt_at AT TIME ZONE 'Asia/Seoul')::date AS event_date
+  FROM public.sch_post_mst s
+  WHERE s.team_id = p_team_id AND s.del_yn = false
+    AND (
+      (p_direction = 'prev' AND (s.evt_stt_at AT TIME ZONE 'Asia/Seoul')::date < p_cursor_date) OR
+      (p_direction = 'next' AND (s.evt_stt_at AT TIME ZONE 'Asia/Seoul')::date > p_cursor_date)
+    )
+),
+comp_dates AS (
+  SELECT DISTINCT c.stt_dt AS event_date
+  FROM public.team_comp_plan_rel tcp
+  JOIN public.comp_mst c ON c.comp_id = tcp.comp_id AND c.vers = 0 AND c.del_yn = false
+  WHERE tcp.team_id = p_team_id AND tcp.vers = 0 AND tcp.del_yn = false
+    AND (
+      (p_direction = 'prev' AND c.stt_dt < p_cursor_date) OR
+      (p_direction = 'next' AND c.stt_dt > p_cursor_date)
+    )
+    AND (
+      EXISTS (SELECT 1 FROM public.comp_reg_rel cr WHERE cr.team_comp_id = tcp.team_comp_id AND cr.vers = 0 AND cr.del_yn = false)
+      OR EXISTS (SELECT 1 FROM my_regs mr WHERE mr.team_comp_id = tcp.team_comp_id)
+    )
+),
+gthr_dates AS (
+  SELECT (g.stt_at AT TIME ZONE 'Asia/Seoul')::date AS event_date
+  FROM public.gthr_mst g
+  WHERE g.team_id = p_team_id AND g.del_yn = false
+    AND (
+      (p_direction = 'prev' AND (g.stt_at AT TIME ZONE 'Asia/Seoul')::date < p_cursor_date) OR
+      (p_direction = 'next' AND (g.stt_at AT TIME ZONE 'Asia/Seoul')::date > p_cursor_date)
+    )
+),
+month_candidates AS (
+  SELECT DISTINCT DATE_TRUNC('month', event_date)::date AS month_start
+  FROM (
+    SELECT event_date FROM sch_dates
+    UNION SELECT event_date FROM comp_dates
+    UNION SELECT event_date FROM gthr_dates
+  ) all_dates
+),
+target_months AS (
+  ( SELECT month_start FROM month_candidates WHERE p_direction = 'prev' ORDER BY month_start DESC LIMIT p_month_limit )
+  UNION ALL
+  ( SELECT month_start FROM month_candidates WHERE p_direction = 'next' ORDER BY month_start ASC  LIMIT p_month_limit )
+),
+date_range AS (
+  SELECT
+    MIN(month_start)                                                  AS range_start,
+    (MAX(month_start) + interval '1 month' - interval '1 day')::date AS range_end
+  FROM target_months
+),
+-- gthr_agg: ::timestamp AT TIME ZONE 'Asia/Seoul' 로 KST 경계 정확히 계산
+gthr_agg AS (
+  SELECT
+    g.gthr_id,
+    COUNT(DISTINCT ar.attd_id) AS attd_count,
+    COUNT(DISTINCT cm.cmnt_id) AS cmnt_count
+  FROM public.gthr_mst g
+  CROSS JOIN date_range
+  LEFT JOIN public.gthr_attd_rel ar ON ar.gthr_id = g.gthr_id
+  LEFT JOIN public.cmnt_mst cm
+    ON cm.entity_type = 'gathering' AND cm.entity_id = g.gthr_id AND cm.del_yn = false
+  WHERE g.team_id = p_team_id AND g.del_yn = false
+    AND date_range.range_start IS NOT NULL
+    AND g.stt_at >= (date_range.range_start::timestamp AT TIME ZONE 'Asia/Seoul')
+    AND g.stt_at <  ((date_range.range_end::timestamp + interval '1 day') AT TIME ZONE 'Asia/Seoul')
+  GROUP BY g.gthr_id
+)
+
+SELECT
+  'sch_post'::text                                AS item_type,
+  s.sch_post_id                                  AS item_id,
+  s.sch_nm                                       AS item_nm,
+  s.post_type,
+  (s.evt_stt_at AT TIME ZONE 'Asia/Seoul')::date AS start_date,
+  NULL::date                                     AS end_date,
+  NULL::text                                     AS loc_nm,
+  s.url,
+  s.cont_txt,
+  s.evt_stt_at,
+  s.evt_end_at,
+  s.crt_by,
+  m.mem_nm                                       AS crt_by_nm,
+  NULL::bigint                                   AS reg_count,
+  COALESCE((
+    SELECT count(*) FROM public.cmnt_mst cm
+    WHERE cm.entity_type = 'sch_post' AND cm.entity_id = s.sch_post_id AND cm.del_yn = false
+  ), 0)                                          AS cmnt_count,
+  s.short_id
+FROM public.sch_post_mst s
+CROSS JOIN date_range
+LEFT JOIN public.mem_mst m ON m.mem_id = s.crt_by
+WHERE s.team_id = p_team_id AND s.del_yn = false
+  AND date_range.range_start IS NOT NULL
+  AND (s.evt_stt_at AT TIME ZONE 'Asia/Seoul')::date BETWEEN date_range.range_start AND date_range.range_end
+
+UNION ALL
+
+SELECT
+  CASE WHEN mr.team_comp_id IS NOT NULL THEN 'mine' ELSE 'comp' END AS item_type,
+  c.comp_id                                                          AS item_id,
+  c.comp_nm                                                          AS item_nm,
+  NULL::text                                                         AS post_type,
+  c.stt_dt                                                           AS start_date,
+  c.end_dt                                                           AS end_date,
+  c.loc_nm,
+  c.src_url                                                          AS url,
+  NULL::text                                                         AS cont_txt,
+  NULL::timestamptz                                                  AS evt_stt_at,
+  NULL::timestamptz                                                  AS evt_end_at,
+  NULL::uuid                                                         AS crt_by,
+  NULL::text                                                         AS crt_by_nm,
+  count(DISTINCT cr.comp_reg_id)                                     AS reg_count,
+  COALESCE((
+    SELECT count(*) FROM public.cmnt_mst cm
+    WHERE cm.entity_type = 'comp' AND cm.entity_id = c.comp_id AND cm.del_yn = false
+  ), 0)                                                              AS cmnt_count,
+  NULL::text                                                         AS short_id
+FROM public.team_comp_plan_rel tcp
+JOIN public.comp_mst c ON c.comp_id = tcp.comp_id AND c.vers = 0 AND c.del_yn = false
+CROSS JOIN date_range
+LEFT JOIN public.comp_reg_rel cr ON cr.team_comp_id = tcp.team_comp_id AND cr.vers = 0 AND cr.del_yn = false
+LEFT JOIN my_regs mr ON mr.team_comp_id = tcp.team_comp_id
+WHERE tcp.team_id = p_team_id AND tcp.vers = 0 AND tcp.del_yn = false
+  AND date_range.range_start IS NOT NULL
+  AND c.stt_dt BETWEEN date_range.range_start AND date_range.range_end
+GROUP BY c.comp_id, c.comp_nm, c.stt_dt, c.end_dt, c.loc_nm, c.src_url, mr.team_comp_id
+HAVING count(DISTINCT cr.comp_reg_id) > 0 OR mr.team_comp_id IS NOT NULL
+
+UNION ALL
+
+-- gathering: ::timestamp AT TIME ZONE 'Asia/Seoul' 로 KST 경계 정확히 계산
+SELECT
+  CASE WHEN ma.gthr_id IS NOT NULL THEN 'gathering_mine' ELSE 'gathering' END AS item_type,
+  g.gthr_id                                                                    AS item_id,
+  g.gthr_nm                                                                    AS item_nm,
+  g.gthr_type_enm                                                              AS post_type,
+  (g.stt_at AT TIME ZONE 'Asia/Seoul')::date                                  AS start_date,
+  NULL::date                                                                   AS end_date,
+  g.loc_txt                                                                    AS loc_nm,
+  NULL::text                                                                   AS url,
+  g.desc_txt                                                                   AS cont_txt,
+  g.stt_at                                                                     AS evt_stt_at,
+  g.end_at                                                                     AS evt_end_at,
+  g.crt_by,
+  m.mem_nm                                                                     AS crt_by_nm,
+  COALESCE(ga.attd_count, 0)                                                   AS reg_count,
+  COALESCE(ga.cmnt_count, 0)                                                   AS cmnt_count,
+  g.short_id
+FROM public.gthr_mst g
+CROSS JOIN date_range
+LEFT JOIN public.mem_mst m   ON m.mem_id  = g.crt_by
+LEFT JOIN my_attd ma          ON ma.gthr_id = g.gthr_id
+LEFT JOIN gthr_agg ga         ON ga.gthr_id = g.gthr_id
+WHERE g.team_id = p_team_id AND g.del_yn = false
+  AND date_range.range_start IS NOT NULL
+  AND g.stt_at >= (date_range.range_start::timestamp AT TIME ZONE 'Asia/Seoul')
+  AND g.stt_at <  ((date_range.range_end::timestamp + interval '1 day') AT TIME ZONE 'Asia/Seoul')
+
+ORDER BY start_date ASC;
+$$;
+
+GRANT EXECUTE ON FUNCTION public.get_schedule_paged(uuid, text, date, uuid, int)
+  TO anon, authenticated, service_role;
+
+
+-- ── 2. get_public_team_gatherings 재정의 (p_start/p_end 경계 교정) ──
+
+CREATE OR REPLACE FUNCTION public.get_public_team_gatherings(
+  p_team_id uuid,
+  p_start   date DEFAULT NULL,
+  p_end     date DEFAULT NULL,
+  p_mem_id  uuid DEFAULT NULL
+)
+RETURNS TABLE (
+  gthr_id       uuid,
+  short_id      text,
+  gthr_nm       text,
+  gthr_type_enm text,
+  stt_at        timestamptz,
+  end_at        timestamptz,
+  loc_txt       text,
+  desc_txt      text,
+  crt_by        uuid,
+  crt_by_nm     text,
+  attd_count    bigint,
+  cmnt_count    bigint,
+  is_attending  boolean
+)
+LANGUAGE sql
+STABLE
+SECURITY DEFINER
+SET search_path = public
+AS $$
+  SELECT
+    g.gthr_id,
+    g.short_id,
+    g.gthr_nm,
+    g.gthr_type_enm,
+    g.stt_at,
+    g.end_at,
+    g.loc_txt,
+    g.desc_txt,
+    g.crt_by,
+    m.mem_nm AS crt_by_nm,
+    (SELECT COUNT(*) FROM public.gthr_attd_rel ar WHERE ar.gthr_id = g.gthr_id) AS attd_count,
+    (SELECT COUNT(*) FROM public.cmnt_mst cm
+      WHERE cm.entity_type = 'gathering' AND cm.entity_id = g.gthr_id AND cm.del_yn = false) AS cmnt_count,
+    CASE WHEN p_mem_id IS NULL THEN false
+         ELSE EXISTS (SELECT 1 FROM public.gthr_attd_rel ar WHERE ar.gthr_id = g.gthr_id AND ar.mem_id = p_mem_id)
+    END AS is_attending
+  FROM public.gthr_mst g
+  LEFT JOIN public.mem_mst m ON m.mem_id = g.crt_by
+  WHERE g.team_id = p_team_id
+    AND g.del_yn  = false
+    AND (p_start IS NULL OR g.stt_at >= (p_start::timestamp AT TIME ZONE 'Asia/Seoul'))
+    AND (p_end   IS NULL OR g.stt_at <  ((p_end::timestamp + interval '1 day') AT TIME ZONE 'Asia/Seoul'))
+  ORDER BY g.stt_at ASC;
+$$;
+
+GRANT EXECUTE ON FUNCTION public.get_public_team_gatherings(uuid, date, date, uuid)
+  TO anon, authenticated, service_role;


### PR DESCRIPTION
- 모임(gthr_mst) DB 스키마, RLS, RPC, 알림 타입 마이그레이션 추가
- 모임 생성/수정/삭제/참석 토글 서버 액션 구현
- 홈 캘린더에 모임 표시 (멀티데이 포함), 딥링크 ?gthr= 처리
- 모임 상세/폼 다이얼로그 구현 (댓글, 공유, 참석자 목록)
- 대회 다이얼로그 공유 버튼 추가 및 short_id 통일
- 알림에서 모임(gthr_*) 딥링크 라우팅 추가
- 댓글/본문 URL 하이퍼링크 렌더링 (TLD 기반 감지)
- 폼 입력 sessionStorage 자동 저장으로 백그라운드 전환 시 초기화 방지
- 공유 텍스트 대괄호 중복 버그 수정

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

# 릴리스 노트

* **새로운 기능**
  * 팀 모임 생성/조회/수정/삭제, 모임 상세 및 공유 기능 추가
  * 모임 참석/취소 및 인원 제한 제어(참석 상태는 요청 전 낙관적 반영)
  * 홈 캘린더 및 일정 목록에 모임 일정 표시, 모임 딥링크 지원
  * 모임 댓글 및 모임 관련 알림 추가
  * 모임/일정 폼 초안 자동 저장/복원

* **개선 사항**
  * 댓글 시간 표시(24시간 이내 상대/초과 절대)
  * 텍스트 내 URL 자동 링크화
  * 일정/모임 날짜 경계(KST) 처리 안정화
<!-- end of auto-generated comment: release notes by coderabbit.ai -->