### PR TITLE
fix(gathering): 모임 QA — 캘린더 색상·필터·비로그인 조회 개선

### DIFF
--- a/app/(main)/page.tsx
+++ b/app/(main)/page.tsx
@@ -221,6 +221,7 @@ async function HomeContent() {
             gatherings={calendarGatherings}
             teamId={teamId}
             memberId={currentMember?.id}
+            memberAvatarUrl={currentMember?.avatar_url ?? null}
             cmmCdRows={cmmCdRows}
             initialMemberStatus={initialMemberStatus}
             initialRegistrationsByCompetitionId={initialRegistrationsByCompetitionId}

--- a/components/home/mini-calendar.tsx
+++ b/components/home/mini-calendar.tsx
@@ -123,6 +123,16 @@ type MiniCalendarProps = {
 
 const WEEKDAYS = ["일", "월", "화", "수", "목", "금", "토"] as const;
 
+type FilterType = "all" | "competition" | "schedule" | "gathering";
+
+function matchesFilter(race: CalendarRace, filterType: FilterType): boolean {
+  if (filterType === "all") return true;
+  if (filterType === "competition") return race.type === "gigang" || race.type === "mine";
+  if (filterType === "schedule") return race.type === "schedule";
+  if (filterType === "gathering") return race.type === "gathering" || race.type === "gathering_mine";
+  return true;
+}
+
 function monthLastDayStr(year: number, month: number): string {
   const d = daysInMonth(year, month);
   return `${year}-${String(month).padStart(2, "0")}-${String(d).padStart(2, "0")}`;
@@ -178,6 +188,7 @@ export function MiniCalendar({
   const [pickerDefaultDate, setPickerDefaultDate] = useState<string | undefined>(undefined);
 
   const [view, setView] = useState<"calendar" | "list">("calendar");
+  const [filterType, setFilterType] = useState<FilterType>("all");
   const [selectedDate, setSelectedDate] = useState<string>(() => todayKST());
   const [selectedCompetition, setSelectedCompetition] = useState<Competition | null>(null);
   const [detailOpen, setDetailOpen] = useState(false);
@@ -315,11 +326,13 @@ export function MiniCalendar({
 
   const allRaces = useMemo(() => [...myRaces, ...schPosts, ...gigangRaces, ...gatherings], [myRaces, schPosts, gigangRaces, gatherings]);
 
+  const filteredRaces = useMemo(() => allRaces.filter((r) => matchesFilter(r, filterType)), [allRaces, filterType]);
+
   // 날짜별 이벤트 목록 (mine 우선, schedule, gigang 순) — 기간 이벤트는 모든 날짜에 전개
   const eventsByDate = useMemo(() => {
     const map = new Map<string, CalendarRace[]>();
     const seen = new Set<string>();
-    for (const race of allRaces) {
+    for (const race of filteredRaces) {
       const endDateStr = race.end_date
         ? dayjs(race.end_date).tz("Asia/Seoul").format("YYYY-MM-DD")
         : race.start_date;
@@ -338,7 +351,7 @@ export function MiniCalendar({
       }
     }
     return map;
-  }, [allRaces]);
+  }, [filteredRaces]);
 
   // 주차별로 날짜 그룹핑
   const weeks = useMemo(() => {
@@ -367,7 +380,7 @@ export function MiniCalendar({
       const weekEnd = validDates[validDates.length - 1];
 
       const seen = new Set<string>();
-      const active = allRaces.filter((race) => {
+      const active = filteredRaces.filter((race) => {
         if (seen.has(race.id)) return false;
         seen.add(race.id);
         const endStr = race.end_date ? dayjs(race.end_date).tz("Asia/Seoul").format("YYYY-MM-DD") : race.start_date;
@@ -407,7 +420,7 @@ export function MiniCalendar({
       // 원래 순서(colStart → id)로 돌려서 반환
       return withSlot.sort((a, b) => a.colStart - b.colStart || a.race.id.localeCompare(b.race.id));
     });
-  }, [weeks, allRaces, year, month]);
+  }, [weeks, filteredRaces, year, month]);
 
   function formatCellDate(day: number): string {
     return `${year}-${String(month).padStart(2, "0")}-${String(day).padStart(2, "0")}`;
@@ -788,6 +801,29 @@ export function MiniCalendar({
         )}
       </div>
 
+      {/* 필터 칩 */}
+      <div className="flex gap-2 overflow-x-auto scrollbar-none pb-1">
+        {([
+          { key: "all", label: "전체" },
+          { key: "competition", label: "🏆 대회" },
+          { key: "schedule", label: "📋 정보" },
+          { key: "gathering", label: "👥 모임" },
+        ] as const).map(({ key, label }) => (
+          <button
+            key={key}
+            onClick={() => setFilterType(key)}
+            className={cn(
+              "shrink-0 rounded-full px-3 py-1 text-xs font-medium transition-colors",
+              filterType === key
+                ? "bg-foreground text-background"
+                : "border border-border bg-transparent text-muted-foreground hover:border-foreground/40"
+            )}
+          >
+            {label}
+          </button>
+        ))}
+      </div>
+
       {view === "calendar" ? (
         <>
           {/* 달력 + 이벤트 */}
@@ -1056,6 +1092,7 @@ export function MiniCalendar({
             memberId={memberId}
             initialMonthKey={viewMonth.slice(0, 7)}
             initialRaces={[...myRaces, ...schPosts, ...gigangRaces, ...gatherings]}
+            filterType={filterType}
             onClickSchedule={openSchPostDetail}
             onClickCompetition={handleRaceClick}
             onClickGathering={openGatheringDetail}

--- a/components/home/mini-calendar.tsx
+++ b/components/home/mini-calendar.tsx
@@ -719,13 +719,17 @@ export function MiniCalendar({
     setGthrDetailOpen(true);
   }
 
-  async function handleSchPostSuccess() {
+  async function refreshMonthData() {
     const { gigang, mine, schPosts: newSch, gatherings: newGthr } = await fetchMonthData(viewMonth);
     setGigangRaces(gigang);
     setMyRaces(mine);
     setSchPosts(newSch);
     setGatherings(newGthr);
     setListViewKey((k) => k + 1);
+  }
+
+  async function handleSchPostSuccess() {
+    await refreshMonthData();
   }
 
   return (
@@ -1117,12 +1121,7 @@ export function MiniCalendar({
           max_prt_cnt: gthrDetailRace?.maxPrtCnt ?? null,
         } : undefined}
         onSuccess={async () => {
-          const { gigang, mine, schPosts: newSch, gatherings: newGthr } = await fetchMonthData(viewMonth);
-          setGigangRaces(gigang);
-          setMyRaces(mine);
-          setSchPosts(newSch);
-          setGatherings(newGthr);
-          setListViewKey((k) => k + 1);
+          await refreshMonthData();
           setGthrEditTarget(null);
         }}
       />
@@ -1146,18 +1145,11 @@ export function MiniCalendar({
           setGthrEditTarget(gthrDetailRace);
           setGthrFormOpen(true);
         }}
-        onDelete={async () => {
-          const { gigang, mine, schPosts: newSch, gatherings: newGthr } = await fetchMonthData(viewMonth);
-          setGigangRaces(gigang);
-          setMyRaces(mine);
-          setSchPosts(newSch);
-          setGatherings(newGthr);
-          setListViewKey((k) => k + 1);
-        }}
+        onDelete={refreshMonthData}
         onAttendanceChange={async () => {
           type GthrDetail = { max_prt_cnt: number | null; sprt_cd: string | null; attendees: GatheringAttendee[] };
-          const [{ gatherings: newGthr }, gthrDetailResult, attdResult] = await Promise.all([
-            fetchMonthData(viewMonth),
+          const [, gthrDetailResult, attdResult] = await Promise.all([
+            refreshMonthData(),
             gthrDetailRace
               ? supabase.rpc("get_gathering_detail", { p_gthr_id: gthrDetailRace.id, p_team_id: teamId })
               : Promise.resolve({ data: null, error: null }),
@@ -1165,7 +1157,6 @@ export function MiniCalendar({
               ? supabase.from("gthr_attd_rel").select("attd_id").eq("gthr_id", gthrDetailRace.id).eq("mem_id", memberId).maybeSingle()
               : Promise.resolve({ data: null }),
           ]);
-          setGatherings(newGthr);
           if (gthrDetailRace && gthrDetailResult.data) {
             const gthrData = gthrDetailResult.data as GthrDetail;
             const attendees: GatheringAttendee[] = gthrData.attendees ?? [];

--- a/components/home/mini-calendar.tsx
+++ b/components/home/mini-calendar.tsx
@@ -697,7 +697,7 @@ export function MiniCalendar({
       memberId
         ? supabase.from("gthr_attd_rel").select("attd_id").eq("gthr_id", race.id).eq("mem_id", memberId).maybeSingle()
         : Promise.resolve({ data: null }),
-      supabase.from("gthr_mst").select("max_prt_cnt, sprt_cd, gthr_attd_rel(mem_id, mem_mst(mem_nm, avatar_url))").eq("gthr_id", race.id).single(),
+      supabase.from("gthr_mst").select("max_prt_cnt, sprt_cd, gthr_attd_rel(mem_id, mem_mst(mem_nm, avatar_url))").eq("gthr_id", race.id).maybeSingle(),
     ]);
     const attendees: GatheringAttendee[] = (gthrResult.data?.gthr_attd_rel ?? []).map((a) => {
       const mem = Array.isArray(a.mem_mst) ? a.mem_mst[0] : a.mem_mst;

--- a/components/home/mini-calendar.tsx
+++ b/components/home/mini-calendar.tsx
@@ -708,8 +708,9 @@ export function MiniCalendar({
       memberId
         ? supabase.from("gthr_attd_rel").select("attd_id").eq("gthr_id", race.id).eq("mem_id", memberId).maybeSingle()
         : Promise.resolve({ data: null }),
-      supabase.rpc("get_gathering_detail", { p_gthr_id: race.id }),
+      supabase.rpc("get_gathering_detail", { p_gthr_id: race.id, p_team_id: teamId }),
     ]);
+    if (gthrDetailResult.error) console.error("[openGatheringDetail]", gthrDetailResult.error);
     const gthrData = gthrDetailResult.data as GthrDetail | null;
     const attendees: GatheringAttendee[] = gthrData?.attendees ?? [];
     setGthrDetailRace({ ...race, regCount: attendees.length, maxPrtCnt: gthrData?.max_prt_cnt ?? null, attendees, sprt_cd: gthrData?.sprt_cd ?? null });
@@ -1154,21 +1155,20 @@ export function MiniCalendar({
           setListViewKey((k) => k + 1);
         }}
         onAttendanceChange={async () => {
-          const [{ gatherings: newGthr }, gthrResult, attdResult] = await Promise.all([
+          type GthrDetail = { max_prt_cnt: number | null; sprt_cd: string | null; attendees: GatheringAttendee[] };
+          const [{ gatherings: newGthr }, gthrDetailResult, attdResult] = await Promise.all([
             fetchMonthData(viewMonth),
             gthrDetailRace
-              ? supabase.from("gthr_mst").select("max_prt_cnt, sprt_cd, gthr_attd_rel(mem_id, mem_mst(mem_nm, avatar_url))").eq("gthr_id", gthrDetailRace.id).maybeSingle()
-              : Promise.resolve({ data: null }),
+              ? supabase.rpc("get_gathering_detail", { p_gthr_id: gthrDetailRace.id, p_team_id: teamId })
+              : Promise.resolve({ data: null, error: null }),
             gthrDetailRace && memberId
               ? supabase.from("gthr_attd_rel").select("attd_id").eq("gthr_id", gthrDetailRace.id).eq("mem_id", memberId).maybeSingle()
               : Promise.resolve({ data: null }),
           ]);
           setGatherings(newGthr);
-          if (gthrDetailRace && gthrResult.data) {
-            const attendees: GatheringAttendee[] = (gthrResult.data.gthr_attd_rel ?? []).map((a) => {
-              const mem = Array.isArray(a.mem_mst) ? a.mem_mst[0] : a.mem_mst;
-              return { mem_id: a.mem_id, mem_nm: (mem as { mem_nm?: string | null } | null)?.mem_nm ?? null, avatar_url: (mem as { avatar_url?: string | null } | null)?.avatar_url ?? null };
-            });
+          if (gthrDetailRace && gthrDetailResult.data) {
+            const gthrData = gthrDetailResult.data as GthrDetail;
+            const attendees: GatheringAttendee[] = gthrData.attendees ?? [];
             setGthrDetailRace((prev) => prev ? { ...prev, regCount: attendees.length, attendees } : prev);
             setGthrDetailAttending(!!attdResult.data);
           }

--- a/components/home/mini-calendar.tsx
+++ b/components/home/mini-calendar.tsx
@@ -699,18 +699,17 @@ export function MiniCalendar({
   }
 
   async function openGatheringDetail(race: CalendarRace) {
-    const [comments, attdResult, gthrResult] = await Promise.all([
+    type GthrDetail = { max_prt_cnt: number | null; sprt_cd: string | null; attendees: GatheringAttendee[] };
+    const [comments, attdResult, gthrDetailResult] = await Promise.all([
       memberId ? fetchComments("gathering", race.id) : Promise.resolve(undefined),
       memberId
         ? supabase.from("gthr_attd_rel").select("attd_id").eq("gthr_id", race.id).eq("mem_id", memberId).maybeSingle()
         : Promise.resolve({ data: null }),
-      supabase.from("gthr_mst").select("max_prt_cnt, sprt_cd, gthr_attd_rel(mem_id, mem_mst(mem_nm, avatar_url))").eq("gthr_id", race.id).maybeSingle(),
+      supabase.rpc("get_gathering_detail", { p_gthr_id: race.id }),
     ]);
-    const attendees: GatheringAttendee[] = (gthrResult.data?.gthr_attd_rel ?? []).map((a) => {
-      const mem = Array.isArray(a.mem_mst) ? a.mem_mst[0] : a.mem_mst;
-      return { mem_id: a.mem_id, mem_nm: (mem as { mem_nm?: string | null } | null)?.mem_nm ?? null, avatar_url: (mem as { avatar_url?: string | null } | null)?.avatar_url ?? null };
-    });
-    setGthrDetailRace({ ...race, regCount: attendees.length, maxPrtCnt: gthrResult.data?.max_prt_cnt ?? null, attendees, sprt_cd: gthrResult.data?.sprt_cd ?? null });
+    const gthrData = gthrDetailResult.data as GthrDetail | null;
+    const attendees: GatheringAttendee[] = gthrData?.attendees ?? [];
+    setGthrDetailRace({ ...race, regCount: attendees.length, maxPrtCnt: gthrData?.max_prt_cnt ?? null, attendees, sprt_cd: gthrData?.sprt_cd ?? null });
     setGthrDetailAttending(!!attdResult.data);
     setGthrDetailComments(comments);
     setGthrDetailOpen(true);
@@ -794,7 +793,7 @@ export function MiniCalendar({
       </div>
 
       {/* 필터 칩 */}
-      <div className="flex gap-2 overflow-x-auto scrollbar-none pb-1">
+      <div className="flex gap-1.5 overflow-x-auto scrollbar-none pb-1">
         {([
           { key: "all", label: "전체" },
           { key: "competition", label: "🏆 대회" },
@@ -805,7 +804,7 @@ export function MiniCalendar({
             key={key}
             onClick={() => setFilterType(key)}
             className={cn(
-              "shrink-0 rounded-full px-3 py-1 text-xs transition-colors",
+              "shrink-0 rounded-full px-2.5 py-0.5 text-[10px] transition-colors",
               filterType === key
                 ? "bg-foreground text-background font-medium"
                 : "border border-border bg-transparent text-muted-foreground hover:border-foreground/40"

--- a/components/home/mini-calendar.tsx
+++ b/components/home/mini-calendar.tsx
@@ -396,9 +396,12 @@ export function MiniCalendar({
         };
       });
 
-      // colSpan 내림차순 → colStart 오름차순 정렬: 긴 이벤트가 낮은 슬롯 선점
+      // 참가한 항목 우선 → colSpan 내림차순 → colStart 오름차순 정렬
+      const isMineType = (type: string) => type === "mine" || type === "gathering_mine";
       const sorted = [...positioned].sort((a, b) =>
-        b.colSpan - a.colSpan || a.colStart - b.colStart
+        Number(isMineType(b.race.type)) - Number(isMineType(a.race.type)) ||
+        b.colSpan - a.colSpan ||
+        a.colStart - b.colStart
       );
 
       const slotEnds: number[] = [];
@@ -917,22 +920,14 @@ export function MiniCalendar({
                             lane.startsThisWeek ? "rounded-l-sm" : "",
                             lane.endsThisWeek ? "rounded-r-sm" : "",
                             lane.race.type === "mine"
-                              ? "bg-success/20 text-success"
+                              ? "bg-warning/60 text-white"
                               : lane.race.type === "schedule"
                                 ? "bg-info/15 text-info"
                                 : lane.race.type === "gathering_mine"
-                                  ? cn(
-                                      "bg-success/20 text-success",
-                                      lane.race.post_type === "regular" && "font-medium",
-                                      lane.race.post_type === "event" && "font-semibold",
-                                    )
+                                  ? "bg-violet-500/60 text-white"
                                   : lane.race.type === "gathering"
-                                  ? lane.race.post_type === "regular"
-                                    ? "bg-violet-500/25 text-violet-600 font-medium"
-                                    : lane.race.post_type === "event"
-                                      ? "bg-violet-600/30 text-violet-700 font-semibold"
-                                      : "bg-violet-400/20 text-violet-500"
-                                  : "bg-warning/15 text-warning",
+                                    ? "bg-violet-500/20 text-violet-600"
+                                    : "bg-warning/15 text-warning",
                           )}
                         >
                           {lane.startsThisWeek ? lane.race.title : ""}
@@ -984,23 +979,23 @@ export function MiniCalendar({
                         <span
                           className={cn(
                             "w-0.5 shrink-0 self-stretch rounded-full",
-                            isMine ? "bg-success"
-                              : race.type === "schedule" ? "bg-info"
-                              : isGatheringMine ? "bg-success"
-                              : isGathering
-                                ? race.post_type === "regular"
-                                  ? "bg-violet-500"
-                                  : race.post_type === "event"
-                                    ? "bg-violet-600"
-                                    : "bg-violet-400"
+                            race.type === "schedule" ? "bg-info"
+                              : isGathering ? "bg-violet-500"
                               : "bg-warning",
                           )}
                         />
                         <span className="flex min-w-0 flex-1 flex-col gap-0.5">
-                          <span className="truncate text-[11px] font-medium text-foreground">
-                            {race.title}
-                            {race.type === "schedule" && race.post_type && schPostTypeInlineLabel[race.post_type as SchPostType] && (
-                              <span className="font-normal text-muted-foreground"> · {schPostTypeInlineLabel[race.post_type as SchPostType]}</span>
+                          <span className="flex min-w-0 items-center gap-1.5">
+                            <span className="truncate text-[11px] font-medium text-foreground">
+                              {race.title}
+                              {race.type === "schedule" && race.post_type && schPostTypeInlineLabel[race.post_type as SchPostType] && (
+                                <span className="font-normal text-muted-foreground"> · {schPostTypeInlineLabel[race.post_type as SchPostType]}</span>
+                              )}
+                            </span>
+                            {isGathering && (race.post_type === "regular" || race.post_type === "event") && (
+                              <span className="shrink-0 rounded-full border border-violet-500/40 bg-violet-500/10 px-1.5 py-px text-[9px] font-medium leading-tight text-violet-400">
+                                {race.post_type === "regular" ? "정기" : "이벤트"}
+                              </span>
                             )}
                           </span>
                           {isComp && (race.location || (race.cmntCount ?? 0) > 0) && (
@@ -1053,7 +1048,7 @@ export function MiniCalendar({
                               "shrink-0 rounded-md border px-2 py-0.5 text-[10px] font-medium",
                               isGatheringMine
                                 ? "border-success/40 bg-success/10 text-success"
-                                : "border-violet-300/60 bg-violet-50 text-violet-500",
+                                : "border-violet-500/40 bg-violet-500/10 text-violet-400",
                             )}
                           >
                             {isGatheringMine ? "참석" : "모임"}

--- a/components/home/mini-calendar.tsx
+++ b/components/home/mini-calendar.tsx
@@ -123,9 +123,9 @@ type MiniCalendarProps = {
 
 const WEEKDAYS = ["일", "월", "화", "수", "목", "금", "토"] as const;
 
-type FilterType = "all" | "competition" | "schedule" | "gathering";
+export type FilterType = "all" | "competition" | "schedule" | "gathering";
 
-function matchesFilter(race: CalendarRace, filterType: FilterType): boolean {
+export function matchesFilter(race: CalendarRace, filterType: FilterType): boolean {
   if (filterType === "all") return true;
   if (filterType === "competition") return race.type === "gigang" || race.type === "mine";
   if (filterType === "schedule") return race.type === "schedule";
@@ -813,9 +813,9 @@ export function MiniCalendar({
             key={key}
             onClick={() => setFilterType(key)}
             className={cn(
-              "shrink-0 rounded-full px-3 py-1 text-xs font-medium transition-colors",
+              "shrink-0 rounded-full px-3 py-1 text-xs transition-colors",
               filterType === key
-                ? "bg-foreground text-background"
+                ? "bg-foreground text-background font-medium"
                 : "border border-border bg-transparent text-muted-foreground hover:border-foreground/40"
             )}
           >
@@ -1013,13 +1013,13 @@ export function MiniCalendar({
                             )}
                           </span>
                           {isComp && (race.location || (race.cmntCount ?? 0) > 0) && (
-                            <span className="flex items-center gap-1 text-[9px] text-muted-foreground">
+                            <Micro className="flex items-center gap-1 text-muted-foreground">
                               {race.location && <span className="truncate">{race.location}</span>}
                               {(race.cmntCount ?? 0) > 0 && <span>💬 {race.cmntCount}</span>}
-                            </span>
+                            </Micro>
                           )}
                           {(race.type === "schedule" || isGathering) && (race.evt_stt_at || race.location || (race.cmntCount ?? 0) > 0) && (
-                            <span className="flex items-center gap-1 text-[9px] text-muted-foreground tabular-nums">
+                            <Micro className="flex items-center gap-1 text-muted-foreground tabular-nums">
                               {isGathering && race.location && <span className="truncate">{race.location}</span>}
                               {race.evt_stt_at && (
                                 <span>
@@ -1035,7 +1035,7 @@ export function MiniCalendar({
                                 </span>
                               )}
                               {(race.cmntCount ?? 0) > 0 && <span>💬 {race.cmntCount}</span>}
-                            </span>
+                            </Micro>
                           )}
                         </span>
                         {isComp && (race.regCount ?? 0) > 0 && (

--- a/components/home/mini-calendar.tsx
+++ b/components/home/mini-calendar.tsx
@@ -123,15 +123,7 @@ type MiniCalendarProps = {
 
 const WEEKDAYS = ["일", "월", "화", "수", "목", "금", "토"] as const;
 
-export type FilterType = "all" | "competition" | "schedule" | "gathering";
-
-export function matchesFilter(race: CalendarRace, filterType: FilterType): boolean {
-  if (filterType === "all") return true;
-  if (filterType === "competition") return race.type === "gigang" || race.type === "mine";
-  if (filterType === "schedule") return race.type === "schedule";
-  if (filterType === "gathering") return race.type === "gathering" || race.type === "gathering_mine";
-  return true;
-}
+import { type FilterType, matchesFilter } from "./schedule-filter";
 
 function monthLastDayStr(year: number, month: number): string {
   const d = daysInMonth(year, month);

--- a/components/home/mini-calendar.tsx
+++ b/components/home/mini-calendar.tsx
@@ -894,9 +894,17 @@ export function MiniCalendar({
                               : lane.race.type === "schedule"
                                 ? "bg-info/15 text-info"
                                 : lane.race.type === "gathering_mine"
-                                  ? "bg-success/20 text-success"
+                                  ? cn(
+                                      "bg-success/20 text-success",
+                                      lane.race.post_type === "regular" && "font-medium",
+                                      lane.race.post_type === "event" && "font-semibold",
+                                    )
                                   : lane.race.type === "gathering"
-                                  ? "bg-violet-400/20 text-violet-500"
+                                  ? lane.race.post_type === "regular"
+                                    ? "bg-violet-500/25 text-violet-600 font-medium"
+                                    : lane.race.post_type === "event"
+                                      ? "bg-violet-600/30 text-violet-700 font-semibold"
+                                      : "bg-violet-400/20 text-violet-500"
                                   : "bg-warning/15 text-warning",
                           )}
                         >
@@ -952,7 +960,12 @@ export function MiniCalendar({
                             isMine ? "bg-success"
                               : race.type === "schedule" ? "bg-info"
                               : isGatheringMine ? "bg-success"
-                              : isGathering ? "bg-violet-400"
+                              : isGathering
+                                ? race.post_type === "regular"
+                                  ? "bg-violet-500"
+                                  : race.post_type === "event"
+                                    ? "bg-violet-600"
+                                    : "bg-violet-400"
                               : "bg-warning",
                           )}
                         />

--- a/components/home/mini-calendar.tsx
+++ b/components/home/mini-calendar.tsx
@@ -115,6 +115,7 @@ type MiniCalendarProps = {
   gatherings: CalendarRace[];
   teamId: string;
   memberId?: string;
+  memberAvatarUrl?: string | null;
   cmmCdRows: CachedCmmCdRow[];
   initialMemberStatus: MemberStatus;
   initialRegistrationsByCompetitionId: Record<string, CompetitionRegistration>;
@@ -134,6 +135,7 @@ export function MiniCalendar({
   gatherings: initGatherings,
   teamId,
   memberId,
+  memberAvatarUrl,
   cmmCdRows,
   initialMemberStatus,
   initialRegistrationsByCompetitionId,
@@ -1096,6 +1098,7 @@ export function MiniCalendar({
         teamId={teamId}
         currentMemberId={memberStatus.status === "ready" ? memberStatus.memberId : undefined}
         currentMemberName={memberStatus.status === "ready" ? memberStatus.fullName : undefined}
+        currentMemberAvatarUrl={memberStatus.status === "ready" ? memberAvatarUrl : undefined}
         isAdmin={memberStatus.status === "ready" ? memberStatus.admin : false}
         isAttending={gthrDetailAttending}
         members={membersCache ?? []}
@@ -1115,8 +1118,24 @@ export function MiniCalendar({
           setListViewKey((k) => k + 1);
         }}
         onAttendanceChange={async () => {
-          const { gatherings: newGthr } = await fetchMonthData(viewMonth);
+          const [{ gatherings: newGthr }, gthrResult, attdResult] = await Promise.all([
+            fetchMonthData(viewMonth),
+            gthrDetailRace
+              ? supabase.from("gthr_mst").select("max_prt_cnt, sprt_cd, gthr_attd_rel(mem_id, mem_mst(mem_nm, avatar_url))").eq("gthr_id", gthrDetailRace.id).maybeSingle()
+              : Promise.resolve({ data: null }),
+            gthrDetailRace && memberId
+              ? supabase.from("gthr_attd_rel").select("attd_id").eq("gthr_id", gthrDetailRace.id).eq("mem_id", memberId).maybeSingle()
+              : Promise.resolve({ data: null }),
+          ]);
           setGatherings(newGthr);
+          if (gthrDetailRace && gthrResult.data) {
+            const attendees: GatheringAttendee[] = (gthrResult.data.gthr_attd_rel ?? []).map((a) => {
+              const mem = Array.isArray(a.mem_mst) ? a.mem_mst[0] : a.mem_mst;
+              return { mem_id: a.mem_id, mem_nm: (mem as { mem_nm?: string | null } | null)?.mem_nm ?? null, avatar_url: (mem as { avatar_url?: string | null } | null)?.avatar_url ?? null };
+            });
+            setGthrDetailRace((prev) => prev ? { ...prev, regCount: attendees.length, attendees } : prev);
+            setGthrDetailAttending(!!attdResult.data);
+          }
         }}
       />
 

--- a/components/home/schedule-filter.ts
+++ b/components/home/schedule-filter.ts
@@ -1,0 +1,11 @@
+import type { CalendarRace } from "./mini-calendar";
+
+export type FilterType = "all" | "competition" | "schedule" | "gathering";
+
+export function matchesFilter(race: CalendarRace, filterType: FilterType): boolean {
+  if (filterType === "all") return true;
+  if (filterType === "competition") return race.type === "gigang" || race.type === "mine";
+  if (filterType === "schedule") return race.type === "schedule";
+  if (filterType === "gathering") return race.type === "gathering" || race.type === "gathering_mine";
+  return true;
+}

--- a/components/home/schedule-list-view.tsx
+++ b/components/home/schedule-list-view.tsx
@@ -185,12 +185,7 @@ function CompetitionItem({
       onClick={onClick}
       className="flex w-full items-stretch gap-2.5 rounded-lg px-2 py-0.5 text-left transition-all active:scale-[0.98] active:bg-secondary hover:bg-secondary/60"
     >
-      <span
-        className={cn(
-          "w-0.5 shrink-0 rounded-full",
-          isMine ? "bg-success" : "bg-warning",
-        )}
-      />
+      <span className="w-0.5 shrink-0 rounded-full bg-warning" />
       <span className="flex min-w-0 flex-1 flex-col gap-0.5">
         <Caption className="truncate font-medium text-foreground">{race.title}</Caption>
         {(race.location || (race.cmntCount ?? 0) > 0) && (
@@ -233,20 +228,16 @@ function GatheringItem({ race, onClick }: { race: CalendarRace; onClick: () => v
       onClick={onClick}
       className="flex w-full items-stretch gap-2.5 rounded-lg px-2 py-0.5 text-left transition-all active:scale-[0.98] active:bg-secondary hover:bg-secondary/60"
     >
-      <span
-        className={cn(
-          "w-0.5 shrink-0 rounded-full",
-          isMine
-            ? "bg-success"
-            : race.post_type === "regular"
-              ? "bg-violet-500"
-              : race.post_type === "event"
-                ? "bg-violet-600"
-                : "bg-violet-400",
-        )}
-      />
+      <span className="w-0.5 shrink-0 rounded-full bg-violet-500" />
       <span className="flex min-w-0 flex-1 flex-col gap-0.5">
-        <Caption className="truncate font-medium text-foreground">{race.title}</Caption>
+        <span className="flex min-w-0 items-center gap-1.5">
+          <Caption className="truncate font-medium text-foreground">{race.title}</Caption>
+          {(race.post_type === "regular" || race.post_type === "event") && (
+            <span className="shrink-0 rounded-full border border-violet-500/40 bg-violet-500/10 px-1.5 py-px text-[9px] font-medium leading-tight text-violet-400">
+              {race.post_type === "regular" ? "정기" : "이벤트"}
+            </span>
+          )}
+        </span>
         {(timeRange || race.location || (race.cmntCount ?? 0) > 0) && (
           <Micro className="flex items-center gap-1.5 tabular-nums text-muted-foreground">
             {race.location && <span className="truncate">{race.location}</span>}
@@ -264,7 +255,7 @@ function GatheringItem({ race, onClick }: { race: CalendarRace; onClick: () => v
             "shrink-0 rounded-md border px-2.5 py-1 text-[11px] font-medium",
             isMine
               ? "border-success/40 bg-success/10 text-success"
-              : "border-violet-300/60 bg-violet-50 text-violet-500",
+              : "border-violet-500/40 bg-violet-500/10 text-violet-400",
           )}
         >
           {isMine ? "참석" : "모임"}
@@ -409,7 +400,7 @@ export function ScheduleListView({
   return (
     <div
       ref={containerRef}
-      className="h-[380px] overflow-x-hidden overflow-y-auto"
+      className="h-[480px] overflow-x-hidden overflow-y-auto"
     >
       {/* 상단 sentinel */}
       <div ref={topSentinelRef} className="flex h-4 items-center justify-center">

--- a/components/home/schedule-list-view.tsx
+++ b/components/home/schedule-list-view.tsx
@@ -19,11 +19,14 @@ type MonthData = {
   races: CalendarRace[];
 };
 
+type FilterType = "all" | "competition" | "schedule" | "gathering";
+
 type Props = {
   teamId: string;
   memberId?: string;
   initialMonthKey: string;
   initialRaces: CalendarRace[];
+  filterType?: FilterType;
   onClickSchedule: (race: CalendarRace) => void;
   onClickCompetition: (race: CalendarRace) => void;
   onClickGathering: (race: CalendarRace) => void;
@@ -118,6 +121,14 @@ async function fetchAdjacent(
     }
   }
   return results;
+}
+
+function matchesFilter(race: CalendarRace, filterType: FilterType): boolean {
+  if (filterType === "all") return true;
+  if (filterType === "competition") return race.type === "gigang" || race.type === "mine";
+  if (filterType === "schedule") return race.type === "schedule";
+  if (filterType === "gathering") return race.type === "gathering" || race.type === "gathering_mine";
+  return true;
 }
 
 function formatTimeRange(sttAt: string | null | undefined, endAt: string | null | undefined): string | null {
@@ -277,6 +288,7 @@ export function ScheduleListView({
   memberId,
   initialMonthKey,
   initialRaces,
+  filterType = "all",
   onClickSchedule,
   onClickCompetition,
   onClickGathering,
@@ -438,13 +450,15 @@ export function ScheduleListView({
                 <div className="h-px flex-1 bg-border" />
               </div>
 
-              {byDate.size === 0 ? (
+              {byDate.size === 0 || (filterType !== "all" && Array.from(byDate.values()).every((rs) => rs.every((r) => !matchesFilter(r, filterType)))) ? (
                 <div className="px-1 py-3">
                   <Caption className="text-muted-foreground">일정 없음</Caption>
                 </div>
               ) : (
                 <div className="flex flex-col divide-y divide-border/40 py-1">
                   {Array.from(byDate.entries()).map(([dateStr, dateRaces]) => {
+                    const filteredDateRaces = dateRaces.filter((r) => matchesFilter(r, filterType));
+                    if (filteredDateRaces.length === 0) return null;
                     const dayjsDate = dayjs(dateStr);
                     const isToday = dateStr === today;
                     return (
@@ -468,7 +482,7 @@ export function ScheduleListView({
 
                         {/* 일정 목록 */}
                         <div className="flex min-w-0 flex-1 flex-col gap-2.5">
-                          {dateRaces.map((race) =>
+                          {filteredDateRaces.map((race) =>
                             race.type === "schedule" ? (
                               <ScheduleItem
                                 key={race.id}

--- a/components/home/schedule-list-view.tsx
+++ b/components/home/schedule-list-view.tsx
@@ -13,8 +13,7 @@ import type { SchPostType } from "@/lib/validations/schedule-types";
 import { Caption, Micro, SectionLabel } from "@/components/common/typography";
 
 import type { CalendarRace } from "./mini-calendar";
-import type { FilterType } from "./mini-calendar";
-import { matchesFilter } from "./mini-calendar";
+import { type FilterType, matchesFilter } from "./schedule-filter";
 
 type MonthData = {
   monthKey: string; // "YYYY-MM"

--- a/components/home/schedule-list-view.tsx
+++ b/components/home/schedule-list-view.tsx
@@ -51,6 +51,19 @@ type SchedulePagedRow = {
   short_id: string | null;
 };
 
+function racesToMonths(races: CalendarRace[]): MonthData[] {
+  const buckets = new Map<string, CalendarRace[]>();
+  for (const race of races) {
+    const key = race.start_date.slice(0, 7);
+    const list = buckets.get(key) ?? [];
+    list.push(race);
+    buckets.set(key, list);
+  }
+  return Array.from(buckets.entries())
+    .sort(([a], [b]) => a.localeCompare(b))
+    .map(([key, r]) => ({ monthKey: key, races: r }));
+}
+
 async function fetchAdjacent(
   supabase: ReturnType<typeof createClient>,
   teamId: string,
@@ -280,22 +293,9 @@ export function ScheduleListView({
 
   const [months, setMonths] = useState<MonthData[]>(() => {
     // start_date의 실제 월(YYYY-MM)로 분류 — 월 경계에 걸친 일정을 올바른 월에 배치
-    const buckets = new Map<string, CalendarRace[]>();
-    for (const race of initialRaces) {
-      const key = race.start_date.slice(0, 7); // "YYYY-MM"
-      const list = buckets.get(key) ?? [];
-      list.push(race);
-      buckets.set(key, list);
-    }
-    if (buckets.size === 0) {
-      return [{ monthKey: initialMonthKey, races: [] }];
-    }
-    return Array.from(buckets.entries())
-      .sort(([a], [b]) => a.localeCompare(b))
-      .map(([key, races]) => ({
-        monthKey: key,
-        races: [...races].sort((a, b) => a.start_date.localeCompare(b.start_date)),
-      }));
+    const result = racesToMonths(initialRaces);
+    if (result.length === 0) return [{ monthKey: initialMonthKey, races: [] }];
+    return result.map((m) => ({ ...m, races: [...m.races].sort((a, b) => a.start_date.localeCompare(b.start_date)) }));
   });
   const [loadingPrev, setLoadingPrev] = useState(false);
   const [loadingNext, setLoadingNext] = useState(false);
@@ -319,16 +319,7 @@ export function ScheduleListView({
         setCanLoadPrev(false);
         return;
       }
-      const buckets = new Map<string, CalendarRace[]>();
-      for (const race of races) {
-        const key = race.start_date.slice(0, 7);
-        const list = buckets.get(key) ?? [];
-        list.push(race);
-        buckets.set(key, list);
-      }
-      const newMonths = Array.from(buckets.entries())
-        .sort(([a], [b]) => a.localeCompare(b))
-        .map(([key, r]) => ({ monthKey: key, races: r }));
+      const newMonths = racesToMonths(races);
       prevScrollHeightRef.current = containerRef.current?.scrollHeight ?? 0;
       setMonths((prev) => [...newMonths, ...prev]);
     } finally {
@@ -347,16 +338,8 @@ export function ScheduleListView({
         setCanLoadNext(false);
         return;
       }
-      const buckets = new Map<string, CalendarRace[]>();
-      for (const race of races) {
-        const key = race.start_date.slice(0, 7);
-        const list = buckets.get(key) ?? [];
-        list.push(race);
-        buckets.set(key, list);
-      }
-      const [firstKey, firstRaces] = Array.from(buckets.entries())
-        .sort(([a], [b]) => a.localeCompare(b))[0];
-      setMonths((prev) => [...prev, { monthKey: firstKey, races: firstRaces }]);
+      const [first] = racesToMonths(races);
+      setMonths((prev) => [...prev, first]);
     } finally {
       setLoadingNext(false);
     }

--- a/components/home/schedule-list-view.tsx
+++ b/components/home/schedule-list-view.tsx
@@ -13,13 +13,13 @@ import type { SchPostType } from "@/lib/validations/schedule-types";
 import { Caption, Micro, SectionLabel } from "@/components/common/typography";
 
 import type { CalendarRace } from "./mini-calendar";
+import type { FilterType } from "./mini-calendar";
+import { matchesFilter } from "./mini-calendar";
 
 type MonthData = {
   monthKey: string; // "YYYY-MM"
   races: CalendarRace[];
 };
-
-type FilterType = "all" | "competition" | "schedule" | "gathering";
 
 type Props = {
   teamId: string;
@@ -121,14 +121,6 @@ async function fetchAdjacent(
     }
   }
   return results;
-}
-
-function matchesFilter(race: CalendarRace, filterType: FilterType): boolean {
-  if (filterType === "all") return true;
-  if (filterType === "competition") return race.type === "gigang" || race.type === "mine";
-  if (filterType === "schedule") return race.type === "schedule";
-  if (filterType === "gathering") return race.type === "gathering" || race.type === "gathering_mine";
-  return true;
 }
 
 function formatTimeRange(sttAt: string | null | undefined, endAt: string | null | undefined): string | null {

--- a/components/home/schedule-list-view.tsx
+++ b/components/home/schedule-list-view.tsx
@@ -231,7 +231,18 @@ function GatheringItem({ race, onClick }: { race: CalendarRace; onClick: () => v
       onClick={onClick}
       className="flex w-full items-stretch gap-2.5 rounded-lg px-2 py-0.5 text-left transition-all active:scale-[0.98] active:bg-secondary hover:bg-secondary/60"
     >
-      <span className={cn("w-0.5 shrink-0 rounded-full", isMine ? "bg-success" : "bg-violet-400")} />
+      <span
+        className={cn(
+          "w-0.5 shrink-0 rounded-full",
+          isMine
+            ? "bg-success"
+            : race.post_type === "regular"
+              ? "bg-violet-500"
+              : race.post_type === "event"
+                ? "bg-violet-600"
+                : "bg-violet-400",
+        )}
+      />
       <span className="flex min-w-0 flex-1 flex-col gap-0.5">
         <Caption className="truncate font-medium text-foreground">{race.title}</Caption>
         {(timeRange || race.location || (race.cmntCount ?? 0) > 0) && (

--- a/components/home/schedule-list-view.tsx
+++ b/components/home/schedule-list-view.tsx
@@ -13,7 +13,7 @@ import type { SchPostType } from "@/lib/validations/schedule-types";
 import { Caption, Micro, SectionLabel } from "@/components/common/typography";
 
 import type { CalendarRace } from "./mini-calendar";
-import { type FilterType, matchesFilter } from "./schedule-filter";
+import { type FilterType, matchesFilter } from "@/components/home/schedule-filter";
 
 type MonthData = {
   monthKey: string; // "YYYY-MM"

--- a/components/schedule/gathering-detail-dialog.tsx
+++ b/components/schedule/gathering-detail-dialog.tsx
@@ -167,7 +167,22 @@ export function GatheringDetailDialog({
           <div className="flex flex-col gap-4">
             {/* 뱃지 */}
             <div className="flex items-center gap-2">
-              {typeLabel && <Badge variant="secondary">{typeLabel}</Badge>}
+              {typeLabel && (() => {
+                const typeBadgeClass =
+                  gathering.post_type === "regular"
+                    ? "border-violet-400/60 bg-violet-50 text-violet-700"
+                    : gathering.post_type === "event"
+                      ? "border-violet-500 bg-violet-100 text-violet-800 font-medium"
+                      : undefined;
+                return (
+                  <Badge
+                    variant={typeBadgeClass ? "outline" : "secondary"}
+                    className={typeBadgeClass}
+                  >
+                    {typeLabel}
+                  </Badge>
+                );
+              })()}
               {sprtLabel && <Badge variant="outline">{sprtLabel}</Badge>}
             </div>
 

--- a/components/schedule/gathering-detail-dialog.tsx
+++ b/components/schedule/gathering-detail-dialog.tsx
@@ -179,7 +179,7 @@ export function GatheringDetailDialog({
                     variant={typeBadgeClass ? "outline" : "secondary"}
                     className={typeBadgeClass}
                   >
-                    {typeLabel}
+                    {gathering.post_type === "event" ? `⭐ ${typeLabel}` : typeLabel}
                   </Badge>
                 );
               })()}

--- a/components/schedule/gathering-detail-dialog.tsx
+++ b/components/schedule/gathering-detail-dialog.tsx
@@ -24,7 +24,7 @@ import {
   ResponsiveDrawerHeader,
   ResponsiveDrawerTitle,
 } from "@/components/common/responsive-drawer";
-import { Caption } from "@/components/common/typography";
+import { Caption, Micro } from "@/components/common/typography";
 import type { CalendarRace } from "@/components/home/mini-calendar";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
@@ -46,6 +46,7 @@ export interface GatheringDetailDialogProps {
   teamId: string;
   currentMemberId?: string;
   currentMemberName?: string | null;
+  currentMemberAvatarUrl?: string | null;
   isAdmin?: boolean;
   isAttending?: boolean;
   members: MemberOption[];
@@ -62,6 +63,7 @@ export function GatheringDetailDialog({
   teamId,
   currentMemberId,
   currentMemberName,
+  currentMemberAvatarUrl,
   isAdmin,
   isAttending: initialIsAttending,
   members,
@@ -117,7 +119,7 @@ export function GatheringDetailDialog({
     if (!currentMemberId || isFull || isToggling) return;
     setIsToggling(true);
     const prev = attending;
-    const myEntry = { mem_id: currentMemberId, mem_nm: currentMemberName ?? null, avatar_url: null };
+    const myEntry = { mem_id: currentMemberId, mem_nm: currentMemberName ?? null, avatar_url: currentMemberAvatarUrl ?? null };
     setAttending(!prev);
     setAttdCount((c) => (!prev ? c + 1 : c - 1));
     setAttendees((list) => !prev ? [...list, myEntry] : list.filter((a) => a.mem_id !== currentMemberId));
@@ -226,8 +228,8 @@ export function GatheringDetailDialog({
               <div className="flex flex-wrap gap-2">
                 {attendees.map((a) => (
                   <div key={a.mem_id} className="flex flex-col items-center gap-0.5">
-                    <Avatar src={a.avatar_url} alt={a.mem_nm ?? ""} size="sm" className="size-4" />
-                    <span className="text-[9px] text-muted-foreground leading-tight">{a.mem_nm ?? ""}</span>
+                    <Avatar src={a.avatar_url} alt={a.mem_nm ?? ""} size="sm" />
+                    <Micro className="leading-tight">{a.mem_nm ?? ""}</Micro>
                   </div>
                 ))}
               </div>

--- a/lib/supabase/database.types.ts
+++ b/lib/supabase/database.types.ts
@@ -2140,6 +2140,12 @@ export type Database = {
           stt_dt: string
         }[]
       }
+      get_gathering_detail: {
+        Args: {
+          p_gthr_id: string
+        }
+        Returns: Json
+      }
       get_public_team_gatherings:
         | {
             Args: { p_end?: string; p_start?: string; p_team_id: string }

--- a/lib/supabase/database.types.ts
+++ b/lib/supabase/database.types.ts
@@ -2143,6 +2143,7 @@ export type Database = {
       get_gathering_detail: {
         Args: {
           p_gthr_id: string
+          p_team_id: string
         }
         Returns: Json
       }

--- a/supabase/migrations/20260622100000_gthr_mst_select_anon.sql
+++ b/supabase/migrations/20260622100000_gthr_mst_select_anon.sql
@@ -21,6 +21,7 @@ CREATE POLICY gthr_attd_rel_select_anon
     EXISTS (
       SELECT 1
       FROM gthr_mst g
+      JOIN public.team_mst t ON t.team_id = g.team_id
       WHERE g.gthr_id = gthr_attd_rel.gthr_id
         AND g.del_yn = false
     )

--- a/supabase/migrations/20260622100000_gthr_mst_select_anon.sql
+++ b/supabase/migrations/20260622100000_gthr_mst_select_anon.sql
@@ -1,11 +1,17 @@
 -- 비로그인(anon) 사용자도 모임 목록/상세 조회 가능하도록 RLS 정책 추가
 -- sch_post_mst_select_anon 과 동일한 패턴 (20260616030000_sch_post_mst_anon_select.sql 참조)
+-- team_id 조건으로 타 팀 모임 직접 접근 차단
 
 CREATE POLICY gthr_mst_select_anon
   ON gthr_mst
   FOR SELECT
   TO anon
-  USING (del_yn = false);
+  USING (
+    del_yn = false
+    AND EXISTS (
+      SELECT 1 FROM public.team_mst t WHERE t.team_id = gthr_mst.team_id
+    )
+  );
 
 CREATE POLICY gthr_attd_rel_select_anon
   ON gthr_attd_rel

--- a/supabase/migrations/20260622100000_gthr_mst_select_anon.sql
+++ b/supabase/migrations/20260622100000_gthr_mst_select_anon.sql
@@ -1,0 +1,21 @@
+-- 비로그인(anon) 사용자도 모임 목록/상세 조회 가능하도록 RLS 정책 추가
+-- sch_post_mst_select_anon 과 동일한 패턴 (20260616030000_sch_post_mst_anon_select.sql 참조)
+
+CREATE POLICY gthr_mst_select_anon
+  ON gthr_mst
+  FOR SELECT
+  TO anon
+  USING (del_yn = false);
+
+CREATE POLICY gthr_attd_rel_select_anon
+  ON gthr_attd_rel
+  FOR SELECT
+  TO anon
+  USING (
+    EXISTS (
+      SELECT 1
+      FROM gthr_mst g
+      WHERE g.gthr_id = gthr_attd_rel.gthr_id
+        AND g.del_yn = false
+    )
+  );

--- a/supabase/migrations/20260622200000_get_gathering_detail_rpc.sql
+++ b/supabase/migrations/20260622200000_get_gathering_detail_rpc.sql
@@ -1,0 +1,35 @@
+-- 비로그인(anon) 사용자도 모임 상세 + 참석자 이름/아바타를 볼 수 있도록
+-- SECURITY DEFINER 함수 추가 (mem_mst 에 anon SELECT 정책 없어도 우회 가능)
+
+CREATE OR REPLACE FUNCTION get_gathering_detail(p_gthr_id uuid)
+RETURNS json
+LANGUAGE sql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+  SELECT json_build_object(
+    'max_prt_cnt', g.max_prt_cnt,
+    'sprt_cd',     g.sprt_cd,
+    'attendees',   COALESCE(
+      (
+        SELECT json_agg(
+          json_build_object(
+            'mem_id',    ar.mem_id,
+            'mem_nm',    m.mem_nm,
+            'avatar_url', m.avatar_url
+          )
+          ORDER BY ar.crt_at ASC
+        )
+        FROM   gthr_attd_rel ar
+        LEFT JOIN mem_mst m ON m.mem_id = ar.mem_id
+        WHERE  ar.gthr_id = p_gthr_id
+      ),
+      '[]'::json
+    )
+  )
+  FROM  gthr_mst g
+  WHERE g.gthr_id = p_gthr_id
+    AND g.del_yn  = false;
+$$;
+
+GRANT EXECUTE ON FUNCTION get_gathering_detail(uuid) TO anon, authenticated;

--- a/supabase/migrations/20260622200000_get_gathering_detail_rpc.sql
+++ b/supabase/migrations/20260622200000_get_gathering_detail_rpc.sql
@@ -1,7 +1,8 @@
 -- 비로그인(anon) 사용자도 모임 상세 + 참석자 이름/아바타를 볼 수 있도록
 -- SECURITY DEFINER 함수 추가 (mem_mst 에 anon SELECT 정책 없어도 우회 가능)
+-- p_team_id로 팀 스코프 검증 — 타 팀 gthr_id 입력 시 null 반환
 
-CREATE OR REPLACE FUNCTION get_gathering_detail(p_gthr_id uuid)
+CREATE OR REPLACE FUNCTION get_gathering_detail(p_gthr_id uuid, p_team_id uuid)
 RETURNS json
 LANGUAGE sql
 SECURITY DEFINER
@@ -28,8 +29,9 @@ AS $$
     )
   )
   FROM  gthr_mst g
-  WHERE g.gthr_id = p_gthr_id
-    AND g.del_yn  = false;
+  WHERE g.gthr_id  = p_gthr_id
+    AND g.team_id  = p_team_id
+    AND g.del_yn   = false;
 $$;
 
-GRANT EXECUTE ON FUNCTION get_gathering_detail(uuid) TO anon, authenticated;
+GRANT EXECUTE ON FUNCTION get_gathering_detail(uuid, uuid) TO anon, authenticated;

--- a/supabase/migrations/20260622210000_drop_gatherings_rpc_overload.sql
+++ b/supabase/migrations/20260622210000_drop_gatherings_rpc_overload.sql
@@ -1,0 +1,3 @@
+-- get_public_team_gatherings 구버전(p_mem_id 없는 오버로드) 제거
+-- PostgREST 오버로드 충돌로 캘린더에서 모임이 보였다 안 보였다 하던 문제 수정
+DROP FUNCTION IF EXISTS public.get_public_team_gatherings(uuid, date, date);


### PR DESCRIPTION
## Summary

- 캘린더/리스트뷰 일정 색상 고정: 대회(주황) / 정보(파랑) / 모임(보라), 참가 여부로 색 바뀌던 것 제거
- 참가한 일정은 캘린더 바에서 진한 배경+흰 글자로 구별, 슬롯 우선 배정
- 정기/이벤트 모임에 보라색 태그 칩 추가 (일반 모임과 시각적 구별)
- 다크모드 대응: 하드코딩된 violet-100/600 → opacity 토큰(violet-500/10, /40, text-violet-400)으로 교체
- 일정 유형 필터 칩 추가 (전체 / 대회 / 정보 / 모임)
- 비로그인 사용자도 모임 상세 참석자 정보 조회 가능 (SECURITY DEFINER RPC)
- `get_public_team_gatherings` 구버전 오버로드 DROP — PostgREST 충돌로 캘린더에서 모임이 보였다 안 보였다 하던 버그 수정
- 리스트뷰 높이 380px → 480px 확대

## Test plan

- [ ] 캘린더뷰 — 대회/정보/모임 색상이 각각 주황/파랑/보라로 고정되는지 확인
- [ ] 내가 참가한 대회/모임이 캘린더 바에서 진하게 표시되고 슬롯 우선 배정되는지 확인
- [ ] 정기/이벤트 모임에 태그 칩이 표시되고 일반 모임엔 없는지 확인
- [ ] 라이트/다크 모드 둘 다 색상 이상 없는지 확인
- [ ] 비로그인 상태에서 캘린더/리스트뷰 모임이 정상 표시되는지 확인
- [ ] 비로그인 상태에서 모임 상세 다이얼로그 참석자 정보 표시 확인
- [ ] 필터 칩으로 대회/정보/모임 필터링 동작 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 일정/대회/정보/모임 필터 칩을 추가하고 달력·일정 목록에 동일하게 적용
* **개선사항**
  * 모임 상세 배지와 참석자 표시를 `post_type` 기준으로 고도화하고, 참석 토글 시 아바타/참석 상태가 즉시 반영
  * 캘린더 레인 정렬 우선순위와 필터링 렌더링을 개선
* **보안/접근성**
  * 비로그인 사용자도 모임 목록과 상세 조회가 가능
<!-- end of auto-generated comment: release notes by coderabbit.ai -->