### PR TITLE
chore: mise.toml에서 존재하지 않는 aqua:runkids/skillshare 제거

### DIFF
--- a/mise.toml
+++ b/mise.toml
@@ -3,7 +3,6 @@ claude-code = "latest"
 node = "22"
 supabase = "latest"
 vercel = "latest"
-"aqua:runkids/skillshare" = "latest"
 
 [env]
 _.file = [".env.development.local", ".env.development"]


### PR DESCRIPTION
## Summary
- aqua 레지스트리에 `runkids/skillshare` 패키지가 존재하지 않아 `mise` 실행 시 매번 경고가 발생하던 문제 수정
- `mise.toml`에서 해당 tool 항목 제거

## Test plan
- [x] `mise` 실행 시 경고 메시지가 더 이상 출력되지 않는지 확인

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * 개발 도구 설정에서 불필요한 항목 1개를 제거했습니다.
  * 다른 환경 설정이나 작업 관련 내용은 변경되지 않았습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->