### PR TITLE
feat(records): 하이록스(HYROX) 랭킹 추가

### DIFF
--- a/app/(main)/records/page.tsx
+++ b/app/(main)/records/page.tsx
@@ -3,6 +3,7 @@ import { Suspense } from "react";
 import { unstable_cache } from "next/cache";
 
 import { secondsToTime } from "@/lib/dayjs";
+import { HYROX_SPRT_CD, HYROX_STATIONS, parseHyroxSplits } from "@/lib/hyrox";
 import { getMyTitleNames } from "@/lib/queries/member";
 import { getRequestTeamContext } from "@/lib/queries/request-team";
 import { createAdminClient } from "@/lib/supabase/admin";
@@ -41,8 +42,8 @@ function getCachedRecordsData(teamId: string) {
     async () => {
       const supabase = createAdminClient();
 
-      // 마라톤 + 철인3종 기록, UTMB 프로필, 대표 칭호 동시 조회
-      const [{ data: raceData }, { data: utmbData }, { data: titleData }] = await Promise.all([
+      // 마라톤 + 철인3종 기록, UTMB 프로필, 대표 칭호, 하이록스 기록 동시 조회
+      const [{ data: raceData }, { data: utmbData }, { data: titleData }, { data: hyroxData }] = await Promise.all([
         supabase.rpc("get_public_team_race_rankings", { p_team_id: teamId }),
         supabase.rpc("get_public_team_utmb_rankings", { p_team_id: teamId }),
         supabase
@@ -52,7 +53,17 @@ function getCachedRecordsData(teamId: string) {
           .eq("is_prmy_yn", true)
           .eq("vers", 0)
           .eq("del_yn", false),
+        // 하이록스: 멤버 기록 + 스테이션 split (팀 필터는 아래에서 raceData mem_id 집합과 교차)
+        supabase
+          .from("rec_race_hist")
+          .select("mem_id, rec_time_sec, race_nm, splits_json, mem_mst!inner(mem_nm), comp_mst!inner(comp_sprt_cd)")
+          .eq("vers", 0)
+          .eq("del_yn", false)
+          .eq("comp_mst.comp_sprt_cd", HYROX_SPRT_CD),
       ]);
+
+      // 팀 active 멤버 집합 (RPC 결과는 team_mem_rel active 조인으로 이미 팀 범위)
+      const teamMemberIds = new Set((raceData ?? []).map((r) => r.mem_id));
 
       // mem_id → { ttl_nm, badge_effect, frame_cd } 맵
       const memberTitleMap = new Map<string, { ttl_nm: string; ttl_desc: string | null; desc_visibility: "always" | "others" | "held" | "never"; badge_effect: string; frame_cd: string }>();
@@ -215,6 +226,42 @@ function getCachedRecordsData(teamId: string) {
         };
       });
 
+      // --- 하이록스 --- (멤버별 총시간 best 1건, 팀 멤버 한정)
+      const hyroxBestByMember = new Map<
+        string,
+        { memId: string; name: string; recordSec: number; raceName: string; splits: import("@/lib/hyrox").HyroxSplits }
+      >();
+      for (const r of hyroxData ?? []) {
+        if (!teamMemberIds.has(r.mem_id)) continue;
+        const mem = Array.isArray(r.mem_mst) ? r.mem_mst[0] : r.mem_mst;
+        const existing = hyroxBestByMember.get(r.mem_id);
+        if (!existing || r.rec_time_sec < existing.recordSec) {
+          hyroxBestByMember.set(r.mem_id, {
+            memId: r.mem_id,
+            name: mem?.mem_nm ?? "",
+            recordSec: r.rec_time_sec,
+            raceName: r.race_nm ?? "",
+            splits: parseHyroxSplits(r.splits_json),
+          });
+        }
+      }
+      const hyroxEntries = Array.from(hyroxBestByMember.values())
+        .sort((a, b) => a.recordSec - b.recordSec)
+        .map((r, i) => ({
+          rank: i + 1,
+          memId: r.memId,
+          name: r.name,
+          record: secondsToTime(r.recordSec),
+          raceName: r.raceName,
+          // 스테이션은 공식 순서로, 빈 칸은 null
+          splits: HYROX_STATIONS.map((s) => ({
+            code: s.code,
+            label: s.label,
+            spec: s.spec,
+            record: r.splits[s.code] != null ? secondsToTime(r.splits[s.code]!) : null,
+          })),
+        }));
+
       // mem_id → 칭호 맵 직렬화 (unstable_cache는 plain object만 반환 가능)
       const memberTitles: Record<string, { ttl_nm: string; ttl_desc: string | null; desc_visibility: "always" | "others" | "held" | "never"; badge_effect: string; frame_cd: string }> =
         Object.fromEntries(memberTitleMap.entries());
@@ -222,6 +269,7 @@ function getCachedRecordsData(teamId: string) {
       return {
         marathon: { events: marathonEvents },
         trail: { entries: trailEntries },
+        hyrox: { entries: hyroxEntries },
         triathlon: { events: triathlonEvents },
         memberTitles,
       };

--- a/app/(main)/records/records-client.tsx
+++ b/app/(main)/records/records-client.tsx
@@ -7,6 +7,13 @@ import { Medal, Search } from "lucide-react";
 import { getFrameCls } from "@/lib/title-effects";
 import { cn } from "@/lib/utils";
 
+import {
+  ResponsiveDrawer,
+  ResponsiveDrawerContent,
+  ResponsiveDrawerDescription,
+  ResponsiveDrawerHeader,
+  ResponsiveDrawerTitle,
+} from "@/components/common/responsive-drawer";
 import { TitleBadge } from "@/components/common/title-badge";
 import { Button } from "@/components/ui/button";
 import { CardItem } from "@/components/ui/card";
@@ -60,9 +67,26 @@ type TriathlonEvent = {
   entries: TriathlonEntry[];
 };
 
+type HyroxStationSplit = {
+  code: string;
+  label: string;
+  spec: string;
+  record: string | null;
+};
+
+type HyroxEntry = {
+  rank: number;
+  memId: string;
+  name: string;
+  record: string;
+  raceName: string | null;
+  splits: HyroxStationSplit[];
+};
+
 type RecordsData = {
   marathon: { events: MarathonEvent[] };
   trail: { entries: TrailEntry[] };
+  hyrox: { entries: HyroxEntry[] };
   triathlon: { events: TriathlonEvent[] };
   memberTitles: Record<string, MemberTitleBase>;
 };
@@ -74,6 +98,7 @@ type RecordsData = {
 const CATEGORIES = [
   { key: "marathon", label: "마라톤" },
   { key: "trail", label: "트레일러닝" },
+  { key: "hyrox", label: "하이록스" },
   { key: "triathlon", label: "철인3종" },
 ] as const;
 
@@ -346,6 +371,122 @@ function TrailContent({
 }
 
 /* ------------------------------------------------------------------ */
+/*  하이록스 탭 콘텐츠                                                  */
+/* ------------------------------------------------------------------ */
+
+function HyroxContent({
+  entries,
+  memberTitles,
+}: {
+  entries: HyroxEntry[];
+  memberTitles: Record<string, MemberTitle>;
+}) {
+  const [selected, setSelected] = useState<HyroxEntry | null>(null);
+
+  if (entries.length === 0) {
+    return (
+      <div className="px-6">
+        <EmptyState />
+      </div>
+    );
+  }
+
+  const selectedHasSplits = selected?.splits.some((s) => s.record !== null);
+
+  return (
+    <>
+      <div className="flex flex-col gap-2 px-6 pt-2">
+        {entries.map((entry) => {
+          const title = memberTitles[entry.memId];
+          const frameCls = getFrameCls(title?.frame_cd);
+          return (
+            <CardItem
+              key={`h-${entry.rank}-${entry.name}`}
+              className={cn(
+                "flex w-full items-center gap-4 p-3 text-left transition-colors hover:bg-muted/40",
+                frameCls,
+              )}
+              asChild
+            >
+              <button type="button" onClick={() => setSelected(entry)}>
+                <RankBadge rank={entry.rank} />
+                <div className="flex min-w-0 flex-1 flex-col gap-0.5">
+                  <div className="flex flex-wrap items-center gap-1.5">
+                    <span className="text-[15px] font-semibold text-foreground">
+                      {entry.name}
+                    </span>
+                    {title && (
+                      <TitleBadge
+                        name={title.ttl_nm}
+                        effect={title.badge_effect}
+                        size="xs"
+                        tooltip={{ desc: title.ttl_desc, visibility: title.desc_visibility, isHeld: title.isHeld, isOwner: false }}
+                      />
+                    )}
+                  </div>
+                  <span className="truncate text-xs text-muted-foreground">
+                    {entry.raceName ?? "-"}
+                  </span>
+                </div>
+                <span
+                  className={cn(
+                    "shrink-0 font-mono text-lg font-bold",
+                    entry.rank === 1 ? "text-primary" : "text-foreground",
+                  )}
+                >
+                  {entry.record}
+                </span>
+              </button>
+            </CardItem>
+          );
+        })}
+      </div>
+
+      <ResponsiveDrawer open={selected !== null} onOpenChange={(o) => !o && setSelected(null)}>
+        <ResponsiveDrawerContent
+          dialogClassName="max-h-[85dvh] max-w-md flex flex-col gap-0 p-0 overflow-hidden"
+          drawerClassName="max-h-[85dvh]"
+        >
+          <ResponsiveDrawerHeader className="shrink-0 border-b border-border px-5 py-4 text-left">
+            <ResponsiveDrawerTitle>
+              {selected?.name} · {selected?.record}
+            </ResponsiveDrawerTitle>
+            <ResponsiveDrawerDescription>
+              {selected?.raceName ?? "스테이션별 기록"}
+            </ResponsiveDrawerDescription>
+          </ResponsiveDrawerHeader>
+
+          <div className="flex-1 overflow-y-auto px-5 pb-6 pt-2">
+            {!selectedHasSplits ? (
+              <p className="py-8 text-center text-sm text-muted-foreground">
+                등록된 스테이션 기록이 없습니다.
+              </p>
+            ) : (
+              <div className="flex flex-col divide-y divide-border">
+                {selected?.splits.map((s, i) => (
+                  <div key={s.code} className="flex items-center gap-3 py-2.5">
+                    <span className="flex size-5 shrink-0 items-center justify-center rounded-full bg-muted text-[11px] font-semibold text-muted-foreground">
+                      {i + 1}
+                    </span>
+                    <div className="flex min-w-0 flex-1 flex-col">
+                      <span className="truncate text-sm text-foreground">{s.label}</span>
+                      <span className="text-[11px] text-muted-foreground">{s.spec}</span>
+                    </div>
+                    <span className="shrink-0 font-mono text-sm font-semibold text-foreground">
+                      {s.record ?? "-"}
+                    </span>
+                  </div>
+                ))}
+              </div>
+            )}
+          </div>
+        </ResponsiveDrawerContent>
+      </ResponsiveDrawer>
+    </>
+  );
+}
+
+/* ------------------------------------------------------------------ */
 /*  철인3종 탭 콘텐츠                                                   */
 /* ------------------------------------------------------------------ */
 
@@ -455,6 +596,10 @@ export function RecordsClient({ data, myTitleNames = [] }: { data: RecordsData; 
     ),
   };
 
+  const filteredHyrox = {
+    entries: data.hyrox.entries.filter((e) => e.name.toLowerCase().includes(q)),
+  };
+
   const filteredTriathlon = {
     events: data.triathlon.events.map((evt) => ({
       ...evt,
@@ -501,6 +646,9 @@ export function RecordsClient({ data, myTitleNames = [] }: { data: RecordsData; 
       )}
       {selectedCategory === "trail" && (
         <TrailContent entries={filteredTrail.entries} memberTitles={memberTitles} />
+      )}
+      {selectedCategory === "hyrox" && (
+        <HyroxContent entries={filteredHyrox.entries} memberTitles={memberTitles} />
       )}
       {selectedCategory === "triathlon" && (
         <TriathlonContent events={filteredTriathlon.events} memberTitles={memberTitles} />

--- a/app/actions/save-race-record.ts
+++ b/app/actions/save-race-record.ts
@@ -3,6 +3,7 @@
 import { revalidateTag } from "next/cache";
 
 import { compEvtTypeContainsHangul } from "@/lib/comp-evt-type";
+import { serializeHyroxSplits } from "@/lib/hyrox";
 import { withActive } from "@/lib/actions/auth";
 import { getRequestTeamContext } from "@/lib/queries/request-team";
 import {
@@ -22,6 +23,8 @@ type SaveRaceRecordInput = {
   swimSeconds: number | null;
   bikeSeconds: number | null;
   runSeconds: number | null;
+  /** 하이록스 스테이션별 시간 {코드: 초|null}. 비-하이록스는 null */
+  stationSplits?: Record<string, number | null> | null;
 };
 
 const MARATHON_EVENTS = new Set(["FULL", "HALF", "10K"]);
@@ -112,11 +115,15 @@ export async function saveRaceRecord(input: SaveRaceRecordInput) {
     );
     if (!resolved.ok) return { ok: false as const, message: resolved.message };
 
+    const stationSplits = input.stationSplits
+      ? serializeHyroxSplits(input.stationSplits)
+      : null;
+
     const { error: insertError } = await supabase.from("rec_race_hist").insert({
       mem_id: member.id, comp_id: input.competitionId, comp_evt_id: resolved.compEvtId,
       rec_time_sec: input.totalSeconds, race_nm: input.competitionTitle, race_dt: input.competitionDate,
       swim_time_sec: input.swimSeconds, bike_time_sec: input.bikeSeconds, run_time_sec: input.runSeconds,
-      rec_src_cd: "manual", vers: 0, del_yn: false,
+      splits_json: stationSplits, rec_src_cd: "manual", vers: 0, del_yn: false,
     });
 
     if (insertError) {

--- a/components/profile/race-record-dialog.tsx
+++ b/components/profile/race-record-dialog.tsx
@@ -8,6 +8,7 @@ import {
   sanitizeAsciiUpperCompEvtTypeInput,
 } from "@/lib/comp-evt-type";
 import { timeStringToSeconds, secondsToTime } from "@/lib/dayjs";
+import { HYROX_STATIONS, isHyroxSport } from "@/lib/hyrox";
 import {
   getCachedExtraction,
   hashImageFile,
@@ -119,6 +120,8 @@ export function RaceRecordDialog({
   const [swimTime, setSwimTime] = useState("");
   const [bikeTime, setBikeTime] = useState("");
   const [runTime, setRunTime] = useState("");
+  // 하이록스 스테이션별 시간 (코드 → "MM:SS" 입력 문자열)
+  const [stationTimes, setStationTimes] = useState<Record<string, string>>({});
 
   // OCR (0단계)
   const [ocrLoading, setOcrLoading] = useState(false);
@@ -140,6 +143,8 @@ export function RaceRecordDialog({
 
   // 트라이애슬론 여부 (step 3 시간 입력용)
   const isTriathlon = (selectedComp?.sport ?? "").includes("triathlon");
+  // 하이록스 여부 (step 3 스테이션 입력용)
+  const isHyrox = isHyroxSport(selectedComp?.sport);
 
   // 종목: comp_evt_cfg 기준 + 스포츠 기본값 중 아직 없는 것만 합침 + 기타(직접 입력, 영문·숫자만)
   const eventTypeOptions = useMemo(() => {
@@ -256,6 +261,7 @@ export function RaceRecordDialog({
       setSwimTime("");
       setBikeTime("");
       setRunTime("");
+      setStationTimes({});
       setError(null);
       fetchCompetitions();
     }
@@ -319,6 +325,7 @@ export function RaceRecordDialog({
     setSwimTime("");
     setBikeTime("");
     setRunTime("");
+    setStationTimes({});
     setError(null);
     applyOcrTimesToStep3();
     setStep(3);
@@ -457,6 +464,14 @@ export function RaceRecordDialog({
     const bikeSeconds = isTriathlon ? timeStringToSeconds(bikeTime) : null;
     const runSeconds = isTriathlon ? timeStringToSeconds(runTime) : null;
 
+    // 하이록스: 스테이션별 시간을 {코드: 초} 맵으로 (빈 칸은 제외)
+    const stationSplits = isHyrox
+      ? HYROX_STATIONS.reduce<Record<string, number | null>>((acc, station) => {
+          acc[station.code] = timeStringToSeconds(stationTimes[station.code] ?? "");
+          return acc;
+        }, {})
+      : null;
+
     const result = await saveRaceRecord({
       competitionId: selectedComp.id,
       registrationCompEvtId: selectedComp.registrationCompEvtId,
@@ -467,6 +482,7 @@ export function RaceRecordDialog({
       swimSeconds,
       bikeSeconds,
       runSeconds,
+      stationSplits,
     });
 
     if (!result.ok) {
@@ -918,6 +934,48 @@ export function RaceRecordDialog({
                       트랜지션이 음수입니다. 시간을 다시 확인해 주세요.
                     </p>
                   )}
+                </div>
+              </div>
+            ) : isHyrox ? (
+              /* 하이록스: 완주 총시간 + 8개 스테이션(선택 입력) */
+              <div className="flex flex-col gap-4">
+                <div className="flex flex-col gap-1.5">
+                  <label className="text-sm font-medium">완주 총시간</label>
+                  <Input
+                    placeholder="HH:MM:SS"
+                    inputMode="numeric"
+                    value={totalTime}
+                    onChange={(e) => setTotalTime(formatTimeInput(e.target.value))}
+                  />
+                </div>
+                <div className="flex flex-col gap-2">
+                  <div className="flex items-baseline justify-between">
+                    <label className="text-sm font-medium">스테이션별 기록</label>
+                    <Micro>선택 입력 · MM:SS</Micro>
+                  </div>
+                  {HYROX_STATIONS.map((station, i) => (
+                    <div key={station.code} className="flex items-center gap-2">
+                      <span className="flex size-5 shrink-0 items-center justify-center rounded-full bg-muted text-[11px] font-semibold text-muted-foreground">
+                        {i + 1}
+                      </span>
+                      <div className="flex min-w-0 flex-1 flex-col">
+                        <span className="truncate text-[13px] text-foreground">{station.label}</span>
+                        <span className="text-[11px] text-muted-foreground">{station.spec}</span>
+                      </div>
+                      <Input
+                        placeholder="MM:SS"
+                        inputMode="numeric"
+                        value={stationTimes[station.code] ?? ""}
+                        onChange={(e) =>
+                          setStationTimes((prev) => ({
+                            ...prev,
+                            [station.code]: formatTimeInput(e.target.value),
+                          }))
+                        }
+                        className="h-9 w-24 shrink-0 text-center font-mono"
+                      />
+                    </div>
+                  ))}
                 </div>
               </div>
             ) : (

--- a/lib/comp-sprt-to-evt-grp.ts
+++ b/lib/comp-sprt-to-evt-grp.ts
@@ -6,6 +6,7 @@ const COMP_SPRT_CD_TO_EVT_GRP_CD: Record<string, string> = {
   road_run: "ROAD_EVT_CD",
   ultra: "ULTRA_EVT_CD",
   trail_run: "TRAIL_EVT_CD",
+  hyrox: "HYROX_EVT_CD",
   triathlon: "TRI_EVT_CD",
   cycling: "CYC_EVT_CD",
 };

--- a/lib/hyrox.ts
+++ b/lib/hyrox.ts
@@ -1,0 +1,67 @@
+/**
+ * 하이록스(HYROX) 종목 상수·헬퍼.
+ *
+ * HYROX = 1km 런 × 8회 + 8개 펑셔널 스테이션을 번갈아 수행하는 하이브리드 종목.
+ * 기강에서는 완주 총시간(`rec_race_hist.rec_time_sec`)을 랭킹 기준으로 쓰고,
+ * 스테이션별 구간기록은 `rec_race_hist.splits_json`(jsonb)에 `{스테이션코드: 초}` 형태로 저장한다.
+ * (런 8회·록스존은 입력 범위 밖 — 총시간에 포함된 것으로 간주)
+ */
+
+/** `comp_mst.comp_sprt_cd` 의 하이록스 스포츠 코드 */
+export const HYROX_SPRT_CD = "hyrox";
+
+/** 하이록스 여부 (대회 sport 문자열 기준) */
+export function isHyroxSport(sport: string | null | undefined): boolean {
+  return (sport ?? "").toLowerCase().includes(HYROX_SPRT_CD);
+}
+
+/** 하이록스 8개 스테이션 (공식 순서). code 는 `splits_json` 의 키로 쓴다. */
+export const HYROX_STATIONS = [
+  { code: "SKIERG", label: "스키에르그", spec: "1000m" },
+  { code: "SLED_PUSH", label: "썰매 밀기", spec: "50m" },
+  { code: "SLED_PULL", label: "썰매 당기기", spec: "50m" },
+  { code: "BURPEE", label: "버피 브로드점프", spec: "80m" },
+  { code: "ROW", label: "로잉", spec: "1000m" },
+  { code: "FARMERS_CARRY", label: "파머스 캐리", spec: "200m" },
+  { code: "LUNGE", label: "샌드백 런지", spec: "100m" },
+  { code: "WALL_BALL", label: "월볼", spec: "100reps" },
+] as const;
+
+export type HyroxStationCode = (typeof HYROX_STATIONS)[number]["code"];
+
+const HYROX_STATION_CODES: readonly string[] = HYROX_STATIONS.map((s) => s.code);
+
+/** 스테이션 코드별 시간(초) 맵 */
+export type HyroxSplits = Partial<Record<HyroxStationCode, number>>;
+
+/**
+ * `splits_json`(jsonb, 알 수 없는 모양) → 검증된 `{스테이션코드: 초}` 맵.
+ * 알려진 스테이션 코드 + 양의 정수만 남긴다. 깨진 값은 조용히 버린다.
+ */
+export function parseHyroxSplits(json: unknown): HyroxSplits {
+  if (!json || typeof json !== "object" || Array.isArray(json)) return {};
+  const out: HyroxSplits = {};
+  for (const [key, value] of Object.entries(json as Record<string, unknown>)) {
+    if (!HYROX_STATION_CODES.includes(key)) continue;
+    if (typeof value !== "number" || !Number.isFinite(value) || value <= 0) continue;
+    out[key as HyroxStationCode] = Math.round(value);
+  }
+  return out;
+}
+
+/**
+ * 입력 폼의 `{스테이션코드: 초|null}` → DB 저장용 jsonb 객체.
+ * 값이 있는(양의 정수) 스테이션만 담는다. 하나도 없으면 null 을 반환해 컬럼을 비운다.
+ */
+export function serializeHyroxSplits(
+  splits: Partial<Record<string, number | null>>,
+): HyroxSplits | null {
+  const out: HyroxSplits = {};
+  for (const station of HYROX_STATIONS) {
+    const value = splits[station.code];
+    if (typeof value === "number" && Number.isFinite(value) && value > 0) {
+      out[station.code] = Math.round(value);
+    }
+  }
+  return Object.keys(out).length > 0 ? out : null;
+}

--- a/lib/supabase/database.types.ts
+++ b/lib/supabase/database.types.ts
@@ -1766,6 +1766,7 @@ export type Database = {
           rec_src_cd: string | null
           rec_time_sec: number
           run_time_sec: number | null
+          splits_json: Json | null
           swim_time_sec: number | null
           upd_at: string
           vers: number
@@ -1783,6 +1784,7 @@ export type Database = {
           rec_src_cd?: string | null
           rec_time_sec: number
           run_time_sec?: number | null
+          splits_json?: Json | null
           swim_time_sec?: number | null
           upd_at?: string
           vers?: number
@@ -1800,6 +1802,7 @@ export type Database = {
           rec_src_cd?: string | null
           rec_time_sec?: number
           run_time_sec?: number | null
+          splits_json?: Json | null
           swim_time_sec?: number | null
           upd_at?: string
           vers?: number


### PR DESCRIPTION
## 개요

랭킹("기강의 전당")을 **마라톤 / 트레일러닝 / 하이록스 / 철인3종** 4개 카테고리로 확장합니다.
하이록스(HYROX)는 1km 런 × 8회 + 8개 펑셔널 스테이션을 번갈아 수행하는 하이브리드 종목이라, 완주 총시간만이 아니라 **스테이션별 기록**까지 입력·표시할 수 있게 했습니다.

> ⚠️ **운영계 배포 보류 중.** "연습 기록"까지 포함하는 더 넓은 요구로 재정의가 필요해, 이번 운영계 배포에선 머지하지 않습니다. 코드 보존용 PR입니다.

## AS-IS
- 랭킹 카테고리: 마라톤 / 트레일러닝 / 철인3종 (3개)
- 기록 입력은 종목별로 완주 총시간(철인3종은 수영·자전거·러닝 split)만 받음
- 하이록스 종목 자체가 없음

## TO-BE
- 랭킹 카테고리: 마라톤 / 트레일러닝 / **하이록스** / 철인3종 (4개)
- 하이록스 기록 입력: **완주 총시간 + 8개 스테이션(선택 입력)**
  - 스테이션: 스키에르그 · 썰매 밀기 · 썰매 당기기 · 버피 브로드점프 · 로잉 · 파머스 캐리 · 샌드백 런지 · 월볼 (공식 순서)
- 하이록스 랭킹: 총시간 순위 리스트 → 항목 클릭 시 **하단 드로어**로 스테이션별 상세 표시

## 데이터 모델
기존 인프라(`rec_race_hist` / `comp_evt_cfg` / 공통코드)에 최대한 맞춰 변화를 최소화했습니다.
- 철인3종 전용 컬럼(`swim/bike/run_time_sec`)과 달리, 스테이션이 8개라 가변 split을 담을 **`rec_race_hist.splits_json jsonb`** 컬럼 1개를 추가 (다른 종목엔 NULL, 무해)
- 총시간(`rec_time_sec`)은 그대로 랭킹 정렬 기준 → `get_public_team_race_rankings` RPC 수정 불필요
- 공통코드: `COMP_SPRT_CD`에 `hyrox`, 신규 그룹 `HYROX_EVT_CD`(OPEN/PRO/DOUBLES/RELAY)
  - 대회 등록·기록 입력 흐름은 전부 공통코드 기반이라, 코드 추가만으로 하이록스 대회 등록→참가→기록입력이 자동 동작

## 변경 파일
| 파일 | 변경 |
|------|------|
| `lib/hyrox.ts` | **신규** — 8개 스테이션 상수 + split 직렬화/파싱 헬퍼 |
| `lib/comp-sprt-to-evt-grp.ts` | `hyrox → HYROX_EVT_CD` 매핑 |
| `components/profile/race-record-dialog.tsx` | HYROX 분기 입력 UI |
| `app/actions/save-race-record.ts` | `stationSplits` → `splits_json` 저장 |
| `app/(main)/records/page.tsx` | 하이록스 데이터 조회(멤버별 총시간 best) |
| `app/(main)/records/records-client.tsx` | 카테고리 4개 + `HyroxContent` 드로어 |
| `lib/supabase/database.types.ts` | `splits_json` 타입 반영 |

## DB 마이그레이션
- **dev Supabase에만** `add_hyrox_sport_and_splits_json` 적용 완료. **prd 미적용.**
- 운영계 재개 시 동일 마이그레이션을 prd에 적용해야 함.

## 검증
- `pnpm exec tsc --noEmit` 통과
- 변경 파일 ESLint 0 errors / 0 warnings (기존 부채 외)
- `vitest run` 115 tests passed (pre-commit 훅)
- 회귀: 기존 마라톤/트레일/철인3종 로직 미변경

## 차후 (범위 외)
- 연습 기록 입력 경로 설계 (← 이번 보류 사유)
- 하이록스 기록증 OCR 자동인식
- 관리자 화면 스테이션 split 편집
- 더블/릴레이 파트너(비회원 포함) 표시

🤖 Generated with [Claude Code](https://claude.com/claude-code)