### PR TITLE
feat(home): 홈 캘린더 SSG + on-demand revalidation

### DIFF
--- a/app/(main)/page.tsx
+++ b/app/(main)/page.tsx
@@ -1,7 +1,6 @@
 import { Suspense } from "react";
 
 import { dayjs, currentMonthKST, gridDateRange } from "@/lib/dayjs";
-import { env } from "@/lib/env";
 import { hasUnreadBoardPosts } from "@/lib/queries/board";
 import { getCachedCmmCdRows } from "@/lib/queries/cmm-cd-cached";
 import { getCurrentMember } from "@/lib/queries/member";
@@ -153,12 +152,10 @@ async function HomeContent() {
     }));
 
   let myRegistrations: CompetitionRegistration[] = [];
-  let isMember = false;
   let calendarMyRaces: CalendarRace[] = [];
 
   if (user) {
     if (currentMember) {
-      isMember = true;
       initialMemberStatus = currentMember.status !== "active"
         ? { status: "inactive", userId: user.id }
         : {
@@ -216,7 +213,8 @@ async function HomeContent() {
 
   return (
     <div className="flex flex-col gap-0">
-      <div className="flex flex-col gap-7 px-6 pb-6">
+      {/* Social fixed 영역(하단 탭바 위) 높이만큼 하단 여백 확보 */}
+      <div className="flex flex-col gap-7 px-6 pb-[calc(6.5rem+env(safe-area-inset-bottom,0px))]">
         <Suspense>
           <MiniCalendar
             gigangRaces={calendarGigangRaces}
@@ -231,10 +229,6 @@ async function HomeContent() {
             initialRegistrationsByCompetitionId={initialRegistrationsByCompetitionId}
           />
         </Suspense>
-
-        <SocialLinksGrid
-          kakaoChatPassword={isMember ? (env.KAKAO_CHAT_PASSWORD ?? "") : undefined}
-        />
       </div>
     </div>
   );
@@ -244,20 +238,12 @@ async function HomeContent() {
 function HomeSkeleton() {
   return (
     <div className="flex flex-col gap-0">
-      <div className="flex flex-col gap-7 px-6 pb-6">
+      {/* Social fixed 영역 높이만큼 하단 여백 확보 */}
+      <div className="flex flex-col gap-7 px-6 pb-[calc(6.5rem+env(safe-area-inset-bottom,0px))]">
         {/* MiniCalendar 영역 */}
         <div className="flex flex-col gap-3">
           <Skeleton className="h-3.5 w-20" />
           <Skeleton className="h-64 rounded-xl" />
-        </div>
-        {/* SocialLinksGrid 영역 */}
-        <div className="flex flex-col gap-4">
-          <Skeleton className="h-3 w-12" />
-          <div className="grid grid-cols-4 gap-2.5">
-            {Array.from({ length: 4 }).map((_, i) => (
-              <Skeleton key={i} className="h-[72px] rounded-2xl" />
-            ))}
-          </div>
         </div>
       </div>
     </div>
@@ -300,6 +286,10 @@ export default function HomePage() {
       <Suspense fallback={<HomeSkeleton />}>
         <HomeContent />
       </Suspense>
+      {/* 탭바(h-14 + safe-area) 위에 fixed 배치 — Suspense 밖이므로 즉시 렌더 */}
+      <div className="fixed bottom-[calc(3.5rem+env(safe-area-inset-bottom,0px))] left-0 right-0 z-40 border-t border-border bg-background px-6 py-3">
+        <SocialLinksGrid />
+      </div>
     </div>
   );
 }

--- a/app/(main)/page.tsx
+++ b/app/(main)/page.tsx
@@ -3,6 +3,7 @@ import { Suspense } from "react";
 import { dayjs, currentMonthKST, gridDateRange } from "@/lib/dayjs";
 import { hasUnreadBoardPosts } from "@/lib/queries/board";
 import { getCachedCmmCdRows } from "@/lib/queries/cmm-cd-cached";
+import { getCachedHomeCalendar } from "@/lib/queries/home-calendar";
 import { getCurrentMember } from "@/lib/queries/member";
 import { getNotifications, getUnreadNotificationCount } from "@/lib/queries/notification";
 import { getRequestTeamContext } from "@/lib/queries/request-team";
@@ -12,7 +13,7 @@ import { H1 } from "@/components/common/typography";
 import { MiniCalendar } from "@/components/home/mini-calendar";
 import type { CalendarRace } from "@/components/home/mini-calendar";
 import { NotificationBellIcon } from "@/components/notifications/notification-bell-icon";
-import type { CompetitionRegistration, MemberStatus } from "@/components/races/types";
+import type { MemberStatus } from "@/components/races/types";
 import { SocialLinksGrid } from "@/components/social-links";
 import { Skeleton } from "@/components/ui/skeleton";
 
@@ -58,58 +59,49 @@ async function HomeHeader() {
 }
 
 async function HomeContent() {
-  const { user, member: currentMember, supabase } = await getCurrentMember();
+  const { user, member: currentMember } = await getCurrentMember();
   const { teamId } = await getRequestTeamContext();
   const monthStart = currentMonthKST();
 
   const [yearStr, monthStr] = monthStart.split("-");
-  // 캘린더 그리드는 앞뒤 달 며칠을 흐리게 함께 그리므로, SSR에서도 그리드 전체 범위로 조회해
-  // 클라이언트 마운트 시 재조회 없이 앞뒤 달 일정까지 한 번에 채운다(MiniCalendar와 동일 범위).
-  // fetchStart는 start보다 1주 앞 — 그리드 시작 직전에 시작해 그리드 안으로 이어지는 일정 누락 방지.
-  const { start: gridStart, end: gridEnd, fetchStart } = gridDateRange(parseInt(yearStr, 10), parseInt(monthStr, 10));
+  const year = parseInt(yearStr, 10);
+  const month = parseInt(monthStr, 10);
+  const { end: gridEnd } = gridDateRange(year, month);
 
+  // 캐시된 공개 데이터 조회 — DB 쿼리 0개 (캐시 히트 시)
+  const [{ comps: calendarComps, schPosts: schPostRows, gatherings: gthrRows }, cmmCdRows] =
+    await Promise.all([
+      getCachedHomeCalendar(teamId, year, month),
+      getCachedCmmCdRows(),
+    ]);
+
+  // memberStatus 판별 (기존 로직 유지)
   let initialMemberStatus: MemberStatus = { status: "signed-out" };
+  if (user) {
+    if (currentMember) {
+      initialMemberStatus = currentMember.status !== "active"
+        ? { status: "inactive", userId: user.id }
+        : {
+            status: "ready",
+            userId: user.id,
+            memberId: currentMember.id,
+            fullName: currentMember.full_name ?? null,
+            email: currentMember.email ?? null,
+            admin: currentMember.admin ?? false,
+          };
+    } else {
+      initialMemberStatus = { status: "needs-onboarding", userId: user.id };
+    }
+  }
 
-  const [
-    { data: calendarComps },
-    cmmCdRows,
-    { data: schPostRows },
-    { data: gthrRows },
-    myRegsResult,
-  ] = await Promise.all([
-    supabase.rpc("get_public_team_competitions", { p_team_id: teamId, p_start: fetchStart, p_end: gridEnd }),
-    getCachedCmmCdRows(),
-    supabase.rpc("get_public_team_sch_posts", {
-      p_team_id: teamId,
-      p_start: fetchStart,
-      p_end: gridEnd,
-    }),
-    supabase.rpc("get_public_team_gatherings", {
-      p_team_id: teamId,
-      p_start: fetchStart,
-      p_end: gridEnd,
-      ...(currentMember ? { p_mem_id: currentMember.id } : {}),
-    }),
-    currentMember
-      ? supabase
-          .from("comp_reg_rel")
-          .select(
-            "comp_reg_id, mem_id, prt_role_cd, crt_at, team_comp_plan_rel!inner(comp_id, comp_mst!inner(comp_id, comp_nm, stt_dt, loc_nm, comp_sprt_cd, comp_evt_cfg(comp_evt_type))), comp_evt_cfg(comp_evt_type)",
-          )
-          .eq("mem_id", currentMember.id)
-          .eq("team_comp_plan_rel.team_id", teamId)
-          .eq("vers", 0)
-          .eq("del_yn", false)
-      : Promise.resolve({ data: null }),
-  ]);
-
-  const calendarGatherings: CalendarRace[] = (gthrRows ?? []).map((row) => ({
+  // 공개 데이터 변환 — 유저별 로직 제거 (gathering은 항상 "gathering", is_attending은 클라이언트에서 overlay)
+  const calendarGatherings: CalendarRace[] = gthrRows.map((row) => ({
     id: row.gthr_id,
     short_id: row.short_id ?? null,
     title: row.gthr_nm,
     start_date: dayjs(row.stt_at).tz("Asia/Seoul").format("YYYY-MM-DD"),
     end_date: row.end_at ? dayjs(row.end_at).tz("Asia/Seoul").format("YYYY-MM-DD") : null,
-    type: (currentMember && ("is_attending" in row ? row.is_attending : false) ? "gathering_mine" : "gathering") as CalendarRace["type"],
+    type: "gathering" as const,
     post_type: row.gthr_type_enm,
     sprt_cd: row.sprt_cd ?? null,
     location: row.loc_txt ?? null,
@@ -122,7 +114,7 @@ async function HomeContent() {
     cmntCount: row.cmnt_count ? Number(row.cmnt_count) : undefined,
   }));
 
-  const calendarSchPosts: CalendarRace[] = (schPostRows ?? []).map((row) => ({
+  const calendarSchPosts: CalendarRace[] = schPostRows.map((row) => ({
     id: row.sch_post_id,
     short_id: row.short_id ?? null,
     title: row.sch_nm,
@@ -139,7 +131,7 @@ async function HomeContent() {
     cmntCount: row.cmnt_count ? Number(row.cmnt_count) : undefined,
   }));
 
-  const calendarGigangRaces: CalendarRace[] = (calendarComps ?? [])
+  const calendarGigangRaces: CalendarRace[] = calendarComps
     .filter((row) => (row.reg_count ?? 0) > 0 && row.stt_dt <= gridEnd)
     .map((row) => ({
       id: row.comp_id,
@@ -151,66 +143,6 @@ async function HomeContent() {
       cmntCount: row.cmnt_count ? Number(row.cmnt_count) : undefined,
     }));
 
-  let myRegistrations: CompetitionRegistration[] = [];
-  let calendarMyRaces: CalendarRace[] = [];
-
-  if (user) {
-    if (currentMember) {
-      initialMemberStatus = currentMember.status !== "active"
-        ? { status: "inactive", userId: user.id }
-        : {
-            status: "ready",
-            userId: user.id,
-            memberId: currentMember.id,
-            fullName: currentMember.full_name ?? null,
-            email: currentMember.email ?? null,
-            admin: currentMember.admin ?? false,
-          };
-
-      const myRegs = myRegsResult?.data ?? null;
-
-      myRegistrations = (myRegs ?? []).map((r) => ({
-        id: r.comp_reg_id,
-        competition_id: (
-          Array.isArray(r.team_comp_plan_rel)
-            ? r.team_comp_plan_rel[0]
-            : r.team_comp_plan_rel
-        ).comp_id,
-        member_id: r.mem_id,
-        role: r.prt_role_cd,
-        event_type:
-          (
-            Array.isArray(r.comp_evt_cfg) ? r.comp_evt_cfg[0] : r.comp_evt_cfg
-          )?.comp_evt_type?.toUpperCase() ?? null,
-        created_at: r.crt_at,
-      })) as CompetitionRegistration[];
-
-      const calendarCompsMetaMap = new Map<string, { regCount: number; cmntCount: number }>();
-      for (const row of calendarComps ?? []) {
-        calendarCompsMetaMap.set(row.comp_id, {
-          regCount: row.reg_count ?? 0,
-          cmntCount: row.cmnt_count ? Number(row.cmnt_count) : 0,
-        });
-      }
-      calendarMyRaces = (myRegs ?? [])
-        .flatMap((r) => {
-          const plan = Array.isArray(r.team_comp_plan_rel) ? r.team_comp_plan_rel[0] : r.team_comp_plan_rel;
-          const comp = Array.isArray(plan.comp_mst) ? plan.comp_mst[0] : plan.comp_mst;
-          if (!comp) return [];
-          const meta = calendarCompsMetaMap.get(comp.comp_id);
-          const race: CalendarRace = { id: comp.comp_id, title: comp.comp_nm, start_date: comp.stt_dt, type: "mine", location: comp.loc_nm ?? null, regCount: meta?.regCount ?? 0, cmntCount: meta?.cmntCount || undefined };
-          return race.start_date >= gridStart && race.start_date <= gridEnd ? [race] : [];
-        });
-    } else {
-      initialMemberStatus = { status: "needs-onboarding", userId: user.id };
-    }
-  }
-
-  const initialRegistrationsByCompetitionId: Record<string, CompetitionRegistration> = {};
-  myRegistrations.forEach((reg) => {
-    initialRegistrationsByCompetitionId[reg.competition_id] = reg;
-  });
-
   return (
     <div className="flex flex-col gap-0">
       {/* Social fixed 영역(하단 탭바 위) 높이만큼 하단 여백 확보 */}
@@ -218,7 +150,7 @@ async function HomeContent() {
         <Suspense>
           <MiniCalendar
             gigangRaces={calendarGigangRaces}
-            myRaces={calendarMyRaces}
+            myRaces={[]}
             schPosts={calendarSchPosts}
             gatherings={calendarGatherings}
             teamId={teamId}
@@ -226,7 +158,7 @@ async function HomeContent() {
             memberAvatarUrl={currentMember?.avatar_url ?? null}
             cmmCdRows={cmmCdRows}
             initialMemberStatus={initialMemberStatus}
-            initialRegistrationsByCompetitionId={initialRegistrationsByCompetitionId}
+            initialRegistrationsByCompetitionId={{}}
           />
         </Suspense>
       </div>

--- a/app/actions/social/get-kakao-password.ts
+++ b/app/actions/social/get-kakao-password.ts
@@ -1,0 +1,14 @@
+"use server";
+
+import { env } from "@/lib/env";
+import { getCurrentMember } from "@/lib/queries/member";
+
+/**
+ * 카카오 오픈채팅 비밀번호 조회
+ * 멤버인 경우 비밀번호 반환, 아닌 경우 null 반환
+ */
+export async function getKakaoChatPassword(): Promise<string | null> {
+  const { member } = await getCurrentMember();
+  if (!member) return null;
+  return env.KAKAO_CHAT_PASSWORD ?? null;
+}

--- a/app/api/revalidate/route.ts
+++ b/app/api/revalidate/route.ts
@@ -3,6 +3,7 @@ import { revalidateTag } from "next/cache";
 import { NextRequest, NextResponse } from "next/server";
 import { COMMON_CODES_CACHE_TAG } from "@/lib/common-codes-cache-tag";
 import { env } from "@/lib/env";
+import { HOME_CALENDAR_CACHE_TAG } from "@/lib/queries/home-calendar";
 
 export async function POST(request: NextRequest) {
   const secret = request.headers.get("x-webhook-secret");
@@ -17,6 +18,8 @@ export async function POST(request: NextRequest) {
   revalidateTag(COMMON_CODES_CACHE_TAG, "max");
   // /records 의 unstable_cache(tags: "records", `records:${teamId}`)
   revalidateTag("records", "max");
+  // 홈 캘린더 캐시 무효화 (대회·일정포스트·모임 변경 시)
+  revalidateTag(HOME_CALENDAR_CACHE_TAG, "max");
 
   return NextResponse.json({ revalidated: true });
 }

--- a/components/home/mini-calendar.tsx
+++ b/components/home/mini-calendar.tsx
@@ -739,11 +739,11 @@ export function MiniCalendar({
       const { start: gridStart, end: gridEnd, fetchStart } = gridDateRange(y, m);
 
       const [{ data: myRegs }, { data: gthrWithAttd }] = await Promise.all([
-        // 내 대회 등록
+        // 내 대회 등록 — 등록 상세 필드 포함 (CompetitionDetailDialog에서 수정/취소에 필요)
         supabase
           .from("comp_reg_rel")
           .select(
-            "team_comp_plan_rel!inner(comp_id, comp_mst!inner(comp_id, comp_nm, stt_dt, loc_nm))",
+            "comp_reg_id, mem_id, prt_role_cd, crt_at, team_comp_plan_rel!inner(comp_id, comp_mst!inner(comp_id, comp_nm, stt_dt, loc_nm, comp_sprt_cd, comp_evt_cfg(comp_evt_type))), comp_evt_cfg(comp_evt_type)",
           )
           .eq("mem_id", memId)
           .eq("team_comp_plan_rel.team_id", teamId)
@@ -758,7 +758,10 @@ export function MiniCalendar({
         }),
       ]);
 
-      // myRaces 구성 — fetchMonthData의 newMine 매핑 로직과 동일
+      // 월 이동이 발생했으면 늦게 온 응답을 버린다
+      if (viewMonthRef.current !== initialMonth) return;
+
+      // myRaces + registrationsByCompetitionId 구성
       if (myRegs) {
         const races = myRegs.flatMap((r) => {
           const plan = Array.isArray(r.team_comp_plan_rel)
@@ -776,6 +779,25 @@ export function MiniCalendar({
           return race.start_date >= gridStart && race.start_date <= gridEnd ? [race] : [];
         });
         setMyRaces(races);
+
+        // 등록 맵 구성 — 대회 클릭 시 수정/취소 흐름에 필요
+        const regs: Record<string, CompetitionRegistration> = {};
+        myRegs.forEach((r) => {
+          const plan = Array.isArray(r.team_comp_plan_rel)
+            ? r.team_comp_plan_rel[0]
+            : r.team_comp_plan_rel;
+          regs[plan.comp_id] = {
+            id: r.comp_reg_id,
+            competition_id: plan.comp_id,
+            member_id: r.mem_id,
+            role: r.prt_role_cd as CompetitionRegistration["role"],
+            event_type:
+              (Array.isArray(r.comp_evt_cfg) ? r.comp_evt_cfg[0] : r.comp_evt_cfg)
+                ?.comp_evt_type?.toUpperCase() ?? null,
+            created_at: r.crt_at,
+          } as CompetitionRegistration;
+        });
+        setRegistrationsByCompetitionId(regs);
       }
 
       // gathering is_attending overlay — 서버에서 "gathering"으로만 내려온 데이터에 참석 여부를 overlay

--- a/components/home/mini-calendar.tsx
+++ b/components/home/mini-calendar.tsx
@@ -725,8 +725,79 @@ export function MiniCalendar({
   // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
-  // SSR(page.tsx)이 처음부터 gridDateRange 범위로 조회해 내려주므로 마운트 시 보강 재조회는 불필요하다.
-  // (달 이동·갱신 시의 fetchMonthData도 같은 gridDateRange를 써서 앞뒤 달 일정을 함께 받아온다)
+  // SSR(page.tsx)이 처음부터 gridDateRange 범위로 공개 데이터를 조회해 내려주므로 공개 데이터 보강 재조회는 불필요하다.
+  // 다만 유저별 데이터(내 대회 등록, 모임 참석 여부)는 캐시에 포함되지 않으므로 마운트 시 클라이언트에서 fetch한다.
+  // (달 이동 시에는 fetchMonthData가 유저별 데이터를 함께 조회하므로 이 useEffect는 초기 마운트 1회만 필요.)
+  useEffect(() => {
+    if (!memberId) return;
+    const memId = memberId; // TypeScript narrowing — async 함수 내에서 non-optional 사용
+
+    async function fetchUserData() {
+      const [yStr, mStr] = initialMonth.split("-");
+      const y = parseInt(yStr, 10);
+      const m = parseInt(mStr, 10);
+      const { start: gridStart, end: gridEnd, fetchStart } = gridDateRange(y, m);
+
+      const [{ data: myRegs }, { data: gthrWithAttd }] = await Promise.all([
+        // 내 대회 등록
+        supabase
+          .from("comp_reg_rel")
+          .select(
+            "team_comp_plan_rel!inner(comp_id, comp_mst!inner(comp_id, comp_nm, stt_dt, loc_nm))",
+          )
+          .eq("mem_id", memId)
+          .eq("team_comp_plan_rel.team_id", teamId)
+          .eq("vers", 0)
+          .eq("del_yn", false),
+        // 모임 참석 여부
+        supabase.rpc("get_public_team_gatherings", {
+          p_team_id: teamId,
+          p_start: fetchStart,
+          p_end: gridEnd,
+          p_mem_id: memId,
+        }),
+      ]);
+
+      // myRaces 구성 — fetchMonthData의 newMine 매핑 로직과 동일
+      if (myRegs) {
+        const races = myRegs.flatMap((r) => {
+          const plan = Array.isArray(r.team_comp_plan_rel)
+            ? r.team_comp_plan_rel[0]
+            : r.team_comp_plan_rel;
+          const comp = Array.isArray(plan?.comp_mst) ? plan.comp_mst[0] : plan?.comp_mst;
+          if (!comp) return [];
+          const race: CalendarRace = {
+            id: comp.comp_id,
+            title: comp.comp_nm,
+            start_date: comp.stt_dt,
+            type: "mine",
+            location: comp.loc_nm ?? null,
+          };
+          return race.start_date >= gridStart && race.start_date <= gridEnd ? [race] : [];
+        });
+        setMyRaces(races);
+      }
+
+      // gathering is_attending overlay — 서버에서 "gathering"으로만 내려온 데이터에 참석 여부를 overlay
+      if (gthrWithAttd) {
+        setGatherings((prev) =>
+          prev.map((g) => {
+            const match = gthrWithAttd.find(
+              (row: { gthr_id: string; is_attending?: boolean }) => row.gthr_id === g.id,
+            );
+            if (match && match.is_attending) {
+              return { ...g, type: "gathering_mine" as const };
+            }
+            return g;
+          }),
+        );
+      }
+    }
+
+    fetchUserData();
+  // initialMonth·supabase·teamId는 마운트 후 변경되지 않으며, memberId 변경 시에만 재실행
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [memberId]);
 
   const swipeTouchStartX = useRef<number | null>(null);
   const swipeDidNavigate = useRef(false);

--- a/components/social-links.stories.tsx
+++ b/components/social-links.stories.tsx
@@ -21,7 +21,8 @@ export const Grid: Story = {
 export const GridWithPassword: Story = {
   render: () => (
     <div className="w-[375px] p-6">
-      <SocialLinksGrid kakaoChatPassword="1234" />
+      {/* kakaoChatPassword prop이 서버 액션으로 전환됨 — 스토리에서는 prop 없이 렌더 */}
+      <SocialLinksGrid />
     </div>
   ),
 };

--- a/components/social-links.tsx
+++ b/components/social-links.tsx
@@ -117,12 +117,15 @@ export function SocialLinksGrid() {
   /** 카카오 버튼 클릭 시 서버 액션으로 비밀번호 조회 */
   const handleKakaoClick = async () => {
     setOpen(true);
-    if (kakaoChatPassword !== null) return; // 이미 조회됨
+    if (kakaoChatPassword !== null || loading) return; // 이미 조회됐거나 조회 중
     setLoading(true);
-    const pw = await getKakaoChatPassword();
-    // null(비멤버)은 undefined로 구분하여 "미조회(null)" 상태와 구별
-    setKakaoChatPassword(pw ?? undefined);
-    setLoading(false);
+    try {
+      const pw = await getKakaoChatPassword();
+      // null(비멤버)은 undefined로 구분하여 "미조회(null)" 상태와 구별
+      setKakaoChatPassword(pw ?? undefined);
+    } finally {
+      setLoading(false);
+    }
   };
 
   const isMember = typeof kakaoChatPassword === "string";

--- a/components/social-links.tsx
+++ b/components/social-links.tsx
@@ -4,6 +4,7 @@ import { useState } from "react";
 
 import Image from "next/image";
 
+import { getKakaoChatPassword } from "@/app/actions/social/get-kakao-password";
 import { SectionLabel } from "@/components/common/typography";
 import { detectInAppBrowser, openExternalBrowser } from "@/components/in-app-browser-gate";
 import { CardItem } from "@/components/ui/card";
@@ -107,13 +108,24 @@ export function SocialLinksRow() {
   );
 }
 
-export function SocialLinksGrid({
-  kakaoChatPassword,
-}: {
-  kakaoChatPassword?: string;
-}) {
+export function SocialLinksGrid() {
   const [open, setOpen] = useState(false);
-  const isMember = !!kakaoChatPassword;
+  // null = 미조회, undefined = 조회 완료(비멤버), string = 비밀번호
+  const [kakaoChatPassword, setKakaoChatPassword] = useState<string | null | undefined>(null);
+  const [loading, setLoading] = useState(false);
+
+  /** 카카오 버튼 클릭 시 서버 액션으로 비밀번호 조회 */
+  const handleKakaoClick = async () => {
+    setOpen(true);
+    if (kakaoChatPassword !== null) return; // 이미 조회됨
+    setLoading(true);
+    const pw = await getKakaoChatPassword();
+    // null(비멤버)은 undefined로 구분하여 "미조회(null)" 상태와 구별
+    setKakaoChatPassword(pw ?? undefined);
+    setLoading(false);
+  };
+
+  const isMember = typeof kakaoChatPassword === "string";
 
   return (
     <>
@@ -125,7 +137,7 @@ export function SocialLinksGrid({
               <CardItem asChild key={key} className="flex flex-col items-center gap-2 py-3">
                 <button
                   type="button"
-                  onClick={() => setOpen(true)}
+                  onClick={handleKakaoClick}
                 >
                   <Image src={logo} alt={label} width={28} height={28} className={invertOnDark ? "dark:invert" : undefined} />
                   <span className="whitespace-nowrap text-xs font-semibold text-foreground">
@@ -156,7 +168,12 @@ export function SocialLinksGrid({
           <DialogHeader>
             <DialogTitle>오픈채팅 참여</DialogTitle>
           </DialogHeader>
-          {isMember ? (
+          {loading ? (
+            // 비밀번호 조회 중 스피너
+            <div className="flex items-center justify-center py-6">
+              <div className="h-6 w-6 animate-spin rounded-full border-2 border-border border-t-primary" />
+            </div>
+          ) : isMember ? (
             <>
               <div className="rounded-2xl border border-border bg-secondary/50 px-5 py-4 text-center">
                 <p className="text-xs text-muted-foreground">

--- a/lib/queries/home-calendar.ts
+++ b/lib/queries/home-calendar.ts
@@ -1,0 +1,68 @@
+import "server-only";
+
+import { cache } from "react";
+import { unstable_cache } from "next/cache";
+
+import { gridDateRange } from "@/lib/dayjs";
+import { createAdminClient } from "@/lib/supabase/admin";
+
+/** 홈 캘린더 공개 데이터 캐시 태그 */
+export const HOME_CALENDAR_CACHE_TAG = "home-calendar";
+
+async function loadHomeCalendar(teamId: string, year: number, month: number) {
+  const supabase = createAdminClient();
+  const { end: gridEnd, fetchStart } = gridDateRange(year, month);
+
+  const [
+    { data: comps, error: compErr },
+    { data: schPosts, error: schErr },
+    { data: gatherings, error: gthrErr },
+  ] = await Promise.all([
+    supabase.rpc("get_public_team_competitions", {
+      p_team_id: teamId,
+      p_start: fetchStart,
+      p_end: gridEnd,
+    }),
+    supabase.rpc("get_public_team_sch_posts", {
+      p_team_id: teamId,
+      p_start: fetchStart,
+      p_end: gridEnd,
+    }),
+    supabase.rpc("get_public_team_gatherings", {
+      p_team_id: teamId,
+      p_start: fetchStart,
+      p_end: gridEnd,
+      // p_mem_id 미전달 — 공개 데이터만 캐싱
+    }),
+  ]);
+
+  if (compErr || schErr || gthrErr) {
+    const err = compErr ?? schErr ?? gthrErr;
+    console.error("홈 캘린더 공개 데이터 조회 실패:", err);
+    throw new Error("홈 캘린더 데이터 조회에 실패했습니다.", { cause: err });
+  }
+
+  return {
+    comps: comps ?? [],
+    schPosts: schPosts ?? [],
+    gatherings: gatherings ?? [],
+  };
+}
+
+function createCachedHomeCalendar(teamId: string, year: number, month: number) {
+  return unstable_cache(
+    () => loadHomeCalendar(teamId, year, month),
+    [`home-calendar-${teamId}-${year}-${month}`],
+    { tags: [HOME_CALENDAR_CACHE_TAG] },
+  );
+}
+
+/**
+ * 홈 캘린더 공개 데이터 (대회·일정포스트·모임) 캐시 조회.
+ * - `unstable_cache`: 요청 간 Next.js 데이터 캐시 (on-demand revalidation 전용)
+ * - `cache()`: 동일 렌더 내 중복 호출 제거
+ */
+export const getCachedHomeCalendar = cache(
+  async (teamId: string, year: number, month: number) =>
+    createCachedHomeCalendar(teamId, year, month)(),
+);

--- a/supabase/migrations/20260629120000_home_calendar_revalidation.sql
+++ b/supabase/migrations/20260629120000_home_calendar_revalidation.sql
@@ -1,0 +1,26 @@
+-- 홈 캘린더 관련 테이블 변경 시 revalidation 트리거
+-- 기존 revalidate_records() 함수를 재활용 (같은 /api/revalidate 엔드포인트 호출)
+
+-- comp_mst (대회 생성/수정/삭제)
+DROP TRIGGER IF EXISTS trg_comp_mst_revalidate ON public.comp_mst;
+CREATE TRIGGER trg_comp_mst_revalidate
+  AFTER INSERT OR UPDATE OR DELETE ON public.comp_mst
+  FOR EACH ROW EXECUTE FUNCTION revalidate_records();
+
+-- team_comp_plan_rel (팀 대회 연결 변경)
+DROP TRIGGER IF EXISTS trg_team_comp_plan_rel_revalidate ON public.team_comp_plan_rel;
+CREATE TRIGGER trg_team_comp_plan_rel_revalidate
+  AFTER INSERT OR UPDATE OR DELETE ON public.team_comp_plan_rel
+  FOR EACH ROW EXECUTE FUNCTION revalidate_records();
+
+-- sch_post_mst (일정 게시글 변경)
+DROP TRIGGER IF EXISTS trg_sch_post_mst_revalidate ON public.sch_post_mst;
+CREATE TRIGGER trg_sch_post_mst_revalidate
+  AFTER INSERT OR UPDATE OR DELETE ON public.sch_post_mst
+  FOR EACH ROW EXECUTE FUNCTION revalidate_records();
+
+-- gthr_mst (모임 변경)
+DROP TRIGGER IF EXISTS trg_gthr_mst_revalidate ON public.gthr_mst;
+CREATE TRIGGER trg_gthr_mst_revalidate
+  AFTER INSERT OR UPDATE OR DELETE ON public.gthr_mst
+  FOR EACH ROW EXECUTE FUNCTION revalidate_records();

--- a/supabase/migrations/20260629120000_home_calendar_revalidation.sql
+++ b/supabase/migrations/20260629120000_home_calendar_revalidation.sql
@@ -24,3 +24,22 @@ DROP TRIGGER IF EXISTS trg_gthr_mst_revalidate ON public.gthr_mst;
 CREATE TRIGGER trg_gthr_mst_revalidate
   AFTER INSERT OR UPDATE OR DELETE ON public.gthr_mst
   FOR EACH ROW EXECUTE FUNCTION revalidate_records();
+
+-- 파생 카운트 테이블 — reg_count, attd_count, cmnt_count 캐시 갱신용
+-- comp_reg_rel (대회 등록 → reg_count)
+DROP TRIGGER IF EXISTS trg_comp_reg_rel_revalidate ON public.comp_reg_rel;
+CREATE TRIGGER trg_comp_reg_rel_revalidate
+  AFTER INSERT OR UPDATE OR DELETE ON public.comp_reg_rel
+  FOR EACH ROW EXECUTE FUNCTION revalidate_records();
+
+-- gthr_attd_rel (모임 참석 → attd_count)
+DROP TRIGGER IF EXISTS trg_gthr_attd_rel_revalidate ON public.gthr_attd_rel;
+CREATE TRIGGER trg_gthr_attd_rel_revalidate
+  AFTER INSERT OR UPDATE OR DELETE ON public.gthr_attd_rel
+  FOR EACH ROW EXECUTE FUNCTION revalidate_records();
+
+-- cmnt_mst (댓글 → cmnt_count)
+DROP TRIGGER IF EXISTS trg_cmnt_mst_revalidate ON public.cmnt_mst;
+CREATE TRIGGER trg_cmnt_mst_revalidate
+  AFTER INSERT OR UPDATE OR DELETE ON public.cmnt_mst
+  FOR EACH ROW EXECUTE FUNCTION revalidate_records();

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -7,6 +7,6 @@ export default defineConfig({
     globals: true,
     environment: "node",
     include: ["**/__tests__/**/*.test.ts", "**/*.test.ts"],
-    exclude: ["node_modules", ".next"],
+    exclude: ["node_modules", ".next", ".claude/**"],
   },
 });


### PR DESCRIPTION
## Summary
- 홈 캘린더 공개 데이터(대회, 일정, 모임)를 `unstable_cache`로 캐싱하여 캐시 히트 시 DB 쿼리 0개
- Social 섹션을 Suspense 밖 하단 fixed로 분리하여 즉시 렌더링 (스켈레톤 제거)
- 유저별 데이터(내 대회 등록, 모임 참석 여부)는 클라이언트에서 마운트 시 fetch하여 overlay
- Supabase DB webhook 트리거로 관련 테이블 변경 시 on-demand 캐시 무효화

### AS-IS ( 매 렌더링마다 다시 페칭해옴 ) 

https://github.com/user-attachments/assets/9fcf737f-bc09-4ce4-88f2-65b6065db062

### TO-BE ( 캐싱처리함 + Supabase측에서 Record 수정될때 on-demand로 찌를예정 ) 

https://github.com/user-attachments/assets/dc8bc4d5-21fb-44bb-b476-c7f94c7a4bff


## AS-IS → TO-BE

**AS-IS:**
- `HomeContent`에서 매 요청마다 5개 DB 쿼리 실행 → Suspense 스켈레톤 표시
- Social 섹션이 캘린더와 함께 Suspense에 묶여 불필요한 로딩

**TO-BE:**
- 공개 데이터는 `unstable_cache`(tag: `home-calendar`)로 캐싱 → 즉시 렌더링
- Social은 Suspense 밖 하단 fixed → 항상 즉시 표시
- 유저별 데이터는 클라이언트 마운트 후 비동기 로딩

## 주요 변경 사항
1. `app/actions/social/get-kakao-password.ts` — 카카오 비밀번호 서버 액션
2. `lib/queries/home-calendar.ts` — 캐시된 캘린더 조회 함수
3. `app/(main)/page.tsx` — HomeContent 캐시 전환, Social 분리
4. `components/home/mini-calendar.tsx` — 유저별 데이터 클라이언트 fetch
5. `app/api/revalidate/route.ts` — `home-calendar` 태그 추가
6. `supabase/migrations/20260629120000_home_calendar_revalidation.sql` — DB 트리거

## Test plan
- [x] `pnpm run build` 성공
- [x] `pnpm run test` 62개 테스트 통과
- [ ] 비로그인 상태에서 홈 진입 시 캘린더 즉시 렌더링 확인
- [ ] 로그인 상태에서 내 대회/모임 참석 badge 정상 표시 확인
- [ ] 카카오 버튼 클릭 시 비밀번호 정상 로딩 확인
- [ ] Social 섹션 하단 fixed 배치 확인

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * 홈 화면 캘린더가 공개 일정 데이터를 더 빠르게 불러오도록 개선됐습니다.
  * 카카오 오픈채팅 안내가 클릭 시점에 확인되도록 변경됐습니다.

* **Bug Fixes**
  * 홈 화면의 일정/모임 표시 방식이 단순화되어 초기 로딩 안정성이 향상됐습니다.
  * 데이터 변경 시 홈 캘린더가 자동으로 새로고침되도록 반영했습니다.

* **Style**
  * 홈 스켈레톤과 소셜 영역 배치가 더 간결하게 정리됐습니다.

* **Tests**
  * 테스트 대상에서 일부 내부 경로가 제외되도록 설정을 조정했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->