### PR TITLE
feat(home): 주간 일정 카톡 공유 기능 추가

### DIFF
--- a/components/common/share-sheet.tsx
+++ b/components/common/share-sheet.tsx
@@ -11,6 +11,7 @@ import {
   ResponsiveDrawerTitle,
   ResponsiveDrawerDescription,
 } from "@/components/common/responsive-drawer";
+import { Caption } from "@/components/common/typography";
 import { Button } from "@/components/ui/button";
 
 type ShareSheetProps = {
@@ -31,6 +32,8 @@ type ShareSheetProps = {
    * (모임처럼 도메인별로 멘트를 다듬고 싶을 때 사용)
    */
   shareText?: string;
+  /** 시트 상단 제목 (기본 "공유하기") — 주간 일정 등 용도별 문구 지정용 */
+  headerTitle?: string;
 };
 
 export function ShareSheet({
@@ -43,6 +46,7 @@ export function ShareSheet({
   contentUrl,
   pageUrl,
   shareText,
+  headerTitle = "공유하기",
 }: ShareSheetProps) {
   const [copiedText, setCopiedText] = useState(false);
 
@@ -92,11 +96,18 @@ export function ShareSheet({
         drawerClassName="h-auto"
       >
         <ResponsiveDrawerHeader className="border-b border-border px-4 py-4 text-left">
-          <ResponsiveDrawerTitle>공유하기</ResponsiveDrawerTitle>
+          <ResponsiveDrawerTitle>{headerTitle}</ResponsiveDrawerTitle>
           <ResponsiveDrawerDescription className="sr-only">공유 옵션</ResponsiveDrawerDescription>
         </ResponsiveDrawerHeader>
 
         <div className="flex flex-col gap-2 p-4">
+          {/* 공유될 본문 미리보기 — 보내기 전에 무엇이 나가는지 그대로 보여준다 */}
+          <div className="max-h-44 overflow-y-auto rounded-xl border border-border bg-muted px-3.5 py-3">
+            <Caption className="whitespace-pre-wrap break-words leading-relaxed">
+              {buildText()}
+            </Caption>
+          </div>
+
           <button
             type="button"
             onClick={handleCopyText}

--- a/components/home/__tests__/build-weekly-share-text.test.ts
+++ b/components/home/__tests__/build-weekly-share-text.test.ts
@@ -1,0 +1,113 @@
+import { describe, expect, it } from "vitest";
+
+import { dayjs } from "@/lib/dayjs";
+
+import { buildWeeklyShareText, currentWeekRangeKST } from "@/components/home/build-weekly-share-text";
+import type { CalendarRace } from "@/components/home/mini-calendar";
+
+const ORIGIN = "https://gigang.team";
+
+function makeRace(partial: Partial<CalendarRace> & Pick<CalendarRace, "id" | "title" | "start_date" | "type">): CalendarRace {
+  return { ...partial } as CalendarRace;
+}
+
+/** 테스트가 실행 요일과 무관하게 통과하도록 오늘/주말 기준 날짜를 쓴다 */
+const today = dayjs().tz("Asia/Seoul").format("YYYY-MM-DD");
+const yesterday = dayjs(today).subtract(1, "day").format("YYYY-MM-DD");
+
+function atKST(date: string, time: string): string {
+  return dayjs.tz(`${date} ${time}`, "Asia/Seoul").toISOString();
+}
+
+describe("currentWeekRangeKST", () => {
+  it("월요일 시작 ~ 일요일 끝이며 오늘을 포함한다", () => {
+    const { start, end } = currentWeekRangeKST();
+    expect(dayjs(start).day()).toBe(1); // 월요일
+    expect(dayjs(end).day()).toBe(0); // 일요일
+    expect(dayjs(end).diff(dayjs(start), "day")).toBe(6);
+    expect(start <= today && today <= end).toBe(true);
+  });
+});
+
+describe("buildWeeklyShareText", () => {
+  const { end } = currentWeekRangeKST();
+
+  it("남은 일정이 없으면 null을 반환한다", () => {
+    const races = [makeRace({ id: "a", title: "어제 모임", start_date: yesterday, type: "gathering" })];
+    expect(buildWeeklyShareText(races, ORIGIN)).toBeNull();
+  });
+
+  it("지난 요일·다음 주는 빼고 남은 일정만 시간순으로 담는다", () => {
+    const nextWeek = dayjs(end).add(1, "day").format("YYYY-MM-DD");
+    const races = [
+      makeRace({ id: "later", title: "주말 모임", start_date: end, type: "gathering", regCount: 3, evt_stt_at: atKST(end, "20:00") }),
+      makeRace({ id: "past", title: "어제 모임", start_date: yesterday, type: "gathering" }),
+      makeRace({ id: "out", title: "다음 주 모임", start_date: nextWeek, type: "gathering" }),
+      makeRace({ id: "earlier", title: "오늘 대회", start_date: today, type: "gigang", regCount: 2, evt_stt_at: atKST(today, "07:00") }),
+    ];
+    const text = buildWeeklyShareText(races, ORIGIN)!;
+    expect(text).toContain("이번 주 기강 일정");
+    expect(text).toContain(ORIGIN);
+    expect(text).not.toContain("어제 모임");
+    expect(text).not.toContain("다음 주 모임");
+    expect(text.indexOf("오늘 대회")).toBeLessThan(text.indexOf("주말 모임"));
+    // 대회도 모임과 동일하게 인원수만 표기
+    expect(text).toContain("오늘 대회 — 2명");
+    expect(text).toContain("주말 모임 — 3명");
+  });
+
+  it("같은 대회가 중복(id)으로 들어와도 한 번만 담는다", () => {
+    const races = [
+      makeRace({ id: "dup", title: "중복 대회", start_date: today, type: "mine", regCount: 1 }),
+      makeRace({ id: "dup", title: "중복 대회", start_date: today, type: "gigang", regCount: 1 }),
+    ];
+    const text = buildWeeklyShareText(races, ORIGIN)!;
+    expect(text.match(/중복 대회/g)).toHaveLength(1);
+  });
+
+  it("정원 있는 모임은 n/m명, 시간 있는 항목은 HH:mm을 표기한다", () => {
+    const races = [
+      makeRace({ id: "g", title: "정원 모임", start_date: today, type: "gathering_mine", regCount: 5, maxPrtCnt: 10, evt_stt_at: atKST(today, "07:30") }),
+    ];
+    const text = buildWeeklyShareText(races, ORIGIN)!;
+    expect(text).toContain("5/10명");
+    expect(text).toContain("07:30");
+  });
+
+  it("기준 날짜를 주면 그 주(월~일) 전체를 담고 '이번 주' 접두어를 뺀다", () => {
+    const nextMonday = dayjs(end).add(1, "day").format("YYYY-MM-DD");
+    const nextSunday = dayjs(nextMonday).add(6, "day").format("YYYY-MM-DD");
+    const races = [
+      makeRace({ id: "n1", title: "다음주 월요 모임", start_date: nextMonday, type: "gathering" }),
+      makeRace({ id: "n2", title: "다음주 일요 대회", start_date: nextSunday, type: "gigang", regCount: 4 }),
+    ];
+    // 다음 주 수요일을 선택한 상황
+    const wednesday = dayjs(nextMonday).add(2, "day").format("YYYY-MM-DD");
+    const text = buildWeeklyShareText(races, ORIGIN, "all", wednesday)!;
+    expect(text).toContain("다음주 월요 모임"); // 기준일 이전 요일도 미래 주면 포함
+    expect(text).toContain("다음주 일요 대회 — 4명");
+    expect(text).not.toContain("이번 주"); // 미래 주는 범위만 표기
+  });
+
+  it("지난 주를 선택하면 전부 지난 일정이라 null", () => {
+    const { start } = currentWeekRangeKST();
+    const lastWednesday = dayjs(start).subtract(5, "day").format("YYYY-MM-DD");
+    const races = [
+      makeRace({ id: "p1", title: "지난주 모임", start_date: lastWednesday, type: "gathering" }),
+    ];
+    expect(buildWeeklyShareText(races, ORIGIN, "all", lastWednesday)).toBeNull();
+  });
+
+  it("필터가 걸려 있으면 해당 종류만 담고 헤더에 필터명을 쓴다", () => {
+    const races = [
+      makeRace({ id: "g1", title: "모임A", start_date: today, type: "gathering" }),
+      makeRace({ id: "c1", title: "대회B", start_date: today, type: "gigang" }),
+    ];
+    const text = buildWeeklyShareText(races, ORIGIN, "gathering")!;
+    expect(text).toContain("이번 주 기강 모임");
+    expect(text).toContain("모임A");
+    expect(text).not.toContain("대회B");
+    // 필터에 맞는 항목이 없으면 null
+    expect(buildWeeklyShareText([races[1]], ORIGIN, "gathering")).toBeNull();
+  });
+});

--- a/components/home/build-weekly-share-text.ts
+++ b/components/home/build-weekly-share-text.ts
@@ -1,0 +1,97 @@
+import { dayjs } from "@/lib/dayjs";
+
+import { matchesFilter, type FilterType } from "@/components/home/schedule-filter";
+
+import type { CalendarRace } from "@/components/home/mini-calendar";
+
+const KST = "Asia/Seoul";
+
+/** 기준 날짜('YYYY-MM-DD')가 속한 주(월~일, KST)의 시작·끝 */
+export function weekRangeKST(baseDate: string): { start: string; end: string } {
+  const base = dayjs.tz(baseDate, KST).startOf("day");
+  const monday = base.subtract((base.day() + 6) % 7, "day"); // day(): 일=0 → 월요일로 당김
+  return { start: monday.format("YYYY-MM-DD"), end: monday.add(6, "day").format("YYYY-MM-DD") };
+}
+
+/** 오늘이 속한 주(월~일, KST) */
+export function currentWeekRangeKST(): { start: string; end: string } {
+  return weekRangeKST(dayjs().tz(KST).format("YYYY-MM-DD"));
+}
+
+/** 필터별 헤더 표기 — 칩 라벨과 동일한 어휘 사용 */
+const FILTER_HEADER_LABEL: Record<FilterType, string> = {
+  all: "일정",
+  mine: "내 일정",
+  competition: "대회",
+  schedule: "정보",
+  gathering: "모임",
+};
+
+/** 항목 한 줄: "· 화 07:00  남산 모닝런 — 5/10명" */
+function buildLine(race: CalendarRace): string {
+  const dayLabel = dayjs(race.start_date).format("ddd");
+  const timeLabel = race.evt_stt_at ? dayjs(race.evt_stt_at).tz(KST).format("HH:mm") : "";
+
+  // 모임·대회 공통 — 인원수만 담백하게 (정원 있는 모임은 n/m명)
+  let countLabel = "";
+  if ((race.regCount ?? 0) > 0) {
+    countLabel = race.maxPrtCnt != null
+      ? ` — ${race.regCount}/${race.maxPrtCnt}명`
+      : ` — ${race.regCount}명`;
+  }
+
+  const when = timeLabel ? `${dayLabel} ${timeLabel}` : dayLabel;
+  return `· ${when}  ${race.title}${countLabel}`;
+}
+
+/**
+ * 이번 주(월~일 KST) 일정을 단톡방 공유용 텍스트로 조립한다.
+ * 일정이 하나도 없으면 null 반환 (호출부에서 안내 토스트 처리).
+ *
+ * @param races 캘린더에 로드된 전체 항목 (대회·일정·모임, 중복 id 허용 — 내부에서 dedupe)
+ * @param origin 사이트 주소 (예: https://gigang.team)
+ * @param filterType 현재 필터 칩 — 걸려 있으면 그 종류만 공유 (기본 "all")
+ * @param baseDate 주간 기준 날짜 'YYYY-MM-DD' — 캘린더뷰는 선택 날짜, 리스트뷰는 오늘 (기본 오늘)
+ */
+export function buildWeeklyShareText(
+  races: CalendarRace[],
+  origin: string,
+  filterType: FilterType = "all",
+  baseDate?: string,
+): string | null {
+  const today = dayjs().tz(KST).format("YYYY-MM-DD");
+  const { start, end } = weekRangeKST(baseDate ?? today);
+  // 지난 요일은 제외 — 이번 주면 오늘부터, 지난 주 선택이면 전부 잘려 null
+  const from = today > start ? today : start;
+  if (from > end) return null;
+
+  // myRaces↔gigangRaces에 같은 대회가 양쪽에 있을 수 있어 id로 dedupe
+  const seen = new Set<string>();
+  const thisWeek = races
+    .filter((r) => {
+      if (!matchesFilter(r, filterType)) return false;
+      if (seen.has(r.id)) return false;
+      seen.add(r.id);
+      // 기간 일정은 남은 범위와 겹치면 포함 (start_date만 있는 항목은 그 날짜 기준)
+      const rEnd = r.end_date ?? r.start_date;
+      return r.start_date <= end && rEnd >= from;
+    })
+    .sort((a, b) =>
+      a.start_date === b.start_date
+        ? (a.evt_stt_at ?? "").localeCompare(b.evt_stt_at ?? "")
+        : a.start_date.localeCompare(b.start_date),
+    );
+
+  if (thisWeek.length === 0) return null;
+
+  const rangeLabel = `${dayjs(from).format("M/D")} ~ ${dayjs(end).format("M/D")}`;
+  // 오늘이 속한 주만 "이번 주" — 미래 주 선택 시엔 범위만 표기
+  const isCurrentWeek = today >= start && today <= end;
+  return [
+    `🗓️ ${isCurrentWeek ? "이번 주 " : ""}기강 ${FILTER_HEADER_LABEL[filterType]} (${rangeLabel})`,
+    "",
+    ...thisWeek.map(buildLine),
+    "",
+    `👉 ${origin}`,
+  ].join("\n");
+}

--- a/components/home/mini-calendar.tsx
+++ b/components/home/mini-calendar.tsx
@@ -4,9 +4,10 @@ import { useCallback, useEffect, useMemo, useRef, useState, useTransition } from
 
 import { useSearchParams } from "next/navigation";
 
-import { CalendarDays, ChevronLeft, ChevronRight, List } from "lucide-react";
+import { CalendarDays, ChevronLeft, ChevronRight, List, Share2 } from "lucide-react";
 import { toast } from "sonner";
 
+import { buildWeeklyShareText } from "@/components/home/build-weekly-share-text";
 import { compEvtTypeContainsHangul } from "@/lib/comp-evt-type";
 import { dayjs, todayKST, currentMonthKST, daysInMonth, gridDateRange } from "@/lib/dayjs";
 import type { CachedCmmCdRow } from "@/lib/queries/cmm-cd-cached";
@@ -83,6 +84,11 @@ const GatheringDetailDialog = dynamic<GatheringDetailDialogProps>(
     import("@/components/schedule/gathering-detail-dialog").then(
       (m) => m.GatheringDetailDialog
     ),
+  { ssr: false }
+);
+
+const ShareSheet = dynamic(
+  () => import("@/components/common/share-sheet").then((m) => m.ShareSheet),
   { ssr: false }
 );
 
@@ -200,6 +206,10 @@ export function MiniCalendar({
   type MonthData = { gigang: CalendarRace[]; mine: CalendarRace[]; schPosts: CalendarRace[]; gatherings: CalendarRace[] };
   const monthCacheRef = useRef(new Map<string, MonthData>());
   const cacheVersionRef = useRef(0);
+
+  // 주간 일정 공유 시트 상태
+  const [weeklyShareOpen, setWeeklyShareOpen] = useState(false);
+  const [weeklyShareText, setWeeklyShareText] = useState("");
 
   // 일정 폼 다이얼로그 상태
   const [formOpen, setFormOpen] = useState(false);
@@ -1096,6 +1106,23 @@ export function MiniCalendar({
     await refreshMonthData();
   }
 
+  /** 주간 일정을 단톡방 공유용 텍스트로 조립해 공유 시트를 연다.
+      기준 주는 FAB와 동일하게 캘린더뷰=선택 날짜, 리스트뷰=오늘. 필터 칩도 그대로 반영. */
+  function openWeeklyShare() {
+    const text = buildWeeklyShareText(
+      [...myRaces, ...schPosts, ...gigangRaces, ...gatherings],
+      window.location.origin,
+      filterType,
+      view === "calendar" ? selectedDate : today,
+    );
+    if (!text) {
+      toast.info("해당 주에 남은 일정이 없어요.");
+      return;
+    }
+    setWeeklyShareText(text);
+    setWeeklyShareOpen(true);
+  }
+
   return (
     <div className="flex flex-col gap-2">
       {/* 헤더 */}
@@ -1135,6 +1162,14 @@ export function MiniCalendar({
               />
             </button>
           </div>
+          {/* 주간 일정 공유 — 이번 주 일정을 텍스트로 단톡방에 붙여넣기 */}
+          <button
+            onClick={openWeeklyShare}
+            aria-label="주간 일정 공유"
+            className="flex size-6 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-secondary hover:text-foreground"
+          >
+            <Share2 className="size-3.5" />
+          </button>
         </div>
 
 
@@ -1505,6 +1540,16 @@ export function MiniCalendar({
           }}
         />
       )}
+
+      {/* 주간 일정 공유 시트 */}
+      <ShareSheet
+        open={weeklyShareOpen}
+        onOpenChange={setWeeklyShareOpen}
+        headerTitle="주간 일정 공유하기"
+        title="이번 주 기강 일정"
+        timeLabel=""
+        shareText={weeklyShareText}
+      />
 
       {/* 모임 폼 다이얼로그 (등록 + 수정 겸용) */}
       <GatheringFormDialog


### PR DESCRIPTION
## 관련 이슈

관련 이슈 없음

## 요약

홈 캘린더에서 주간 일정(월~일)을 텍스트로 조립해 카카오톡 단톡방에 붙여넣을 수 있는 공유 버튼을 추가한다. 카톡은 봇 자동 발송이 불가하므로, 탭 3번으로 끝나는 반자동 공유 방식을 채택했다. 공유 시트에는 실제 공유될 본문 미리보기를 함께 추가한다.

## AS-IS (변경 전)

- 주간 일정을 단톡방에 공유하려면 캘린더를 보며 수동으로 타이핑해야 함
- 공유 시트(ShareSheet)는 복사/공유 버튼만 있고 어떤 내용이 나가는지 누르기 전엔 알 수 없음

## TO-BE (변경 후)

- 캘린더 헤더(뷰 토글 옆)에 주간 공유 버튼 추가 — 누르면 아래 형식의 텍스트가 조립되어 공유 시트가 열림:

```
🗓️ 이번 주 기강 일정 (7/6 ~ 7/12)

· 화 07:30  남산 모닝런 — 5/10명
· 토 08:00  청광종주 트런 — 10/12명

👉 https://gigang.team
```

- **기준 주**: 캘린더뷰=선택 날짜가 속한 주, 리스트뷰=오늘 주 (FAB와 동일 규칙)
- **필터 연동**: 필터 칩(대회/정보/모임/내 일정)이 걸려 있으면 그 종류만 공유, 헤더에 필터명 반영 — 화면과 동일한 `matchesFilter` 재사용으로 "보이는 것 = 공유되는 것" 보장
- **지난 요일 제외**: 날짜 단위로 오늘부터 담음. 미래 주 선택 시 주 전체 포함 + "이번 주" 접두어 생략. 지난 주 선택 시 안내 토스트
- **인원 표기 통일**: 모임·대회 모두 `N명`, 정원 있는 모임은 `N/M명`
- **공유 시트 미리보기**: 복사/공유 버튼이 사용하는 `buildText()` 결과를 그대로 상단에 표시 — 주간 공유뿐 아니라 모임·일정·대회 상세의 기존 공유하기에도 자동 적용
- ShareSheet에 `headerTitle` prop 추가 (주간 공유는 "주간 일정 공유하기", 기존 사용처는 기본 "공유하기" 유지)
- 텍스트 빌더는 순수 함수로 분리, 단위 테스트 8개 추가 (주 범위 계산·필터·지난 요일 제외·중복 제거·표기)

## 변경 흐름 (Mermaid)

```mermaid
flowchart TD
    A[공유 버튼 탭] --> B["buildWeeklyShareText<br/>(캘린더뷰: 선택 주 / 리스트뷰: 오늘 주)"]
    B --> C{남은 일정 있나}
    C -->|없음| D[안내 토스트]
    C -->|있음| E[ShareSheet 오픈<br/>본문 미리보기 표시]
    E --> F[텍스트로 복사]
    E --> G[다른 앱으로 공유 → 카카오톡]
```

## 검증

- vitest 142개 통과 (신규 8개 포함), 타입체크·린트 클린
- dev 서버 구동 후 홈 렌더 및 공유 버튼 노출 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)