### PR TITLE
feat(gathering): 모임 공유 메시지 개선 — 참여 유도형 본문

### DIFF
--- a/components/common/share-sheet.tsx
+++ b/components/common/share-sheet.tsx
@@ -26,6 +26,11 @@ type ShareSheetProps = {
   contentUrl?: string;
   /** 이 게시물 상세보기 딥링크. 없으면 현재 페이지 URL 사용 */
   pageUrl?: string;
+  /**
+   * 완성된 공유 본문을 직접 지정. 주어지면 title/timeLabel 등 자동 조립을 무시하고 이 텍스트를 그대로 공유한다.
+   * (모임처럼 도메인별로 멘트를 다듬고 싶을 때 사용)
+   */
+  shareText?: string;
 };
 
 export function ShareSheet({
@@ -37,6 +42,7 @@ export function ShareSheet({
   contentSnippet,
   contentUrl,
   pageUrl,
+  shareText,
 }: ShareSheetProps) {
   const [copiedText, setCopiedText] = useState(false);
 
@@ -45,6 +51,9 @@ export function ShareSheet({
   }
 
   function buildText() {
+    // 호출부가 완성 본문을 넘기면 그대로 사용(모임 등 도메인별 멘트)
+    if (shareText) return shareText;
+
     const lines = [title, timeLabel];
 
     if (locationText) lines.push(locationText);

--- a/components/schedule/gathering-detail-dialog.tsx
+++ b/components/schedule/gathering-detail-dialog.tsx
@@ -127,16 +127,24 @@ export function GatheringDetailDialog({
   const sprtLabel = gathering.sprt_cd ? (gthrSprtLabels[gathering.sprt_cd as GthrSprtType] ?? gathering.sprt_cd) : null;
 
   // 공유 텍스트용
-  const shareTitle = gathering.maxPrtCnt != null
-    ? `[${gathering.title}] - ${gathering.maxPrtCnt}명`
-    : `[${gathering.title}]`;
-  const shareTimeLabel = end
-    ? `${stt.format("YYYY년 M월 D일 (ddd) HH:mm")} ~ ${stt.format("YYYY-MM-DD") === end.format("YYYY-MM-DD") ? end.format("HH:mm") : end.format("YYYY년 M월 D일 (ddd) HH:mm")}`
-    : stt.format("YYYY년 M월 D일 (ddd) HH:mm");
   const gthrRef = gathering.short_id ?? gathering.id;
   const sharePageUrl = typeof window !== "undefined"
     ? `${window.location.origin}/?gthr=${gthrRef}`
     : `/?gthr=${gthrRef}`;
+
+  // 단톡방 공유 본문 — 정보 나열이 아니라 "같이 뛰어요 + CTA"로 참여를 유도한다.
+  // 시간: 오전/오후 + 분 단위(A h:mm). 인원: 2명 이상일 때만(처음 공유는 작성자 1명뿐이라 생략).
+  const shareDateTime = end
+    ? `${stt.format("M/D (ddd) A h:mm")} ~ ${stt.format("YYYY-MM-DD") === end.format("YYYY-MM-DD") ? end.format("A h:mm") : end.format("M/D (ddd) A h:mm")}`
+    : stt.format("M/D (ddd) A h:mm");
+  const shareLines = ["🏃‍♂️ 같이 뛰어요!", "", `「${gathering.title}」`, `🗓 ${shareDateTime}`];
+  if (gathering.location) shareLines.push(`📍 ${gathering.location}`);
+  if (gathering.crt_by_nm) shareLines.push(`🙋 ${gathering.crt_by_nm}`);
+  if (attdCount >= 2) {
+    shareLines.push(`👥 ${gathering.maxPrtCnt != null ? `${attdCount}/${gathering.maxPrtCnt}명` : `${attdCount}명`}`);
+  }
+  shareLines.push("", "참여하기 👇", sharePageUrl);
+  const gthrShareText = shareLines.join("\n");
 
   async function handleToggleAttendance() {
     if (!currentMemberId || isFull || togglingRef.current) return;
@@ -356,11 +364,10 @@ export function GatheringDetailDialog({
     <ShareSheet
       open={shareOpen}
       onOpenChange={setShareOpen}
-      title={shareTitle}
-      timeLabel={shareTimeLabel}
-      locationText={gathering.location ?? undefined}
-      contentSnippet={gathering.cont_txt ?? undefined}
+      title={gathering.title}
+      timeLabel={shareDateTime}
       pageUrl={sharePageUrl}
+      shareText={gthrShareText}
     />
     </>
   );


### PR DESCRIPTION
## 개요

모임을 단톡방에 공유할 때 메시지가 밋밋하고 "뭘 하라는 건지" CTA가 없던 문제를 개선.

## AS-IS
```
[인터벌 RUN]
2026년 7월 1일 (수) 19:00 ~ 20:00
반포 or 교대 트랙

https://gigang.team/?gthr=ni5sFzC
```
- 정보만 나열, 개설자·CTA 없음

## TO-BE
```
🏃‍♂️ 같이 뛰어요!

「인터벌 RUN」
🗓 7/1 (수) 오후 7:00 ~ 8:00
📍 반포 or 교대 트랙
🙋 김민수

참여하기 👇
https://gigang.team/?gthr=ni5sFzC
```

## 변경 규칙
- **시간**: 오전/오후 + 분 단위(`A h:mm`)
- **개설자**: 이름만 표시
- **인원수**: 2명 이상일 때만 표시(첫 공유는 작성자 1명뿐이라 생략 → 재공유 시 "몇 명 모였다"로 참여 유도). 정원 있으면 `N/최대명`
- **CTA**: "참여하기 👇" 추가

## 구현
- `ShareSheet`에 `shareText` prop 추가 — 도메인별로 완성 본문을 직접 넘길 수 있게(대회·정보 공유는 기존 자동 조립 유지).
- 모임 다이얼로그에서 위 규칙으로 본문 조립.

tsc / lint 통과.

🤖 Generated with [Claude Code](https://claude.com/claude-code)