### PR TITLE
fix/perf(gathering·calendar·records): 버그 3건 수정 + 등록·기록 페이지 속도 개선

### DIFF
--- a/app/(info)/projects/records/page.tsx
+++ b/app/(info)/projects/records/page.tsx
@@ -1,9 +1,21 @@
 import { redirect } from "next/navigation";
 import { Suspense } from "react";
 import { Skeleton } from "@/components/ui/skeleton";
+import { currentMonthKST, prevMonthStr } from "@/lib/dayjs";
 import { getCurrentMember } from "@/lib/queries/member";
 import { getRequestTeamContext } from "@/lib/queries/request-team";
+import { fetchActivityRecords } from "@/lib/queries/activity-records";
 import { RecordsClient } from "./records-client";
+
+/** 첫 렌더에서 보여줄 기본 월 (현재월이 이벤트 범위 내면 현재월, 아니면 첫 세그먼트=연습월). 클라와 동일 로직 */
+function resolveDefaultMonth(startDt: string, endDt: string): string {
+  const curMonth = currentMonthKST();
+  const practiceMonth = prevMonthStr(startDt.slice(0, 7) + "-01");
+  const endMonth = endDt.slice(0, 7) + "-01";
+  // 현재월이 [연습월, 종료월] 범위 안이면 현재월, 아니면 연습월(첫 세그먼트)
+  if (curMonth >= practiceMonth && curMonth <= endMonth) return curMonth;
+  return practiceMonth;
+}
 
 export default async function ProjectRecordsPage() {
   const { user, member, supabase } = await getCurrentMember();
@@ -21,10 +33,10 @@ export default async function ProjectRecordsPage() {
 
   if (!event) redirect("/projects");
 
-  // 참여 여부 확인
+  // 참여 여부 확인 (prt_id까지 받아 첫 달 기록 prefetch에 재사용 → 클라 중복 조회 제거)
   const { data: prt } = await supabase
     .from("evt_team_prt_rel")
-    .select("aprv_yn")
+    .select("prt_id, aprv_yn")
     .eq("evt_id", event.evt_id)
     .eq("mem_id", member.id)
     .eq("aprv_yn", true)
@@ -32,13 +44,21 @@ export default async function ProjectRecordsPage() {
 
   if (!prt) redirect("/projects");
 
+  // 첫 화면에 보여줄 달의 기록을 서버에서 미리 조회 → 클라 useEffect 깜빡임 제거.
+  // (월 전환은 클라이언트에서 계속 조회하므로 SPA 전환 속도는 유지)
+  const initialMonth = resolveDefaultMonth(event.stt_dt, event.end_dt);
+  const initialRecords = await fetchActivityRecords(supabase, prt.prt_id, initialMonth);
+
   return (
     <Suspense fallback={<Skeleton className="mx-6 mt-4 h-96 rounded-2xl" />}>
       <RecordsClient
         evtId={event.evt_id}
         memId={member.id}
+        prtId={prt.prt_id}
         evtStartDt={event.stt_dt}
         evtEndDt={event.end_dt}
+        initialMonth={initialMonth}
+        initialRecords={initialRecords}
       />
     </Suspense>
   );

--- a/app/(info)/projects/records/records-client.tsx
+++ b/app/(info)/projects/records/records-client.tsx
@@ -1,11 +1,12 @@
 "use client";
 
-import { useEffect, useState, useCallback } from "react";
+import { useEffect, useState, useCallback, useRef } from "react";
 
 import { Pencil, Trash2, Lock } from "lucide-react";
 
 import { todayDayKST, currentMonthKST, prevMonthStr } from "@/lib/dayjs";
 import { MILEAGE_SPORT_LABELS, type MileageSport } from "@/lib/mileage";
+import { fetchActivityRecords, type ActivityRecord } from "@/lib/queries/activity-records";
 import { createClient } from "@/lib/supabase/client";
 
 import { deleteActivity } from "@/app/actions/mileage-run";
@@ -36,23 +37,14 @@ import {
 
 
 
-type ActivityRecord = {
-  act_id: string;
-  act_dt: string;
-  sprt_enm: string;
-  distance_km: number;
-  elevation_m: number | null;
-  base_mlg: number;
-  applied_mults: { mult_id: string; mult_nm: string; mult_val: number }[] | null;
-  final_mlg: number;
-  review: string | null;
-};
-
 type Props = {
   evtId: string;
   memId: string;
+  prtId: string;
   evtStartDt: string;
   evtEndDt: string;
+  initialMonth: string;
+  initialRecords: ActivityRecord[];
 };
 
 function isEditLocked(actDt: string): boolean {
@@ -77,69 +69,35 @@ function buildMonthSegments(startDt: string, endDt: string) {
   return segments;
 }
 
-export function RecordsClient({ evtId, memId, evtStartDt, evtEndDt }: Props) {
-  const curMonth = currentMonthKST();
+export function RecordsClient({ evtId, memId, prtId, evtStartDt, evtEndDt, initialMonth, initialRecords }: Props) {
   const segments = buildMonthSegments(evtStartDt, evtEndDt);
 
-  // 현재월이 범위 내이면 현재월, 아니면 첫 번째 세그먼트
-  const defaultMonth = segments.find((s) => s.value === curMonth)
-    ? curMonth
-    : segments[0]?.value ?? curMonth;
-
-  const [month, setMonth] = useState(defaultMonth);
-  const [records, setRecords] = useState<ActivityRecord[]>([]);
-  const [loading, setLoading] = useState(true);
+  // 첫 달은 서버에서 prefetch한 데이터로 시작 → 진입 시 깜빡임 없음
+  const [month, setMonth] = useState(initialMonth);
+  const [records, setRecords] = useState<ActivityRecord[]>(initialRecords);
+  const [loading, setLoading] = useState(false);
 
   const [deleteTarget, setDeleteTarget] = useState<ActivityRecord | null>(null);
   const [deleting, setDeleting] = useState(false);
   const [editTarget, setEditTarget] = useState<ActivityRecord | null>(null);
 
+  // 주입받은 prt_id로 바로 조회 (participant 재조회 제거). 서버 prefetch와 동일한 공용 헬퍼 사용.
   const loadRecords = useCallback(async () => {
     setLoading(true);
-    const supabase = createClient();
-    const [y, m] = month.split("-").map(Number);
-    const nextM = m === 12 ? 1 : m + 1;
-    const nextY = m === 12 ? y + 1 : y;
-    const monthEnd = `${nextY}-${String(nextM).padStart(2, "0")}-01`;
-
-    const { data: participant } = await supabase
-      .from("evt_team_prt_rel")
-      .select("prt_id")
-      .eq("evt_id", evtId)
-      .eq("mem_id", memId)
-      .maybeSingle();
-
-    if (!participant) {
-      setRecords([]);
+    try {
+      setRecords(await fetchActivityRecords(createClient(), prtId, month));
+    } finally {
       setLoading(false);
+    }
+  }, [prtId, month]);
+
+  // 첫 마운트는 initialRecords(initialMonth)로 충분하므로 스킵하고, 월이 바뀔 때만 재조회한다.
+  const isFirst = useRef(true);
+  useEffect(() => {
+    if (isFirst.current) {
+      isFirst.current = false;
       return;
     }
-
-    const { data } = await supabase
-      .from("evt_mlg_act_hist")
-      .select("act_id, act_dt, sprt_enm, dst_km, elv_m, base_mlg, aply_mults, final_mlg, review")
-      .eq("prt_id", participant.prt_id)
-      .gte("act_dt", month)
-      .lt("act_dt", monthEnd)
-      .order("act_dt", { ascending: false });
-
-    setRecords(
-      (data ?? []).map((r) => ({
-        ...r,
-        distance_km: Number(r.dst_km),
-        elevation_m: r.elv_m ? Number(r.elv_m) : null,
-        base_mlg: Number(r.base_mlg),
-        applied_mults: (r.aply_mults ?? null) as ActivityRecord["applied_mults"],
-        final_mlg: Number(r.final_mlg),
-        review: r.review ?? null,
-      })),
-    );
-    setLoading(false);
-  }, [evtId, memId, month]);
-
-   
-  useEffect(() => {
-    // eslint-disable-next-line react-hooks/set-state-in-effect
     loadRecords();
   }, [loadRecords]);
 

--- a/app/actions/gathering/manage-gathering.ts
+++ b/app/actions/gathering/manage-gathering.ts
@@ -44,7 +44,7 @@ export async function createGathering(input: {
         crt_by: member.id,
         del_yn: false,
       })
-      .select("gthr_id")
+      .select("gthr_id, short_id")
       .single();
 
     if (error || !data) throw new Error("모임 개설에 실패했습니다.");
@@ -94,7 +94,7 @@ export async function createGathering(input: {
     });
 
     revalidatePath("/");
-    return { gthr_id: gthrId };
+    return { gthr_id: gthrId, short_id: data.short_id };
   });
 }
 

--- a/components/home/mini-calendar.tsx
+++ b/components/home/mini-calendar.tsx
@@ -750,6 +750,22 @@ export function MiniCalendar({
   // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
+  // 등록 직후 전용: 조회 없이 즉시 상세를 연다.
+  // 새 모임이라 댓글 0·참석자=작성자 1명·상세=폼 입력값으로 자명하므로 쿼리를 생략해
+  // 등록→상세 오픈 사이의 직렬 대기(달력 재조회 + 상세 3쿼리)를 제거한다.
+  const openGatheringDetailInstant = useCallback((race: CalendarRace & { maxPrtCnt?: number | null }) => {
+    const me = memberStatus.status === "ready"
+      ? [{ mem_id: memberStatus.memberId, mem_nm: memberStatus.fullName ?? null, avatar_url: memberAvatarUrl ?? null }]
+      : [];
+    setGthrJustCreated(true);
+    setGthrDetailRace({ ...race, regCount: me.length, maxPrtCnt: race.maxPrtCnt ?? null, attendees: me, sprt_cd: race.sprt_cd ?? null });
+    setGthrDetailAttending(true); // 작성자는 자동 참석
+    setGthrDetailComments([]);     // 새 모임 — 댓글 없음
+    setGthrDetailOpen(true);
+  // memberStatus/memberAvatarUrl은 렌더마다 안정적
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [memberAvatarUrl]);
+
   const openGatheringDetail = useCallback(async (race: CalendarRace, justCreated = false) => {
     // 등록 직후 경로(justCreated)는 사용자 클릭과 무관하게 반드시 열어야 하므로 락을 무시한다
     if (openingLock.current && !justCreated) return;
@@ -1195,39 +1211,15 @@ export function MiniCalendar({
           desc_txt: gthrEditTarget.cont_txt ?? null,
           max_prt_cnt: gthrDetailRace?.maxPrtCnt ?? null,
         } : undefined}
-        onSuccess={async (createdGthrId) => {
-          const { gatherings: newGthr } = await refreshMonthData();
+        onSuccess={(createdGthrId, createdRace) => {
           setGthrEditTarget(null);
-          // 신규 등록(createdGthrId는 create일 때만 채워짐)이면 해당 모임 상세를 열고 공유 유도 안내 노출
-          if (!createdGthrId) return;
-          let created = newGthr.find((g) => g.id === createdGthrId) ?? null;
-          // 현재 보고 있는 달과 다른 달(예: 리스트뷰에서 오늘 날짜로 등록)이면 갱신 목록에 없으므로 직접 조회
-          if (!created) {
-            const { data } = await supabase
-              .from("gthr_mst")
-              .select("gthr_id, short_id, gthr_nm, gthr_type_enm, sprt_cd, stt_at, end_at, loc_txt, desc_txt, crt_by")
-              .eq("gthr_id", createdGthrId)
-              .maybeSingle();
-            if (data) {
-              created = {
-                id: data.gthr_id,
-                short_id: data.short_id ?? null,
-                title: data.gthr_nm,
-                start_date: dayjs(data.stt_at).tz("Asia/Seoul").format("YYYY-MM-DD"),
-                type: "gathering_mine",
-                post_type: data.gthr_type_enm,
-                sprt_cd: data.sprt_cd ?? null,
-                location: data.loc_txt ?? null,
-                cont_txt: data.desc_txt ?? null,
-                evt_stt_at: data.stt_at,
-                evt_end_at: data.end_at ?? null,
-                crt_by: data.crt_by,
-              };
-            }
+          // 신규 등록이면 폼이 넘겨준 데이터로 상세를 "즉시" 연다(조회 대기 없음).
+          // 새 모임이라 댓글 0·참석자=작성자 1명·상세=입력값으로 자명하므로 쿼리를 생략한다.
+          if (createdGthrId && createdRace) {
+            openGatheringDetailInstant(createdRace);
           }
-          if (created) {
-            await openGatheringDetail(created, true);
-          }
+          // 달력 갱신은 await하지 않고 백그라운드로 — 상세 오픈을 막지 않는다.
+          void refreshMonthData();
         }}
       />
 
@@ -1327,7 +1319,7 @@ export function MiniCalendar({
               ? { sch_post_id: "", sch_nm: "", evt_stt_at: editTarget.start_date }
               : undefined
         }
-        onSuccess={handleSchPostSuccess}
+        onSuccess={() => { void refreshMonthData(); }}
       />
 
       {/* 대회 상세 다이얼로그 */}

--- a/components/home/mini-calendar.tsx
+++ b/components/home/mini-calendar.tsx
@@ -404,12 +404,13 @@ export function MiniCalendar({
         };
       });
 
-      // 참가한 항목 우선 → colSpan 내림차순 → colStart 오름차순 정렬
-      const isMineType = (type: string) => type === "mine" || type === "gathering_mine";
+      // 슬롯 배정은 colStart(→ 긴 일정 우선) 순으로 한다.
+      // 슬롯은 가로 한 행 전체를 점유하므로, 참석 우선 등으로 늦게 시작하는 일정을 위 슬롯에
+      // 올리면 그 일정이 없는 앞 날짜 칸의 윗줄이 비어버린다(겹치지도 않는데 빈칸 발생).
+      // 따라서 "겹치지 않으면 가장 위 빈 슬롯"이 되도록 colStart 순으로만 배정한다.
       const sorted = [...positioned].sort((a, b) =>
-        Number(isMineType(b.race.type)) - Number(isMineType(a.race.type)) ||
-        b.colSpan - a.colSpan ||
-        a.colStart - b.colStart
+        a.colStart - b.colStart ||
+        b.colSpan - a.colSpan
       );
 
       const slotEnds: number[] = [];
@@ -772,7 +773,10 @@ export function MiniCalendar({
       const gthrData = gthrDetailResult.data as GthrDetail | null;
       const attendees: GatheringAttendee[] = gthrData?.attendees ?? [];
       setGthrDetailRace({ ...race, regCount: attendees.length, maxPrtCnt: gthrData?.max_prt_cnt ?? null, attendees, sprt_cd: gthrData?.sprt_cd ?? null });
-      setGthrDetailAttending(!!attdResult.data);
+      // 등록 직후(justCreated)엔 작성자가 자동 참석되므로 무조건 참석 상태로 확정한다.
+      // (자동 참석 INSERT 직후라 attd 조회가 read-after-write 지연으로 null을 반환할 수 있어
+      //  조회 결과만 믿으면 데스크톱처럼 빠른 환경에서 참석 토글이 꼬인다)
+      setGthrDetailAttending(justCreated || !!attdResult.data);
       setGthrDetailComments(comments);
       setGthrDetailOpen(true);
     } finally {

--- a/components/schedule/gathering-form-dialog.tsx
+++ b/components/schedule/gathering-form-dialog.tsx
@@ -48,6 +48,22 @@ import { Separator } from "@/components/ui/separator";
 const formSchema = createGthrSchema.omit({ team_id: true });
 type FormValues = z.infer<typeof formSchema>;
 
+/** 등록 직후 상세를 조회 없이 즉시 열기 위한 모임 데이터(폼 입력값 + 반환 id 기반). CalendarRace 호환. */
+export type CreatedGathering = {
+  id: string;
+  short_id: string | null;
+  title: string;
+  start_date: string;
+  type: "gathering_mine";
+  post_type: string;
+  sprt_cd: string | null;
+  location: string | null;
+  cont_txt: string | null;
+  evt_stt_at: string;
+  evt_end_at: string | null;
+  maxPrtCnt: number | null;
+};
+
 export type GatheringFormDialogProps = {
   open: boolean;
   onOpenChange: (open: boolean) => void;
@@ -64,8 +80,8 @@ export type GatheringFormDialogProps = {
     desc_txt?: string | null;
     max_prt_cnt?: number | null;
   };
-  /** 등록(create) 성공 시 새 모임 id 전달. 수정(edit)일 땐 undefined */
-  onSuccess?: (createdGthrId?: string) => void | Promise<void>;
+  /** 등록(create) 성공 시 새 모임 id·데이터 전달. 수정(edit)일 땐 둘 다 undefined */
+  onSuccess?: (createdGthrId?: string, createdRace?: CreatedGathering) => void | Promise<void>;
 };
 
 function toDatetimeLocal(utcIso: string) {
@@ -139,15 +155,33 @@ export function GatheringFormDialog({
     setRootError(null);
     try {
       let createdGthrId: string | undefined;
+      let createdRace: CreatedGathering | undefined;
       if (mode === "edit" && initialData) {
         await updateGathering({ gthr_id: initialData.gthr_id, ...values });
       } else {
         const result = await createGathering(values);
         createdGthrId = result.gthr_id;
+        // 등록 직후 상세를 조회 없이 즉시 열 수 있도록, 입력값+반환 id로 모임 데이터를 구성해 넘긴다.
+        const sttIso = dayjs.tz(values.stt_at, "Asia/Seoul").toISOString();
+        const endIso = values.end_at ? dayjs.tz(values.end_at, "Asia/Seoul").toISOString() : null;
+        createdRace = {
+          id: result.gthr_id,
+          short_id: result.short_id ?? null,
+          title: values.gthr_nm,
+          start_date: dayjs(sttIso).tz("Asia/Seoul").format("YYYY-MM-DD"),
+          type: "gathering_mine",
+          post_type: values.gthr_type_enm,
+          sprt_cd: values.sprt_cd ?? null,
+          location: values.loc_txt ?? null,
+          cont_txt: values.desc_txt ?? null,
+          evt_stt_at: sttIso,
+          evt_end_at: endIso,
+          maxPrtCnt: values.max_prt_cnt ?? null,
+        };
       }
       clearDraft();
       onOpenChange(false);
-      await onSuccess?.(createdGthrId);
+      onSuccess?.(createdGthrId, createdRace);
     } catch (e) {
       setRootError(e instanceof Error ? e.message : "오류가 발생했습니다. 다시 시도해 주세요.");
     }

--- a/lib/queries/activity-records.ts
+++ b/lib/queries/activity-records.ts
@@ -1,0 +1,53 @@
+import type { SupabaseClient } from "@supabase/supabase-js";
+
+/** 마일리지 활동 기록 1건 (records 화면 표시용) */
+export type ActivityRecord = {
+  act_id: string;
+  act_dt: string;
+  sprt_enm: string;
+  distance_km: number;
+  elevation_m: number | null;
+  base_mlg: number;
+  applied_mults: { mult_id: string; mult_nm: string; mult_val: number }[] | null;
+  final_mlg: number;
+  review: string | null;
+};
+
+/**
+ * 특정 참가자(prt_id)의 한 달치 활동 기록을 조회한다.
+ * 서버 컴포넌트(첫 렌더 prefetch)와 클라이언트(월 전환)에서 공용으로 쓰도록
+ * supabase 클라이언트를 주입받는다.
+ *
+ * @param month "YYYY-MM-01" 형식의 조회 월 시작일
+ */
+export async function fetchActivityRecords(
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  supabase: SupabaseClient<any, any, any>,
+  prtId: string,
+  month: string,
+): Promise<ActivityRecord[]> {
+  const [y, m] = month.split("-").map(Number);
+  const nextM = m === 12 ? 1 : m + 1;
+  const nextY = m === 12 ? y + 1 : y;
+  const monthEnd = `${nextY}-${String(nextM).padStart(2, "0")}-01`;
+
+  const { data } = await supabase
+    .from("evt_mlg_act_hist")
+    .select("act_id, act_dt, sprt_enm, dst_km, elv_m, base_mlg, aply_mults, final_mlg, review")
+    .eq("prt_id", prtId)
+    .gte("act_dt", month)
+    .lt("act_dt", monthEnd)
+    .order("act_dt", { ascending: false });
+
+  return (data ?? []).map((r) => ({
+    act_id: r.act_id,
+    act_dt: r.act_dt,
+    sprt_enm: r.sprt_enm,
+    distance_km: Number(r.dst_km),
+    elevation_m: r.elv_m ? Number(r.elv_m) : null,
+    base_mlg: Number(r.base_mlg),
+    applied_mults: (r.aply_mults ?? null) as ActivityRecord["applied_mults"],
+    final_mlg: Number(r.final_mlg),
+    review: r.review ?? null,
+  }));
+}


### PR DESCRIPTION
## 버그 수정
- **모임 등록 후 참석 토글 꼬임**: 등록 직후 작성자 참석 여부를 조회로 판단했는데 자동참석 INSERT 직후 read-after-write 지연으로 false로 시작 → 데스크톱(빠른 환경)에서 토글이 거꾸로 돎. justCreated면 참석=true로 확정.
- **캘린더 빈 슬롯**: 'mine 우선' 슬롯 정렬이 늦게 시작하는 참석 일정을 위 슬롯에 올려, 겹치지도 않는 앞 날짜 칸의 윗줄이 비던 문제 → colStart(날짜)순 배정으로 수정.

## 성능 개선
- **모임 등록 후 상세 즉시 오픈**: '달력 재조회 → 상세 3쿼리' 직렬 대기 제거. 등록 직후 데이터가 자명하므로 조회 없이 즉시 상세 구성·오픈, 달력 갱신은 백그라운드.
- **기록 페이지 prefetch**: 진입 시 클라 useEffect 조회로 인한 깜빡임 제거. 서버에서 첫 달 기록 prefetch + participant 중복 조회 제거. 월 전환은 클라 조회 유지.

## 점검 결과(변경 없음)
- 아바타: 카카오 http+referrer 차단 CDN이라 unoptimized가 정당 → 유지
- mini-calendar: 무거운 다이얼로그는 이미 dynamic 분리됨 → 추가 분리 실효 없어 보류

🤖 Generated with [Claude Code](https://claude.com/claude-code)