### PR TITLE
fix(api): 미들웨어 /api 차단 해제로 홈 캘린더 참석자수 캐시 갱신 정상화

### DIFF
--- a/app/api/cron/keep-alive/route.ts
+++ b/app/api/cron/keep-alive/route.ts
@@ -8,7 +8,8 @@ export async function GET() {
     env.NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY
   );
 
-  const { error } = await supabase.from("members").select("id").limit(1);
+  // RLS로 빈 결과가 와도 무방 — 쿼리가 에러 없이 DB에 도달하기만 하면 슬립 방지 목적 달성
+  const { error } = await supabase.from("mem_mst").select("mem_id").limit(1);
 
   if (error) {
     return NextResponse.json({ ok: false, error: error.message }, { status: 500 });

--- a/app/api/og/route.ts
+++ b/app/api/og/route.ts
@@ -36,10 +36,31 @@ export async function GET(req: NextRequest) {
   }
 
   try {
-    const res = await fetch(url, {
-      headers: { "User-Agent": "Mozilla/5.0 (compatible; Googlebot/2.1)" },
-      next: { revalidate: 3600 },
-    });
+    // 리다이렉트를 수동으로 따라가며 홉마다 호스트를 재검증 —
+    // 공개 URL이 내부망으로 리다이렉트해 최초 검사를 우회하는 SSRF 방지
+    const MAX_REDIRECTS = 3;
+    let target = parsed;
+    let res: Response | undefined;
+    for (let hop = 0; hop <= MAX_REDIRECTS; hop++) {
+      res = await fetch(target.toString(), {
+        headers: { "User-Agent": "Mozilla/5.0 (compatible; Googlebot/2.1)" },
+        redirect: "manual",
+        next: { revalidate: 3600 },
+      });
+      if (res.status < 300 || res.status >= 400) break;
+
+      const location = res.headers.get("location");
+      if (!location) break;
+      const next = new URL(location, target);
+      if (!["http:", "https:"].includes(next.protocol) || isBlockedHost(next.hostname)) {
+        return NextResponse.json({ error: "invalid url" }, { status: 400 });
+      }
+      target = next;
+    }
+    // 리다이렉트 한도 초과 등으로 최종 응답을 못 얻으면 미리보기 없음 처리
+    if (!res || (res.status >= 300 && res.status < 400)) {
+      return NextResponse.json({ title: null, image: null, description: null, hostname: null });
+    }
     const html = await res.text();
 
     const get = (prop: string) => {

--- a/app/api/og/route.ts
+++ b/app/api/og/route.ts
@@ -1,8 +1,39 @@
 import { NextRequest, NextResponse } from "next/server";
 
+/**
+ * SSRF 방지: 내부망을 가리킬 수 있는 호스트 차단.
+ * 이 라우트는 임의 URL을 서버에서 fetch하므로 루프백·사설·링크로컬(메타데이터) 대역을 거부한다.
+ */
+function isBlockedHost(hostname: string): boolean {
+  const h = hostname.toLowerCase();
+  if (h === "localhost" || h.endsWith(".local") || h.endsWith(".internal")) return true;
+  // IPv6 리터럴은 링크 미리보기 용도에 불필요 — 전부 차단
+  if (h.includes(":") || h.startsWith("[")) return true;
+  const m = h.match(/^(\d{1,3})\.(\d{1,3})\.(\d{1,3})\.(\d{1,3})$/);
+  if (m) {
+    const a = Number(m[1]);
+    const b = Number(m[2]);
+    if (a === 0 || a === 10 || a === 127) return true; // 루프백·사설 A
+    if (a === 172 && b >= 16 && b <= 31) return true; // 사설 B
+    if (a === 192 && b === 168) return true; // 사설 C
+    if (a === 169 && b === 254) return true; // 링크로컬·클라우드 메타데이터
+  }
+  return false;
+}
+
 export async function GET(req: NextRequest) {
   const url = req.nextUrl.searchParams.get("url");
   if (!url) return NextResponse.json({ error: "url required" }, { status: 400 });
+
+  let parsed: URL;
+  try {
+    parsed = new URL(url);
+  } catch {
+    return NextResponse.json({ error: "invalid url" }, { status: 400 });
+  }
+  if (!["http:", "https:"].includes(parsed.protocol) || isBlockedHost(parsed.hostname)) {
+    return NextResponse.json({ error: "invalid url" }, { status: 400 });
+  }
 
   try {
     const res = await fetch(url, {

--- a/lib/supabase/proxy.ts
+++ b/lib/supabase/proxy.ts
@@ -24,7 +24,8 @@ export async function updateSession(request: NextRequest) {
   const isPublic =
     publicPaths.includes(pathname) ||
     pathname.startsWith("/auth") ||
-    pathname.startsWith("/api");
+    pathname === "/api" ||
+    pathname.startsWith("/api/");
 
   // 세션 쿠키가 아예 없으면 Supabase 서버 호출 없이 즉시 리다이렉트 (100~700ms 절약)
   // Supabase는 토큰이 크면 쿠키를 청크 분할함 (sb-*-auth-token.0, .1, ...)

--- a/lib/supabase/proxy.ts
+++ b/lib/supabase/proxy.ts
@@ -19,8 +19,12 @@ export async function updateSession(request: NextRequest) {
   // 비로그인 상태에서도 접근 가능한 공개 경로 목록
   const pathname = request.nextUrl.pathname;
   const publicPaths = ["/", "/rules", "/join", "/newbie", "/races", "/records", "/projects", "/terms", "/privacy", "/policy", "/settings"];
+  // /api/* 는 각 라우트가 자체 인증(멤버 체크·웹훅 시크릿)을 수행하므로 리다이렉트 제외.
+  // 쿠키 없는 서버-투-서버 요청(revalidate 웹훅, OG 봇, 크론)을 로그인 페이지로 보내면 안 됨.
   const isPublic =
-    publicPaths.includes(pathname) || pathname.startsWith("/auth");
+    publicPaths.includes(pathname) ||
+    pathname.startsWith("/auth") ||
+    pathname.startsWith("/api");
 
   // 세션 쿠키가 아예 없으면 Supabase 서버 호출 없이 즉시 리다이렉트 (100~700ms 절약)
   // Supabase는 토큰이 크면 쿠키를 청크 분할함 (sb-*-auth-token.0, .1, ...)

--- a/supabase/migrations/20260705130000_revalidate_records_use_pg_net.sql
+++ b/supabase/migrations/20260705130000_revalidate_records_use_pg_net.sql
@@ -1,0 +1,46 @@
+-- revalidate_records()를 net.http_post(pg_net, 비동기)로 통일.
+-- 기존 dev는 extensions.http_post(http 확장, 동기)를 사용해 두 가지 문제가 있었다:
+--   1. 트리거가 걸린 테이블의 모든 쓰기 트랜잭션이 HTTP 응답을 기다림 (수백 ms 지연)
+--   2. pg_net만 설치된 환경(prd)에서는 함수가 조용히 실패 (EXCEPTION 핸들러가 삼킴)
+-- prd는 이미 net.http_post를 사용 중이라 이 마이그레이션은 no-op.
+-- pg_net은 요청을 큐에 쌓고 커밋 후 백그라운드 워커가 발송하므로 트랜잭션을 막지 않는다.
+
+CREATE OR REPLACE FUNCTION public.revalidate_records()
+RETURNS trigger
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path TO 'pg_catalog', 'public', 'extensions', 'vault'
+AS $$
+DECLARE
+  _secret text;
+  _revalidate_url text;
+BEGIN
+  SELECT decrypted_secret INTO _secret
+  FROM vault.decrypted_secrets
+  WHERE name = 'revalidate_secret'
+  LIMIT 1;
+
+  SELECT decrypted_secret INTO _revalidate_url
+  FROM vault.decrypted_secrets
+  WHERE name = 'revalidate_url'
+  LIMIT 1;
+
+  IF _revalidate_url IS NULL THEN
+    RAISE WARNING 'revalidate_records: revalidate_url not found in vault';
+    RETURN NULL;
+  END IF;
+
+  PERFORM net.http_post(
+    url := _revalidate_url,
+    headers := jsonb_build_object(
+      'Content-Type', 'application/json',
+      'x-webhook-secret', _secret
+    ),
+    body := '{}'::jsonb
+  );
+  RETURN NULL;
+EXCEPTION WHEN OTHERS THEN
+  RAISE WARNING 'revalidate_records failed: %', SQLERRM;
+  RETURN NULL;
+END;
+$$;


### PR DESCRIPTION
## 관련 이슈

관련 이슈 없음

## 요약

홈탭 캘린더뷰·리스트뷰의 모임 참석자수가 실제와 어긋나던 문제의 근본 원인(인증 미들웨어가 쿠키 없는 revalidation 웹훅을 로그인 페이지로 리다이렉트)을 수정한다. 점검 과정에서 발견된 keep-alive 크론의 죽은 테이블 참조, `/api/og` SSRF 여지, dev/prd 간 `revalidate_records()` 드리프트도 함께 해결한다.

## AS-IS (변경 전)

- `lib/supabase/proxy.ts`의 인증 미들웨어가 세션 쿠키 없는 모든 요청을 `/auth/login`으로 307 리다이렉트
- 이 때문에 DB 트리거 → pg_net 웹훅 → `POST /api/revalidate` 경로가 `307 → /auth/login → 405`로 실패, `home-calendar` 캐시가 영영 무효화되지 않아 홈탭 참석자수가 옛 값에 고정 (모임 상세는 실시간 조회라 숫자가 서로 다르게 보임)
- 같은 이유로 `/api/og`(링크 미리보기), `/api/cron/keep-alive`, 기존 `/records` revalidation 웹훅까지 쿠키 없는 외부 호출 전부 차단된 상태
- keep-alive 크론은 v2 스키마에서 사라진 `members` 테이블을 조회 (미들웨어에 가려 드러나지 않던 500)
- `revalidate_records()`가 dev는 `extensions.http_post`(동기), prd는 `net.http_post`(비동기)로 달라 소스·환경 간 드리프트 존재

## TO-BE (변경 후)

- 미들웨어에서 `/api/*`를 리다이렉트 대상에서 제외 — 각 API 라우트는 자체 인증(웹훅 시크릿·멤버 체크) 수행, 로그인 브라우저 요청의 토큰 갱신은 기존대로 동작
- 참석 토글 → 트리거 → 웹훅 → `revalidateTag("home-calendar")` 경로가 끝까지 연결되어 홈탭 참석자수가 실제와 동기화
- `app/api/cron/keep-alive/route.ts`: `mem_mst` 조회로 교체해 슬립 방지 크론 정상화
- `app/api/og/route.ts`: 공개 전환에 따른 SSRF 가드 추가 (http/https 스킴 제한, localhost·사설·링크로컬 대역 차단)
- `supabase/migrations/20260705130000_revalidate_records_use_pg_net.sql`: `net.http_post`(pg_net, 비동기)로 통일 — dev 적용 완료, prd는 no-op

## 변경 흐름 (Mermaid)

```mermaid
sequenceDiagram
    participant U as 유저 (참석 토글)
    participant DB as Supabase (트리거 + pg_net)
    participant MW as 미들웨어
    participant API as /api/revalidate

    U->>DB: gthr_attd_rel INSERT/DELETE
    DB->>MW: POST /api/revalidate (쿠키 없음)
    rect rgb(255, 230, 230)
    Note over MW: AS-IS: 307 → /auth/login → 405<br/>캐시 무효화 실패
    end
    rect rgb(230, 255, 230)
    Note over MW: TO-BE: /api/* 리다이렉트 제외
    MW->>API: 통과
    API->>API: 시크릿 검증 → revalidateTag("home-calendar")
    end
```

## 배포 후 확인

1. `curl -X POST https://gigang.team/api/revalidate` → 307 대신 `401 Unauthorized`(JSON)면 정상
2. 아무 모임 참석 토글 → 홈탭 참석자수 즉시 갱신 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * 공개 API 요청에 대한 인증 우회 처리가 개선되어, 서버 간 요청이나 크론 작업에서 불필요한 로그인 리다이렉트가 줄었습니다.
  * 이미지 생성용 엔드포인트에서 위험한 URL 입력을 차단해 더 안전하게 처리합니다.

* **Bug Fixes**
  * 유지용 요청이 데이터베이스에 정상 도달하면 슬립 방지로 간주하도록 동작을 정리했습니다.
  * 기록 재검증 요청이 더 안정적으로 전달되도록 처리 방식이 개선되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->