### PR TITLE
feat(dues): 프로젝트별 회비 추적 SP2 — 마스터·귀속·명단·모금액

### DIFF
--- a/.claude/docs/database-abbreviation-dictionary.md
+++ b/.claude/docs/database-abbreviation-dictionary.md
@@ -38,6 +38,7 @@
 | `sprt` | sport (종목/스포츠) |
 | `ttl` | title (칭호) |
 | `pay` | payment (납부) |
+| `prj` | project (프로젝트/모금 — `fee_prj_mst`; 단 `fee_txn_hist.project_id`는 P1 선행 컬럼이라 전체 철자) |
 | `attd` | attendance (출석/참석) |
 | `prt` | participation (참가) |
 | `src` | source (출처) |
@@ -108,6 +109,8 @@
 | `fee_due_exm_cfg` | 회비 면제 규칙 |
 | `fee_due_exm_hist` | 회비 면제 적용 이력 |
 | `fee_mem_bal_snap` | 회원 회비 누적 스냅샷 |
+| `fee_prj_mst` | 회비 프로젝트(모금) 마스터 (SP2, 거래 귀속은 `fee_txn_hist.project_id`) |
+| `fee_payer_alias` | 입금자명→회원 매칭 학습 |
 | `evt_team_mst` | 팀 이벤트 마스터 |
 | `evt_team_prt_rel` | 이벤트 참가 관계(참가자 기준 루트) |
 | `evt_mlg_mth_snap` | 마일리지 월별 목표/집계 스냅샷 |

--- a/app/(info)/admin/dues/inbox/inbox-row.tsx
+++ b/app/(info)/admin/dues/inbox/inbox-row.tsx
@@ -6,7 +6,7 @@ import { dayjs } from "@/lib/dayjs";
 import { cn } from "@/lib/utils";
 import { memberLabel } from "@/lib/dues/homonyms";
 import type { Decision, ItemCd } from "@/lib/dues/confirm-payload";
-import type { InboxTxn, MemberOption } from "@/lib/queries/dues";
+import type { InboxTxn, MemberOption, ProjectOption } from "@/lib/queries/dues";
 
 import { Body, Caption, Micro } from "@/components/common/typography";
 import { Badge } from "@/components/ui/badge";
@@ -37,7 +37,8 @@ const BUCKET_BADGE: Record<InboxTxn["bucket"], { label: string; cls: string }> =
 
 /**
  * 통합 테이블의 행 1건.
- * - editable(needsReview): 분류 Select + 회비면 후보 칩·직접선택 + 기억하기.
+ * - editable(needsReview): 분류 Select + 회비·프로젝트면 후보 칩·직접선택(+회비는 기억하기),
+ *   프로젝트면 귀속 프로젝트 Select 추가.
  * - 읽기(autoDone/excluded): 저장값을 텍스트로만 표시.
  * 키보드: 행 자체(빈 영역) 포커스 시 1/2/3=분류, ↑/↓=행 이동, Enter=다음.
  * 내부 입력에서의 타이핑은 e.target===e.currentTarget 검사로 가로채지 않는다.
@@ -45,6 +46,7 @@ const BUCKET_BADGE: Record<InboxTxn["bucket"], { label: string; cls: string }> =
 export function InboxRow({
   txn,
   members,
+  projects,
   dupNames,
   nameById,
   decision,
@@ -60,6 +62,7 @@ export function InboxRow({
 }: {
   txn: InboxTxn;
   members: MemberOption[];
+  projects: ProjectOption[];
   dupNames: Set<string>;
   nameById: Map<string, string>;
   decision: Decision | null;
@@ -75,7 +78,12 @@ export function InboxRow({
   /** 다른 행 삭제 진행 중 — 중복 실행 방지 */
   deleteBusy: boolean;
 }) {
-  const decided = !editable || (!!decision && (decision.itemCd !== "due" || !!decision.memId));
+  // 결정 조건: 회비=회원 필수, 프로젝트=귀속 프로젝트 필수(회원은 권장·선택), 제외=분류만.
+  const decided =
+    !editable ||
+    (!!decision &&
+      (decision.itemCd === "other" ||
+        (decision.itemCd === "due" ? !!decision.memId : !!decision.prjId)));
   const badge = BUCKET_BADGE[txn.bucket];
 
   function handleKeyDown(e: KeyboardEvent<HTMLTableRowElement>) {
@@ -117,7 +125,7 @@ export function InboxRow({
           <Caption className="text-foreground">
             {txn.bucket === "autoDone" && txn.memId ? (nameById.get(txn.memId) ?? "—") : "—"}
           </Caption>
-        ) : decision?.itemCd === "due" ? (
+        ) : decision && decision.itemCd !== "other" ? (
           <div className="flex flex-wrap items-center gap-1.5">
             {txn.candidates.length === 0 && <Caption>후보 없음</Caption>}
             {txn.candidates.map((c) => (
@@ -157,6 +165,28 @@ export function InboxRow({
                 ))}
               </SelectContent>
             </Select>
+            {decision.itemCd === "event_fee" && (
+              <Select
+                value={decision.prjId ?? ""}
+                onValueChange={(v) => onChange({ prjId: v })}
+              >
+                <SelectTrigger className="h-8 w-28">
+                  <SelectValue placeholder="프로젝트…" />
+                </SelectTrigger>
+                <SelectContent>
+                  {projects.length === 0 && (
+                    <SelectItem value="__none" disabled>
+                      모금 중인 프로젝트 없음
+                    </SelectItem>
+                  )}
+                  {projects.map((p) => (
+                    <SelectItem key={p.prjId} value={p.prjId}>
+                      {p.name}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            )}
             {decision.itemCd === "due" && decision.memId && (
               <label className="flex items-center gap-1.5">
                 <Checkbox

--- a/app/(info)/admin/dues/inbox/inbox-table.tsx
+++ b/app/(info)/admin/dues/inbox/inbox-table.tsx
@@ -8,7 +8,7 @@ import { confirmAndRecalc } from "@/app/actions/dues/confirm-and-recalc";
 import { deleteTransaction } from "@/app/actions/dues/delete-transaction";
 import { buildConfirmPayload, type Decision, type ItemCd } from "@/lib/dues/confirm-payload";
 import { duplicateNames } from "@/lib/dues/homonyms";
-import type { FeeItemOption, InboxTxn, MemberOption, ProcessedTxn } from "@/lib/queries/dues";
+import type { FeeItemOption, InboxTxn, MemberOption, ProcessedTxn, ProjectOption } from "@/lib/queries/dues";
 
 import { EmptyState } from "@/components/common/empty-state";
 import { InfoRow } from "@/components/common/info-row";
@@ -32,12 +32,21 @@ import { UploadXlsxButton } from "./upload-xlsx-button";
 type Filter = "all" | "needsReview" | "autoDone" | "excluded" | "processed";
 
 /**
- * 확인필요 행의 초기 판단값: 회비 분류 + **후보가 딱 1명일 때만** 그 회원을 자동 선택.
- * 후보가 2명 이상(동명이인·복수 유사매칭)이면 memId를 비워 둔다 — 운영자가 직접 골라야
- * 확정 가능(그 전엔 미결정으로 강조). 낮은 확신의 자동추측이 그대로 반영되는 것을 막는다.
+ * 확인필요 행의 초기 판단값.
+ * - 분류·귀속은 **저장값을 시드**로 쓴다 — 수동 등록(event_fee+프로젝트)이나 확정취소로
+ *   재노출된 행이 무조건 '회비'로 되돌아가 조용히 개인 납부로 오기록되는 것을 막는다.
+ * - 회원은 저장 매칭이 있으면 그것, 없으면 **후보가 딱 1명일 때만** 자동 선택.
+ *   후보가 2명 이상(동명이인·복수 유사매칭)이면 비워 둔다 — 운영자가 직접 골라야
+ *   확정 가능(그 전엔 미결정으로 강조). 낮은 확신의 자동추측이 그대로 반영되는 것을 막는다.
  */
 function defaultDecision(t: InboxTxn): Decision {
-  return { memId: t.candidates.length === 1 ? t.candidates[0].memId : null, itemCd: "due", remember: false };
+  const isEventFee = t.feeItemCd === "event_fee";
+  return {
+    memId: t.memId ?? (t.candidates.length === 1 ? t.candidates[0].memId : null),
+    itemCd: isEventFee ? "event_fee" : "due",
+    remember: false,
+    prjId: isEventFee ? t.projectId : null,
+  };
 }
 
 export function InboxTable({
@@ -47,6 +56,7 @@ export function InboxTable({
   processedCapped,
   processedError = false,
   feeItems,
+  projects,
 }: {
   members: MemberOption[];
   txns: InboxTxn[];
@@ -57,6 +67,8 @@ export function InboxTable({
   processedError?: boolean;
   /** 수동 등록 분류 선택지 — FEE_ITEM_CD 전체 */
   feeItems: FeeItemOption[];
+  /** 프로젝트(event_fee) 귀속 선택지 — 모금 중(active)만 */
+  projects: ProjectOption[];
 }) {
   const review = useMemo(() => txns.filter((t) => t.bucket === "needsReview"), [txns]);
   const autoDone = useMemo(() => txns.filter((t) => t.bucket === "autoDone"), [txns]);
@@ -104,11 +116,12 @@ export function InboxTable({
   // 키보드 ↑↓ 이동 대상: 화면에 보이는 needsReview 행 순서.
   const editableVisible = useMemo(() => visible.filter((t) => t.bucket === "needsReview"), [visible]);
 
-  // 결정된 확인필요 행: 회비면 회원 지정됨, 그 외(프로젝트/제외)면 분류 선택만으로 결정.
+  // 결정된 확인필요 행: 회비=회원 지정, 프로젝트=귀속 프로젝트 지정(회원은 선택), 제외=분류만.
   // 부분 확정 — 미결정 행은 이번 확정에서 빠지고 인박스에 남아 다음에 처리한다.
+  // (inbox-row.tsx의 decided 계산과 반드시 같은 규칙을 유지할 것)
   const decidedReview = review.filter((t) => {
     const d = decisions[t.txnId];
-    return d && (d.itemCd !== "due" || d.memId);
+    return d && (d.itemCd === "other" || (d.itemCd === "due" ? !!d.memId : !!d.prjId));
   });
   const undecidedCount = review.length - decidedReview.length;
   // 자동완료·제외는 판단이 필요 없으므로 항상 확정 대상 + 결정된 확인필요 행.
@@ -202,7 +215,7 @@ export function InboxTable({
       <div className="flex items-center justify-between">
         <H2>거래내역 처리</H2>
         <div className="flex items-center gap-2">
-          <ManualTxnButton members={members} dupNames={dupNames} feeItems={feeItems} />
+          <ManualTxnButton members={members} dupNames={dupNames} feeItems={feeItems} projects={projects} />
           <UploadXlsxButton onResult={setMsg} />
         </div>
       </div>
@@ -288,6 +301,7 @@ export function InboxTable({
                   key={t.txnId}
                   txn={t}
                   members={members}
+                  projects={projects}
                   dupNames={dupNames}
                   nameById={nameById}
                   decision={t.bucket === "needsReview" ? decisions[t.txnId] : null}

--- a/app/(info)/admin/dues/inbox/manual-txn-button.tsx
+++ b/app/(info)/admin/dues/inbox/manual-txn-button.tsx
@@ -5,7 +5,7 @@ import { useRouter } from "next/navigation";
 
 import { addManualTransaction } from "@/app/actions/dues/add-manual-transaction";
 import { dayjs } from "@/lib/dayjs";
-import type { FeeItemOption, MemberOption } from "@/lib/queries/dues";
+import type { FeeItemOption, MemberOption, ProjectOption } from "@/lib/queries/dues";
 
 import { Caption, Micro } from "@/components/common/typography";
 import { Button } from "@/components/ui/button";
@@ -38,10 +38,12 @@ export function ManualTxnButton({
   members,
   dupNames,
   feeItems,
+  projects,
 }: {
   members: MemberOption[];
   dupNames: Set<string>;
   feeItems: FeeItemOption[];
+  projects: ProjectOption[];
 }) {
   const [open, setOpen] = useState(false);
   const [txnDt, setTxnDt] = useState(() => dayjs().tz("Asia/Seoul").format("YYYY-MM-DD"));
@@ -49,6 +51,7 @@ export function ManualTxnButton({
   const [amount, setAmount] = useState("");
   const [rawName, setRawName] = useState("");
   const [itemCd, setItemCd] = useState<string>("due");
+  const [prjId, setPrjId] = useState<string | null>(null);
   const [memId, setMemId] = useState<string | null>(null);
   const [memo, setMemo] = useState("");
   const [err, setErr] = useState<string | null>(null);
@@ -65,6 +68,7 @@ export function ManualTxnButton({
         rawName,
         feeItemCd: itemCd,
         memId,
+        prjId: itemCd === "event_fee" ? prjId : null,
         memo: memo || null,
       });
       if (res.ok) {
@@ -72,6 +76,7 @@ export function ManualTxnButton({
         setAmount("");
         setRawName("");
         setMemId(null);
+        setPrjId(null);
         setMemo("");
         router.refresh();
       } else {
@@ -139,6 +144,28 @@ export function ManualTxnButton({
                 </Select>
               </div>
             </div>
+            {itemCd === "event_fee" && (
+              <div className="flex flex-col gap-1.5">
+                <Label>귀속 프로젝트</Label>
+                <Select value={prjId ?? ""} onValueChange={setPrjId}>
+                  <SelectTrigger>
+                    <SelectValue placeholder="프로젝트 선택…" />
+                  </SelectTrigger>
+                  <SelectContent>
+                    {projects.length === 0 && (
+                      <SelectItem value="__none" disabled>
+                        모금 중인 프로젝트 없음
+                      </SelectItem>
+                    )}
+                    {projects.map((p) => (
+                      <SelectItem key={p.prjId} value={p.prjId}>
+                        {p.name}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+              </div>
+            )}
             <div className="flex flex-col gap-1.5">
               <Label htmlFor="manual-name">이름(적요)</Label>
               <Input
@@ -162,7 +189,11 @@ export function ManualTxnButton({
             <Button type="button" variant="outline" onClick={() => setOpen(false)}>
               닫기
             </Button>
-            <Button type="button" disabled={pending || !amount || !rawName.trim()} onClick={onSubmit}>
+            <Button
+              type="button"
+              disabled={pending || !amount || !rawName.trim() || (itemCd === "event_fee" && !prjId)}
+              onClick={onSubmit}
+            >
               {pending ? "등록 중…" : "등록"}
             </Button>
           </DialogFooter>

--- a/app/(info)/admin/dues/inbox/page.tsx
+++ b/app/(info)/admin/dues/inbox/page.tsx
@@ -1,4 +1,5 @@
 import {
+  getActiveProjects,
   getFeeItemOptions,
   getInboxTxns,
   getProcessedTxns,
@@ -13,6 +14,7 @@ export default async function DuesInboxPage() {
   // 인박스 조회 실패는 기존대로 throw — 빈 화면이 정상으로 위장되면 안 된다.
   const inboxPromise = getInboxTxns();
   const feeItemsPromise = getFeeItemOptions();
+  const projectsPromise = getActiveProjects();
   let processed: ProcessedTxn[] = [];
   let processedError = false;
   try {
@@ -21,7 +23,11 @@ export default async function DuesInboxPage() {
     console.error("[DuesInboxPage] 처리된 거래 조회 실패:", e);
     processedError = true;
   }
-  const [{ members, txns }, feeItems] = await Promise.all([inboxPromise, feeItemsPromise]);
+  const [{ members, txns }, feeItems, projects] = await Promise.all([
+    inboxPromise,
+    feeItemsPromise,
+    projectsPromise,
+  ]);
 
   return (
     <InboxTable
@@ -31,6 +37,7 @@ export default async function DuesInboxPage() {
       processedCapped={processed.length >= PROCESSED_TXN_LIMIT}
       processedError={processedError}
       feeItems={feeItems}
+      projects={projects}
     />
   );
 }

--- a/app/(info)/admin/dues/inbox/processed-rows.tsx
+++ b/app/(info)/admin/dues/inbox/processed-rows.tsx
@@ -48,6 +48,7 @@ export function ProcessedRows({
           <td className="px-2 py-2">
             <Caption className="text-foreground">
               {t.feeItemCd ? (PROCESSED_ITEM_LABEL[t.feeItemCd] ?? t.feeItemCd) : "—"}
+              {t.prjName ? ` · ${t.prjName}` : ""}
             </Caption>
           </td>
           <td className="px-2 py-2">

--- a/app/(info)/admin/dues/layout.tsx
+++ b/app/(info)/admin/dues/layout.tsx
@@ -17,9 +17,9 @@ export default async function DuesAdminLayout({ children }: { children: React.Re
         <Link href="/admin/dues/inbox">
           <Caption className="text-foreground">📥 처리</Caption>
         </Link>
-        <span title="P2 예정">
-          <Caption>🎯 프로젝트</Caption>
-        </span>
+        <Link href="/admin/dues/projects">
+          <Caption className="text-foreground">🎯 프로젝트</Caption>
+        </Link>
       </nav>
       {children}
     </div>

--- a/app/(info)/admin/dues/projects/[prjId]/page.tsx
+++ b/app/(info)/admin/dues/projects/[prjId]/page.tsx
@@ -1,0 +1,86 @@
+import Link from "next/link";
+import { notFound } from "next/navigation";
+
+import { dayjs } from "@/lib/dayjs";
+import { getProjectDetail } from "@/lib/queries/dues";
+import { cn } from "@/lib/utils";
+
+import { EmptyState } from "@/components/common/empty-state";
+import { Body, Caption, H2, Micro } from "@/components/common/typography";
+import { Button } from "@/components/ui/button";
+import { CardItem } from "@/components/ui/card";
+
+import { ProjectStatusButton } from "./project-status-button";
+
+/**
+ * 프로젝트(모금) 상세 — 참여자 명단·모금액 (SP2).
+ * 귀속된 확정 거래만 집계한다(인박스에 남은 미확정 귀속은 제외).
+ * 개별 건 정정은 처리 화면의 '처리됨'에서.
+ */
+export default async function DuesProjectDetailPage({
+  params,
+}: {
+  params: Promise<{ prjId: string }>;
+}) {
+  const { prjId } = await params;
+  const detail = await getProjectDetail(prjId);
+  if (!detail) notFound();
+
+  return (
+    <div className="flex flex-col gap-4 px-6 pb-6 pt-4">
+      <div className="flex items-center justify-between">
+        <H2>{detail.name}</H2>
+        <div className="flex items-center gap-2">
+          <ProjectStatusButton prjId={detail.prjId} stCd={detail.stCd} />
+          <Button asChild size="sm" variant="outline">
+            <Link href="/admin/dues/projects">목록</Link>
+          </Button>
+        </div>
+      </div>
+      {detail.memo && <Caption>{detail.memo}</Caption>}
+
+      <CardItem className="flex items-center justify-between p-4">
+        <div className="flex flex-col gap-0.5">
+          <Caption>모금액 (확정 기준)</Caption>
+          <Micro>
+            {detail.stCd === "active" ? "모금 중 — 거래 처리에서 귀속 가능" : "마감됨"} ·{" "}
+            {detail.rows.length}건
+          </Micro>
+        </div>
+        <Body className="text-lg font-bold">{detail.totalAmt.toLocaleString()}원</Body>
+      </CardItem>
+
+      {detail.rows.length === 0 ? (
+        <EmptyState
+          variant="card"
+          message="아직 귀속된 거래가 없습니다. 거래내역 처리에서 분류를 '프로젝트'로 지정해 보세요."
+        />
+      ) : (
+        <CardItem className="flex flex-col divide-y divide-border p-0 overflow-hidden">
+          {detail.rows.map((r) => (
+            <div key={r.txnId} className="flex items-center justify-between gap-3 px-4 py-3">
+              <div className="flex min-w-0 flex-col gap-0.5">
+                <Body className="truncate font-semibold">{r.memName ?? r.rawName}</Body>
+                <Micro>
+                  {dayjs(r.txnDt).format("YY.MM.DD")}
+                  {r.memName && r.memName !== r.rawName ? ` · 입금자명 ${r.rawName}` : ""}
+                  {!r.memName ? " · 회원 미매칭" : ""}
+                </Micro>
+              </div>
+              <Body
+                className={cn("shrink-0 font-semibold", r.io === "withdrawal" && "text-destructive")}
+              >
+                {r.io === "withdrawal" ? "-" : "+"}
+                {r.amt.toLocaleString()}원
+              </Body>
+            </div>
+          ))}
+        </CardItem>
+      )}
+
+      <Caption className="text-muted-foreground">
+        잘못 귀속된 건은 거래내역 처리의 &lsquo;처리됨&rsquo;에서 취소 후 다시 처리하세요.
+      </Caption>
+    </div>
+  );
+}

--- a/app/(info)/admin/dues/projects/[prjId]/project-status-button.tsx
+++ b/app/(info)/admin/dues/projects/[prjId]/project-status-button.tsx
@@ -1,0 +1,34 @@
+"use client";
+
+import { useTransition } from "react";
+import { useRouter } from "next/navigation";
+
+import { setProjectStatus } from "@/app/actions/dues/manage-projects";
+
+import { Button } from "@/components/ui/button";
+
+/** 프로젝트 모금 상태 토글 — 마감하면 인박스 귀속 선택지에서 빠진다(기존 귀속은 유지). */
+export function ProjectStatusButton({ prjId, stCd }: { prjId: string; stCd: "active" | "closed" }) {
+  const [pending, startTransition] = useTransition();
+  const router = useRouter();
+  const next = stCd === "active" ? "closed" : "active";
+
+  function onToggle() {
+    const q =
+      next === "closed"
+        ? "모금을 마감할까요? 거래 처리의 프로젝트 선택지에서 빠집니다(이미 귀속된 거래는 유지)."
+        : "모금을 다시 열까요?";
+    if (!confirm(q)) return;
+    startTransition(async () => {
+      const res = await setProjectStatus(prjId, next);
+      if (!res.ok) alert(res.message);
+      router.refresh();
+    });
+  }
+
+  return (
+    <Button size="sm" variant="outline" disabled={pending} onClick={onToggle}>
+      {pending ? "변경 중…" : next === "closed" ? "모금 마감" : "다시 열기"}
+    </Button>
+  );
+}

--- a/app/(info)/admin/dues/projects/page.tsx
+++ b/app/(info)/admin/dues/projects/page.tsx
@@ -1,0 +1,9 @@
+import { getProjects } from "@/lib/queries/dues";
+
+import { ProjectsClient } from "./projects-client";
+
+/** 회비 프로젝트(모금) 목록 — SP2. 생성·마감과 프로젝트별 모금액 요약. */
+export default async function DuesProjectsPage() {
+  const projects = await getProjects();
+  return <ProjectsClient projects={projects} />;
+}

--- a/app/(info)/admin/dues/projects/projects-client.tsx
+++ b/app/(info)/admin/dues/projects/projects-client.tsx
@@ -1,0 +1,141 @@
+"use client";
+
+import { useState, useTransition } from "react";
+import Link from "next/link";
+import { useRouter } from "next/navigation";
+
+import { createProject } from "@/app/actions/dues/manage-projects";
+import type { ProjectSummary } from "@/lib/queries/dues";
+
+import { EmptyState } from "@/components/common/empty-state";
+import { Body, Caption, H2, Micro } from "@/components/common/typography";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { CardItem } from "@/components/ui/card";
+import {
+  Dialog,
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+
+/**
+ * 프로젝트(모금) 목록 화면. 생성 다이얼로그 + 프로젝트별 모금액·건수 요약.
+ * 상태 변경·명단은 상세 화면에서 한다.
+ */
+export function ProjectsClient({ projects }: { projects: ProjectSummary[] }) {
+  const [open, setOpen] = useState(false);
+  const [name, setName] = useState("");
+  const [memo, setMemo] = useState("");
+  const [err, setErr] = useState<string | null>(null);
+  const [pending, startTransition] = useTransition();
+  const router = useRouter();
+
+  function onCreate() {
+    setErr(null);
+    startTransition(async () => {
+      const res = await createProject({ name, memo: memo || null });
+      if (res.ok) {
+        setOpen(false);
+        setName("");
+        setMemo("");
+        router.refresh();
+      } else {
+        setErr(res.message);
+      }
+    });
+  }
+
+  const active = projects.filter((p) => p.stCd === "active");
+  const closed = projects.filter((p) => p.stCd === "closed");
+
+  return (
+    <div className="flex flex-col gap-4 px-6 pb-6 pt-4">
+      <div className="flex items-center justify-between">
+        <H2>프로젝트 모금</H2>
+        <Button size="sm" onClick={() => setOpen(true)}>
+          새 프로젝트
+        </Button>
+      </div>
+      <Caption>
+        단체복·야유회 같은 프로젝트성 입금을 모아 봅니다. 거래내역 처리에서 분류를
+        &lsquo;프로젝트&rsquo;로 하고 여기 만든 프로젝트에 귀속시키면 명단·모금액이 집계됩니다.
+      </Caption>
+
+      {projects.length === 0 ? (
+        <EmptyState variant="card" message="아직 프로젝트가 없습니다. 첫 프로젝트를 만들어 보세요." />
+      ) : (
+        <>
+          {[
+            { label: "모금 중", rows: active },
+            { label: "마감", rows: closed },
+          ].map(
+            (g) =>
+              g.rows.length > 0 && (
+                <div key={g.label} className="flex flex-col gap-2">
+                  <Caption className="font-semibold text-foreground">{g.label}</Caption>
+                  <CardItem className="flex flex-col divide-y divide-border p-0 overflow-hidden">
+                    {g.rows.map((p) => (
+                      <Link
+                        key={p.prjId}
+                        href={`/admin/dues/projects/${p.prjId}`}
+                        className="flex items-center justify-between gap-3 px-4 py-3"
+                      >
+                        <div className="flex min-w-0 flex-col gap-0.5">
+                          <div className="flex items-center gap-1.5">
+                            <Body className="truncate font-semibold">{p.name}</Body>
+                            {p.stCd === "closed" && (
+                              <Badge className="border-0 bg-muted text-muted-foreground">마감</Badge>
+                            )}
+                          </div>
+                          <Micro>
+                            {p.txnCount}건{p.memo ? ` · ${p.memo}` : ""}
+                          </Micro>
+                        </div>
+                        <Body className="shrink-0 font-semibold">{p.totalAmt.toLocaleString()}원</Body>
+                      </Link>
+                    ))}
+                  </CardItem>
+                </div>
+              ),
+          )}
+        </>
+      )}
+
+      <Dialog open={open} onOpenChange={setOpen}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>새 프로젝트</DialogTitle>
+          </DialogHeader>
+          <div className="flex flex-col gap-3">
+            <div className="flex flex-col gap-1.5">
+              <Label htmlFor="prj-name">이름</Label>
+              <Input
+                id="prj-name"
+                placeholder="단체복 2026"
+                value={name}
+                onChange={(e) => setName(e.target.value)}
+              />
+            </div>
+            <div className="flex flex-col gap-1.5">
+              <Label htmlFor="prj-memo">메모 (선택)</Label>
+              <Input id="prj-memo" value={memo} onChange={(e) => setMemo(e.target.value)} />
+            </div>
+            {err && <Caption className="text-destructive">{err}</Caption>}
+          </div>
+          <DialogFooter>
+            <Button type="button" variant="outline" onClick={() => setOpen(false)}>
+              닫기
+            </Button>
+            <Button type="button" disabled={pending || !name.trim()} onClick={onCreate}>
+              {pending ? "생성 중…" : "만들기"}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </div>
+  );
+}

--- a/app/actions/dues/add-manual-transaction.ts
+++ b/app/actions/dues/add-manual-transaction.ts
@@ -15,6 +15,8 @@ type AddManualTxnInput = {
   rawName: string;
   feeItemCd: string;
   memId?: string | null;
+  /** 프로젝트(event_fee) 귀속 — event_fee 분류에서만 저장 */
+  prjId?: string | null;
   memo?: string | null;
 };
 
@@ -99,6 +101,20 @@ export async function addManualTransaction(input: AddManualTxnInput) {
       return { ok: false as const, message: "존재하지 않는 분류입니다. 분류 항목을 확인해 주세요." };
     }
 
+    // 프로젝트 분류는 귀속 필수 + 이 팀의 프로젝트인지 검증(타 팀 prjId 주입 차단)
+    const prjId = input.feeItemCd === "event_fee" ? (input.prjId?.trim() || null) : null;
+    if (input.feeItemCd === "event_fee") {
+      if (!prjId) return { ok: false as const, message: "귀속 프로젝트를 선택해 주세요." };
+      const { data: prj } = await db
+        .from("fee_prj_mst")
+        .select("prj_id")
+        .eq("team_id", teamId)
+        .eq("prj_id", prjId)
+        .eq("del_yn", false)
+        .maybeSingle();
+      if (!prj) return { ok: false as const, message: "프로젝트를 찾을 수 없습니다." };
+    }
+
     const updId = await getOrCreateManualBatch(db, teamId, member.id);
     if (!updId) return { ok: false as const, message: "수동 등록 배치 생성에 실패했습니다." };
 
@@ -124,6 +140,7 @@ export async function addManualTransaction(input: AddManualTxnInput) {
         match_st_cd: matchStatus,
         mem_id: memId,
         fee_item_cd: input.feeItemCd,
+        project_id: prjId,
         is_cfm_yn: false,
         del_yn: false,
       })

--- a/app/actions/dues/confirm-transactions.ts
+++ b/app/actions/dues/confirm-transactions.ts
@@ -14,6 +14,8 @@ export type ConfirmItem = {
   feeItemCd?: string | null;
   /** 확정과 함께 적용할 회원 매칭(로컬로 바꾼 값). 없으면 기존 매칭 유지. */
   memId?: string | null;
+  /** 프로젝트(event_fee) 귀속. 없으면(undefined) 기존 값 유지, null이면 해제. */
+  prjId?: string | null;
 };
 
 /**
@@ -40,14 +42,14 @@ export async function confirmTransactions(items: ConfirmItem[]) {
     // 대상 거래 일괄 조회
     const { data: txns, error: selErr } = await db
       .from("fee_txn_hist")
-      .select("txn_id, mem_id, txn_amt, txn_dt, fee_item_cd, is_cfm_yn, match_st_cd")
+      .select("txn_id, mem_id, txn_amt, txn_dt, fee_item_cd, is_cfm_yn, match_st_cd, project_id")
       .eq("team_id", teamId)
       .eq("del_yn", false)
       .in("txn_id", txnIds);
 
     if (selErr) return { ok: false as const, message: "거래 조회에 실패했습니다." };
 
-    // 로컬 변경(분류·매칭)을 병합한 "확정 시점의 최종 상태" 계산
+    // 로컬 변경(분류·매칭·프로젝트)을 병합한 "확정 시점의 최종 상태" 계산
     const validCds = await getValidFeeItemCds(db);
     const merged = (txns ?? [])
       .filter((t) => !t.is_cfm_yn)
@@ -57,13 +59,41 @@ export async function confirmTransactions(items: ConfirmItem[]) {
         // 매칭을 새로 지정했으면 matched 로 승격
         const memId = it?.memId !== undefined && it.memId !== null ? it.memId : t.mem_id;
         const matchStCd = it?.memId ? "matched" : t.match_st_cd;
-        return { ...t, fee_item_cd: feeItemCd, mem_id: memId, match_st_cd: matchStCd };
+        // 프로젝트 귀속은 undefined=유지, null=해제, 값=지정. 회비/제외 분류면 항상 해제
+        // (분류를 프로젝트→회비로 바꿔 확정할 때 낡은 귀속이 남지 않도록).
+        const prjId = feeItemCd === "event_fee" ? (it?.prjId !== undefined ? it.prjId : t.project_id) : null;
+        return { ...t, fee_item_cd: feeItemCd, mem_id: memId, match_st_cd: matchStCd, project_id: prjId };
       });
 
     // 분류 유효성 검증 — 무효 분류가 있으면 전체 거부 (잘못된 확정 방지)
     const invalid = merged.find((t) => !t.fee_item_cd || !validCds.has(t.fee_item_cd));
     if (invalid) {
       return { ok: false as const, message: "분류가 없거나 유효하지 않은 거래가 있습니다." };
+    }
+
+    // 프로젝트 귀속 검증 — 클라이언트 결정 규칙(프로젝트=귀속 필수)을 서버도 강제한다.
+    // 이번 호출이 프로젝트로 분류한(feeItemCd 전송) 행만 대상 — 저장값으로만 확정되는
+    // autoDone/excluded 경로는 UI에서 귀속을 고칠 수 없으므로 막지 않는다(기존 데이터 관용).
+    const missingPrj = merged.find((t) => {
+      const it = itemMap.get(t.txn_id);
+      return it?.feeItemCd === "event_fee" && !t.project_id;
+    });
+    if (missingPrj) {
+      return { ok: false as const, message: "프로젝트 분류는 귀속 프로젝트를 선택해야 확정할 수 있습니다." };
+    }
+
+    // 귀속 프로젝트가 실제 이 팀 것인지 검증 — 타 팀 prjId 주입 차단
+    const prjIds = [...new Set(merged.map((t) => t.project_id).filter((v): v is string => !!v))];
+    if (prjIds.length > 0) {
+      const { data: prjs, error: prjErr } = await db
+        .from("fee_prj_mst")
+        .select("prj_id")
+        .eq("team_id", teamId)
+        .eq("del_yn", false)
+        .in("prj_id", prjIds);
+      if (prjErr || (prjs ?? []).length !== prjIds.length) {
+        return { ok: false as const, message: "존재하지 않는 프로젝트가 지정된 거래가 있습니다." };
+      }
     }
 
     const skipped = txnIds.length - merged.length;
@@ -77,7 +107,7 @@ export async function confirmTransactions(items: ConfirmItem[]) {
     //    (분류/매칭 변경이 없는 건은 묶어서 단일 UPDATE)
     const changed = merged.filter((t) => {
       const it = itemMap.get(t.txn_id);
-      return it?.feeItemCd != null || (it?.memId != null);
+      return it?.feeItemCd != null || it?.memId != null || it?.prjId !== undefined;
     });
     const unchanged = merged.filter((t) => !changed.includes(t));
 
@@ -104,6 +134,7 @@ export async function confirmTransactions(items: ConfirmItem[]) {
           fee_item_cd: t.fee_item_cd,
           mem_id: t.mem_id,
           match_st_cd: t.match_st_cd,
+          project_id: t.project_id,
           is_cfm_yn: true,
           cfm_by_mem_id: member.id,
           cfm_at: nowIso,

--- a/app/actions/dues/manage-projects.ts
+++ b/app/actions/dues/manage-projects.ts
@@ -1,0 +1,62 @@
+"use server";
+
+import { withAdmin } from "@/lib/actions/auth";
+import { getRequestTeamContext } from "@/lib/queries/request-team";
+import { createAdminClient } from "@/lib/supabase/admin";
+
+/**
+ * 회비 프로젝트(모금) 생성. 활성 이름 중복은 유니크 인덱스(uk_fee_prj_mst_team_nm)가 막는다.
+ */
+export async function createProject(input: { name: string; memo?: string | null }) {
+  return withAdmin(async ({ member }) => {
+    const { teamId } = await getRequestTeamContext();
+    const db = createAdminClient();
+
+    const name = input.name.trim();
+    if (!name) return { ok: false as const, message: "프로젝트 이름을 입력해 주세요." };
+
+    const { data, error } = await db
+      .from("fee_prj_mst")
+      .insert({
+        team_id: teamId,
+        prj_nm: name,
+        memo_txt: input.memo?.trim() || null,
+        created_by: member.id,
+        st_cd: "active",
+        vers: 0,
+        del_yn: false,
+      })
+      .select("prj_id")
+      .single();
+
+    if (error) {
+      if (error.code === "23505") {
+        return { ok: false as const, message: "같은 이름의 프로젝트가 이미 있습니다." };
+      }
+      return { ok: false as const, message: "프로젝트 생성에 실패했습니다." };
+    }
+    return { ok: true as const, message: null, prjId: data.prj_id };
+  });
+}
+
+/**
+ * 프로젝트 모금 상태 변경. closed 되면 인박스 선택지에서 빠진다(이미 귀속된 거래는 유지).
+ */
+export async function setProjectStatus(prjId: string, stCd: "active" | "closed") {
+  return withAdmin(async () => {
+    const { teamId } = await getRequestTeamContext();
+    const db = createAdminClient();
+
+    const { data, error } = await db
+      .from("fee_prj_mst")
+      .update({ st_cd: stCd })
+      .eq("team_id", teamId)
+      .eq("prj_id", prjId)
+      .eq("del_yn", false)
+      .select("prj_id");
+
+    if (error) return { ok: false as const, message: "상태 변경에 실패했습니다." };
+    if (!data?.length) return { ok: false as const, message: "프로젝트를 찾을 수 없습니다." };
+    return { ok: true as const, message: null };
+  });
+}

--- a/lib/__tests__/confirm-payload.test.ts
+++ b/lib/__tests__/confirm-payload.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from "vitest";
 import { buildConfirmPayload, type Decision } from "@/lib/dues/confirm-payload";
 
 const ref = (txnId: string, rawName = txnId) => ({ txnId, rawName });
+const d = (p: Partial<Decision>): Decision => ({ memId: null, itemCd: "due", remember: false, prjId: null, ...p });
 
 describe("buildConfirmPayload", () => {
   it("autoDone·excluded는 txnId만 넘긴다", () => {
@@ -15,34 +16,44 @@ describe("buildConfirmPayload", () => {
     expect(items).toEqual([{ txnId: "a1" }, { txnId: "x1" }]);
   });
 
-  it("review 회비는 feeItemCd=due + memId", () => {
+  it("review 회비는 feeItemCd=due + memId (prjId는 null)", () => {
     const decisions: Record<string, Decision> = {
-      r1: { memId: "m1", itemCd: "due", remember: false },
+      r1: d({ memId: "m1", itemCd: "due" }),
     };
     const { items } = buildConfirmPayload({ autoDone: [], excluded: [], review: [ref("r1")], decisions });
-    expect(items).toEqual([{ txnId: "r1", feeItemCd: "due", memId: "m1" }]);
+    expect(items).toEqual([{ txnId: "r1", feeItemCd: "due", memId: "m1", prjId: null }]);
   });
 
-  it("review 프로젝트·제외는 memId null", () => {
+  it("review 프로젝트는 memId·prjId를 함께 넘긴다 — 명단의 핵심", () => {
     const decisions: Record<string, Decision> = {
-      r1: { memId: "m1", itemCd: "event_fee", remember: false },
-      r2: { memId: null, itemCd: "other", remember: false },
+      r1: d({ memId: "m1", itemCd: "event_fee", prjId: "p1" }),
     };
-    const { items } = buildConfirmPayload({
-      autoDone: [], excluded: [], review: [ref("r1"), ref("r2")], decisions,
-    });
-    expect(items).toEqual([
-      { txnId: "r1", feeItemCd: "event_fee", memId: null },
-      { txnId: "r2", feeItemCd: "other", memId: null },
-    ]);
+    const { items } = buildConfirmPayload({ autoDone: [], excluded: [], review: [ref("r1")], decisions });
+    expect(items).toEqual([{ txnId: "r1", feeItemCd: "event_fee", memId: "m1", prjId: "p1" }]);
+  });
+
+  it("review 제외는 memId·prjId 모두 null", () => {
+    const decisions: Record<string, Decision> = {
+      r1: d({ memId: "m1", itemCd: "other", prjId: "p1" }),
+    };
+    const { items } = buildConfirmPayload({ autoDone: [], excluded: [], review: [ref("r1")], decisions });
+    expect(items).toEqual([{ txnId: "r1", feeItemCd: "other", memId: null, prjId: null }]);
+  });
+
+  it("회비로 확정하면 프로젝트 귀속은 실리지 않는다(prjId null)", () => {
+    const decisions: Record<string, Decision> = {
+      r1: d({ memId: "m1", itemCd: "due", prjId: "p1" }), // 프로젝트 골랐다가 회비로 되돌린 경우
+    };
+    const { items } = buildConfirmPayload({ autoDone: [], excluded: [], review: [ref("r1")], decisions });
+    expect(items).toEqual([{ txnId: "r1", feeItemCd: "due", memId: "m1", prjId: null }]);
   });
 
   it("aliasLearn은 remember && 회비 && memId 인 것만", () => {
     const decisions: Record<string, Decision> = {
-      r1: { memId: "m1", itemCd: "due", remember: true },
-      r2: { memId: "m2", itemCd: "due", remember: false },
-      r3: { memId: "m3", itemCd: "event_fee", remember: true },
-      r4: { memId: null, itemCd: "due", remember: true },
+      r1: d({ memId: "m1", itemCd: "due", remember: true }),
+      r2: d({ memId: "m2", itemCd: "due", remember: false }),
+      r3: d({ memId: "m3", itemCd: "event_fee", remember: true, prjId: "p1" }),
+      r4: d({ memId: null, itemCd: "due", remember: true }),
     };
     const { aliasLearn } = buildConfirmPayload({
       autoDone: [], excluded: [],
@@ -57,7 +68,7 @@ describe("buildConfirmPayload", () => {
       autoDone: [ref("a1")],
       excluded: [ref("x1")],
       review: [ref("r1")],
-      decisions: { r1: { memId: "m1", itemCd: "due", remember: false } },
+      decisions: { r1: d({ memId: "m1", itemCd: "due" }) },
     });
     expect(items.map((i) => i.txnId)).toEqual(["a1", "x1", "r1"]);
   });

--- a/lib/__tests__/upload-bucketize.test.ts
+++ b/lib/__tests__/upload-bucketize.test.ts
@@ -18,4 +18,11 @@ describe("bucketOf", () => {
   it("입금+회비+동명이인 → 확인필요", () => {
     expect(bucketOf({ io: "deposit", itemCd: "due", matchStatus: "ambiguous" })).toBe("needsReview");
   });
+  it("입금+프로젝트(event_fee) → 확인필요 (귀속 판단 필요)", () => {
+    expect(bucketOf({ io: "deposit", itemCd: "event_fee", matchStatus: "matched" })).toBe("needsReview");
+  });
+  it("triage 어휘 밖 분류(goods·커스텀)는 제외 — 확인필요에 두면 기본 결정이 분류를 덮어쓴다", () => {
+    expect(bucketOf({ io: "deposit", itemCd: "goods", matchStatus: "matched" })).toBe("excluded");
+    expect(bucketOf({ io: "deposit", itemCd: "custom_cd", matchStatus: "unmatched" })).toBe("excluded");
+  });
 });

--- a/lib/dues/confirm-payload.ts
+++ b/lib/dues/confirm-payload.ts
@@ -6,6 +6,8 @@ export type Decision = {
   memId: string | null;
   itemCd: ItemCd;
   remember: boolean;
+  /** 프로젝트(event_fee) 귀속 대상 — 프로젝트 분류에서만 의미 있음 */
+  prjId: string | null;
 };
 
 type TxnRef = { txnId: string; rawName: string };
@@ -13,7 +15,9 @@ type TxnRef = { txnId: string; rawName: string };
 /**
  * 확정 액션에 넘길 payload를 순수하게 구성한다.
  * - autoDone·excluded: 업로드 시 저장된 분류를 유지하므로 txnId만.
- * - review: 로컬 판단(분류·회원)을 함께 넘긴다. 회비가 아니면 memId는 null.
+ * - review: 로컬 판단(분류·회원·프로젝트)을 함께 넘긴다. 회원 매칭은 회비뿐 아니라
+ *   프로젝트(event_fee)에도 저장한다 — "누가 이 프로젝트에 냈나"가 명단의 핵심.
+ *   제외(other)만 memId를 비운다. prjId는 프로젝트 분류에서만.
  * - aliasLearn: "기억하기" 체크된 회비+회원 건만(확정 성공 후 학습).
  */
 export function buildConfirmPayload(input: {
@@ -29,7 +33,12 @@ export function buildConfirmPayload(input: {
     // 순수 함수 계약: 모든 review 항목은 대응하는 decision을 가져야 한다. 없으면
     // 모호한 TypeError 대신 명확한 에러로 계약 위반을 드러낸다(aliasLearn도 d를 쓰므로 여기서 선차단).
     if (!d) throw new Error(`buildConfirmPayload: review 항목 ${t.txnId}에 대응하는 decision이 없습니다`);
-    return { txnId: t.txnId, feeItemCd: d.itemCd, memId: d.itemCd === "due" ? d.memId : null };
+    return {
+      txnId: t.txnId,
+      feeItemCd: d.itemCd,
+      memId: d.itemCd === "other" ? null : d.memId,
+      prjId: d.itemCd === "event_fee" ? d.prjId : null,
+    };
   });
 
   const aliasLearn = input.review

--- a/lib/dues/upload-bucketize.ts
+++ b/lib/dues/upload-bucketize.ts
@@ -4,9 +4,13 @@ export type Bucket = "autoDone" | "needsReview" | "excluded";
 
 /**
  * 업로드 거래 1건을 3버킷 중 하나로 분류한다(순수 함수).
- * - excluded: 출금이거나 `other`/`expense` 분류(예금이자·타행자동이체·지출)
+ * - excluded: 출금이거나 triage 대상이 아닌 분류(other/expense/goods/커스텀 등 전부)
  * - autoDone: 입금 + 회비(due) + 매칭 성공
- * - needsReview: 입금이면서 위 둘에 해당하지 않는 것(미매칭·동명이인 회비)
+ * - needsReview: 입금 + 회비(미매칭·동명이인) 또는 프로젝트(event_fee — 귀속 판단 필요)
+ *
+ * triage(확인필요)의 판단 어휘는 회비/프로젝트/제외 3종뿐이므로, 그 밖의 분류(goods 등
+ * 수동 등록·커스텀 코드)는 excluded 로 보내 저장값 그대로 확정되게 한다 — needsReview 에
+ * 떨어뜨리면 기본 결정이 그 분류를 표현하지 못해 확정 시 조용히 덮어써진다.
  */
 export function bucketOf(input: {
   io: "deposit" | "withdrawal";
@@ -14,7 +18,7 @@ export function bucketOf(input: {
   matchStatus: MatchStatus;
 }): Bucket {
   if (input.io === "withdrawal") return "excluded";
-  if (input.itemCd === "other" || input.itemCd === "expense") return "excluded";
+  if (input.itemCd !== "due" && input.itemCd !== "event_fee") return "excluded";
   if (input.itemCd === "due" && input.matchStatus === "matched") return "autoDone";
   return "needsReview";
 }

--- a/lib/queries/dues.ts
+++ b/lib/queries/dues.ts
@@ -18,6 +18,8 @@ export type InboxTxn = {
   memId: string | null;
   matchStatus: "matched" | "unmatched" | "ambiguous";
   feeItemCd: string | null;
+  /** 저장된 프로젝트 귀속 — 수동 등록·확정취소로 재노출된 event_fee 행의 기본값 시드 */
+  projectId: string | null;
   bucket: "autoDone" | "needsReview" | "excluded";
   candidates: { memId: string; name: string; score: number; birthDt: string | null }[];
 };
@@ -77,7 +79,7 @@ export async function getInboxTxns(): Promise<{
   // fee_txn_hist에는 vers 컬럼이 없다 — del_yn만 필터한다.
   const { data: rows, error: rowsErr } = await db
     .from("fee_txn_hist")
-    .select("txn_id, txn_dt, txn_tm, txn_amt, txn_io_enm, raw_name, mem_id, match_st_cd, fee_item_cd")
+    .select("txn_id, txn_dt, txn_tm, txn_amt, txn_io_enm, raw_name, mem_id, match_st_cd, fee_item_cd, project_id")
     .eq("team_id", teamId)
     .eq("is_cfm_yn", false)
     .eq("del_yn", false)
@@ -101,6 +103,7 @@ export async function getInboxTxns(): Promise<{
       memId: r.mem_id,
       matchStatus,
       feeItemCd: r.fee_item_cd,
+      projectId: r.project_id,
       bucket,
       candidates: match.candidates.map((c) => ({ ...c, birthDt: birthFor(c.memId, c.name) })),
     };
@@ -123,6 +126,8 @@ export type ProcessedTxn = {
   rawName: string;
   memName: string | null;
   feeItemCd: string | null;
+  /** 프로젝트(event_fee) 귀속 프로젝트명 */
+  prjName: string | null;
   cfmAt: string;
   cfmByName: string | null;
 };
@@ -141,7 +146,7 @@ export async function getProcessedTxns(): Promise<ProcessedTxn[]> {
   const { data: rows, error } = await db
     .from("fee_txn_hist")
     .select(
-      "txn_id, txn_dt, txn_amt, raw_name, fee_item_cd, cfm_at, mem:mem_mst!fk_fee_txn_hist__mem_mst(mem_nm), cfm_by:mem_mst!fk_fee_txn_hist__cfm_mem_mst(mem_nm)",
+      "txn_id, txn_dt, txn_amt, raw_name, fee_item_cd, cfm_at, mem:mem_mst!fk_fee_txn_hist__mem_mst(mem_nm), cfm_by:mem_mst!fk_fee_txn_hist__cfm_mem_mst(mem_nm), prj:fee_prj_mst!fk_fee_txn_hist__fee_prj_mst(prj_nm)",
     )
     .eq("team_id", teamId)
     .eq("is_cfm_yn", true)
@@ -155,6 +160,11 @@ export async function getProcessedTxns(): Promise<ProcessedTxn[]> {
     return (item as { mem_nm: string } | null)?.mem_nm ?? null;
   };
 
+  const prjNameOf = (raw: unknown): string | null => {
+    const item = Array.isArray(raw) ? raw[0] : raw;
+    return (item as { prj_nm: string } | null)?.prj_nm ?? null;
+  };
+
   return (rows ?? []).map((r) => ({
     txnId: r.txn_id,
     txnDt: r.txn_dt,
@@ -162,6 +172,7 @@ export async function getProcessedTxns(): Promise<ProcessedTxn[]> {
     rawName: r.raw_name,
     memName: nameOf(r.mem),
     feeItemCd: r.fee_item_cd,
+    prjName: prjNameOf(r.prj),
     cfmAt: r.cfm_at as string,
     cfmByName: nameOf(r.cfm_by),
   }));
@@ -184,6 +195,148 @@ export async function getFeeItemOptions(): Promise<FeeItemOption[]> {
     .order("sort_ord", { ascending: true });
   if (error) throw new Error(`분류 코드 조회 실패: ${error.message}`);
   return (data ?? []).map((c) => ({ cd: c.cd, label: c.cd_nm }));
+}
+
+export type ProjectOption = { prjId: string; name: string };
+
+/** 인박스·수동등록에서 귀속 대상으로 고를 수 있는 모금 중(active) 프로젝트. */
+export async function getActiveProjects(): Promise<ProjectOption[]> {
+  const { teamId } = await getRequestTeamContext();
+  const db = createAdminClient();
+  const { data, error } = await db
+    .from("fee_prj_mst")
+    .select("prj_id, prj_nm")
+    .eq("team_id", teamId)
+    .eq("st_cd", "active")
+    .eq("vers", 0)
+    .eq("del_yn", false)
+    .order("crt_at", { ascending: false });
+  if (error) throw new Error(`프로젝트 조회 실패: ${error.message}`);
+  return (data ?? []).map((p) => ({ prjId: p.prj_id, name: p.prj_nm }));
+}
+
+export type ProjectSummary = {
+  prjId: string;
+  name: string;
+  stCd: "active" | "closed";
+  memo: string | null;
+  crtAt: string;
+  /** 확정된 귀속 입금 합계(모금액) − 출금 */
+  totalAmt: number;
+  txnCount: number;
+};
+
+/**
+ * 프로젝트 목록 + 모금액 집계. 집계는 확정(is_cfm_yn=true) 거래만 —
+ * 인박스에 남아 있는 미확정 귀속은 아직 돈으로 치지 않는다.
+ */
+export async function getProjects(): Promise<ProjectSummary[]> {
+  const { teamId } = await getRequestTeamContext();
+  const db = createAdminClient();
+
+  const [{ data: prjs, error: prjErr }, { data: txns, error: txnErr }] = await Promise.all([
+    db
+      .from("fee_prj_mst")
+      .select("prj_id, prj_nm, st_cd, memo_txt, crt_at")
+      .eq("team_id", teamId)
+      .eq("vers", 0)
+      .eq("del_yn", false)
+      .order("crt_at", { ascending: false }),
+    db
+      .from("fee_txn_hist")
+      .select("project_id, txn_amt, txn_io_enm")
+      .eq("team_id", teamId)
+      .eq("is_cfm_yn", true)
+      .eq("del_yn", false)
+      .not("project_id", "is", null),
+  ]);
+  if (prjErr) throw new Error(`프로젝트 조회 실패: ${prjErr.message}`);
+  if (txnErr) throw new Error(`프로젝트 집계 실패: ${txnErr.message}`);
+
+  const agg = new Map<string, { total: number; count: number }>();
+  for (const t of txns ?? []) {
+    const cur = agg.get(t.project_id!) ?? { total: 0, count: 0 };
+    cur.total += t.txn_io_enm === "deposit" ? t.txn_amt : -t.txn_amt;
+    cur.count += 1;
+    agg.set(t.project_id!, cur);
+  }
+
+  return (prjs ?? []).map((p) => ({
+    prjId: p.prj_id,
+    name: p.prj_nm,
+    stCd: p.st_cd as "active" | "closed",
+    memo: p.memo_txt,
+    crtAt: p.crt_at,
+    totalAmt: agg.get(p.prj_id)?.total ?? 0,
+    txnCount: agg.get(p.prj_id)?.count ?? 0,
+  }));
+}
+
+export type ProjectTxnRow = {
+  txnId: string;
+  txnDt: string;
+  rawName: string;
+  memName: string | null;
+  amt: number;
+  io: "deposit" | "withdrawal";
+};
+
+export type ProjectDetail = {
+  prjId: string;
+  name: string;
+  stCd: "active" | "closed";
+  memo: string | null;
+  totalAmt: number;
+  rows: ProjectTxnRow[];
+};
+
+/** 프로젝트 상세 — 귀속된 확정 거래 명단(참여자)·모금액. 팀 밖 prjId면 null. */
+export async function getProjectDetail(prjId: string): Promise<ProjectDetail | null> {
+  const { teamId } = await getRequestTeamContext();
+  const db = createAdminClient();
+
+  const { data: prj } = await db
+    .from("fee_prj_mst")
+    .select("prj_id, prj_nm, st_cd, memo_txt")
+    .eq("team_id", teamId)
+    .eq("prj_id", prjId)
+    .eq("vers", 0)
+    .eq("del_yn", false)
+    .maybeSingle();
+  if (!prj) return null;
+
+  const { data: txns, error } = await db
+    .from("fee_txn_hist")
+    .select("txn_id, txn_dt, raw_name, txn_amt, txn_io_enm, mem:mem_mst!fk_fee_txn_hist__mem_mst(mem_nm)")
+    .eq("team_id", teamId)
+    .eq("project_id", prjId)
+    .eq("is_cfm_yn", true)
+    .eq("del_yn", false)
+    .order("txn_dt", { ascending: false });
+  if (error) throw new Error(`프로젝트 거래 조회 실패: ${error.message}`);
+
+  const nameOf = (raw: unknown): string | null => {
+    const item = Array.isArray(raw) ? raw[0] : raw;
+    return (item as { mem_nm: string } | null)?.mem_nm ?? null;
+  };
+
+  const rows: ProjectTxnRow[] = (txns ?? []).map((t) => ({
+    txnId: t.txn_id,
+    txnDt: t.txn_dt,
+    rawName: t.raw_name,
+    memName: nameOf(t.mem),
+    amt: t.txn_amt,
+    io: t.txn_io_enm as "deposit" | "withdrawal",
+  }));
+
+  return {
+    prjId: prj.prj_id,
+    name: prj.prj_nm,
+    stCd: prj.st_cd as "active" | "closed",
+    memo: prj.memo_txt,
+    totalAmt: rows.reduce((s, r) => s + (r.io === "deposit" ? r.amt : -r.amt), 0),
+    rows,
+  };
 }
 
 export type MemberDuesItem = {
@@ -256,7 +409,7 @@ export async function getMemberDuesDetail(memId: string): Promise<MemberDuesDeta
         .limit(100),
       db
         .from("fee_txn_hist")
-        .select("txn_id, txn_dt, txn_amt, txn_io_enm, fee_item_cd")
+        .select("txn_id, txn_dt, txn_amt, txn_io_enm, fee_item_cd, prj:fee_prj_mst!fk_fee_txn_hist__fee_prj_mst(prj_nm)")
         .eq("team_id", teamId)
         .eq("mem_id", memId)
         .eq("is_cfm_yn", true)
@@ -295,14 +448,19 @@ export async function getMemberDuesDetail(memId: string): Promise<MemberDuesDeta
       note: e.rsn_txt,
       pending: !e.rflt_yn,
     })),
-    ...(otherTxns ?? []).map((t) => ({
-      id: t.txn_id,
-      date: t.txn_dt,
-      itemLabel: itemLabelMap.get(t.fee_item_cd ?? "") ?? t.fee_item_cd ?? "-",
-      ioLabel: t.txn_io_enm === "deposit" ? ("입금" as const) : ("출금" as const),
-      amt: t.txn_amt,
-      cancelled: false,
-    })),
+    ...(otherTxns ?? []).map((t) => {
+      const prjRaw = Array.isArray(t.prj) ? t.prj[0] : t.prj;
+      const prjNm = (prjRaw as { prj_nm: string } | null)?.prj_nm ?? null;
+      const base = itemLabelMap.get(t.fee_item_cd ?? "") ?? t.fee_item_cd ?? "-";
+      return {
+        id: t.txn_id,
+        date: t.txn_dt,
+        itemLabel: prjNm ? `${base} · ${prjNm}` : base,
+        ioLabel: t.txn_io_enm === "deposit" ? ("입금" as const) : ("출금" as const),
+        amt: t.txn_amt,
+        cancelled: false,
+      };
+    }),
   ].sort((a, b) => b.date.localeCompare(a.date));
 
   return {

--- a/lib/supabase/database.types.ts
+++ b/lib/supabase/database.types.ts
@@ -1251,6 +1251,60 @@ export type Database = {
           },
         ]
       }
+      fee_prj_mst: {
+        Row: {
+          created_by: string | null
+          crt_at: string
+          del_yn: boolean
+          memo_txt: string | null
+          prj_id: string
+          prj_nm: string
+          st_cd: string
+          team_id: string
+          upd_at: string
+          vers: number
+        }
+        Insert: {
+          created_by?: string | null
+          crt_at?: string
+          del_yn?: boolean
+          memo_txt?: string | null
+          prj_id?: string
+          prj_nm: string
+          st_cd?: string
+          team_id: string
+          upd_at?: string
+          vers?: number
+        }
+        Update: {
+          created_by?: string | null
+          crt_at?: string
+          del_yn?: boolean
+          memo_txt?: string | null
+          prj_id?: string
+          prj_nm?: string
+          st_cd?: string
+          team_id?: string
+          upd_at?: string
+          vers?: number
+        }
+        Relationships: [
+          {
+            foreignKeyName: "fk_fee_prj_mst__crt_mem_mst"
+            columns: ["created_by"]
+            isOneToOne: false
+            referencedRelation: "mem_mst"
+            referencedColumns: ["mem_id"]
+          },
+          {
+            foreignKeyName: "fk_fee_prj_mst__team_mst"
+            columns: ["team_id"]
+            isOneToOne: false
+            referencedRelation: "team_mst"
+            referencedColumns: ["team_id"]
+          },
+        ]
+      }
       fee_txn_hist: {
         Row: {
           adm_memo_txt: string | null
@@ -1328,6 +1382,13 @@ export type Database = {
             isOneToOne: false
             referencedRelation: "mem_mst"
             referencedColumns: ["mem_id"]
+          },
+          {
+            foreignKeyName: "fk_fee_txn_hist__fee_prj_mst"
+            columns: ["project_id"]
+            isOneToOne: false
+            referencedRelation: "fee_prj_mst"
+            referencedColumns: ["prj_id"]
           },
           {
             foreignKeyName: "fk_fee_txn_hist__fee_xlsx_upd_hist"

--- a/supabase/migrations/20260703090000_fee_prj_mst.sql
+++ b/supabase/migrations/20260703090000_fee_prj_mst.sql
@@ -1,0 +1,67 @@
+-- 회비 프로젝트(모금) 마스터 — SP2 프로젝트별 추적.
+-- 단체복·야유회 같은 프로젝트성 모금(fee_item_cd='event_fee') 입금을 특정 프로젝트에
+-- 귀속시켜 프로젝트별 참여자 명단·모금액을 집계한다.
+-- fee_txn_hist.project_id 는 P1(20260701120000)에서 선행 추가된 컬럼 — 여기서 FK 를 붙인다.
+-- 패턴 준거: 20260701120000_fee_payer_alias.sql (RLS admin FOR ALL + service_role 앱 접근)
+
+CREATE TABLE public.fee_prj_mst (
+  prj_id uuid NOT NULL DEFAULT gen_random_uuid(),
+  team_id uuid NOT NULL,
+  prj_nm text NOT NULL,
+  st_cd text NOT NULL DEFAULT 'active',
+  memo_txt text,
+  created_by uuid,
+  vers integer NOT NULL DEFAULT 0,
+  del_yn boolean NOT NULL DEFAULT false,
+  crt_at timestamptz NOT NULL DEFAULT now(),
+  upd_at timestamptz NOT NULL DEFAULT now(),
+  CONSTRAINT pk_fee_prj_mst PRIMARY KEY (prj_id),
+  CONSTRAINT fk_fee_prj_mst__team_mst FOREIGN KEY (team_id) REFERENCES public.team_mst (team_id) ON DELETE RESTRICT,
+  CONSTRAINT fk_fee_prj_mst__crt_mem_mst FOREIGN KEY (created_by) REFERENCES public.mem_mst (mem_id) ON DELETE SET NULL,
+  CONSTRAINT ck_fee_prj_mst_prj_nm CHECK (length(prj_nm) > 0),
+  CONSTRAINT ck_fee_prj_mst_st_cd CHECK (st_cd IN ('active', 'closed'))
+);
+
+-- 활성 프로젝트 이름은 팀 내 유일(del_yn=true 과거는 재사용 허용)
+CREATE UNIQUE INDEX uk_fee_prj_mst_team_nm
+  ON public.fee_prj_mst (team_id, prj_nm)
+  WHERE del_yn = false;
+
+CREATE INDEX ix_fee_prj_mst_team_id ON public.fee_prj_mst (team_id);
+
+CREATE TRIGGER fee_prj_mst_set_upd_at
+  BEFORE UPDATE ON public.fee_prj_mst
+  FOR EACH ROW
+  EXECUTE FUNCTION public.set_v2_upd_at();
+
+COMMENT ON TABLE public.fee_prj_mst IS '회비 프로젝트(모금) 마스터 — 프로젝트성 입금 귀속·집계 (SP2)';
+COMMENT ON COLUMN public.fee_prj_mst.st_cd IS 'active=모금 중(인박스 선택지 노출) | closed=마감';
+
+ALTER TABLE public.fee_prj_mst ENABLE ROW LEVEL SECURITY;
+
+-- 앱 읽기/쓰기는 전부 service_role admin 클라이언트 경유. 관리자 직접 접근만 열어둔다.
+CREATE POLICY fee_prj_mst_mutate_admin
+  ON public.fee_prj_mst FOR ALL TO authenticated
+  USING (EXISTS (
+    SELECT 1 FROM public.team_mem_rel r
+    WHERE r.team_id = fee_prj_mst.team_id AND r.mem_id = auth.uid()
+      AND r.team_role_cd IN ('owner', 'admin') AND r.vers = 0 AND r.del_yn = false))
+  WITH CHECK (EXISTS (
+    SELECT 1 FROM public.team_mem_rel r
+    WHERE r.team_id = fee_prj_mst.team_id AND r.mem_id = auth.uid()
+      AND r.team_role_cd IN ('owner', 'admin') AND r.vers = 0 AND r.del_yn = false));
+
+GRANT ALL ON TABLE public.fee_prj_mst TO anon;
+GRANT ALL ON TABLE public.fee_prj_mst TO authenticated;
+GRANT ALL ON TABLE public.fee_prj_mst TO service_role;
+
+-- P1 선행 컬럼에 FK·인덱스 연결 (프로젝트 삭제 시 거래 귀속만 해제)
+ALTER TABLE public.fee_txn_hist
+  ADD CONSTRAINT fk_fee_txn_hist__fee_prj_mst FOREIGN KEY (project_id)
+  REFERENCES public.fee_prj_mst (prj_id) ON DELETE SET NULL;
+
+CREATE INDEX ix_fee_txn_hist_project_id
+  ON public.fee_txn_hist (project_id)
+  WHERE project_id IS NOT NULL;
+
+COMMENT ON COLUMN public.fee_txn_hist.project_id IS '프로젝트성 모금 귀속 (fee_prj_mst.prj_id, SP2)';


### PR DESCRIPTION
## 관련 이슈

관련 이슈 없음 (SP1 설계 문서의 후속 SP2 — `docs/superpowers/specs/2026-07-02-회비-거래처리-테이블-개편-design.md` §후속)

## 요약

"어떤 사람의 입금을 프로젝트로 처리하고, 그 프로젝트로 낸 사람 명단을 본다"를 완성합니다. 프로젝트 마스터를 만들고, 인박스에서 입금을 특정 프로젝트에 귀속시키며, 프로젝트 탭에서 참여자 명단·모금액을 봅니다.

## AS-IS (변경 전)

- 분류 '프로젝트'(event_fee)는 하나로 뭉뚱그려져 어떤 프로젝트인지 구분 불가, 명단·모금액 화면 없음 (나브의 🎯 프로젝트 탭은 비활성 자리만)
- **프로젝트 분류 시 운영자가 고른 회원 매칭이 버려짐** (`confirm-payload`가 회비 외엔 memId를 null로) — 누가 냈는지 기록 불가
- `fee_txn_hist.project_id`는 P1 선행 컬럼(항상 NULL, FK 없음)

## TO-BE (변경 후)

- **프로젝트 마스터** `fee_prj_mst` + `project_id` FK 연결 (RLS admin, 활성명 유니크) — **dev DB 적용·마이그레이션 히스토리 정렬 완료**
- **인박스**: 분류=프로젝트 → 회원 후보/직접선택 유지 + 귀속 프로젝트 선택(필수, 미선택 시 미결정). 서버도 동일 규칙 강제 + 타 팀 prjId 주입 차단
- **프로젝트 탭**(`/admin/dues/projects`): 모금 중/마감 목록(모금액=확정 입금−출금·건수) → 상세: 참여자 명단(회원명, 미매칭은 입금자명)·모금액·모금 마감 토글
- **수동 등록**도 프로젝트 귀속(필수), 처리됨·회원 상세에 프로젝트명 표시
- 리뷰에서 잡은 **P0 수정**: 인박스 기본 결정이 저장된 분류·귀속·매칭을 시드하도록 변경 — 수동등록·확정취소로 재노출된 프로젝트 거래가 무조건 '회비'로 되돌아가 조용히 개인 납부로 오기록되던 경로 차단. triage 어휘 밖 분류(goods 등)는 제외 버킷으로 보내 저장값 그대로 확정

## 변경 흐름

```mermaid
flowchart LR
  P[프로젝트 생성<br/>/admin/dues/projects] --> I[인박스 triage<br/>분류=프로젝트 + 회원 + 귀속]
  I --> C[확정<br/>mem_id·project_id 저장]
  C --> D[프로젝트 상세<br/>명단·모금액]
  C -.취소 시 귀속 보존.-> I
```

## 주요 변경 사항

- `supabase/migrations/20260703090000_fee_prj_mst.sql` (dev 적용 완료, prd 적용 필요)
- `app/actions/dues/manage-projects.ts` (신규) — 생성·모금 상태 변경
- `confirm-payload.ts`/`confirm-transactions.ts` — prjId 스레딩, 프로젝트에도 memId 저장, 서버 가드
- `lib/queries/dues.ts` — getActiveProjects/getProjects/getProjectDetail, InboxTxn.projectId
- `app/(info)/admin/dues/projects/**` (신규 2화면), 인박스·수동등록·처리됨·회원상세 반영
- `lib/dues/upload-bucketize.ts` — event_fee=확인필요, 어휘 밖 분류=제외
- 테스트 134개 통과(신규 6: payload 프로젝트 규칙·bucketize)

리뷰: 정합성(sonnet) P0 1건 발견→수정, P2 2건 반영(서버 가드) / 규칙검사(haiku) 위반 없음.

## 배포 체크리스트

- [ ] prd 배포 시 마이그레이션 `20260703090000_fee_prj_mst.sql` 적용

🤖 Generated with [Claude Code](https://claude.com/claude-code)