### PR TITLE
chore: CLAUDE.local.md를 gitignore에 추가

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -69,6 +69,7 @@ next-env.d.ts
 
 # claude code
 .claude/settings.local.json
+CLAUDE.local.md
 
 # MCP 설정 (access token 포함)
 .mcp.json


### PR DESCRIPTION
## 관련 이슈

관련 이슈 없음

## 요약

개인용 프로젝트 메모리 파일 `CLAUDE.local.md`를 공용 `.gitignore`에 추가합니다. 각자 로컬에서 개인 Claude Code 지시(개인 위키 습관 등)를 `CLAUDE.local.md`에 두되 저장소엔 커밋되지 않도록 하는 팀 관례입니다.

## AS-IS (변경 전)

- `.gitignore`에 `CLAUDE.local.md` 항목 없음 → 실수로 `git add .` 시 개인 로컬 메모리가 커밋될 수 있음.

## TO-BE (변경 후)

- `# claude code` 섹션에 `CLAUDE.local.md` 추가 → 협업자 각자 개인 프로젝트 지시를 안전하게 로컬에만 보관. 공용 `CLAUDE.md`는 팀 공유용으로 깨끗하게 유지.

🤖 Generated with [Claude Code](https://claude.com/claude-code)