### PR TITLE
feat(avatar): 프사 미설정 멤버 랜덤 아바타 폴백 (DiceBear dylan)

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -220,8 +220,12 @@ import { SegmentControl } from "@/components/common/segment-control";
 ```tsx
 import { Avatar } from "@/components/common/avatar";
 
-<Avatar src={member.avatar_url} size="md" />  // sm=32px, md=40px, lg=56px, xl=64px
+<Avatar src={member.avatar_url} seed={member.id} size="md" />  // sm=32px, md=40px, lg=56px, xl=64px
 ```
+
+- `seed`(멤버 id 권장)를 넘기면 프사 미설정 시 DiceBear 랜덤(고정) 아바타로 폴백. **멤버 아바타는 항상 `src`+`seed`를 함께 전달.**
+- 폴백 스타일은 `avatar.tsx`의 `FALLBACK_AVATAR_STYLE` 한 곳에서 관리 (스타일 교체 시 이 상수만 수정).
+- `seed`도 없으면 `fallbackIcon`(기본 UserRound)으로 폴백.
 
 ### 정보 행 목록
 

--- a/app/(info)/admin/members/admin-members-client.tsx
+++ b/app/(info)/admin/members/admin-members-client.tsx
@@ -701,7 +701,7 @@ export function AdminMembersClient({ teamId, initialTeamMemId }: { teamId: strin
             <div className="flex flex-col gap-6 px-6">
               {/* 헤더 */}
               <div className="flex items-center gap-4">
-                <Avatar src={selectedMember.avatar_url} size="lg" />
+                <Avatar src={selectedMember.avatar_url} seed={selectedMember.id} size="lg" />
                 <div className="flex flex-1 flex-col gap-1">
                   <div className="flex items-center gap-2 flex-wrap">
                     <span className="text-lg font-bold text-foreground">

--- a/app/(info)/gatherings/[id]/page.tsx
+++ b/app/(info)/gatherings/[id]/page.tsx
@@ -160,7 +160,7 @@ export default async function GatheringDetailPage({
                 const mem = Array.isArray(a.mem_mst) ? a.mem_mst[0] : a.mem_mst;
                 return (
                   <div key={a.mem_id} className="flex flex-col items-center gap-1">
-                    <Avatar src={mem?.avatar_url} alt={mem?.mem_nm ?? ""} size="sm" />
+                    <Avatar src={mem?.avatar_url} seed={a.mem_id} alt={mem?.mem_nm ?? ""} size="sm" />
                     <Micro className="text-muted-foreground">{mem?.mem_nm ?? ""}</Micro>
                   </div>
                 );

--- a/app/(main)/profile/page.tsx
+++ b/app/(main)/profile/page.tsx
@@ -95,6 +95,7 @@ async function ProfileContent() {
         <ProfileCard
           fullName={member.full_name}
           avatarUrl={member.avatar_url}
+          memId={member.id}
           genderLabel={genderLabel}
           joinedDate={joinedDate}
           teamMemId={member.team_mem_id}

--- a/components/comment/comment-item.tsx
+++ b/components/comment/comment-item.tsx
@@ -78,7 +78,7 @@ export function CommentItem({
 
   return (
     <div className={`flex gap-2.5 py-2.5 ${isReply ? "pl-10" : ""}`}>
-      <Avatar src={comment.avatar_url} size="sm" />
+      <Avatar src={comment.avatar_url} seed={comment.mem_id} size="sm" />
       <div className="flex-1 min-w-0">
         <div className="flex items-center gap-x-2">
           <Body className="text-sm font-semibold">{comment.mem_nm}</Body>

--- a/components/common/avatar.tsx
+++ b/components/common/avatar.tsx
@@ -31,7 +31,7 @@ type AvatarSize = keyof typeof SIZE_MAP;
 /**
  * 프사 미설정 멤버에게 보여줄 랜덤(고정) 아바타 스타일.
  * DiceBear 스타일 이름만 바꾸면 전체 폴백 아바타가 교체된다.
- * 후보: fun-emoji, bottts, thumbs, notionists, adventurer, lorelei 등
+ * 후보: dylan, fun-emoji, bottts, thumbs, notionists, adventurer, lorelei 등
  * @see https://www.dicebear.com/styles
  */
 const FALLBACK_AVATAR_STYLE = "dylan";
@@ -62,21 +62,35 @@ const Avatar = React.forwardRef<HTMLDivElement, AvatarProps>(
     { className, src, seed, alt, size = "md", fallbackIcon: Icon = UserRound, ...props },
     ref,
   ) => {
-    const [imgError, setImgError] = React.useState(false);
+    // 실제 프사 실패 → DiceBear 폴백 → 그것도 실패 → 아이콘. 단계별로 플래그를 분리한다.
+    const [srcError, setSrcError] = React.useState(false);
+    const [fallbackError, setFallbackError] = React.useState(false);
 
-    // src 우선, 없으면 seed 기반 랜덤(고정) 아바타로 폴백
-    const imageSrc =
-      src && src.length > 0
-        ? src
-        : seed != null && String(seed).length > 0
-          ? buildFallbackAvatarUrl(seed)
-          : null;
-    const showImage = imageSrc && !imgError;
+    // 판정·표시·비교에 모두 trim된 값을 써서 일관성을 유지한다.
+    const trimmedSrc = src?.trim() || null;
+    const fallbackUrl =
+      seed != null && String(seed).trim().length > 0 ? buildFallbackAvatarUrl(seed) : null;
 
-    // 이미지 소스가 변경되면 에러 상태 리셋
+    // 프사 우선 → 깨지면 DiceBear → 그것도 깨지면 아이콘(null)
+    const showingSrc = trimmedSrc != null && !srcError;
+    const imageSrc = showingSrc
+      ? trimmedSrc
+      : fallbackUrl && !fallbackError
+        ? fallbackUrl
+        : null;
+    const showImage = imageSrc != null;
+
+    // src/seed가 바뀌면 에러 상태 리셋 (다른 멤버로 재사용되는 경우)
     React.useEffect(() => {
-      setImgError(false);
-    }, [imageSrc]);
+      setSrcError(false);
+      setFallbackError(false);
+    }, [src, seed]);
+
+    const handleImageError = () => {
+      // 실제 프사를 표시 중이었으면 프사 실패로(→ DiceBear 폴백), 아니면 폴백 실패로(→ 아이콘) 처리
+      if (showingSrc) setSrcError(true);
+      else setFallbackError(true);
+    };
 
     return (
       <div
@@ -97,7 +111,7 @@ const Avatar = React.forwardRef<HTMLDivElement, AvatarProps>(
             className="size-full object-cover"
             referrerPolicy="no-referrer"
             unoptimized
-            onError={() => setImgError(true)}
+            onError={handleImageError}
           />
         ) : (
           <Icon className={cn("text-foreground/50", ICON_SIZE_MAP[size])} />

--- a/components/common/avatar.tsx
+++ b/components/common/avatar.tsx
@@ -28,29 +28,55 @@ const ICON_SIZE_MAP = {
 
 type AvatarSize = keyof typeof SIZE_MAP;
 
+/**
+ * 프사 미설정 멤버에게 보여줄 랜덤(고정) 아바타 스타일.
+ * DiceBear 스타일 이름만 바꾸면 전체 폴백 아바타가 교체된다.
+ * 후보: fun-emoji, bottts, thumbs, notionists, adventurer, lorelei 등
+ * @see https://www.dicebear.com/styles
+ */
+const FALLBACK_AVATAR_STYLE = "dylan";
+
+/** seed(멤버 id 등)로 고정된 DiceBear 아바타 SVG URL을 만든다. */
+function buildFallbackAvatarUrl(seed: string | number): string {
+  return `https://api.dicebear.com/9.x/${FALLBACK_AVATAR_STYLE}/svg?seed=${encodeURIComponent(String(seed))}`;
+}
+
 type AvatarProps = React.HTMLAttributes<HTMLDivElement> & {
   /** 프로필 이미지 URL */
   src?: string | null;
+  /**
+   * 프사 미설정 시 생성할 랜덤 아바타의 seed (멤버 id 권장).
+   * 같은 seed = 항상 같은 아바타. 없으면 fallbackIcon으로 폴백.
+   */
+  seed?: string | number | null;
   /** 이미지 alt 텍스트 */
   alt?: string;
   /** 아바타 크기 */
   size?: AvatarSize;
-  /** 이미지 없을 때 폴백 아이콘 */
+  /** 이미지·seed 모두 없을 때 폴백 아이콘 */
   fallbackIcon?: React.ComponentType<{ className?: string }>;
 };
 
 const Avatar = React.forwardRef<HTMLDivElement, AvatarProps>(
   (
-    { className, src, alt, size = "md", fallbackIcon: Icon = UserRound, ...props },
+    { className, src, seed, alt, size = "md", fallbackIcon: Icon = UserRound, ...props },
     ref,
   ) => {
     const [imgError, setImgError] = React.useState(false);
-    const showImage = src && src.length > 0 && !imgError;
 
-    // src가 변경되면 에러 상태 리셋
+    // src 우선, 없으면 seed 기반 랜덤(고정) 아바타로 폴백
+    const imageSrc =
+      src && src.length > 0
+        ? src
+        : seed != null && String(seed).length > 0
+          ? buildFallbackAvatarUrl(seed)
+          : null;
+    const showImage = imageSrc && !imgError;
+
+    // 이미지 소스가 변경되면 에러 상태 리셋
     React.useEffect(() => {
       setImgError(false);
-    }, [src]);
+    }, [imageSrc]);
 
     return (
       <div
@@ -64,7 +90,7 @@ const Avatar = React.forwardRef<HTMLDivElement, AvatarProps>(
       >
         {showImage ? (
           <Image
-            src={src}
+            src={imageSrc}
             alt={alt ?? ""}
             width={SIZE_PX[size]}
             height={SIZE_PX[size]}

--- a/components/profile/profile-card.tsx
+++ b/components/profile/profile-card.tsx
@@ -47,7 +47,7 @@ export function ProfileCard({
   return (
     <>
       <CardItem className={cn("flex items-center gap-4 p-5", frameCls)}>
-        <Avatar src={avatarUrl} alt={fullName} size="xl" />
+        <Avatar src={avatarUrl} seed={teamMemId} alt={fullName} size="xl" />
         <div className="flex min-w-0 flex-1 flex-col gap-1.5">
           <div className="flex flex-wrap items-center gap-2">
             <span className="text-[17px] font-bold text-foreground">{fullName}</span>

--- a/components/profile/profile-card.tsx
+++ b/components/profile/profile-card.tsx
@@ -15,6 +15,7 @@ import { CardItem } from "@/components/ui/card";
 export function ProfileCard({
   fullName,
   avatarUrl,
+  memId,
   genderLabel,
   joinedDate,
   teamMemId,
@@ -29,6 +30,8 @@ export function ProfileCard({
 }: {
   fullName: string;
   avatarUrl: string | null;
+  /** 멤버 고유 id — 폴백 아바타 seed. 다른 화면(댓글·모임)과 동일하게 mem_id로 통일 */
+  memId: string;
   genderLabel: string;
   joinedDate: string;
   teamMemId: string;
@@ -47,7 +50,7 @@ export function ProfileCard({
   return (
     <>
       <CardItem className={cn("flex items-center gap-4 p-5", frameCls)}>
-        <Avatar src={avatarUrl} seed={teamMemId} alt={fullName} size="xl" />
+        <Avatar src={avatarUrl} seed={memId} alt={fullName} size="xl" />
         <div className="flex min-w-0 flex-1 flex-col gap-1.5">
           <div className="flex flex-wrap items-center gap-2">
             <span className="text-[17px] font-bold text-foreground">{fullName}</span>

--- a/components/schedule/gathering-detail-dialog.tsx
+++ b/components/schedule/gathering-detail-dialog.tsx
@@ -279,7 +279,7 @@ export function GatheringDetailDialog({
               <div className="flex flex-wrap gap-2">
                 {attendees.map((a) => (
                   <div key={a.mem_id} className="flex flex-col items-center gap-0.5">
-                    <Avatar src={a.avatar_url} alt={a.mem_nm ?? ""} size="sm" />
+                    <Avatar src={a.avatar_url} seed={a.mem_id} alt={a.mem_nm ?? ""} size="sm" />
                     <Micro className="leading-tight">{a.mem_nm ?? ""}</Micro>
                   </div>
                 ))}


### PR DESCRIPTION
## 개요

프로필 사진 미설정 멤버에게 멤버 id 기반 **고정 랜덤 아바타**(DiceBear `dylan`)를 보여주는 기능을 **운영(main)에 직접 배포**합니다.

> ⚠️ **이 PR은 dev를 경유하지 않고 `feat/random-avatar-fallback` → `main`으로 직접 올립니다.**
> dev에는 아직 운영에 나가면 안 되는 검증 중 커밋(#376/#370/#373/#372)이 쌓여 있어, dev→main 통째 승격 대신 이 기능만 분리 배포합니다.
> 이 브랜치는 `main + 아바타 커밋 2개`로만 구성되어 위 4개 커밋은 **포함되지 않음**을 확인했습니다.

## 포함 커밋

- `feat(avatar)`: 프사 미설정 멤버 랜덤 아바타 폴백 (DiceBear dylan)
- `fix(avatar)`: 폴백 체인 수정 + src trim 일관화

## 변경 사항

**1. `Avatar`에 `seed` 기반 랜덤 아바타 폴백**
- AS-IS: 프사 없으면 회색 + `UserRound` 아이콘으로 모두 동일 → 구분 불가, 밋밋
- TO-BE: `src`(실제 프사) → 실패/없음 시 `seed`(멤버 id) 기반 DiceBear → 그것도 실패 시 아이콘. 같은 멤버 = 항상 같은 아바타

**2. 단계별 폴백 체인 (fix)**
- 실제 프사 로딩 실패 시에도 DiceBear 폴백을 거치도록 `srcError`/`fallbackError` 플래그 분리
- `src`/`seed` 공백 방어(trim), 판정·표시·에러처리에 trim 값 일관 사용

**3. 폴백 스타일 일원화 + 호출부 연결**
- `avatar.tsx`의 `FALLBACK_AVATAR_STYLE` 한 곳에서 스타일 관리 (현재 `dylan`)
- 댓글·모임 상세·프로필·관리자 호출부에 `seed={멤버id}` 연결
- `DESIGN.md`에 `src`+`seed` 동반 규칙 추가

## 부하 / 의존성

- DiceBear는 브라우저 → api.dicebear.com 직통이라 서버 부하 0
- 프사 미설정 멤버 + 화면 노출분만 요청, 브라우저 URL 캐시 → 멤버당 사실상 1회
- 외부 장애 시 아이콘으로 자연 폴백

## 검증

- ✅ `tsc --noEmit` 통과
- ✅ 위험 커밋(#376/#370/#373/#372) 미포함 확인 (`git log origin/main..HEAD`)
- ⬜ 실제 화면 확인은 배포 후 (프사 없는 멤버 댓글/프로필)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
