### PR TITLE
feat(dues): 회비 거래 부분 확정

### DIFF
--- a/app/(info)/admin/dues/inbox/inbox-table.tsx
+++ b/app/(info)/admin/dues/inbox/inbox-table.tsx
@@ -60,11 +60,15 @@ export function InboxTable({ members, txns }: { members: MemberOption[]; txns: I
   // 키보드 ↑↓ 이동 대상: 화면에 보이는 needsReview 행 순서.
   const editableVisible = useMemo(() => visible.filter((t) => t.bucket === "needsReview"), [visible]);
 
-  const allDecided = review.every((t) => {
+  // 결정된 확인필요 행: 회비면 회원 지정됨, 그 외(프로젝트/제외)면 분류 선택만으로 결정.
+  // 부분 확정 — 미결정 행은 이번 확정에서 빠지고 인박스에 남아 다음에 처리한다.
+  const decidedReview = review.filter((t) => {
     const d = decisions[t.txnId];
     return d && (d.itemCd !== "due" || d.memId);
   });
-  const totalToConfirm = autoDone.length + review.length + excluded.length;
+  const undecidedCount = review.length - decidedReview.length;
+  // 자동완료·제외는 판단이 필요 없으므로 항상 확정 대상 + 결정된 확인필요 행.
+  const confirmCount = autoDone.length + excluded.length + decidedReview.length;
 
   const selectableIds = editableVisible.map((t) => t.txnId);
   const allSelected = selectableIds.length > 0 && selectableIds.every((id) => selected.has(id));
@@ -102,7 +106,7 @@ export function InboxTable({ members, txns }: { members: MemberOption[]; txns: I
   }
 
   function onSubmit() {
-    const { items, aliasLearn } = buildConfirmPayload({ autoDone, excluded, review, decisions });
+    const { items, aliasLearn } = buildConfirmPayload({ autoDone, excluded, review: decidedReview, decisions });
     setMsg(null);
     startTransition(async () => {
       const res = await confirmAndRecalc({ items, aliasLearn });
@@ -147,7 +151,7 @@ export function InboxTable({ members, txns }: { members: MemberOption[]; txns: I
         />
       </div>
 
-      {totalToConfirm === 0 ? (
+      {txns.length === 0 ? (
         <EmptyState variant="card" message="처리할 거래가 없습니다." />
       ) : (
         <div className="overflow-x-auto">
@@ -209,12 +213,17 @@ export function InboxTable({ members, txns }: { members: MemberOption[]; txns: I
       {msg && <Caption className="text-foreground">{msg}</Caption>}
 
       <div className="sticky bottom-0 -mx-6 border-t border-border bg-background px-6 py-3">
+        {undecidedCount > 0 && (
+          <Caption className="mb-2 block text-muted-foreground">
+            미결정 {undecidedCount}건은 이번 확정에서 제외 — 다음에 처리
+          </Caption>
+        )}
         <Button
           className="w-full"
-          disabled={pending || !allDecided || totalToConfirm === 0}
+          disabled={pending || confirmCount === 0}
           onClick={onSubmit}
         >
-          {pending ? "처리 중…" : `${totalToConfirm}건 확정 + 회비 재계산`}
+          {pending ? "처리 중…" : `${confirmCount}건 확정 + 회비 재계산`}
         </Button>
       </div>
     </div>


### PR DESCRIPTION
## 관련 이슈

관련 이슈 없음 (라이브 QA 중 발견)

## 요약

회비 거래처리 화면에서 확인필요 건을 **한 번에 다 확정하지 않고, 결정한 것만 부분 확정**할 수 있게 한다. 나머지 미결정 건은 인박스에 남아 다음에 처리.

## AS-IS (변경 전)

- 확정 버튼이 **확인필요 전건이 결정돼야** 활성화되고, 누르면 **배치 전체를 한 번에** 확정.
- 확인필요가 26건이면 26건 모두 처리해야 확정 가능 → 나눠서 처리 불가.

## TO-BE (변경 후)

- **부분 확정**: 결정한 확인필요 행 + 자동완료 + 제외만 확정. **미결정 확인필요 행은 인박스에 남아 다음에** 처리.
- 확정 버튼은 "전건 결정" 요구 없이 **확정 대상이 1건이라도 있으면** 활성화. 라벨은 실제 확정 건수로 표시.
- 미결정이 있으면 "미결정 N건은 이번 확정에서 제외 — 다음에 처리" 안내.
- 자동완료·제외는 판단이 필요 없으므로 항상 함께 확정(운영자 선택).

## 변경 흐름 (Mermaid)

\`\`\`mermaid
flowchart TD
    R["확인필요 26건"] --> D{"행별 결정?"}
    D -->|결정 10건| C["확정 대상: 자동+제외+결정 10건"]
    D -->|미결정 16건| K["인박스 유지 (다음에)"]
    C --> S["confirmAndRecalc"]
\`\`\`

## 검증

- tsc 0 · 테스트 111/111 · lint = baseline
- 확정 로직은 `buildConfirmPayload`에 `review: decidedReview`만 전달 → 미결정 행 제외

🤖 Generated with [Claude Code](https://claude.com/claude-code)