### PR TITLE
perf(home): 달 전환 캐싱·프리페치 + Social fixed 제거

### DIFF
--- a/app/(main)/page.tsx
+++ b/app/(main)/page.tsx
@@ -161,9 +161,6 @@ async function HomeContent() {
           />
         </Suspense>
       </div>
-      <div className="px-6 pb-6">
-        <SocialLinksGrid />
-      </div>
     </div>
   );
 }
@@ -219,6 +216,9 @@ export default function HomePage() {
       <Suspense fallback={<HomeSkeleton />}>
         <HomeContent />
       </Suspense>
+      <div className="px-6 pb-6">
+        <SocialLinksGrid />
+      </div>
     </div>
   );
 }

--- a/app/(main)/page.tsx
+++ b/app/(main)/page.tsx
@@ -145,8 +145,7 @@ async function HomeContent() {
 
   return (
     <div className="flex flex-col gap-0">
-      {/* Social fixed 영역(하단 탭바 위) 높이만큼 하단 여백 확보 */}
-      <div className="flex flex-col gap-7 px-6 pb-[calc(6.5rem+env(safe-area-inset-bottom,0px))]">
+      <div className="flex flex-col gap-7 px-6 pb-6">
         <Suspense>
           <MiniCalendar
             gigangRaces={calendarGigangRaces}
@@ -162,6 +161,9 @@ async function HomeContent() {
           />
         </Suspense>
       </div>
+      <div className="px-6 pb-6">
+        <SocialLinksGrid />
+      </div>
     </div>
   );
 }
@@ -170,8 +172,7 @@ async function HomeContent() {
 function HomeSkeleton() {
   return (
     <div className="flex flex-col gap-0">
-      {/* Social fixed 영역 높이만큼 하단 여백 확보 */}
-      <div className="flex flex-col gap-7 px-6 pb-[calc(6.5rem+env(safe-area-inset-bottom,0px))]">
+      <div className="flex flex-col gap-7 px-6 pb-6">
         {/* MiniCalendar 영역 */}
         <div className="flex flex-col gap-3">
           <Skeleton className="h-3.5 w-20" />
@@ -218,10 +219,6 @@ export default function HomePage() {
       <Suspense fallback={<HomeSkeleton />}>
         <HomeContent />
       </Suspense>
-      {/* 탭바(h-14 + safe-area) 위에 fixed 배치 — Suspense 밖이므로 즉시 렌더 */}
-      <div className="fixed bottom-[calc(3.5rem+env(safe-area-inset-bottom,0px))] left-0 right-0 z-40 border-t border-border bg-background px-6 py-3">
-        <SocialLinksGrid />
-      </div>
     </div>
   );
 }

--- a/components/home/mini-calendar.tsx
+++ b/components/home/mini-calendar.tsx
@@ -167,6 +167,7 @@ export function MiniCalendar({
   // 월별 데이터 캐시 — 이미 조회한 달은 즉시 반영, 인접 달은 프리페치
   type MonthData = { gigang: CalendarRace[]; mine: CalendarRace[]; schPosts: CalendarRace[]; gatherings: CalendarRace[] };
   const monthCacheRef = useRef(new Map<string, MonthData>());
+  const cacheVersionRef = useRef(0);
 
   // 일정 폼 다이얼로그 상태
   const [formOpen, setFormOpen] = useState(false);
@@ -706,12 +707,15 @@ export function MiniCalendar({
 
   // 인접 달(prev/next) 프리페치 — 캐시에 없는 달만 백그라운드로 조회
   const prefetchAdjacent = useCallback((monthFirst: string) => {
+    const version = cacheVersionRef.current;
     const prev = dayjs(monthFirst).subtract(1, "month").format("YYYY-MM-01");
     const next = dayjs(monthFirst).add(1, "month").format("YYYY-MM-01");
     for (const m of [prev, next]) {
       if (!monthCacheRef.current.has(m)) {
         fetchMonthDataRef.current(m).then((data) => {
-          monthCacheRef.current.set(m, data);
+          if (version === cacheVersionRef.current) {
+            monthCacheRef.current.set(m, data);
+          }
         }).catch(() => { /* 프리페치 실패는 무시 */ });
       }
     }
@@ -741,9 +745,11 @@ export function MiniCalendar({
 
     // 캐시 미스 — 조회 중 isPending으로 흐림 처리
     startTransition(async () => {
+      const version = cacheVersionRef.current;
       const data = await fetchMonthDataRef.current(monthFirst);
-      if (viewMonthRef.current !== monthFirst) return;
+      if (version !== cacheVersionRef.current) return;
       monthCacheRef.current.set(monthFirst, data);
+      if (viewMonthRef.current !== monthFirst) return;
       applyMonthData(data);
       prefetchAdjacent(monthFirst);
     });
@@ -963,15 +969,18 @@ export function MiniCalendar({
   }, []);
 
   async function refreshMonthData() {
+    const monthFirst = viewMonthRef.current;
+    cacheVersionRef.current += 1;
+    const version = cacheVersionRef.current;
     monthCacheRef.current.clear();
-    const data = await fetchMonthData(viewMonth);
-    monthCacheRef.current.set(viewMonth, data);
-    setGigangRaces(data.gigang);
-    setMyRaces(data.mine);
-    setSchPosts(data.schPosts);
-    setGatherings(data.gatherings);
-    setListViewKey((k) => k + 1);
-    prefetchAdjacent(viewMonth);
+    const data = await fetchMonthDataRef.current(monthFirst);
+    if (version !== cacheVersionRef.current) return data;
+    monthCacheRef.current.set(monthFirst, data);
+    if (viewMonthRef.current === monthFirst) {
+      applyMonthData(data);
+      setListViewKey((k) => k + 1);
+      prefetchAdjacent(monthFirst);
+    }
     return data;
   }
 

--- a/components/home/mini-calendar.tsx
+++ b/components/home/mini-calendar.tsx
@@ -164,6 +164,10 @@ export function MiniCalendar({
   const [listViewKey, setListViewKey] = useState(0);
   const [isPending, startTransition] = useTransition();
 
+  // 월별 데이터 캐시 — 이미 조회한 달은 즉시 반영, 인접 달은 프리페치
+  type MonthData = { gigang: CalendarRace[]; mine: CalendarRace[]; schPosts: CalendarRace[]; gatherings: CalendarRace[] };
+  const monthCacheRef = useRef(new Map<string, MonthData>());
+
   // 일정 폼 다이얼로그 상태
   const [formOpen, setFormOpen] = useState(false);
   const [formMode, setFormMode] = useState<"create" | "edit">("create");
@@ -700,23 +704,51 @@ export function MiniCalendar({
   const fetchMonthDataRef = useRef(fetchMonthData);
   fetchMonthDataRef.current = fetchMonthData;
 
+  // 인접 달(prev/next) 프리페치 — 캐시에 없는 달만 백그라운드로 조회
+  const prefetchAdjacent = useCallback((monthFirst: string) => {
+    const prev = dayjs(monthFirst).subtract(1, "month").format("YYYY-MM-01");
+    const next = dayjs(monthFirst).add(1, "month").format("YYYY-MM-01");
+    for (const m of [prev, next]) {
+      if (!monthCacheRef.current.has(m)) {
+        fetchMonthDataRef.current(m).then((data) => {
+          monthCacheRef.current.set(m, data);
+        }).catch(() => { /* 프리페치 실패는 무시 */ });
+      }
+    }
+  }, []);
+
+  // 월 데이터를 적용하는 헬퍼
+  const applyMonthData = useCallback((data: MonthData) => {
+    setGigangRaces(data.gigang);
+    setMyRaces(data.mine);
+    setSchPosts(data.schPosts);
+    setGatherings(data.gatherings);
+  }, []);
+
   // 특정 월(YYYY-MM-01)로 이동하며 데이터를 교체. 흐린 다른 달 셀 클릭 시에도 재사용한다.
-  // 화면(viewMonth)은 즉시 전환하고, 데이터 조회만 백그라운드(startTransition)로 돌린다.
-  // 흐린 셀의 일정은 이미 현재 범위에 조회돼 있어 전환 직후에도 그대로 보이고 클릭까지 가능하므로,
-  // "그 달로 먼저 가고, 새 범위(중순 등)는 로딩되면 채운다"가 자연스럽다. 조회 중엔 isPending 흐림 유지.
   const goToMonth = useCallback((monthFirst: string) => {
     if (openingLock.current) return;
     if (monthFirst === viewMonthRef.current) return;
-    setViewMonth(monthFirst); // 즉시 전환 — 기존 데이터로 먼저 그린다(겹치는 월초·월말은 이미 있음)
+    setViewMonth(monthFirst);
+
+    // 캐시 히트 — 즉시 반영 (isPending 없이 전환)
+    const cached = monthCacheRef.current.get(monthFirst);
+    if (cached) {
+      applyMonthData(cached);
+      prefetchAdjacent(monthFirst);
+      return;
+    }
+
+    // 캐시 미스 — 조회 중 isPending으로 흐림 처리
     startTransition(async () => {
-      const { gigang, mine, schPosts: newSch, gatherings: newGthr } = await fetchMonthDataRef.current(monthFirst);
-      // 연속 전환 시 늦게 온 이전 월 응답이 현재 화면을 덮지 않도록, 여전히 그 달을 보고 있을 때만 반영
+      const data = await fetchMonthDataRef.current(monthFirst);
       if (viewMonthRef.current !== monthFirst) return;
-      setGigangRaces(gigang);
-      setMyRaces(mine);
-      setSchPosts(newSch);
-      setGatherings(newGthr);
+      monthCacheRef.current.set(monthFirst, data);
+      applyMonthData(data);
+      prefetchAdjacent(monthFirst);
     });
+  // applyMonthData·prefetchAdjacent는 deps [] 로 안정화됨
+  // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
   const navigate = useCallback((dir: -1 | 1) => {
@@ -820,6 +852,12 @@ export function MiniCalendar({
   // initialMonth·supabase·teamId는 마운트 후 변경되지 않으며, memberId 변경 시에만 재실행
   // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [memberId]);
+
+  // 마운트 시 인접 달 프리페치 시작
+  useEffect(() => {
+    prefetchAdjacent(initialMonth);
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
   const swipeTouchStartX = useRef<number | null>(null);
   const swipeDidNavigate = useRef(false);
@@ -925,12 +963,15 @@ export function MiniCalendar({
   }, []);
 
   async function refreshMonthData() {
+    monthCacheRef.current.clear();
     const data = await fetchMonthData(viewMonth);
+    monthCacheRef.current.set(viewMonth, data);
     setGigangRaces(data.gigang);
     setMyRaces(data.mine);
     setSchPosts(data.schPosts);
     setGatherings(data.gatherings);
     setListViewKey((k) => k + 1);
+    prefetchAdjacent(viewMonth);
     return data;
   }
 


### PR DESCRIPTION
## 관련 이슈

관련 이슈 없음

## 요약

홈 캘린더 달 전환 시 네트워크 요청 없이 즉시 반영되도록 클라이언트 캐싱 + 인접 달 프리페치를 추가합니다. Social 영역은 fixed 하단 배치에서 일반 흐름으로 변경합니다.

## AS-IS (변경 전)

- 달 전환(화살표/스와이프) 시 매번 **4개 RPC 쿼리**를 클라이언트→Supabase로 요청
- 이미 방문한 달로 돌아가도 동일한 재조회 발생 → 체감 딜레이
- Social 영역이 `fixed bottom` + `z-40`으로 하단 고정 → 캘린더 콘텐츠와 겹쳐 안 보이는 문제

## TO-BE (변경 후)

- **월별 데이터 캐시**: `Map<string, MonthData>` ref로 이미 조회한 달은 즉시 반영 (네트워크 0)
- **인접 달 프리페치**: 현재 달 로드 완료 시 prev/next 달을 백그라운드 조회 → 첫 전환만 로딩, 이후 즉시
- **캐시 무효화**: `refreshMonthData` (일정 생성/수정/삭제) 시 전체 캐시 클리어 + 재프리페치
- **Social**: 캘린더 아래 일반 흐름 배치 → 항상 보임

## 변경 흐름

```mermaid
flowchart LR
    A[달 전환 클릭] --> B{캐시 히트?}
    B -->|Yes| C[즉시 반영]
    B -->|No| D[4 RPC 조회<br/>isPending 흐림]
    D --> E[캐시 저장]
    C --> F[인접 달 프리페치]
    E --> F
    F --> G[prev/next 백그라운드 조회]
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * 달 이동 시 이전에 본 달은 더 빠르게 표시되고, 인접한 달도 미리 불러와 전환이 한결 부드러워졌습니다.
* **Bug Fixes**
  * 하단 소셜 링크 영역이 메인 콘텐츠 흐름에 자연스럽게 포함되도록 조정되어, 로딩 및 스켈레톤 표시가 더 일관되게 보입니다.
  * 하단 여백 처리도 화면 안전 영역에 더 잘 맞도록 개선되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->