### PR TITLE
perf(api): 테이블별 캐시 무효화로 불필요한 캐시 재구축 제거

### DIFF
--- a/app/(protected)/onboarding/page.tsx
+++ b/app/(protected)/onboarding/page.tsx
@@ -31,10 +31,11 @@ async function OnboardingContent({
   }
 
   // OAuth 프로필 사진 URL 추출 (카카오: avatar_url/picture, 구글: picture/avatar_url)
-  const initialAvatarUrl =
+  const rawAvatarUrl =
     user.user_metadata?.picture ??
     user.user_metadata?.avatar_url ??
     null;
+  const initialAvatarUrl = typeof rawAvatarUrl === "string" ? rawAvatarUrl : null;
 
   // OAuth 이름 후보 추출 — 한글 2~5자만 prefill(검증 통과 값), 그 외는 빈 값
   const rawName =

--- a/app/actions/comment/manage-comment.ts
+++ b/app/actions/comment/manage-comment.ts
@@ -1,6 +1,5 @@
 "use server"
 
-import { revalidatePath } from "next/cache"
 import { after } from "next/server"
 
 import { dayjs } from "@/lib/dayjs"
@@ -118,7 +117,6 @@ export async function createComment(input: CreateCommentInput) {
       }
     })
 
-    revalidatePath("/")
     return { ok: true as const, data: cmnt }
   })
 }
@@ -147,7 +145,6 @@ export async function updateComment(input: UpdateCommentInput) {
       await admin.from("cmnt_mention_rel").insert(uniqueMentions.map((memId) => ({ cmnt_id: parsed.cmntId, mem_id: memId })))
     }
 
-    revalidatePath("/")
     return { ok: true as const }
   })
 }
@@ -169,7 +166,6 @@ export async function deleteComment(input: DeleteCommentInput) {
 
     if (error) return { ok: false as const, message: "댓글 삭제 실패" }
 
-    revalidatePath("/")
     return { ok: true as const }
   })
 }

--- a/app/actions/gathering/manage-gathering.ts
+++ b/app/actions/gathering/manage-gathering.ts
@@ -96,7 +96,7 @@ export async function createGathering(input: {
       }
     });
 
-    revalidatePath("/");
+    // 홈(/)은 dynamic 렌더라 revalidatePath("/")는 no-op — 갱신은 클라이언트 재조회(refreshMonthData) + DB 트리거 웹훅이 담당
     return { gthr_id: gthrId, short_id: data.short_id };
   });
 }
@@ -175,7 +175,7 @@ export async function updateGathering(input: {
       }
     });
 
-    revalidatePath("/");
+    // 홈은 클라이언트 재조회가 갱신 담당 — 직접 URL 방문 대비 모임 상세만 무효화
     revalidatePath(`/gatherings/${input.gthr_id}`);
   });
 }
@@ -231,6 +231,5 @@ export async function deleteGathering(gthr_id: string) {
       }
     });
 
-    revalidatePath("/");
   });
 }

--- a/app/actions/schedule/manage-sch-post.ts
+++ b/app/actions/schedule/manage-sch-post.ts
@@ -1,6 +1,5 @@
 "use server";
 
-import { revalidatePath } from "next/cache";
 import { after } from "next/server";
 
 import { dayjs } from "@/lib/dayjs";
@@ -76,7 +75,6 @@ export async function createSchPost(input: {
       }
     });
 
-    revalidatePath("/");
     return { sch_post_id: postId };
   });
 }
@@ -124,7 +122,6 @@ export async function updateSchPost(input: {
 
     if (error) throw new Error("수정 권한이 없거나 일정 수정에 실패했습니다.");
 
-    revalidatePath("/");
   });
 }
 
@@ -152,6 +149,5 @@ export async function deleteSchPost(sch_post_id: string) {
       .eq("sch_post_id", sch_post_id);
     if (error) throw new Error("일정 삭제에 실패했습니다.");
 
-    revalidatePath("/");
   });
 }

--- a/app/api/revalidate/route.ts
+++ b/app/api/revalidate/route.ts
@@ -1,4 +1,3 @@
-import { revalidatePath } from "next/cache";
 import { revalidateTag } from "next/cache";
 import { NextRequest, NextResponse } from "next/server";
 import { COMMON_CODES_CACHE_TAG } from "@/lib/common-codes-cache-tag";
@@ -12,8 +11,8 @@ const COMP_TABLES = new Set(["comp_mst", "team_comp_plan_rel", "comp_reg_rel"]);
 /** 랭킹(/records)에 반영되는 테이블 */
 const RECORDS_TABLES = new Set(["personal_best", "utmb_profile"]);
 
+// 홈(/)·랭킹(/records)은 dynamic 렌더라 revalidatePath는 no-op — 태그 무효화만 수행
 function revalidateHomeCalendar() {
-  revalidatePath("/");
   revalidateTag(HOME_CALENDAR_CACHE_TAG, "max");
 }
 
@@ -24,7 +23,6 @@ function revalidateCompetitions() {
 }
 
 function revalidateRecords() {
-  revalidatePath("/records");
   // /records 의 unstable_cache(tags: "records", `records:${teamId}`)
   revalidateTag("records", "max");
 }

--- a/app/api/revalidate/route.ts
+++ b/app/api/revalidate/route.ts
@@ -5,6 +5,38 @@ import { COMMON_CODES_CACHE_TAG } from "@/lib/common-codes-cache-tag";
 import { env } from "@/lib/env";
 import { HOME_CALENDAR_CACHE_TAG } from "@/lib/queries/home-calendar";
 
+/** 홈 캘린더 데이터에 반영되는 테이블 (모임·참석·일정포스트·댓글 카운트) */
+const HOME_TABLES = new Set(["gthr_mst", "gthr_attd_rel", "sch_post_mst", "cmnt_mst"]);
+/** 대회 목록·등록 카운트에 반영되는 테이블 (홈 캘린더에도 대회가 표시되므로 함께 무효화) */
+const COMP_TABLES = new Set(["comp_mst", "team_comp_plan_rel", "comp_reg_rel"]);
+/** 랭킹(/records)에 반영되는 테이블 */
+const RECORDS_TABLES = new Set(["personal_best", "utmb_profile"]);
+
+function revalidateHomeCalendar() {
+  revalidatePath("/");
+  revalidateTag(HOME_CALENDAR_CACHE_TAG, "max");
+}
+
+function revalidateCompetitions() {
+  revalidateTag("competitions", "max");
+  // 대회는 홈 캘린더에도 표시됨 (reg_count 포함)
+  revalidateHomeCalendar();
+}
+
+function revalidateRecords() {
+  revalidatePath("/records");
+  // /records 의 unstable_cache(tags: "records", `records:${teamId}`)
+  revalidateTag("records", "max");
+}
+
+/** 테이블 정보가 없거나 매핑에 없는 테이블 → 기존 동작대로 전체 무효화 (하위호환 폴백) */
+function revalidateAll() {
+  revalidateHomeCalendar();
+  revalidateCompetitions();
+  revalidateRecords();
+  revalidateTag(COMMON_CODES_CACHE_TAG, "max");
+}
+
 export async function POST(request: NextRequest) {
   const secret = request.headers.get("x-webhook-secret");
 
@@ -12,14 +44,28 @@ export async function POST(request: NextRequest) {
     return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
   }
 
-  revalidatePath("/records");
-  revalidatePath("/");
-  revalidateTag("competitions", "max");
-  revalidateTag(COMMON_CODES_CACHE_TAG, "max");
-  // /records 의 unstable_cache(tags: "records", `records:${teamId}`)
-  revalidateTag("records", "max");
-  // 홈 캘린더 캐시 무효화 (대회·일정포스트·모임 변경 시)
-  revalidateTag(HOME_CALENDAR_CACHE_TAG, "max");
+  // DB 트리거(revalidate_records)가 body에 변경 테이블명을 실어 보냄
+  let table: string | null = null;
+  try {
+    const payload = await request.json();
+    if (typeof payload?.table === "string") table = payload.table;
+  } catch {
+    // body가 비었거나 JSON이 아니면 전체 무효화 폴백
+  }
 
-  return NextResponse.json({ revalidated: true });
+  if (table === null) {
+    revalidateAll();
+  } else if (HOME_TABLES.has(table)) {
+    revalidateHomeCalendar();
+  } else if (COMP_TABLES.has(table)) {
+    revalidateCompetitions();
+  } else if (RECORDS_TABLES.has(table)) {
+    revalidateRecords();
+  } else if (table === "cmm_cd_mst") {
+    revalidateTag(COMMON_CODES_CACHE_TAG, "max");
+  } else {
+    revalidateAll();
+  }
+
+  return NextResponse.json({ revalidated: true, table });
 }

--- a/app/api/revalidate/route.ts
+++ b/app/api/revalidate/route.ts
@@ -10,6 +10,8 @@ const HOME_TABLES = new Set(["gthr_mst", "gthr_attd_rel", "sch_post_mst", "cmnt_
 const COMP_TABLES = new Set(["comp_mst", "team_comp_plan_rel", "comp_reg_rel"]);
 /** 랭킹(/records)에 반영되는 테이블 */
 const RECORDS_TABLES = new Set(["personal_best", "utmb_profile"]);
+/** 공통코드 캐시에 반영되는 테이블 */
+const CMM_CD_TABLES = new Set(["cmm_cd_mst"]);
 
 // 홈(/)·랭킹(/records)은 dynamic 렌더라 revalidatePath는 no-op — 태그 무효화만 수행
 function revalidateHomeCalendar() {
@@ -59,7 +61,7 @@ export async function POST(request: NextRequest) {
     revalidateCompetitions();
   } else if (RECORDS_TABLES.has(table)) {
     revalidateRecords();
-  } else if (table === "cmm_cd_mst") {
+  } else if (CMM_CD_TABLES.has(table)) {
     revalidateTag(COMMON_CODES_CACHE_TAG, "max");
   } else {
     revalidateAll();

--- a/lib/queries/home-calendar.ts
+++ b/lib/queries/home-calendar.ts
@@ -1,6 +1,5 @@
 import "server-only";
 
-import { cache } from "react";
 import { unstable_cache } from "next/cache";
 
 import { gridDateRange } from "@/lib/dayjs";
@@ -53,16 +52,16 @@ function createCachedHomeCalendar(teamId: string, year: number, month: number) {
   return unstable_cache(
     () => loadHomeCalendar(teamId, year, month),
     [`home-calendar-${teamId}-${year}-${month}`],
-    { tags: [HOME_CALENDAR_CACHE_TAG] },
+    // revalidate: 무효화 주경로는 DB 트리거 웹훅(revalidateTag)이고,
+    // 시간 만료는 웹훅 유실 시 영구 stale을 막는 안전망 (stale-while-revalidate라 대기 유저 없음)
+    { tags: [HOME_CALENDAR_CACHE_TAG], revalidate: 3600 },
   );
 }
 
 /**
  * 홈 캘린더 공개 데이터 (대회·일정포스트·모임) 캐시 조회.
- * - `unstable_cache`: 요청 간 Next.js 데이터 캐시 (on-demand revalidation 전용)
- * - `cache()`: 동일 렌더 내 중복 호출 제거
+ * `unstable_cache`: 요청 간 Next.js 데이터 캐시 (웹훅 태그 무효화 + 1시간 만료 안전망)
  */
-export const getCachedHomeCalendar = cache(
-  async (teamId: string, year: number, month: number) =>
-    createCachedHomeCalendar(teamId, year, month)(),
-);
+export async function getCachedHomeCalendar(teamId: string, year: number, month: number) {
+  return createCachedHomeCalendar(teamId, year, month)();
+}

--- a/lib/queries/member.ts
+++ b/lib/queries/member.ts
@@ -21,16 +21,39 @@ export type { AppMemberProfile };
  *
  * @see {@link verifyAdmin} 팀 관리자(owner/admin) 확인
  */
+/**
+ * JWT 클레임 기반 경량 유저.
+ * `auth.getUser()`(Auth 서버 왕복) 대신 `getClaims()`(로컬 서명 검증, 왕복 0회)를 쓴다 —
+ * 미들웨어(proxy.ts)가 이미 같은 기준으로 세션을 검증하고, 권한 판정은 DB(team_mem_rel)로 하므로
+ * 신뢰 수준 저하 없이 모든 dynamic 페이지 TTFB에서 Auth 왕복 1회를 제거한다.
+ * 트레이드오프: 강제 로그아웃·계정 삭제가 액세스 토큰 만료까지 반영 지연 (미들웨어와 동일 기준).
+ */
+export type AuthClaimsUser = {
+  id: string;
+  email?: string;
+  // supabase User와 동일하게 느슨한 타입 유지 (기존 소비처 호환)
+  user_metadata: Record<string, unknown>;
+  app_metadata: Record<string, unknown>;
+};
+
 export const getCurrentMember = cache(async () => {
   const supabase = await createClient();
 
-  // auth.getUser()와 getRequestTeamContext()는 서로 의존하지 않으므로 병렬 실행
-  const [{ data: { user } }, { teamId }] = await Promise.all([
-    supabase.auth.getUser(),
+  // getClaims()와 getRequestTeamContext()는 서로 의존하지 않으므로 병렬 실행
+  const [{ data: claimsData }, { teamId }] = await Promise.all([
+    supabase.auth.getClaims(),
     getRequestTeamContext(),
   ]);
 
-  if (!user) return { user: null, member: null, supabase };
+  const claims = claimsData?.claims;
+  if (!claims?.sub) return { user: null, member: null, supabase };
+
+  const user: AuthClaimsUser = {
+    id: claims.sub,
+    email: typeof claims.email === "string" ? claims.email : undefined,
+    user_metadata: (claims.user_metadata ?? {}) as Record<string, unknown>,
+    app_metadata: (claims.app_metadata ?? {}) as Record<string, unknown>,
+  };
 
   validateUUID(user.id);
 

--- a/supabase/migrations/20260705150000_revalidate_records_send_table.sql
+++ b/supabase/migrations/20260705150000_revalidate_records_send_table.sql
@@ -28,6 +28,12 @@ BEGIN
     RETURN NULL;
   END IF;
 
+  -- 시크릿 누락 시 웹훅이 401로 조용히 실패하므로 원인 추적용 경고를 남기고 중단
+  IF _secret IS NULL THEN
+    RAISE WARNING 'revalidate_records: revalidate_secret not found in vault';
+    RETURN NULL;
+  END IF;
+
   PERFORM net.http_post(
     url := _revalidate_url,
     headers := jsonb_build_object(

--- a/supabase/migrations/20260705150000_revalidate_records_send_table.sql
+++ b/supabase/migrations/20260705150000_revalidate_records_send_table.sql
@@ -1,0 +1,44 @@
+-- revalidate_records() 웹훅 body에 변경 테이블명(TG_TABLE_NAME)을 포함.
+-- /api/revalidate가 테이블 → 캐시 태그 매핑으로 관련 캐시만 무효화할 수 있게 한다.
+-- (기존: 어느 테이블이 바뀌든 모든 태그 전체 무효화 → 참석 토글 1건에 랭킹 캐시까지 재구축)
+-- 구버전 라우트는 body를 무시하므로 배포 순서와 무관하게 안전하다.
+
+CREATE OR REPLACE FUNCTION public.revalidate_records()
+RETURNS trigger
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path TO 'pg_catalog', 'public', 'extensions', 'vault'
+AS $$
+DECLARE
+  _secret text;
+  _revalidate_url text;
+BEGIN
+  SELECT decrypted_secret INTO _secret
+  FROM vault.decrypted_secrets
+  WHERE name = 'revalidate_secret'
+  LIMIT 1;
+
+  SELECT decrypted_secret INTO _revalidate_url
+  FROM vault.decrypted_secrets
+  WHERE name = 'revalidate_url'
+  LIMIT 1;
+
+  IF _revalidate_url IS NULL THEN
+    RAISE WARNING 'revalidate_records: revalidate_url not found in vault';
+    RETURN NULL;
+  END IF;
+
+  PERFORM net.http_post(
+    url := _revalidate_url,
+    headers := jsonb_build_object(
+      'Content-Type', 'application/json',
+      'x-webhook-secret', _secret
+    ),
+    body := jsonb_build_object('table', TG_TABLE_NAME)
+  );
+  RETURN NULL;
+EXCEPTION WHEN OTHERS THEN
+  RAISE WARNING 'revalidate_records failed: %', SQLERRM;
+  RETURN NULL;
+END;
+$$;


### PR DESCRIPTION
## 관련 이슈

관련 이슈 없음

## 요약

revalidation 웹훅이 어느 테이블이 바뀌든 모든 캐시 태그를 전체 무효화하던 구조를 테이블 → 관련 태그만 무효화하도록 개선하고, 성능 점검에서 나온 개선안 3건(getClaims 전환·캐시 안전망·죽은 코드 정리)을 함께 반영한다.

## AS-IS (변경 전)

- 웹훅이 **무조건 전체 무효화**: 참석 토글 1건에 랭킹·대회·공통코드 캐시까지 재구축 → 직후 각 페이지 첫 방문자가 전부 DB 재조회 대기
- `getCurrentMember`가 매 dynamic 페이지 렌더마다 `auth.getUser()`(Auth 서버 왕복) 실행 — 미들웨어 `getClaims()`와 이중 검증이며 TTFB 크리티컬 패스에 왕복 1회 추가
- 홈 캘린더 캐시(`home-calendar`)에 시간 만료가 없어 웹훅 유실 시 영구 stale
- dynamic 페이지 대상 no-op `revalidatePath("/")` 9곳 + 호출자 1곳뿐인 `cache()` 이중 래퍼

## TO-BE (변경 후)

**1. 테이블별 캐시 무효화** — `revalidate_records()`가 웹훅 body에 `{ "table": TG_TABLE_NAME }` 포함 (마이그레이션, dev·prd 적용 완료). `/api/revalidate`가 매핑으로 필요한 캐시만 무효화:

| 변경 테이블 | 무효화 대상 |
|------------|-----------|
| `gthr_mst` / `gthr_attd_rel` / `sch_post_mst` / `cmnt_mst` | 홈 캘린더 |
| `comp_mst` / `team_comp_plan_rel` / `comp_reg_rel` | 대회 목록 + 홈 캘린더 |
| `personal_best` / `utmb_profile` | 랭킹 |
| `cmm_cd_mst` | 공통코드 |
| 정보 없음 / 미지의 테이블 | 전체 무효화 (하위호환 폴백) |

배포 순서 안전: 구함수+신라우트 → 폴백 전체 무효화, 신함수+구라우트 → body 무시.

**2. `getUser()` → `getClaims()` 전환** — 로컬 ES256 서명 검증(왕복 0회)으로 모든 dynamic 페이지 TTFB ~50–150ms 단축. 미들웨어와 동일 신뢰 기준이며 권한 판정은 기존대로 DB(team_mem_rel). 민감 지점(로그인 콜백·온보딩 확정)은 `getUser()` 유지. 프로젝트 JWKS에서 ES256 비대칭 키 확인 완료.

**3. 홈 캐시 안전망** — `revalidate: 3600` 추가. 웹훅 장애 시에도 최대 1시간 내 자동 복구 (stale-while-revalidate라 대기 유저 없음).

**4. 죽은 코드 정리** — dynamic 페이지 대상 no-op `revalidatePath("/")` 9곳 제거(홈 갱신은 클라이언트 재조회 + 트리거 웹훅이 담당), `cache()` 이중 래퍼 제거.

## 변경 흐름 (Mermaid)

```mermaid
flowchart TD
    A[테이블 변경] --> B[revalidate_records 트리거]
    B --> C["POST /api/revalidate<br/>body: { table }"]
    C --> D{table 매핑}
    D -->|모임·참석·일정·댓글| E[home-calendar만 무효화]
    D -->|대회 관련| F[competitions + home-calendar]
    D -->|기록 관련| G[records만 무효화]
    D -->|정보 없음·미지| H[전체 무효화 폴백]
```

## 검증

- 타입체크·린트·vitest 134개 통과
- dev 서버 구동 스모크 테스트: `/`·`/races`·`/records` 200, 비로그인 `/profile` → 로그인 리다이렉트 정상, 서버 로그 에러 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * 변경된 항목에 따라 필요한 부분만 다시 불러오도록 업데이트되어, 화면 갱신이 더 빠르고 효율적으로 동작합니다.

* **Bug Fixes**
  * 일부 프로필 이미지가 잘못 처리되던 문제를 개선해, 올바른 이미지 URL만 사용하도록 정리했습니다.
  * 댓글, 일정, 모임, 게시글 변경 후 불필요한 전체 새로고침을 줄여 더 안정적인 반영이 되도록 했습니다.

* **Performance**
  * 현재 사용자 확인과 홈 데이터 조회 성능이 개선되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->