### PR TITLE
perf(home): 대회 등록/취소 시 캘린더 낙관적 UI 업데이트

### DIFF
--- a/components/home/mini-calendar.tsx
+++ b/components/home/mini-calendar.tsx
@@ -557,7 +557,15 @@ export function MiniCalendar({
       ...prev,
       [competitionId]: { id: data.comp_reg_id, competition_id: competitionId, member_id: data.mem_id, role: data.prt_role_cd as "participant" | "cheering" | "volunteer", event_type: eventType, created_at: data.crt_at },
     }));
-    handleSchPostSuccess();
+    // 낙관적 UI: gigangRaces → myRaces 즉시 이동 + regCount 증가
+    setGigangRaces((prev) => prev.map((r) => r.id === competitionId ? { ...r, regCount: (r.regCount ?? 0) + 1 } : r));
+    setMyRaces((prev) => {
+      if (prev.some((r) => r.id === competitionId)) return prev;
+      const source = gigangRaces.find((r) => r.id === competitionId);
+      if (!source) return prev;
+      return [...prev, { ...source, type: "mine" as const, regCount: (source.regCount ?? 0) + 1 }];
+    });
+    void refreshMonthData();
     return { ok: true as const, message: "참가 신청 완료" };
   };
 
@@ -590,7 +598,7 @@ export function MiniCalendar({
       ...prev,
       [competitionId]: { id: data.comp_reg_id, competition_id: competitionId, member_id: data.mem_id, role: data.prt_role_cd as "participant" | "cheering" | "volunteer", event_type: eventType, created_at: data.crt_at },
     }));
-    handleSchPostSuccess();
+    void refreshMonthData();
     return { ok: true as const, message: "업데이트 완료" };
   };
 
@@ -602,7 +610,10 @@ export function MiniCalendar({
       delete next[competitionId];
       return next;
     });
-    handleSchPostSuccess();
+    // 낙관적 UI: myRaces에서 제거 + gigangRaces regCount 감소
+    setMyRaces((prev) => prev.filter((r) => r.id !== competitionId));
+    setGigangRaces((prev) => prev.map((r) => r.id === competitionId ? { ...r, regCount: Math.max(0, (r.regCount ?? 1) - 1) } : r));
+    void refreshMonthData();
     return { ok: true as const, message: "취소 완료" };
   };
 


### PR DESCRIPTION
## 관련 이슈

관련 이슈 없음

## 요약

대회 참가·취소 후 `refreshMonthData` (4개 RPC 재조회) 완료를 기다리지 않고, 캘린더 상태를 즉시 반영하여 체감 속도를 개선합니다. 추가로 dev Supabase에 `http` extension 설치 및 revalidation 마이그레이션을 적용했습니다 (DB 작업은 이미 완료).

## AS-IS (변경 전)

- `createRegistration` / `deleteRegistration` 성공 후 `handleSchPostSuccess()` → `refreshMonthData()` 를 **await** 하여 4개 RPC 쿼리 완료를 기다린 후에야 캘린더가 갱신됨
- 모달에서 등록/취소 후 캘린더 이벤트 바 색상·참가인원 반영까지 체감 딜레이 발생
- dev Supabase에 `http` extension 미설치 → `revalidate_records()` 트리거가 실패하여 on-demand revalidation 미작동

## TO-BE (변경 후)

- **낙관적 UI**: DB 성공 즉시 로컬 상태를 업데이트
  - 등록 시: `gigangRaces` regCount+1, `myRaces`에 "mine" 타입으로 추가 → 이벤트 바 색상 즉시 전환
  - 취소 시: `myRaces`에서 제거, `gigangRaces` regCount-1 → 이벤트 바 즉시 복원
- `refreshMonthData()`는 `void`로 백그라운드 호출하여 최종 동기화
- dev Supabase `http` extension 설치 완료 → revalidation 정상 작동

## 변경 흐름

```mermaid
sequenceDiagram
    participant U as 사용자
    participant M as 모달
    participant C as 캘린더
    participant DB as Supabase

    U->>M: 참가 신청
    M->>DB: comp_reg_rel INSERT
    DB-->>M: 성공
    M->>C: 즉시 상태 업데이트 (낙관적)
    Note over C: gigangRaces→myRaces 이동<br/>regCount+1, 색상 전환
    M-->>DB: void refreshMonthData()
    Note over DB: 백그라운드 4 RPC 재조회
    DB-->>C: 최종 동기화
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새 기능**
  * 대회 참가 신청, 수정, 취소 후 화면이 즉시 반영되도록 개선했습니다.
  * 신청 성공 시 참가 수가 바로 증가하고, 내 대회 목록에 없던 대회는 자동으로 추가됩니다.
  * 신청 취소 시 내 대회 목록에서 즉시 제거되고 참가 수도 즉시 감소합니다.

* **버그 수정**
  * 월간 일정 데이터가 뒤늦게 갱신되던 문제를 줄이고, 백그라운드 재조회로 더 자연스러운 화면 동작을 제공하도록 개선했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->