### PR TITLE
fix(home): 주간 공유 리뷰 반영 — 월 이동 기준 주 보정 및 표기 간소화

### DIFF
--- a/components/home/__tests__/build-weekly-share-text.test.ts
+++ b/components/home/__tests__/build-weekly-share-text.test.ts
@@ -51,9 +51,9 @@ describe("buildWeeklyShareText", () => {
     expect(text).not.toContain("어제 모임");
     expect(text).not.toContain("다음 주 모임");
     expect(text.indexOf("오늘 대회")).toBeLessThan(text.indexOf("주말 모임"));
-    // 대회도 모임과 동일하게 인원수만 표기
-    expect(text).toContain("오늘 대회 — 2명");
-    expect(text).toContain("주말 모임 — 3명");
+    // 시작일·시간·제목만 담백하게 — 인원수 미표기
+    expect(text).toContain("07:00  오늘 대회");
+    expect(text).not.toContain("명");
   });
 
   it("같은 대회가 중복(id)으로 들어와도 한 번만 담는다", () => {
@@ -65,13 +65,14 @@ describe("buildWeeklyShareText", () => {
     expect(text.match(/중복 대회/g)).toHaveLength(1);
   });
 
-  it("정원 있는 모임은 n/m명, 시간 있는 항목은 HH:mm을 표기한다", () => {
+  it("시간 있는 항목은 HH:mm을 표기하고, 인원수·종료일은 표기하지 않는다", () => {
     const races = [
       makeRace({ id: "g", title: "정원 모임", start_date: today, type: "gathering_mine", regCount: 5, maxPrtCnt: 10, evt_stt_at: atKST(today, "07:30") }),
     ];
     const text = buildWeeklyShareText(races, ORIGIN)!;
-    expect(text).toContain("5/10명");
-    expect(text).toContain("07:30");
+    expect(text).toContain("07:30  정원 모임");
+    expect(text).not.toContain("5/10");
+    expect(text).not.toContain("명");
   });
 
   it("기준 날짜를 주면 그 주(월~일) 전체를 담고 '이번 주' 접두어를 뺀다", () => {
@@ -85,7 +86,7 @@ describe("buildWeeklyShareText", () => {
     const wednesday = dayjs(nextMonday).add(2, "day").format("YYYY-MM-DD");
     const text = buildWeeklyShareText(races, ORIGIN, "all", wednesday)!;
     expect(text).toContain("다음주 월요 모임"); // 기준일 이전 요일도 미래 주면 포함
-    expect(text).toContain("다음주 일요 대회 — 4명");
+    expect(text).toContain("다음주 일요 대회");
     expect(text).not.toContain("이번 주"); // 미래 주는 범위만 표기
   });
 

--- a/components/home/build-weekly-share-text.ts
+++ b/components/home/build-weekly-share-text.ts
@@ -27,21 +27,12 @@ const FILTER_HEADER_LABEL: Record<FilterType, string> = {
   gathering: "모임",
 };
 
-/** 항목 한 줄: "· 화 07:00  남산 모닝런 — 5/10명" */
+/** 항목 한 줄: "· 화 07:00  남산 모닝런" — 시작일·시간·제목만 담백하게 (인원수·종료일 미표기) */
 function buildLine(race: CalendarRace): string {
   const dayLabel = dayjs(race.start_date).format("ddd");
   const timeLabel = race.evt_stt_at ? dayjs(race.evt_stt_at).tz(KST).format("HH:mm") : "";
-
-  // 모임·대회 공통 — 인원수만 담백하게 (정원 있는 모임은 n/m명)
-  let countLabel = "";
-  if ((race.regCount ?? 0) > 0) {
-    countLabel = race.maxPrtCnt != null
-      ? ` — ${race.regCount}/${race.maxPrtCnt}명`
-      : ` — ${race.regCount}명`;
-  }
-
   const when = timeLabel ? `${dayLabel} ${timeLabel}` : dayLabel;
-  return `· ${when}  ${race.title}${countLabel}`;
+  return `· ${when}  ${race.title}`;
 }
 
 /**
@@ -72,9 +63,8 @@ export function buildWeeklyShareText(
       if (!matchesFilter(r, filterType)) return false;
       if (seen.has(r.id)) return false;
       seen.add(r.id);
-      // 기간 일정은 남은 범위와 겹치면 포함 (start_date만 있는 항목은 그 날짜 기준)
-      const rEnd = r.end_date ?? r.start_date;
-      return r.start_date <= end && rEnd >= from;
+      // 시작일 기준으로만 판정 — end_date는 항목별 포맷(KST 날짜 vs 원시 타임스탬프)이 섞여 있어 쓰지 않는다
+      return r.start_date >= from && r.start_date <= end;
     })
     .sort((a, b) =>
       a.start_date === b.start_date

--- a/components/home/mini-calendar.tsx
+++ b/components/home/mini-calendar.tsx
@@ -1107,13 +1107,17 @@ export function MiniCalendar({
   }
 
   /** 주간 일정을 단톡방 공유용 텍스트로 조립해 공유 시트를 연다.
-      기준 주는 FAB와 동일하게 캘린더뷰=선택 날짜, 리스트뷰=오늘. 필터 칩도 그대로 반영. */
+      기준 주는 캘린더뷰=선택 날짜, 리스트뷰=오늘. 필터 칩도 그대로 반영. */
   function openWeeklyShare() {
+    // 월 이동(화살표/스와이프)은 selectedDate를 안 바꾸므로, 선택 날짜가 보고 있는 달
+    // 밖이면 그 달 1일을 기준으로 — 로드된 데이터(현재 달)와 기준 주가 어긋나는 것 방지
+    const calendarBase =
+      selectedDate.slice(0, 7) === viewMonth.slice(0, 7) ? selectedDate : viewMonth;
     const text = buildWeeklyShareText(
       [...myRaces, ...schPosts, ...gigangRaces, ...gatherings],
       window.location.origin,
       filterType,
-      view === "calendar" ? selectedDate : today,
+      view === "calendar" ? calendarBase : today,
     );
     if (!text) {
       toast.info("해당 주에 남은 일정이 없어요.");


### PR DESCRIPTION
## 관련 이슈

관련 이슈 없음 (#404 후속 — 코드리뷰 확정 결함 수정)

## 요약

주간 일정 공유(#404)의 코드리뷰에서 확정된 결함 2건을 수정하고, 공유 텍스트를 "요일 시간 제목"만 표기하도록 간소화한다.

## AS-IS (변경 전)

- **월 이동 버그**: 화살표/스와이프로 다른 달을 보는 중엔 `selectedDate`가 갱신되지 않아, 공유 버튼이 이전 달 날짜 기준 주를 계산 → 로드된 데이터(현재 달)와 겹치지 않아 화면에 일정이 보이는데도 "일정이 없어요" 토스트
- **end_date 형식 불일치**: 일정 포스트의 `end_date`가 KST 정규화 없는 원시 UTC 타임스탬프라, 주간 포함 판정(문자열 비교)이 캘린더 그리드와 다른 날로 판정 — KST 자정 넘어 끝나는 일정이 공유에서 누락 가능
- 공유 항목에 인원수(`— 5/10명`)까지 표기

## TO-BE (변경 후)

- 캘린더뷰 공유 기준: 선택 날짜가 보고 있는 달 안이면 그 날짜, 밖이면 **그 달 1일** 기준 주
- 주간 포함 판정을 **시작일 기준**으로 단순화 — `end_date`를 아예 사용하지 않아 형식 불일치 이슈 원천 제거
- 공유 항목 표기: `· 요일 HH:mm  제목` (인원수·종료일 제거)

```
🗓️ 이번 주 기강 일정 (7/6 ~ 7/12)

· 화 07:30  남산 모닝런
· 토 08:00  청광종주 트런

👉 https://gigang.team
```

## 검증

- vitest 142개 통과 (빌더 테스트를 새 표기·판정 기준으로 갱신), 타입체크·린트 클린
- 리뷰 3번(일요일 탭 시 그리드 행과 공유 주 불일치)은 의도된 동작으로 확정하고 미수정 — 탭한 날짜가 포함된 월~일 주를 공유하며, 시트 미리보기로 범위 확인 가능

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * 주간 공유 텍스트에서 인원수 표기가 더 이상 표시되지 않고, 시간과 제목만 간단히 보이도록 변경되었습니다.
  * 이번 주 일정 포함 기준이 더 정확해져, 해당 주에 시작하는 일정만 공유 목록에 반영됩니다.
  * 캘린더에서 선택한 날짜와 표시 중인 월이 다를 때도, 공유 텍스트가 현재 월 기준으로 맞게 생성됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->