### PR TITLE
fix(mileage): 거리 입력 소수점 2자리 초과 방지

### DIFF
--- a/components/projects/activity-log-batch-form.tsx
+++ b/components/projects/activity-log-batch-form.tsx
@@ -274,7 +274,12 @@ export function ActivityLogBatchForm({ evtId, onSuccess }: ActivityLogBatchFormP
                     min="0.01"
                     placeholder="예: 10.55"
                     value={d.distance_km}
-                    onChange={(e) => updateDraft(d.id, { distance_km: e.target.value })}
+                    onChange={(e) => {
+                      const val = e.target.value;
+                      const dot = val.indexOf(".");
+                      if (dot !== -1 && val.length - dot > 3) return;
+                      updateDraft(d.id, { distance_km: val });
+                    }}
                     className="h-10 rounded-lg border text-sm"
                   />
                 </div>

--- a/components/projects/activity-log-form.tsx
+++ b/components/projects/activity-log-form.tsx
@@ -251,6 +251,13 @@ export function ActivityLogForm({
           placeholder="예: 10.55"
           className="h-12 rounded-xl border-[1.5px] text-[15px]"
           {...register("distance_km", { valueAsNumber: true })}
+          onInput={(e) => {
+            const val = e.currentTarget.value;
+            const dot = val.indexOf(".");
+            if (dot !== -1 && val.length - dot > 3) {
+              e.currentTarget.value = val.slice(0, dot + 3);
+            }
+          }}
         />
         {errors.distance_km && (
           <p className="text-sm text-destructive">{errors.distance_km.message}</p>


### PR DESCRIPTION
## Summary
- 거리(km) 입력 시 소수점 3자리 이상 입력하면 불명확한 에러("입력값이 올바르지 않습니다")만 표시되는 문제
- Input 레벨에서 소수점 2자리까지만 입력 가능하도록 제한하여 원천 차단
- 단건 입력(`activity-log-form`) / 일괄 입력(`activity-log-batch-form`) 모두 적용

<img width="1251" height="655" alt="Screenshot 2026-06-29 at 00 29 36" src="https://github.com/user-attachments/assets/b5b88e11-c7c2-47cb-9bff-1faf421e997b" />
