### PR TITLE
feat(dues): 프로젝트 명단에서 바로 귀속 취소

### DIFF
--- a/app/(info)/admin/dues/projects/[prjId]/page.tsx
+++ b/app/(info)/admin/dues/projects/[prjId]/page.tsx
@@ -10,6 +10,7 @@ import { Body, Caption, H2, Micro } from "@/components/common/typography";
 import { Button } from "@/components/ui/button";
 import { CardItem } from "@/components/ui/card";
 
+import { ProjectCancelButton } from "./project-cancel-button";
 import { ProjectStatusButton } from "./project-status-button";
 
 /**
@@ -67,19 +68,22 @@ export default async function DuesProjectDetailPage({
                   {!r.memName ? " · 회원 미매칭" : ""}
                 </Micro>
               </div>
-              <Body
-                className={cn("shrink-0 font-semibold", r.io === "withdrawal" && "text-destructive")}
-              >
-                {r.io === "withdrawal" ? "-" : "+"}
-                {r.amt.toLocaleString()}원
-              </Body>
+              <div className="flex shrink-0 items-center gap-2">
+                <Body
+                  className={cn("font-semibold", r.io === "withdrawal" && "text-destructive")}
+                >
+                  {r.io === "withdrawal" ? "-" : "+"}
+                  {r.amt.toLocaleString()}원
+                </Body>
+                <ProjectCancelButton txnId={r.txnId} rawName={r.rawName} amt={r.amt} />
+              </div>
             </div>
           ))}
         </CardItem>
       )}
 
       <Caption className="text-muted-foreground">
-        잘못 귀속된 건은 거래내역 처리의 &lsquo;처리됨&rsquo;에서 취소 후 다시 처리하세요.
+        취소하면 거래가 처리 대기(인박스)로 돌아가고, 분류·회원은 그대로 남아 다시 처리할 수 있습니다.
       </Caption>
     </div>
   );

--- a/app/(info)/admin/dues/projects/[prjId]/project-cancel-button.tsx
+++ b/app/(info)/admin/dues/projects/[prjId]/project-cancel-button.tsx
@@ -1,0 +1,60 @@
+"use client";
+
+import { useState, useTransition } from "react";
+import { useRouter } from "next/navigation";
+
+import { cancelTransaction } from "@/app/actions/dues/cancel-transaction";
+
+import { Button } from "@/components/ui/button";
+
+/**
+ * 프로젝트 명단 행에서 바로 귀속을 취소한다 — '처리됨' 화면을 거치지 않는 지름길.
+ * cancelTransaction 이 확정을 해제해 거래를 인박스로 되돌리므로, 명단에서 사라지고
+ * (is_cfm_yn=false 필터) 모금액도 그만큼 줄어든다. 되돌린 행은 인박스에 분류·귀속·회원이
+ * 그대로 남아 재확정만 하면 복구된다.
+ */
+export function ProjectCancelButton({
+  txnId,
+  rawName,
+  amt,
+}: {
+  txnId: string;
+  rawName: string;
+  amt: number;
+}) {
+  const [pending, startTransition] = useTransition();
+  const [err, setErr] = useState<string | null>(null);
+  const router = useRouter();
+
+  function onCancel() {
+    if (
+      !confirm(
+        `${rawName} ${amt.toLocaleString()}원의 프로젝트 귀속을 취소하시겠습니까?\n거래가 처리 대기(인박스)로 돌아갑니다.`,
+      )
+    )
+      return;
+    setErr(null);
+    startTransition(async () => {
+      const res = await cancelTransaction(txnId);
+      if (res.ok) {
+        router.refresh();
+      } else {
+        setErr(res.message);
+        alert(res.message);
+      }
+    });
+  }
+
+  return (
+    <Button
+      type="button"
+      size="xs"
+      variant="outline"
+      disabled={pending}
+      onClick={onCancel}
+      aria-label={err ?? undefined}
+    >
+      {pending ? "취소 중…" : "취소"}
+    </Button>
+  );
+}


### PR DESCRIPTION
## 관련 이슈

관련 이슈 없음 (SP2 후속 편의 개선)

## 요약

프로젝트 참여자 명단에서 잘못 들어간 건을 그 자리에서 바로 취소할 수 있게 합니다. 지금은 '처리됨' 화면으로 이동해서 찾아 취소해야 하는데, 명단 행에 '취소' 버튼을 달아 한 번에 처리합니다.

## AS-IS → TO-BE

- **AS-IS**: 프로젝트 상세 명단은 읽기 전용. 잘못 귀속된 건은 거래내역 처리 → '처리됨' 탭으로 가서 찾아 취소해야 함
- **TO-BE**: 명단 각 행에 '취소' 버튼(confirm) → 그 자리에서 `cancelTransaction` 호출 → 거래가 인박스로 돌아가 명단에서 빠지고 모금액도 줄어듦. 분류·귀속·회원은 보존돼 재확정으로 복구 가능

## 주요 변경 사항

- `app/(info)/admin/dues/projects/[prjId]/project-cancel-button.tsx` (신규) — 명단 행 취소 버튼
- `app/(info)/admin/dues/projects/[prjId]/page.tsx` — 행에 버튼 배치, 안내 문구 갱신

기존 `cancelTransaction`을 그대로 재사용(event_fee는 확정 해제 + 회원 재계산만, 납부원장 취소·앵커 체크는 due 전용이라 건너뜀 — 확인함). DB·서버 액션 변경 없음, 테스트 134개 통과.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * 프로젝트 상세 목록의 각 거래 행에서 바로 취소할 수 있는 버튼이 추가되었습니다.
  * 취소 중에는 버튼이 비활성화되고, 완료 후 목록이 자동으로 갱신됩니다.

* **Bug Fixes**
  * 금액 표시가 거래 유형에 따라 더 명확하게 보이도록 개선되었습니다.
  * 하단 안내 문구를 업데이트해, 취소한 거래가 다시 처리 대기 상태로 돌아간다는 점을 분명히 했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->