### PR TITLE
fix(push): 웹은 푸시 권한 요청 안 함 — iOS·Android 설치 유도로 통일

### DIFF
--- a/components/pwa-install-prompt-gate.tsx
+++ b/components/pwa-install-prompt-gate.tsx
@@ -1,22 +1,11 @@
-import { getCurrentMember } from "@/lib/queries/member";
-
 import { PwaInstallPrompt } from "@/components/pwa-install-prompt";
 
 /**
- * 설치 배너 + 로그인 여부 조회를 묶은 서버 컴포넌트.
+ * 설치 배너 게이트.
  *
- * 로그인 여부(loggedIn)는 설치 거부 후 Android 알림 폴백을 멤버에게만 적용하기 위해 필요한데,
- * cookies() 의존 조회를 루트 layout 본문에서 직접 하면 페이지 전체 렌더가 막힌다.
- * 이 컴포넌트를 <Suspense>로 감싸 조회를 경계 안에 가둔다(본문은 즉시 렌더).
+ * 설치 배너는 로그인 여부와 무관하게 미설치 모바일 웹에 노출한다(설치 자체는 비로그인도 가능).
+ * 푸시 권한은 설치 후 PushPermissionPrompt가 별도로 유도한다.
  */
-export async function PwaInstallPromptGate() {
-  let loggedIn = false;
-  try {
-    const { member } = await getCurrentMember();
-    loggedIn = member !== null;
-  } catch {
-    loggedIn = false;
-  }
-
-  return <PwaInstallPrompt variant="banner" loggedIn={loggedIn} />;
+export function PwaInstallPromptGate() {
+  return <PwaInstallPrompt variant="banner" />;
 }

--- a/components/pwa-install-prompt.tsx
+++ b/components/pwa-install-prompt.tsx
@@ -3,9 +3,7 @@
 import { useEffect, useState } from "react";
 
 import { Share, X } from "lucide-react";
-import { toast } from "sonner";
 
-import { subscribePush } from "@/lib/push/client";
 import { cn } from "@/lib/utils";
 
 import { Body, Caption } from "@/components/common/typography";
@@ -39,8 +37,6 @@ type PwaInstallPromptProps = {
   /** banner=전역 하단 고정(7일 dismiss), inline=가입 완료 카드 내부 */
   variant?: "banner" | "inline";
   className?: string;
-  /** 로그인 멤버 여부. true일 때만 Android에서 "안보기" 후 알림 권한 요청으로 이어짐 */
-  loggedIn?: boolean;
 };
 
 /**
@@ -48,13 +44,12 @@ type PwaInstallPromptProps = {
  * - 이미 설치(standalone)되었거나 인앱 브라우저면 렌더하지 않음.
  * - Android/Chrome: beforeinstallprompt 캡처 후 네이티브 설치.
  * - iOS Safari: "공유 → 홈 화면에 추가" 안내.
- * - Android 로그인 멤버가 설치를 "안보기"로 거부하면, 설치 없이 알림 권한 요청으로 이어준다
- *   (Android는 웹에서도 푸시 가능 — iOS는 설치 필수라 폴백 없음).
+ * - 푸시 알림은 설치된 PWA에서만 받는다(iOS·Android 공통). 웹에서는 권한을 요청하지 않고
+ *   설치만 유도하며, 설치 후 PushPermissionPrompt가 권한을 유도한다.
  */
 export function PwaInstallPrompt({
   variant = "banner",
   className,
-  loggedIn = false,
 }: PwaInstallPromptProps) {
   const [visible, setVisible] = useState(false);
   const [iosGuide, setIosGuide] = useState(false);
@@ -90,17 +85,8 @@ export function PwaInstallPrompt({
 
   if (!visible) return null;
 
-  // 로그인 멤버가 설치를 "거부"(안보기/닫기 또는 설치 팝업 취소)하면 알림 권한 요청으로 이어준다.
-  // 설치 안 함이라는 결과가 같으므로 두 경로 모두 동일하게 처리.
-  // subscribePush가 OS를 분기한다: iOS 미설치는 needs-install로 빠져 권한 요청을 하지 않고,
-  // Android는 설치 없이 바로 권한 요청한다. 데스크톱도 내부에서 제외된다.
-  const offerPushAfterDecline = () => {
-    if (variant !== "banner" || !loggedIn) return;
-    void subscribePush().then((result) => {
-      if (result.ok) toast.success("푸시 알림이 켜졌어요");
-    });
-  };
-
+  // 정책: 웹(브라우저)에서는 푸시 권한을 요청하지 않는다 (iOS·Android 공통).
+  // 푸시는 설치된 PWA에서만 — 설치 후 PushPermissionPrompt가 권한을 유도한다.
   const handleInstall = async () => {
     if (isIOS()) {
       setIosGuide((v) => !v);
@@ -115,8 +101,6 @@ export function PwaInstallPrompt({
     }
     setDeferred(null);
     setVisible(false);
-    // 설치를 취소했으면 "안보기"와 동일하게 알림 요청으로 이어준다
-    if (choice.outcome === "dismissed") offerPushAfterDecline();
   };
 
   const handleDismiss = () => {
@@ -124,7 +108,6 @@ export function PwaInstallPrompt({
       window.localStorage.setItem(DISMISS_KEY, String(Date.now()));
     }
     setVisible(false);
-    offerPushAfterDecline();
   };
 
   const installButton = (
@@ -172,23 +155,12 @@ export function PwaInstallPrompt({
         <div className="flex items-start gap-2">
           <div className="flex-1">
             <Body className="font-bold leading-snug">
-              {isIOS()
-                ? "📲 기강이 풀렸군. 홈 화면에 모시고 알림 켜라!"
-                : "📲 기강이 풀렸군. 홈 화면에 모셔라!"}
+              📲 기강이 풀렸군. 홈 화면에 모시고 알림 켜라!
             </Body>
             <Caption className="mt-1 block leading-relaxed">
-              {isIOS() ? (
-                <>
-                  iPhone은 홈 화면에 추가해야{" "}
-                  <span className="font-semibold text-foreground">새 모임·정보·댓글</span>{" "}
-                  알림을 받을 수 있다. 🫡
-                </>
-              ) : (
-                <>
-                  앱처럼 한 번에 열고{" "}
-                  <span className="font-semibold text-foreground">알림</span>도 칼같이 받아라. 🫡
-                </>
-              )}
+              홈 화면에 추가해야{" "}
+              <span className="font-semibold text-foreground">새 모임·정보·댓글</span>{" "}
+              알림을 받을 수 있다. 🫡
             </Caption>
             {iosGuideBlock}
           </div>

--- a/lib/push/client.ts
+++ b/lib/push/client.ts
@@ -40,16 +40,21 @@ function isSupported(): boolean {
   );
 }
 
-/** iOS 웹(미설치)이라 권한 요청 전에 PWA 설치가 필요한 상태인가 */
+/**
+ * 모바일 웹(미설치)이라 권한 요청 전에 PWA 설치가 필요한 상태인가.
+ * 정책: 웹(브라우저)에서는 푸시 권한을 요청하지 않는다. 웹 권한과 설치된 PWA 권한이
+ * 분리돼 혼란을 주므로, iOS·Android 모두 "알림 받으려면 앱 설치"로 통일한다.
+ * 설치된 PWA(standalone)에서만 푸시를 켠다.
+ */
 export function needsInstall(): boolean {
-  return isIOS() && !isStandalone();
+  return isMobile() && !isStandalone();
 }
 
-/** 이 환경에서 푸시 구독이 가능한가 (데스크톱·iOS 미설치 제외) */
+/** 이 환경에서 푸시 구독이 가능한가 (데스크톱·모바일 미설치 제외 → 설치된 PWA만) */
 export function canUsePush(): boolean {
   if (!isSupported()) return false;
   if (!isMobile()) return false; // 데스크톱 제외 (정책 1)
-  if (needsInstall()) return false; // iOS 웹은 설치 먼저 (정책 2)
+  if (needsInstall()) return false; // 모바일 웹은 설치 먼저 (정책 2 — iOS·Android 공통)
   return true;
 }
 


### PR DESCRIPTION
## 개요
웹(브라우저) 권한과 설치된 PWA 권한이 분리돼 혼란을 주므로, **모바일 웹(미설치)에서는 푸시 권한을 요청하지 않고 PWA 설치만 유도**한다. 푸시는 설치된 PWA에서만.

## 변경
- `needsInstall()`을 `isMobile() && !isStandalone()`로 확장 (기존 iOS 전용 → Android 포함)
  → `canUsePush()`/`subscribePush()`가 Android 웹도 `needs-install`로 분기
- 설치 거부 후 푸시 요청하던 `offerPushAfterDecline` 폴백 제거(죽은 코드)
  → `loggedIn` prop, `PwaInstallPromptGate`의 `getCurrentMember` 조회 제거
- 설치 배너 문구 iOS·Android 통일

## 참고
- 권한 배너(`PushPermissionPrompt`) 노출 로직은 점검 결과 정상 — 변경 없음
  (로그인+PWA+미닫음+OS권한 default+구독없음일 때 노출; 이미 켰으면 안 뜸)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * 모바일 웹의 설치 안내가 로그인 여부와 관계없이 표시되도록 변경되었습니다.
  * 설치되지 않은 모바일 환경에서는 푸시 권한 요청이 더 이상 노출되지 않습니다.

* **Bug Fixes**
  * 설치 배너를 닫거나 거부해도 불필요한 푸시 권한 흐름으로 이어지지 않도록 개선했습니다.
  * 설치 상태에 따라 안내 문구가 더 일관되게 표시되도록 정리했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->