### PR TITLE
fix(mileage): 실패한 달에서 목표 연쇄가 끊기던 회귀 수정

### DIFF
--- a/app/actions/mileage-run.ts
+++ b/app/actions/mileage-run.ts
@@ -15,7 +15,7 @@ import {
 import {
   calcBaseMileage,
   calcFinalMileage,
-  calcNextMonthGoal,
+  computeGoalChain,
   roundMileage,
   countMonths,
   DEPOSIT_PER_MONTH,
@@ -576,26 +576,26 @@ async function recalcGoalsFromMonth(
     if (found > 0) anchorIdx = found;
   }
 
+  const chain = computeGoalChain(
+    goals.map((g) => ({
+      base_dt: g.base_dt as string,
+      goal_mlg: Number(g.goal_mlg),
+      achv_mlg: roundedAchvByMonth.get(g.base_dt as string) ?? 0,
+    })),
+    evtStartMonth,
+    anchorIdx,
+  );
+
   for (let i = anchorIdx + 1; i < goals.length; i++) {
-    const prev = goals[i - 1];
     const cur = goals[i];
-    const prevMonth = prev.base_dt as string;
-    const prevGoalVal = Number(prev.goal_mlg);
+    const next = chain[i];
+    if (Number(cur.goal_mlg) === next.goal_mlg) continue;
 
-    if (prevMonth < evtStartMonth) continue;
-    if (!prev.achv_yn) break;
-
-    const calculatedGoal = calcNextMonthGoal(prevGoalVal, true);
-    const finalGoal = Math.max(calculatedGoal, Number(cur.goal_mlg));
-
-    if (Number(cur.goal_mlg) !== finalGoal) {
-      const newAchvYn = Math.round((roundedAchvByMonth.get(cur.base_dt as string) ?? 0) * 10) / 10 >= finalGoal;
-      await db
-        .from("evt_mlg_mth_snap")
-        .update({ goal_mlg: finalGoal, achv_yn: newAchvYn, updated_at: dayjs().toISOString() })
-        .eq("goal_id", cur.goal_id);
-      cur.goal_mlg = finalGoal;
-      cur.achv_yn = newAchvYn;
-    }
+    await db
+      .from("evt_mlg_mth_snap")
+      .update({ goal_mlg: next.goal_mlg, achv_yn: next.achv_yn, updated_at: dayjs().toISOString() })
+      .eq("goal_id", cur.goal_id);
+    cur.goal_mlg = next.goal_mlg;
+    cur.achv_yn = next.achv_yn;
   }
 }

--- a/app/actions/mileage-run.ts
+++ b/app/actions/mileage-run.ts
@@ -16,6 +16,7 @@ import {
   calcBaseMileage,
   calcFinalMileage,
   computeGoalChain,
+  isMonthAchieved,
   roundMileage,
   countMonths,
   DEPOSIT_PER_MONTH,
@@ -246,7 +247,12 @@ export async function logActivity(
 
     if (error) return { ok: false, message: "활동 기록 추가에 실패했습니다" };
 
-    await recalcGoalsFromMonth(evtId, participant.prt_id);
+    try {
+      await recalcGoalsFromMonth(evtId, participant.prt_id);
+    } catch (e) {
+      console.error("[mileage] 목표 재계산 실패(logActivity)", e);
+      return { ok: false, message: "목표 재계산에 실패했습니다. 잠시 후 다시 시도해주세요" };
+    }
 
     const { data: teamMemRow, error: teamMemErr } = await db
       .from("team_mem_rel")
@@ -347,7 +353,12 @@ export async function logActivitiesBatch(
     const { error } = await db.from("evt_mlg_act_hist").insert(rows);
     if (error) return { ok: false, message: "활동 기록 저장에 실패했습니다" };
 
-    await recalcGoalsFromMonth(evtId, participant.prt_id);
+    try {
+      await recalcGoalsFromMonth(evtId, participant.prt_id);
+    } catch (e) {
+      console.error("[mileage] 목표 재계산 실패(logActivitiesBatch)", e);
+      return { ok: false, message: "목표 재계산에 실패했습니다. 잠시 후 다시 시도해주세요" };
+    }
 
     const { data: teamMemRow } = await db
       .from("team_mem_rel")
@@ -430,7 +441,12 @@ export async function updateActivity(
 
     if (error) return { ok: false, message: "활동 기록 수정에 실패했습니다" };
 
-    await recalcGoalsFromMonth(existingParticipant.evt_id, existing.prt_id);
+    try {
+      await recalcGoalsFromMonth(existingParticipant.evt_id, existing.prt_id);
+    } catch (e) {
+      console.error("[mileage] 목표 재계산 실패(updateActivity)", e);
+      return { ok: false, message: "목표 재계산에 실패했습니다. 잠시 후 다시 시도해주세요" };
+    }
 
     revalidatePath("/projects");
     return { ok: true, message: null };
@@ -464,7 +480,12 @@ export async function deleteActivity(actId: string): Promise<ActionResult> {
     const { error } = await db.from("evt_mlg_act_hist").delete().eq("act_id", actId);
     if (error) return { ok: false, message: "활동 기록 삭제에 실패했습니다" };
 
-    await recalcGoalsFromMonth(existingParticipant.evt_id, existing.prt_id);
+    try {
+      await recalcGoalsFromMonth(existingParticipant.evt_id, existing.prt_id);
+    } catch (e) {
+      console.error("[mileage] 목표 재계산 실패(deleteActivity)", e);
+      return { ok: false, message: "목표 재계산에 실패했습니다. 잠시 후 다시 시도해주세요" };
+    }
 
     revalidatePath("/projects");
     return { ok: true, message: null };
@@ -504,7 +525,12 @@ export async function updateMonthlyGoal(goalId: string, newGoal: number): Promis
 
     if (error) return { ok: false, message: "목표 수정에 실패했습니다" };
 
-    await recalcGoalsFromMonth(evtId, existing.prt_id, goalId);
+    try {
+      await recalcGoalsFromMonth(evtId, existing.prt_id, goalId);
+    } catch (e) {
+      console.error("[mileage] 목표 재계산 실패(updateMonthlyGoal)", e);
+      return { ok: false, message: "목표 재계산에 실패했습니다. 잠시 후 다시 시도해주세요" };
+    }
 
     revalidatePath("/projects");
     return { ok: true, message: null };
@@ -561,12 +587,13 @@ async function recalcGoalsFromMonth(
     const achvMlg = roundedAchvByMonth.get(month) ?? 0;
     const actCnt = cntByMonth.get(month) ?? 0;
     const lstActDt = lastDtByMonth.get(month) ?? null;
-    const achvYn = Math.round(achvMlg * 10) / 10 >= Number(g.goal_mlg);
+    const achvYn = isMonthAchieved(achvMlg, Number(g.goal_mlg));
 
-    await db
+    const { error: snapErr } = await db
       .from("evt_mlg_mth_snap")
       .update({ achv_mlg: achvMlg, act_cnt: actCnt, lst_act_dt: lstActDt, achv_yn: achvYn, updated_at: dayjs().toISOString() })
       .eq("goal_id", g.goal_id);
+    if (snapErr) throw new Error(`월별 집계 갱신 실패 (goal_id=${g.goal_id}): ${snapErr.message}`);
     g.achv_yn = achvYn;
   }
 
@@ -591,10 +618,11 @@ async function recalcGoalsFromMonth(
     const next = chain[i];
     if (Number(cur.goal_mlg) === next.goal_mlg) continue;
 
-    await db
+    const { error: chainErr } = await db
       .from("evt_mlg_mth_snap")
       .update({ goal_mlg: next.goal_mlg, achv_yn: next.achv_yn, updated_at: dayjs().toISOString() })
       .eq("goal_id", cur.goal_id);
+    if (chainErr) throw new Error(`목표 연쇄 갱신 실패 (goal_id=${cur.goal_id}): ${chainErr.message}`);
     cur.goal_mlg = next.goal_mlg;
     cur.achv_yn = next.achv_yn;
   }

--- a/lib/__tests__/mileage.test.ts
+++ b/lib/__tests__/mileage.test.ts
@@ -7,7 +7,9 @@ import {
   calcMonthRefundRate,
   calcNextMonthGoal,
   calcPaceRatio,
+  computeGoalChain,
   countMonths,
+  isMonthAchieved,
   roundMileage,
 } from "@/lib/mileage";
 
@@ -148,5 +150,90 @@ describe("roundMileage", () => {
 
   it("정수는 그대로", () => {
     expect(roundMileage(10)).toBe(10);
+  });
+});
+
+describe("isMonthAchieved", () => {
+  it("소수 첫째 자리 반올림 후 목표 이상이면 달성 (199.96 → 200.0)", () => {
+    expect(isMonthAchieved(199.96, 200)).toBe(true);
+    expect(isMonthAchieved(199.94, 200)).toBe(false);
+  });
+
+  it("정확히 목표면 달성", () => {
+    expect(isMonthAchieved(100, 100)).toBe(true);
+  });
+});
+
+describe("computeGoalChain", () => {
+  const START = "2026-05-01"; // 4월은 프리시즌
+
+  it("프리시즌(4월) 달성은 5월 목표에 영향 없음", () => {
+    const chain = computeGoalChain(
+      [
+        { base_dt: "2026-04-01", goal_mlg: 100, achv_mlg: 124.07 }, // 프리시즌 달성
+        { base_dt: "2026-05-01", goal_mlg: 100, achv_mlg: 0 },
+      ],
+      START,
+    );
+    expect(chain[1].goal_mlg).toBe(100); // 5월은 그대로
+  });
+
+  it("회귀: 실패한 달 뒤의 달성이 다음 달 목표에 반영된다 (권우현 케이스)", () => {
+    // 5월 실패(88.93) → 6월 성공(120.15) → 7월은 100이 아니라 120이어야 함
+    const chain = computeGoalChain(
+      [
+        { base_dt: "2026-04-01", goal_mlg: 100, achv_mlg: 124.07 },
+        { base_dt: "2026-05-01", goal_mlg: 100, achv_mlg: 88.93 }, // 실패
+        { base_dt: "2026-06-01", goal_mlg: 100, achv_mlg: 120.15 }, // 성공
+        { base_dt: "2026-07-01", goal_mlg: 100, achv_mlg: 0 },
+      ],
+      START,
+    );
+    expect(chain[1].achv_yn).toBe(false); // 5월 미달성
+    expect(chain[2].goal_mlg).toBe(100); // 6월: 5월 실패라 유지
+    expect(chain[2].achv_yn).toBe(true); // 6월 달성
+    expect(chain[3].goal_mlg).toBe(120); // 7월: 6월 달성 반영 (버그였다면 100)
+  });
+
+  it("수동 상향 목표는 재계산이 낮추지 않는다 (김남현 케이스)", () => {
+    // 6월 성공 → 7월 자동값 140인데, 관리자가 170으로 올림 → 170 유지 + 이후 달도 170
+    const chain = computeGoalChain(
+      [
+        { base_dt: "2026-05-01", goal_mlg: 100, achv_mlg: 124.17 }, // 성공
+        { base_dt: "2026-06-01", goal_mlg: 120, achv_mlg: 133.3 }, // 성공
+        { base_dt: "2026-07-01", goal_mlg: 170, achv_mlg: 0 }, // 수동 상향
+        { base_dt: "2026-08-01", goal_mlg: 170, achv_mlg: 0 },
+      ],
+      START,
+    );
+    expect(chain[2].goal_mlg).toBe(170); // 자동 140 < 수동 170 → 170 유지
+    expect(chain[3].goal_mlg).toBe(170); // 8월도 170에서 연쇄
+  });
+
+  it("연속 달성 시 구간별로 증가한다", () => {
+    const chain = computeGoalChain(
+      [
+        { base_dt: "2026-05-01", goal_mlg: 100, achv_mlg: 110 }, // 성공 → +20
+        { base_dt: "2026-06-01", goal_mlg: 100, achv_mlg: 130 }, // 성공
+        { base_dt: "2026-07-01", goal_mlg: 100, achv_mlg: 0 },
+      ],
+      START,
+    );
+    expect(chain[1].goal_mlg).toBe(120); // 6월 = 100 + 20
+    expect(chain[2].goal_mlg).toBe(140); // 7월 = 120 + 20
+  });
+
+  it("anchorIdx 이전 달은 재계산하지 않는다", () => {
+    const chain = computeGoalChain(
+      [
+        { base_dt: "2026-05-01", goal_mlg: 100, achv_mlg: 110 },
+        { base_dt: "2026-06-01", goal_mlg: 150, achv_mlg: 0 }, // 앵커(수동 지정)
+        { base_dt: "2026-07-01", goal_mlg: 100, achv_mlg: 0 },
+      ],
+      START,
+      1, // 6월을 기준점으로
+    );
+    expect(chain[1].goal_mlg).toBe(150); // 앵커 그대로
+    expect(chain[2].goal_mlg).toBe(150); // 7월: 6월 미달성 → 유지(150), 100에서 상향
   });
 });

--- a/lib/mileage.ts
+++ b/lib/mileage.ts
@@ -47,6 +47,47 @@ export function calcNextMonthGoal(currentGoal: number, achieved: boolean): numbe
   return currentGoal + 20;
 }
 
+/** 달성 판정: 달성 마일리지를 소수 첫째 자리 반올림해 목표와 비교 (199.96 → 200.0 → 달성) */
+export function isMonthAchieved(achvMlg: number, goalMlg: number): boolean {
+  return Math.round(achvMlg * 10) / 10 >= goalMlg;
+}
+
+export interface MonthGoalSnapshot {
+  base_dt: string; // 'YYYY-MM-01'
+  goal_mlg: number;
+  achv_mlg: number; // 반올림된 달성 마일리지
+}
+
+/**
+ * 월별 목표 연쇄 재계산 (순수 함수)
+ *
+ * anchorIdx 다음 달부터, 이전 달의 목표·달성 여부를 근거로 각 달 목표를 다시 계산한다.
+ * - 프리시즌(base_dt < evtStartMonth)인 이전 달은 다음 달 목표에 영향을 주지 않음 → 건너뜀
+ * - 인시즌: 이전 달 달성 시 calcNextMonthGoal로 증가, **미달성이어도 연쇄를 멈추지 않고** 목표 유지
+ *   (과거 #319에서 미달성 시 break로 연쇄를 중단해, 실패한 달 뒤의 달성이 반영되지 않던 버그를 수정)
+ * - Math.max(자동값, 기존값)으로 수동 상향 목표는 재계산이 낮추지 않음
+ */
+export function computeGoalChain(
+  months: MonthGoalSnapshot[],
+  evtStartMonth: string,
+  anchorIdx = 0,
+): { goal_mlg: number; achv_yn: boolean }[] {
+  const out = months.map((m) => ({
+    goal_mlg: m.goal_mlg,
+    achv_yn: isMonthAchieved(m.achv_mlg, m.goal_mlg),
+  }));
+
+  for (let i = anchorIdx + 1; i < months.length; i++) {
+    if (months[i - 1].base_dt < evtStartMonth) continue;
+    const auto = calcNextMonthGoal(out[i - 1].goal_mlg, out[i - 1].achv_yn);
+    const finalGoal = Math.max(auto, out[i].goal_mlg);
+    if (finalGoal !== out[i].goal_mlg) {
+      out[i] = { goal_mlg: finalGoal, achv_yn: isMonthAchieved(months[i].achv_mlg, finalGoal) };
+    }
+  }
+  return out;
+}
+
 /** 월 환급률 (0.0 ~ 1.0) */
 export function calcMonthRefundRate(
   achievedMileage: number,


### PR DESCRIPTION
#319에서 도입된 `if (!prev.achv_yn) break`가 미달성 달을 만나면
목표 재계산 전체를 중단시켜, 실패한 달 뒤에 달성한 달이 있어도
그 다음 달 목표가 상향되지 않던 버그.

예) 5월 실패 → 6월 성공 시 7월 목표가 6월 달성을 반영하지 못함.
(권우현 7월이 120이어야 하는데 100에 정체)

- 연쇄 로직을 순수 함수 computeGoalChain으로 추출
- 미달성 시 break 대신 목표 유지하며 연쇄 계속 (calcNextMonthGoal에 실제 달성 여부 전달)
- Math.max(자동값, 기존값)은 유지 → 수동 상향 목표 보호(김남현 7월 170)
- #319의 정당한 수정(achv_yn 소수 첫째자리 반올림)은 isMonthAchieved로 보존
- 회귀 테스트 추가: 실패→성공 반영, 수동 상향 보존, 구간별 증가, anchorIdx

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * 마일리지 월별 목표가 이전 달 결과를 반영해 더 일관되게 연쇄 재계산되도록 개선되었습니다.
  * 기준 시점 이전 구간은 유지되고, 이후 구간만 재계산되도록 동작이 정교해졌습니다.

* **Bug Fixes**
  * 달성 여부 판정이 소수점 반올림 기준으로 더 정확해졌습니다.
  * 수동으로 높인 목표가 자동 재계산 과정에서 낮아지지 않도록 개선되었습니다.
  * 연속 달성/미달성 시 목표 반영 방식이 더 안정적으로 동작합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->