### PR TITLE
fix(home): home schedule UX improvements and stale closure fixes

### DIFF
--- a/components/home/mini-calendar.tsx
+++ b/components/home/mini-calendar.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useMemo, useRef, useState, useTransition } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState, useTransition } from "react";
 
 import { useRouter, useSearchParams } from "next/navigation";
 
@@ -182,6 +182,8 @@ export function MiniCalendar({
   const [view, setView] = useState<"calendar" | "list">("calendar");
   const [filterType, setFilterType] = useState<FilterType>("all");
   const [selectedDate, setSelectedDate] = useState<string>(() => todayKST());
+  const [openingId, setOpeningId] = useState<string | null>(null);
+  const openingLock = useRef(false);
   const [selectedCompetition, setSelectedCompetition] = useState<Competition | null>(null);
   const [detailOpen, setDetailOpen] = useState(false);
   const [compDetailInitialComments, setCompDetailInitialComments] = useState<CmntRow[] | undefined>(undefined);
@@ -446,49 +448,58 @@ export function MiniCalendar({
     })
   }
 
-  async function handleRaceClick(race: CalendarRace) {
-    const [{ data }, comments] = await Promise.all([
-      supabase
-        .from("comp_mst")
-        .select("comp_id, short_id, comp_nm, comp_sprt_cd, stt_dt, end_dt, loc_nm, src_url, comp_evt_cfg(comp_evt_type)")
-        .eq("comp_id", race.id)
-        .single(),
-      memberId ? fetchComments("comp", race.id) : Promise.resolve(undefined),
-    ]);
+  const handleRaceClick = useCallback(async (race: CalendarRace) => {
+    if (openingLock.current) return;
+    openingLock.current = true;
+    setOpeningId(race.id);
+    try {
+      const [{ data }, comments] = await Promise.all([
+        supabase
+          .from("comp_mst")
+          .select("comp_id, short_id, comp_nm, comp_sprt_cd, stt_dt, end_dt, loc_nm, src_url, comp_evt_cfg(comp_evt_type)")
+          .eq("comp_id", race.id)
+          .single(),
+        memberId ? fetchComments("comp", race.id) : Promise.resolve(undefined),
+      ]);
 
-    const comp: Competition = data
-      ? {
-          id: data.comp_id,
-          short_id: data.short_id ?? null,
-          external_id: "",
-          sport: data.comp_sprt_cd ?? null,
-          title: data.comp_nm,
-          start_date: data.stt_dt,
-          end_date: data.end_dt ?? null,
-          location: data.loc_nm ?? null,
-          event_types: (data.comp_evt_cfg as { comp_evt_type: string | null }[])
-            .map((e) => e.comp_evt_type?.toUpperCase())
-            .filter((e): e is string => Boolean(e)),
-          source_url: data.src_url ?? null,
-        }
-      : {
-          id: race.id,
-          short_id: null,
-          external_id: "",
-          sport: null,
-          title: race.title,
-          start_date: race.start_date,
-          end_date: null,
-          location: null,
-          event_types: null,
-          source_url: null,
-        };
+      const comp: Competition = data
+        ? {
+            id: data.comp_id,
+            short_id: data.short_id ?? null,
+            external_id: "",
+            sport: data.comp_sprt_cd ?? null,
+            title: data.comp_nm,
+            start_date: data.stt_dt,
+            end_date: data.end_dt ?? null,
+            location: data.loc_nm ?? null,
+            event_types: (data.comp_evt_cfg as { comp_evt_type: string | null }[])
+              .map((e) => e.comp_evt_type?.toUpperCase())
+              .filter((e): e is string => Boolean(e)),
+            source_url: data.src_url ?? null,
+          }
+        : {
+            id: race.id,
+            short_id: null,
+            external_id: "",
+            sport: null,
+            title: race.title,
+            start_date: race.start_date,
+            end_date: null,
+            location: null,
+            event_types: null,
+            source_url: null,
+          };
 
-    // fetch 완료 후 한 번에 설정 — 이전 댓글이 남는 버그 방지
-    setSelectedCompetition(comp);
-    setCompDetailInitialComments(comments);
-    setDetailOpen(true);
-  }
+      setSelectedCompetition(comp);
+      setCompDetailInitialComments(comments);
+      setDetailOpen(true);
+    } finally {
+      openingLock.current = false;
+      setOpeningId(null);
+    }
+  // supabase/memberId/teamId는 컴포넌트 생애 내 불변
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
   const createRegistration = async (
     competitionId: string,
@@ -654,18 +665,40 @@ export function MiniCalendar({
     return { gigang: newGigang, mine: newMine, schPosts: newSchPosts, gatherings: newGatherings };
   }
 
-  function navigate(dir: -1 | 1) {
+  const viewMonthRef = useRef(viewMonth);
+  useEffect(() => { viewMonthRef.current = viewMonth; }, [viewMonth]);
+
+  const fetchMonthDataRef = useRef(fetchMonthData);
+  fetchMonthDataRef.current = fetchMonthData;
+
+  const navigate = useCallback((dir: -1 | 1) => {
+    if (openingLock.current) return;
     startTransition(async () => {
-      const newMonthDayjs = dayjs(viewMonth).add(dir, "month");
-      const newMonth = newMonthDayjs.format("YYYY-MM-01");
-      const { gigang, mine, schPosts: newSch, gatherings: newGthr } = await fetchMonthData(newMonth);
+      const newMonth = dayjs(viewMonthRef.current).add(dir, "month").format("YYYY-MM-01");
+      const { gigang, mine, schPosts: newSch, gatherings: newGthr } = await fetchMonthDataRef.current(newMonth);
       setViewMonth(newMonth);
       setGigangRaces(gigang);
       setMyRaces(mine);
       setSchPosts(newSch);
       setGatherings(newGthr);
     });
-  }
+  }, []);
+
+  const swipeTouchStartX = useRef<number | null>(null);
+  const swipeDidNavigate = useRef(false);
+  const handleSwipeTouchStart = useCallback((e: React.TouchEvent) => {
+    swipeTouchStartX.current = e.touches[0].clientX;
+    swipeDidNavigate.current = false;
+  }, []);
+  const handleSwipeTouchEnd = useCallback((e: React.TouchEvent) => {
+    if (swipeTouchStartX.current === null || isPending) return;
+    const dx = e.changedTouches[0].clientX - swipeTouchStartX.current;
+    swipeTouchStartX.current = null;
+    if (Math.abs(dx) < 75) return;
+    swipeDidNavigate.current = true;
+    navigate(dx < 0 ? 1 : -1);
+  // navigate는 deps [] 로 안정화됨
+  }, [isPending, navigate]); // eslint-disable-line react-hooks/exhaustive-deps
 
   function openCreateForm(defaultDate?: string, postType?: SchPostType) {
     setFormMode("create");
@@ -693,31 +726,51 @@ export function MiniCalendar({
     await handleSchPostSuccess();
   }
 
-  async function openSchPostDetail(race: CalendarRace) {
-    const comments = memberId ? await fetchComments("sch_post", race.id) : undefined;
-    // fetch 완료 후 한 번에 설정 — 이전 댓글이 남는 버그 방지
-    setSchDetailPost(race);
-    setSchDetailInitialComments(comments);
-    setSchDetailOpen(true);
-  }
+  const openSchPostDetail = useCallback(async (race: CalendarRace) => {
+    if (openingLock.current) return;
+    openingLock.current = true;
+    setOpeningId(race.id);
+    try {
+      const comments = memberId ? await fetchComments("sch_post", race.id) : undefined;
+      setSchDetailPost(race);
+      setSchDetailInitialComments(comments);
+      setSchDetailOpen(true);
+    } finally {
+      openingLock.current = false;
+      setOpeningId(null);
+    }
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
-  async function openGatheringDetail(race: CalendarRace) {
-    type GthrDetail = { max_prt_cnt: number | null; sprt_cd: string | null; attendees: GatheringAttendee[] };
-    const [comments, attdResult, gthrDetailResult] = await Promise.all([
-      memberId ? fetchComments("gathering", race.id) : Promise.resolve(undefined),
-      memberId
-        ? supabase.from("gthr_attd_rel").select("attd_id").eq("gthr_id", race.id).eq("mem_id", memberId).maybeSingle()
-        : Promise.resolve({ data: null }),
-      supabase.rpc("get_gathering_detail", { p_gthr_id: race.id, p_team_id: teamId }),
-    ]);
-    if (gthrDetailResult.error) console.error("[openGatheringDetail]", gthrDetailResult.error);
-    const gthrData = gthrDetailResult.data as GthrDetail | null;
-    const attendees: GatheringAttendee[] = gthrData?.attendees ?? [];
-    setGthrDetailRace({ ...race, regCount: attendees.length, maxPrtCnt: gthrData?.max_prt_cnt ?? null, attendees, sprt_cd: gthrData?.sprt_cd ?? null });
-    setGthrDetailAttending(!!attdResult.data);
-    setGthrDetailComments(comments);
-    setGthrDetailOpen(true);
-  }
+  const openGatheringDetail = useCallback(async (race: CalendarRace) => {
+    if (openingLock.current) return;
+    openingLock.current = true;
+    setOpeningId(race.id);
+    try {
+      type GthrDetail = { max_prt_cnt: number | null; sprt_cd: string | null; attendees: GatheringAttendee[] };
+      const [comments, attdResult, gthrDetailResult] = await Promise.all([
+        memberId ? fetchComments("gathering", race.id) : Promise.resolve(undefined),
+        memberId
+          ? supabase.from("gthr_attd_rel").select("attd_id").eq("gthr_id", race.id).eq("mem_id", memberId).maybeSingle()
+          : Promise.resolve({ data: null }),
+        supabase.rpc("get_gathering_detail", { p_gthr_id: race.id, p_team_id: teamId }),
+      ]);
+      if (gthrDetailResult.error) {
+        console.error("[openGatheringDetail]", gthrDetailResult.error);
+        throw gthrDetailResult.error;
+      }
+      const gthrData = gthrDetailResult.data as GthrDetail | null;
+      const attendees: GatheringAttendee[] = gthrData?.attendees ?? [];
+      setGthrDetailRace({ ...race, regCount: attendees.length, maxPrtCnt: gthrData?.max_prt_cnt ?? null, attendees, sprt_cd: gthrData?.sprt_cd ?? null });
+      setGthrDetailAttending(!!attdResult.data);
+      setGthrDetailComments(comments);
+      setGthrDetailOpen(true);
+    } finally {
+      openingLock.current = false;
+      setOpeningId(null);
+    }
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
   async function refreshMonthData() {
     const { gigang, mine, schPosts: newSch, gatherings: newGthr } = await fetchMonthData(viewMonth);
@@ -777,9 +830,9 @@ export function MiniCalendar({
         {/* 월 네비게이션 — 캘린더뷰에서만 표시 */}
         {view === "calendar" && (
           <div className="flex items-center gap-1">
-            <Micro className="font-medium tabular-nums text-foreground">
+            <SectionLabel className="tabular-nums text-foreground">
               {year}.{String(month).padStart(2, "0")}
-            </Micro>
+            </SectionLabel>
             <button
               onClick={() => navigate(-1)}
               disabled={isPending}
@@ -801,7 +854,7 @@ export function MiniCalendar({
       </div>
 
       {/* 필터 칩 */}
-      <div className="flex gap-1.5 overflow-x-auto scrollbar-none pb-1">
+      <div className="flex gap-1.5 overflow-x-auto scrollbar-none py-0.5">
         {([
           { key: "all", label: "전체" },
           { key: "competition", label: "🏆 대회" },
@@ -812,7 +865,7 @@ export function MiniCalendar({
             key={key}
             onClick={() => setFilterType(key)}
             className={cn(
-              "shrink-0 rounded-full px-2.5 py-0.5 text-[10px] transition-colors",
+              "shrink-0 rounded-full px-3 py-1 text-[11px] transition-colors",
               filterType === key
                 ? "bg-foreground text-background font-medium"
                 : "border border-border bg-transparent text-muted-foreground hover:border-foreground/40"
@@ -826,7 +879,11 @@ export function MiniCalendar({
       {view === "calendar" ? (
         <>
           {/* 달력 + 이벤트 */}
-          <div className={cn("flex flex-col transition-opacity", isPending && "opacity-50")}>
+          <div
+            className={cn("flex flex-col transition-opacity", isPending && "opacity-50")}
+            onTouchStart={handleSwipeTouchStart}
+            onTouchEnd={handleSwipeTouchEnd}
+          >
             {/* 요일 헤더 */}
             <div className="grid grid-cols-7 text-center">
               {WEEKDAYS.map((wd) => (
@@ -859,7 +916,7 @@ export function MiniCalendar({
                         return (
                           <button
                             key={`ol-${dateStr}`}
-                            onClick={() => setSelectedDate(dateStr)}
+                            onClick={() => { if (swipeDidNavigate.current) { swipeDidNavigate.current = false; return; } setSelectedDate(dateStr); }}
                             className={cn(
                               "pointer-events-auto h-full w-full transition-colors",
                               isSelected && "bg-secondary/60",
@@ -979,7 +1036,8 @@ export function MiniCalendar({
                               ? openGatheringDetail(race)
                               : handleRaceClick(race)
                         }
-                        className="flex w-full items-center gap-1.5 rounded-lg px-1 py-0.5 text-left transition-all active:scale-[0.98] active:bg-secondary hover:bg-secondary/60"
+                        disabled={openingId === race.id}
+                        className="flex w-full items-center gap-1.5 rounded-lg px-1 py-0.5 text-left transition-all active:scale-[0.98] active:bg-secondary hover:bg-secondary/60 disabled:opacity-60"
                       >
                         <span
                           className={cn(
@@ -1084,6 +1142,7 @@ export function MiniCalendar({
             initialMonthKey={viewMonth.slice(0, 7)}
             initialRaces={[...myRaces, ...schPosts, ...gigangRaces, ...gatherings]}
             filterType={filterType}
+            openingId={openingId}
             onClickSchedule={openSchPostDetail}
             onClickCompetition={handleRaceClick}
             onClickGathering={openGatheringDetail}

--- a/components/home/schedule-list-view.tsx
+++ b/components/home/schedule-list-view.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { memo, useCallback, useEffect, useMemo, useRef, useState } from "react";
 
 import { MapPin } from "lucide-react";
 
@@ -26,6 +26,7 @@ type Props = {
   initialMonthKey: string;
   initialRaces: CalendarRace[];
   filterType?: FilterType;
+  openingId?: string | null;
   onClickSchedule: (race: CalendarRace) => void;
   onClickCompetition: (race: CalendarRace) => void;
   onClickGathering: (race: CalendarRace) => void;
@@ -148,13 +149,14 @@ function formatTimeRange(sttAt: string | null | undefined, endAt: string | null 
 }
 
 // schedule 타입 아이템
-function ScheduleItem({ race, onClick }: { race: CalendarRace; onClick: () => void }) {
+function ScheduleItem({ race, onClick, loading }: { race: CalendarRace; onClick: () => void; loading?: boolean }) {
   const timeRange = formatTimeRange(race.evt_stt_at, race.evt_end_at);
 
   return (
     <button
       onClick={onClick}
-      className="flex w-full items-stretch gap-2.5 rounded-lg px-2 py-0.5 text-left transition-all active:scale-[0.98] active:bg-secondary hover:bg-secondary/60"
+      disabled={loading}
+      className="flex w-full items-stretch gap-2.5 rounded-lg px-2 py-0.5 text-left transition-all active:scale-[0.98] active:bg-secondary hover:bg-secondary/60 disabled:opacity-60"
     >
       <span className="w-0.5 shrink-0 rounded-full bg-info" />
       <span className="flex min-w-0 flex-1 flex-col gap-0.5">
@@ -187,16 +189,19 @@ function ScheduleItem({ race, onClick }: { race: CalendarRace; onClick: () => vo
 function CompetitionItem({
   race,
   onClick,
+  loading,
 }: {
   race: CalendarRace;
   onClick: () => void;
+  loading?: boolean;
 }) {
   const isMine = race.type === "mine";
 
   return (
     <button
       onClick={onClick}
-      className="flex w-full items-stretch gap-2.5 rounded-lg px-2 py-0.5 text-left transition-all active:scale-[0.98] active:bg-secondary hover:bg-secondary/60"
+      disabled={loading}
+      className="flex w-full items-stretch gap-2.5 rounded-lg px-2 py-0.5 text-left transition-all active:scale-[0.98] active:bg-secondary hover:bg-secondary/60 disabled:opacity-60"
     >
       <span className="w-0.5 shrink-0 rounded-full bg-warning" />
       <span className="flex min-w-0 flex-1 flex-col gap-0.5">
@@ -232,14 +237,15 @@ function CompetitionItem({
   );
 }
 
-function GatheringItem({ race, onClick }: { race: CalendarRace; onClick: () => void }) {
+function GatheringItem({ race, onClick, loading }: { race: CalendarRace; onClick: () => void; loading?: boolean }) {
   const isMine = race.type === "gathering_mine";
   const timeRange = formatTimeRange(race.evt_stt_at, race.evt_end_at);
 
   return (
     <button
       onClick={onClick}
-      className="flex w-full items-stretch gap-2.5 rounded-lg px-2 py-0.5 text-left transition-all active:scale-[0.98] active:bg-secondary hover:bg-secondary/60"
+      disabled={loading}
+      className="flex w-full items-stretch gap-2.5 rounded-lg px-2 py-0.5 text-left transition-all active:scale-[0.98] active:bg-secondary hover:bg-secondary/60 disabled:opacity-60"
     >
       <span className="w-0.5 shrink-0 rounded-full bg-violet-500" />
       <span className="flex min-w-0 flex-1 flex-col gap-0.5">
@@ -278,12 +284,13 @@ function GatheringItem({ race, onClick }: { race: CalendarRace; onClick: () => v
   );
 }
 
-export function ScheduleListView({
+export const ScheduleListView = memo(function ScheduleListView({
   teamId,
   memberId,
   initialMonthKey,
   initialRaces,
   filterType = "all",
+  openingId,
   onClickSchedule,
   onClickCompetition,
   onClickGathering,
@@ -299,8 +306,6 @@ export function ScheduleListView({
   });
   const [loadingPrev, setLoadingPrev] = useState(false);
   const [loadingNext, setLoadingNext] = useState(false);
-  const [canLoadPrev, setCanLoadPrev] = useState(true);
-  const [canLoadNext, setCanLoadNext] = useState(true);
   const oldestMonth = months[0].monthKey;
   const newestMonth = months[months.length - 1].monthKey;
 
@@ -309,42 +314,59 @@ export function ScheduleListView({
   const containerRef = useRef<HTMLDivElement>(null);
   const prevScrollHeightRef = useRef(0);
 
+  const loadingPrevRef = useRef(false);
+  const canLoadPrevRef = useRef(true);
+  const loadingNextRef = useRef(false);
+  const canLoadNextRef = useRef(true);
+  const oldestMonthRef = useRef(oldestMonth);
+  const newestMonthRef = useRef(newestMonth);
+  const teamIdRef = useRef(teamId);
+  const memberIdRef = useRef(memberId);
+  useEffect(() => { oldestMonthRef.current = oldestMonth; }, [oldestMonth]);
+  useEffect(() => { newestMonthRef.current = newestMonth; }, [newestMonth]);
+  useEffect(() => { teamIdRef.current = teamId; }, [teamId]);
+  useEffect(() => { memberIdRef.current = memberId; }, [memberId]);
+
   const loadPrev = useCallback(async () => {
-    if (loadingPrev || !canLoadPrev) return;
+    if (loadingPrevRef.current || !canLoadPrevRef.current) return;
+    loadingPrevRef.current = true;
     setLoadingPrev(true);
     try {
-      const cursorDate = dayjs(oldestMonth + "-01").format("YYYY-MM-DD");
-      const races = await fetchAdjacent(supabase, teamId, memberId, "prev", cursorDate, 2);
+      const cursorDate = dayjs(oldestMonthRef.current + "-01").format("YYYY-MM-DD");
+      const races = await fetchAdjacent(supabase, teamIdRef.current, memberIdRef.current, "prev", cursorDate, 2);
       if (races.length === 0) {
-        setCanLoadPrev(false);
+        canLoadPrevRef.current = false;
         return;
       }
       const newMonths = racesToMonths(races);
       prevScrollHeightRef.current = containerRef.current?.scrollHeight ?? 0;
       setMonths((prev) => [...newMonths, ...prev]);
     } finally {
+      loadingPrevRef.current = false;
       setLoadingPrev(false);
     }
   // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [loadingPrev, canLoadPrev, oldestMonth, teamId, memberId]);
+  }, []);
 
   const loadNext = useCallback(async () => {
-    if (loadingNext || !canLoadNext) return;
+    if (loadingNextRef.current || !canLoadNextRef.current) return;
+    loadingNextRef.current = true;
     setLoadingNext(true);
     try {
-      const cursorDate = dayjs(newestMonth + "-01").endOf("month").format("YYYY-MM-DD");
-      const races = await fetchAdjacent(supabase, teamId, memberId, "next", cursorDate, 1);
+      const cursorDate = dayjs(newestMonthRef.current + "-01").endOf("month").format("YYYY-MM-DD");
+      const races = await fetchAdjacent(supabase, teamIdRef.current, memberIdRef.current, "next", cursorDate, 1);
       if (races.length === 0) {
-        setCanLoadNext(false);
+        canLoadNextRef.current = false;
         return;
       }
       const [first] = racesToMonths(races);
       setMonths((prev) => [...prev, first]);
     } finally {
+      loadingNextRef.current = false;
       setLoadingNext(false);
     }
   // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [loadingNext, canLoadNext, newestMonth, teamId, memberId]);
+  }, []);
 
   // 이전 달 prepend 후 스크롤 위치 보정
   useEffect(() => {
@@ -356,7 +378,7 @@ export function ScheduleListView({
     prevScrollHeightRef.current = 0;
   }, [months]);
 
-  // IntersectionObserver — root를 스크롤 컨테이너로 지정해 마운트 시 자동 발화 방지
+  // IntersectionObserver — deps [] 로 마운트 1회만 생성, loadPrev/loadNext는 ref 기반으로 항상 최신값 참조
   useEffect(() => {
     const container = containerRef.current;
     if (!container) return;
@@ -378,7 +400,8 @@ export function ScheduleListView({
     if (topSentinelRef.current) obs.observe(topSentinelRef.current);
     if (bottomSentinelRef.current) obs.observe(bottomSentinelRef.current);
     return () => obs.disconnect();
-  }, [loadPrev, loadNext]);
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
   return (
     <div
@@ -452,18 +475,21 @@ export function ScheduleListView({
                               <ScheduleItem
                                 key={race.id}
                                 race={race}
+                                loading={openingId === race.id}
                                 onClick={() => onClickSchedule(race)}
                               />
                             ) : race.type === "gathering" || race.type === "gathering_mine" ? (
                               <GatheringItem
                                 key={race.id}
                                 race={race}
+                                loading={openingId === race.id}
                                 onClick={() => onClickGathering(race)}
                               />
                             ) : (
                               <CompetitionItem
                                 key={race.id}
                                 race={race}
+                                loading={openingId === race.id}
                                 onClick={() => onClickCompetition(race)}
                               />
                             ),
@@ -485,4 +511,4 @@ export function ScheduleListView({
       </div>
     </div>
   );
-}
+});


### PR DESCRIPTION
- swipe-to-navigate month change on calendar view
- filter chip size and margin adjustments
- loading indicator when opening schedule/gathering/competition items
- openingLock mutex to prevent duplicate dialog opens
- useCallback stabilization for handleRaceClick, openSchPostDetail, openGatheringDetail
- fetchMonthDataRef pattern to eliminate stale closure in navigate
- teamIdRef/memberIdRef in ScheduleListView to prevent stale closure in loadPrev/loadNext
- swipeDidNavigate reset on tap to prevent click suppression after swipe
- throw instead of return in openGatheringDetail RPC error path to ensure lock release

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 캘린더 월 네비게이션 터치 스와이프 기능 추가

* **개선 사항**
  * 일정/대회/모임 상세 열기 시 중복 클릭 방지 처리 추가
  * 상세 여는 항목의 버튼 비활성화 상태 시각적 피드백 추가
  * 무한 스크롤 성능 개선

<!-- end of auto-generated comment: release notes by coderabbit.ai -->