### PR TITLE
fix(push): 푸시 알림 테스트 버그 수정 (배포 누락·비로그인·실시간 뱃지)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,8 +39,7 @@
 # production
 /build
 
-# Service Worker (빌드 시 자동 생성)
-/public/sw.js
+# Service Worker 자동 생성 산출물 (serwist 등). 푸시 수신용 public/sw.js는 직접 관리하므로 추적함.
 /public/sw.js.map
 
 # misc

--- a/app/(main)/layout.tsx
+++ b/app/(main)/layout.tsx
@@ -1,7 +1,7 @@
 import { Suspense } from "react";
 
 import { BottomTabBar } from "@/components/bottom-tab-bar";
-import { PushPermissionPrompt } from "@/components/push-permission-prompt";
+import { PushPermissionPromptGate } from "@/components/push-permission-prompt-gate";
 import { Skeleton } from "@/components/ui/skeleton";
 
 function AppShellFallback() {
@@ -43,7 +43,9 @@ export default function MainLayout({
         <main className="pb-[calc(3.5rem+env(safe-area-inset-bottom,0px))]">
           {children}
         </main>
-        <PushPermissionPrompt />
+        <Suspense fallback={null}>
+          <PushPermissionPromptGate />
+        </Suspense>
       </Suspense>
       <BottomTabBar />
     </div>

--- a/components/notifications/notification-bell-icon.tsx
+++ b/components/notifications/notification-bell-icon.tsx
@@ -134,16 +134,10 @@ export function NotificationBellIcon({ initialCount, initialNotifications, membe
     }
   }
 
+  // realtime 구독은 팝오버 open 여부와 무관하게 로그인(memberId) 상태면 항상 유지한다.
+  // → 홈탭 등 다른 화면에 있어도 알림이 오면 빨간 뱃지가 실시간으로 갱신된다.
   useEffect(() => {
-    if (!open || !memberId) return;
-
-    if (!notificationsLoaded.current) {
-      notificationsLoaded.current = true;
-       
-      setCursor(null);
-      setHasMore(true);
-      fetchNotifications(true, null);
-    }
+    if (!memberId) return;
 
     const supabase = createClient();
     const channel = supabase
@@ -155,8 +149,13 @@ export function NotificationBellIcon({ initialCount, initialNotifications, membe
         filter: `mem_id=eq.${memberId}`,
       }, (payload) => {
         const noti = payload.new as Notification;
-        setNotifications((prev) => [noti, ...prev]);
         setUnreadCount((c) => c + 1);
+        // 목록이 이미 로드된 경우에만 앞에 추가 (중복 방지)
+        if (notificationsLoaded.current) {
+          setNotifications((prev) =>
+            prev.some((n) => n.noti_id === noti.noti_id) ? prev : [noti, ...prev],
+          );
+        }
       })
       .on("postgres_changes", {
         event: "UPDATE",
@@ -182,6 +181,17 @@ export function NotificationBellIcon({ initialCount, initialNotifications, membe
       supabase.removeChannel(channel);
       realtimeRef.current = null;
     };
+  }, [memberId]);
+
+  // 알림 목록은 팝오버를 처음 열 때 1회 로드 (뱃지 카운트와 분리)
+  useEffect(() => {
+    if (!open || !memberId) return;
+    if (notificationsLoaded.current) return;
+    notificationsLoaded.current = true;
+    setCursor(null);
+    setHasMore(true);
+    fetchNotifications(true, null);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [open, memberId]);
 
   // 팝오버 내부 스크롤 무한스크롤

--- a/components/push-permission-prompt-gate.tsx
+++ b/components/push-permission-prompt-gate.tsx
@@ -1,0 +1,23 @@
+import { getCurrentMember } from "@/lib/queries/member";
+
+import { PushPermissionPrompt } from "@/components/push-permission-prompt";
+
+/**
+ * 푸시 권한 soft prompt + 로그인 여부 조회를 묶은 서버 컴포넌트.
+ *
+ * (main) 레이아웃은 비로그인도 접근 가능한 홈을 포함하므로, 권한 배너를 무조건 띄우면
+ * 비로그인 사용자에게도 권한 요청이 뜬다. 허용해도 구독 저장(withMember)이 거부돼
+ * "권한은 granted인데 구독은 없는" 반쪽 상태가 되므로, 로그인 멤버에게만 노출한다.
+ * cookies() 의존 조회는 <Suspense> 경계 안에 둬 페이지 본문 렌더를 막지 않는다.
+ */
+export async function PushPermissionPromptGate() {
+  let loggedIn = false;
+  try {
+    const { member } = await getCurrentMember();
+    loggedIn = member !== null;
+  } catch {
+    loggedIn = false;
+  }
+
+  return <PushPermissionPrompt loggedIn={loggedIn} />;
+}

--- a/components/push-permission-prompt.tsx
+++ b/components/push-permission-prompt.tsx
@@ -30,11 +30,13 @@ const DISMISS_KEY = "push-prompt-dismissed";
  * - 거부하면 다시 자동으로 조르지 않는다 — localStorage 영구 dismiss.
  *   마음 바뀌면 우측 상단 알림 설정 토글에서 직접 켠다.
  */
-export function PushPermissionPrompt() {
+export function PushPermissionPrompt({ loggedIn }: { loggedIn: boolean }) {
   const [visible, setVisible] = useState(false);
 
   useEffect(() => {
     if (typeof window === "undefined") return;
+    // 로그인 멤버만 — 비로그인은 구독 저장(withMember)이 거부되므로 권한을 받아도 반쪽 상태가 됨
+    if (!loggedIn) return;
     if (window.localStorage.getItem(DISMISS_KEY)) return;
     // 설치된 PWA에서만 (미설치 웹은 설치 배너가 담당)
     if (!isStandalone()) return;
@@ -51,7 +53,7 @@ export function PushPermissionPrompt() {
     return () => {
       cancelled = true;
     };
-  }, []);
+  }, [loggedIn]);
 
   if (!visible) return null;
 

--- a/public/sw.js
+++ b/public/sw.js
@@ -8,9 +8,6 @@
  * ⚠️ serwist/next-pwa 미사용 — 빌드로 덮어쓰이지 않으므로 이 파일을 직접 관리한다.
  */
 
-const GROUP_TAG = "gigang";
-const SUMMARY_TAG = "gigang-summary";
-
 // 새 SW가 바로 활성화되도록
 self.addEventListener("install", () => self.skipWaiting());
 self.addEventListener("activate", (event) =>
@@ -28,50 +25,18 @@ self.addEventListener("push", (event) => {
 
   const title = payload.title || "기강";
   const url = payload.url || "/";
-  const options = {
-    body: payload.body || "",
-    icon: "/android-icon-192x192.png",
-    badge: "/android-icon-192x192.png",
-    tag: payload.tag || `gigang-${Date.now()}`,
-    data: { url },
-    // Android: 같은 그룹으로 묶어 알림창에서 1줄로 보이게
-    renotify: false,
-  };
-
-  event.waitUntil(showWithGroupSummary(title, options));
+  // 개별 알림만 띄운다. 같은 앱 알림의 "N개" 묶음(접으면 1줄, 펼치면 개별)은
+  // 안드로이드 OS가 자동으로 처리하므로 수동 요약을 만들지 않는다.
+  event.waitUntil(
+    self.registration.showNotification(title, {
+      body: payload.body || "",
+      icon: "/android-icon-192x192.png",
+      badge: "/android-icon-192x192.png",
+      tag: payload.tag || `gigang-${Date.now()}`,
+      data: { url },
+    }),
+  );
 });
-
-/**
- * 개별 알림을 표시하고, Android에서 그룹 요약(접혔을 때 1줄)을 갱신한다.
- * iOS는 group/isGroupSummary 미지원 — OS가 앱별로 자동 그룹핑하므로 개별 알림만 띄운다.
- */
-async function showWithGroupSummary(title, options) {
-  await self.registration.showNotification(title, options);
-
-  // 그룹 요약은 Android 계열에서만 의미가 있다. 실패해도 개별 알림은 이미 떴으므로 무시.
-  try {
-    const existing = await self.registration.getNotifications({
-      tag: SUMMARY_TAG,
-    });
-    // 요약 자신을 제외한 실제 알림 개수
-    const all = await self.registration.getNotifications();
-    const count = all.filter((n) => n.tag !== SUMMARY_TAG).length;
-    if (count > 1) {
-      await self.registration.showNotification("기강", {
-        body: `새 알림 ${count}개`,
-        icon: "/android-icon-192x192.png",
-        badge: "/android-icon-192x192.png",
-        tag: SUMMARY_TAG,
-        data: { url: "/" },
-        silent: true,
-      });
-    }
-    void existing;
-  } catch {
-    // iOS 등 미지원 환경 — 무시
-  }
-  void GROUP_TAG;
-}
 
 self.addEventListener("notificationclick", (event) => {
   event.notification.close();

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,0 +1,114 @@
+/**
+ * 푸시 수신 전용 서비스워커 (얇은 파일).
+ *
+ * 이 프로젝트는 캐싱/오프라인 목적의 서비스워커를 쓰지 않는다.
+ * 오직 웹 푸시 수신(push 이벤트)과 알림 클릭 처리(notificationclick)만 담당한다.
+ * 탭이 닫혀 있어도 OS가 이 서비스워커를 깨워 push 이벤트를 전달한다.
+ *
+ * ⚠️ serwist/next-pwa 미사용 — 빌드로 덮어쓰이지 않으므로 이 파일을 직접 관리한다.
+ */
+
+const GROUP_TAG = "gigang";
+const SUMMARY_TAG = "gigang-summary";
+
+// 새 SW가 바로 활성화되도록
+self.addEventListener("install", () => self.skipWaiting());
+self.addEventListener("activate", (event) =>
+  event.waitUntil(self.clients.claim()),
+);
+
+self.addEventListener("push", (event) => {
+  let payload = {};
+  try {
+    payload = event.data ? event.data.json() : {};
+  } catch {
+    // 페이로드 파싱 실패 시 빈 알림 방지: 본문만 텍스트로 시도
+    payload = { title: "기강", body: event.data ? event.data.text() : "" };
+  }
+
+  const title = payload.title || "기강";
+  const url = payload.url || "/";
+  const options = {
+    body: payload.body || "",
+    icon: "/android-icon-192x192.png",
+    badge: "/android-icon-192x192.png",
+    tag: payload.tag || `gigang-${Date.now()}`,
+    data: { url },
+    // Android: 같은 그룹으로 묶어 알림창에서 1줄로 보이게
+    renotify: false,
+  };
+
+  event.waitUntil(showWithGroupSummary(title, options));
+});
+
+/**
+ * 개별 알림을 표시하고, Android에서 그룹 요약(접혔을 때 1줄)을 갱신한다.
+ * iOS는 group/isGroupSummary 미지원 — OS가 앱별로 자동 그룹핑하므로 개별 알림만 띄운다.
+ */
+async function showWithGroupSummary(title, options) {
+  await self.registration.showNotification(title, options);
+
+  // 그룹 요약은 Android 계열에서만 의미가 있다. 실패해도 개별 알림은 이미 떴으므로 무시.
+  try {
+    const existing = await self.registration.getNotifications({
+      tag: SUMMARY_TAG,
+    });
+    // 요약 자신을 제외한 실제 알림 개수
+    const all = await self.registration.getNotifications();
+    const count = all.filter((n) => n.tag !== SUMMARY_TAG).length;
+    if (count > 1) {
+      await self.registration.showNotification("기강", {
+        body: `새 알림 ${count}개`,
+        icon: "/android-icon-192x192.png",
+        badge: "/android-icon-192x192.png",
+        tag: SUMMARY_TAG,
+        data: { url: "/" },
+        silent: true,
+      });
+    }
+    void existing;
+  } catch {
+    // iOS 등 미지원 환경 — 무시
+  }
+  void GROUP_TAG;
+}
+
+self.addEventListener("notificationclick", (event) => {
+  event.notification.close();
+  // 심층 방어: 서버가 내려준 url이라도 상대경로(앱 내부)만 허용 (open redirect/javascript: 차단)
+  const raw = event.notification.data?.url || "/";
+  const safeUrl = typeof raw === "string" && raw.startsWith("/") ? raw : "/";
+
+  event.waitUntil(handleClick(safeUrl));
+});
+
+async function handleClick(safeUrl) {
+  const clientList = await self.clients.matchAll({
+    type: "window",
+    includeUncontrolled: true,
+  });
+  const sameOrigin = clientList.filter((c) =>
+    c.url.startsWith(self.location.origin),
+  );
+
+  // 1순위: 이미 목적지와 같은 URL인 탭이 있으면 그 탭만 focus
+  const exact = sameOrigin.find(
+    (c) => c.url === self.location.origin + safeUrl,
+  );
+  if (exact && "focus" in exact) return exact.focus();
+
+  // 2순위: 같은 origin 탭을 목적지로 이동 + focus.
+  // iOS PWA에서 navigate()가 거부/무시될 수 있으므로 await하고, 실패하면 openWindow로 폴백.
+  const first = sameOrigin[0];
+  if (first && "focus" in first) {
+    try {
+      if (first.navigate) await first.navigate(safeUrl);
+      return await first.focus();
+    } catch {
+      // navigate 실패(iOS 등) → 새 창으로 폴백
+    }
+  }
+
+  // 없거나 폴백: 새 탭으로 open
+  if (self.clients.openWindow) return self.clients.openWindow(safeUrl);
+}


### PR DESCRIPTION
## Summary

푸시 알림 dev 배포 후 실기기 테스트에서 발견한 버그 4건 수정.
**핵심은 `public/sw.js`가 .gitignore에 걸려 배포에 누락된 문제** — 이로 인해 FCM은 수신해도 폰에 알림이 표시되지 않았다.

## AS-IS (문제)

- **푸시가 폰에 안 뜸**: `public/sw.js`가 serwist 시절 `.gitignore` 규칙(`/public/sw.js`)에 걸려 git·배포에 안 올라감 → Vercel에 SW 파일이 없어 등록 실패 → FCM 수신해도 표시 불가
- **비로그인에게 권한 배너 노출**: `(main)` 레이아웃은 비로그인도 접근하는 홈을 포함하는데 `PushPermissionPrompt`가 로그인 체크를 안 함. 비로그인이 허용해도 구독 저장(withMember)이 거부돼 "권한은 granted인데 구독 없는" 반쪽 상태
- **실시간 뱃지 미갱신**: realtime 구독이 벨 팝오버 open일 때만 활성화 → 홈탭 등에서 알림이 와도 새로고침/벨 클릭 전엔 빨간 뱃지가 안 늘어남
- **sw.js 수동 그룹 요약 중복**: 안드로이드 OS 자동 그룹핑 위에 수동 요약 알림을 또 띄워 표시가 꼬일 소지 + badge가 미존재 파일 참조

## TO-BE (수정)

- **`.gitignore`에서 `/public/sw.js` 제거** + `public/sw.js` 추적 시작 → 배포에 포함
- **`PushPermissionPromptGate`** 추가: 서버에서 `getCurrentMember` 조회 후 **로그인 멤버에게만** 권한 배너 노출 (Suspense 경계 안에 둬 본문 렌더 비차단)
- realtime 구독을 팝오버 open과 분리 → **로그인 상태면 항상 구독**, 어느 화면에서든 알림 오면 즉시 뱃지 갱신 (목록 로드는 팝오버 첫 오픈 시 1회로 분리)
- sw.js **수동 그룹 요약 제거** → OS 자동 그룹핑에 위임("기강 N개" 접으면 1줄/펼치면 개별). badge를 존재하는 아이콘으로 교체

## Test plan

- [ ] dev 배포 후 폰 PWA에서 재구독 → `push_sub_rel`에 구독 저장 확인
- [ ] 테스트 푸시 또는 실제 알림(모임/댓글) → **폰에 알림 표시** 확인 (이번 수정 핵심)
- [ ] 비로그인 상태에서 홈 진입 → 권한 배너 **안 뜸** 확인
- [ ] 홈탭에 있을 때 알림 오면 빨간 뱃지 **실시간 갱신** 확인
- [ ] 알림 여러 개 → 안드로이드 알림창에서 "기강 N개"로 그룹핑 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * 푸시 알림을 앱에 직접 등록된 서비스 워커로 처리해, 알림 클릭 시 앱 탭으로 바로 이동하거나 기존 탭을 우선 활용하도록 개선했습니다.
  * 푸시 권한 안내가 로그인 상태에 따라 더 적절하게 표시되도록 변경했습니다.

* **Bug Fixes**
  * 알림 목록이 더 안정적으로 실시간 갱신되며, 중복 알림 추가를 줄였습니다.
  * 비로그인 상태에서 불필요한 푸시 안내 표시를 방지했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->