### PR TITLE
fix(gathering): 모임 등록 후 공유 유도 노출 + 참석 버튼 즉시 반영 + 등록 응답 단축

### DIFF
--- a/app/(info)/gatherings/[id]/gathering-attend-button.tsx
+++ b/app/(info)/gatherings/[id]/gathering-attend-button.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useTransition } from "react";
+import { useRef, useState, useTransition } from "react";
 
 import { toast } from "sonner";
 
@@ -20,12 +20,15 @@ type Props = {
 export function GatheringAttendButton({ gthrId, initialAttending, maxPrtCnt, currentAttdCount }: Props) {
   const [attending, setAttending] = useState(initialAttending);
   const [attdCount, setAttdCount] = useState(currentAttdCount);
-  const [isPending, startTransition] = useTransition();
+  const [, startTransition] = useTransition();
+  // 동기적 재진입 가드 — isPending(리렌더 의존)은 같은 렌더 내 연타를 못 막으므로 ref로 막는다.
+  const togglingRef = useRef(false);
 
   const isFull = !attending && maxPrtCnt !== null && attdCount >= maxPrtCnt;
 
   function handleToggle() {
-    if (isFull) return;
+    if (isFull || togglingRef.current) return; // 처리 중이면 재클릭 무시(중복 방지) — 버튼은 흐려지지 않음
+    togglingRef.current = true;
     startTransition(async () => {
       const prev = attending;
       setAttending(!prev);
@@ -40,6 +43,8 @@ export function GatheringAttendButton({ gthrId, initialAttending, maxPrtCnt, cur
       } catch {
         setAttending(prev);
         setAttdCount((c) => (prev ? c - 1 : c + 1));
+      } finally {
+        togglingRef.current = false;
       }
     });
   }
@@ -47,7 +52,9 @@ export function GatheringAttendButton({ gthrId, initialAttending, maxPrtCnt, cur
   return (
     <Button
       onClick={handleToggle}
-      disabled={isPending || isFull}
+      // 처리 중(isPending)엔 disabled 대신 handleToggle 가드로 재클릭만 막아 버튼이 흐려지지 않게 한다.
+      // 낙관적 업데이트로 색이 즉시 바뀌므로 사용자는 "바로 눌렸다"고 느낀다.
+      disabled={isFull}
       variant={attending ? "default" : "outline"}
       className={cn(
         "w-full",

--- a/app/actions/gathering/manage-gathering.ts
+++ b/app/actions/gathering/manage-gathering.ts
@@ -50,10 +50,6 @@ export async function createGathering(input: {
     if (error || !data) throw new Error("모임 개설에 실패했습니다.");
 
     const gthrId = data.gthr_id;
-
-    // 작성자 자동 참석 등록
-    const { error: attdError } = await supabase.from("gthr_attd_rel").insert({ gthr_id: gthrId, mem_id: member.id });
-    if (attdError) throw new Error("자동 참석 등록에 실패했습니다.");
     const authorId = member.id;
     const gthrNm = parsed.gthr_nm;
     const gthrType = parsed.gthr_type_enm;
@@ -61,9 +57,15 @@ export async function createGathering(input: {
       general: "gthr_new", regular: "gthr_new", event: "gthr_new",
     };
 
+    // 작성자 자동 참석 + 알림 발송을 응답 후 백그라운드로 — 등록 응답을 1 RTT 빠르게.
+    // 상세 화면은 작성자를 이미 "참석" 상태로 그리므로(openGatheringDetailInstant) 체감 동일.
     after(async () => {
       try {
         const admin = createUntypedAdminClient();
+
+        // 자동 참석 등록 (응답 경로에서 분리). after는 요청 컨텍스트 종료 후라 admin 클라이언트 사용.
+        const { error: attdError } = await admin.from("gthr_attd_rel").insert({ gthr_id: gthrId, mem_id: authorId });
+        if (attdError) console.error("[gthr_new] 자동 참석 등록 실패", attdError);
 
         const { data: members } = await admin
           .from("team_mem_rel")

--- a/components/schedule/gathering-detail-dialog.tsx
+++ b/components/schedule/gathering-detail-dialog.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { useEffect, useRef, useState } from "react";
 
 import { Pencil, Share2, Trash2 } from "lucide-react";
 import { toast } from "sonner";
@@ -79,11 +79,15 @@ export function GatheringDetailDialog({
   const [attending, setAttending] = useState(initialIsAttending ?? false);
   const [attdCount, setAttdCount] = useState(gathering?.regCount ?? 0);
   const [attendees, setAttendees] = useState(gathering?.attendees ?? []);
-  const [isToggling, setIsToggling] = useState(false);
+  // 참석 토글 재진입 가드 — 동기 ref로 같은 렌더 내 연타까지 막는다(리렌더 의존 state는 못 막음).
+  // 버튼 흐림 없이 재클릭만 무시하므로 UI에 노출할 state는 불필요.
+  const togglingRef = useRef(false);
   const [isDeleting, setIsDeleting] = useState(false);
   const [shareOpen, setShareOpen] = useState(false);
   // 방금 등록한 직후에만 공유 유도 안내 노출. 공유하기를 누르면 숨긴다.
   const [showShareHint, setShowShareHint] = useState(justCreated ?? false);
+  // 등록 직후 다이얼로그가 맨 위에서 열려 하단 공유 유도가 안 보이는 문제 → 공유 영역으로 스크롤
+  const shareHintRef = useRef<HTMLDivElement>(null);
 
   // gathering prop이 바뀌거나 justCreated가 바뀌면 로컬 상태 동기화
   // (렌더 중 파생 state 업데이트 — React 공식 패턴: https://react.dev/learn/you-might-not-need-an-effect#adjusting-some-state-when-a-prop-changes)
@@ -98,6 +102,16 @@ export function GatheringDetailDialog({
     setAttendees(gathering?.attendees ?? []);
     setShowShareHint(justCreated ?? false);
   }
+
+  // 등록 직후 열렸을 때, 다이얼로그 본문이 길어 하단 공유 유도가 가려지지 않도록 그 영역으로 스크롤.
+  useEffect(() => {
+    if (!open || !justCreated) return;
+    // 다이얼로그/콘텐츠 마운트 후 레이아웃이 잡힌 다음 스크롤
+    const id = setTimeout(() => {
+      shareHintRef.current?.scrollIntoView({ behavior: "smooth", block: "center" });
+    }, 150);
+    return () => clearTimeout(id);
+  }, [open, justCreated, gKey]);
 
   if (!gathering) return null;
 
@@ -125,8 +139,8 @@ export function GatheringDetailDialog({
     : `/?gthr=${gthrRef}`;
 
   async function handleToggleAttendance() {
-    if (!currentMemberId || isFull || isToggling) return;
-    setIsToggling(true);
+    if (!currentMemberId || isFull || togglingRef.current) return;
+    togglingRef.current = true;
     const prev = attending;
     const myEntry = { mem_id: currentMemberId, mem_nm: currentMemberName ?? null, avatar_url: currentMemberAvatarUrl ?? null };
     setAttending(!prev);
@@ -144,7 +158,7 @@ export function GatheringDetailDialog({
       setAttdCount((c) => (prev ? c + 1 : c - 1));
       setAttendees(gathering!.attendees ?? []);
     } finally {
-      setIsToggling(false);
+      togglingRef.current = false;
     }
   }
 
@@ -242,7 +256,9 @@ export function GatheringDetailDialog({
             {currentMemberId && (
               <Button
                 onClick={handleToggleAttendance}
-                disabled={isToggling || isFull}
+                // 처리 중엔 disabled 대신 handleToggleAttendance의 togglingRef 가드로 재클릭만 막아 흐려지지 않게.
+                // 낙관적 업데이트로 색이 즉시 바뀌어 "바로 눌렸다"고 느끼게 한다.
+                disabled={isFull}
                 variant={attending ? "default" : "outline"}
                 className={attending ? "w-full bg-success hover:bg-success/90 border-success" : "w-full"}
               >
@@ -271,8 +287,8 @@ export function GatheringDetailDialog({
               </div>
             )}
 
-            {/* 공유/수정/삭제 */}
-            <div className="flex items-center justify-between gap-2">
+            {/* 공유/수정/삭제 (등록 직후 이 영역으로 자동 스크롤 — 안내+버튼이 함께 보이게) */}
+            <div ref={shareHintRef} className="scroll-mt-4 flex items-center justify-between gap-2">
               <Button
                 variant={showShareHint ? "default" : "outline"}
                 size="sm"


### PR DESCRIPTION
## 개요

모임 등록·참석 흐름의 체감 속도와 UX를 개선하는 핫픽스.

## AS-IS → TO-BE

### 1. 등록 직후 공유 유도가 안 보임
- **AS-IS**: 모임 등록 → 상세가 스크롤 맨 위에서 열려, 하단의 "공유하기 유도"가 화면 밖으로 밀려 안 보임.
- **TO-BE**: 등록 직후(`justCreated`) 공유 영역으로 자동 스크롤(`scrollIntoView`, 화면 중앙). 안내+버튼이 바로 보임.

### 2. 참석 버튼이 로딩 동안 흐려져 답답함
- **AS-IS**: 참석 누르면 `disabled`로 버튼이 흐려짐(opacity↓) → "되는지 안 되는지" 헷갈려 기다리게 됨.
- **TO-BE**: `disabled` 대신 ref 재진입 가드로 재클릭만 막아, 낙관적 업데이트 색(진한 초록)이 즉시 보임. 나가도 백그라운드로 참석 처리됨.
  - `isPending`/`isToggling`(리렌더 의존)은 같은 렌더 내 연타를 못 막으므로 **ref 가드로 교체**(중복 토글 방지).

### 3. 등록 응답 지연
- **AS-IS**: `createGathering`이 작성자 자동 참석 INSERT까지 순차 `await` → 응답 +1 RTT.
- **TO-BE**: 자동 참석 INSERT를 `after()`로 이동해 응답을 1 RTT 단축. 상세 화면은 작성자를 이미 참석 상태로 그리므로 체감 동일(실패 시 로그, 새로고침으로 복구).

## 검증
- tsc / lint / 테스트 134개 통과
- 결함 체크: 재진입 가드 stale closure 위험을 ref로 보강, 공유 ref를 항상 렌더되는 영역으로 이동(빈 div 여백 제거)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새 기능**
  * 모임 상세 화면에서 새로 생성한 모임의 공유/편집/삭제 영역이 자동으로 보이도록 개선했습니다.

* **버그 수정**
  * 참석 버튼을 빠르게 연속 클릭해도 중복 요청이 발생하지 않도록 안정성을 높였습니다.
  * 참석 상태 변경 시 실패하면 이전 상태로 되돌아가도록 처리했습니다.

* **개선**
  * 모임 생성 시 작성자 참석 등록이 더 유연하게 처리되도록 조정했습니다.
  * 모임이 꽉 찬 경우에만 참석 버튼이 비활성화되도록 단순화했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->