### PR TITLE
fix(dialog): 데스크톱에서 다이얼로그 닫기 시 사이트 밖으로 이탈하는 버그 수정

### DIFF
--- a/.claude/docs/KNOWLEDGE.md
+++ b/.claude/docs/KNOWLEDGE.md
@@ -76,6 +76,13 @@ Supabase JS `.upsert({ onConflict: "a,b,c" })` 는 `ON CONFLICT (a,b,c)` 만 보
 `navigator.serviceWorker.getRegistration("/sw.js")`처럼 스크립트 경로를 넘기면 브라우저마다 다르게 동작(Safari는 undefined 반환 가능). 등록 스코프 기준으로 조회해야 한다.
 **해결:** 등록은 `register("/sw.js", { scope: "/" })`, 조회는 `getRegistration("/")`로 통일. (`lib/push/client.ts`, `components/service-worker-register.tsx`)
 
+### 열린 다이얼로그의 Root(Dialog↔Drawer)가 교체되면 히스토리 스택이 어긋난다 — 해결됨 (2026-07-06)
+`ResponsiveDrawer`의 `useMediaQuery`가 초기값 `false`로 시작해 이펙트에서 보정하던 탓에, 데스크톱에서 상세 다이얼로그가 **open 상태로 마운트**되면(null 가드로 조건부 렌더되는 상세류의 첫 오픈) 첫 렌더는 Drawer로 `pushState` → 직후 Dialog로 교체되며 Drawer 언마운트 cleanup이 `history.back()` 회수 + Dialog가 재푸시. 큐된 back() 트래버설이 **원래 앱 엔트리로 착지**해, 이후 X 닫기의 `back()`이 한 칸 더 나가 **사이트 진입 이전 페이지로 이탈**했다. 모바일은 교체가 없어 정상 → "데스크톱에서만 닫기가 이전 사이트로 튕김" 증상.
+**해결 1(근본):** `useMediaQuery` 초기값을 lazy initializer로 `window.matchMedia(query).matches` 즉시 읽기 — 첫 렌더부터 올바른 Root로 마운트되어 교체가 사라짐. (`components/common/responsive-drawer.tsx`)
+**해결 2(방어):** `useDialogHistoryBack` cleanup은 `history.state.dialog === id`(현재 항목이 자기 것)이거나 `pendingProgrammaticBack > 0`(같은 커밋에서 중첩 다이얼로그가 동시에 닫혀 위쪽 back()이 큐만 된 상태 — history.state가 잠시 낡음)일 때만 `back()` 호출 — 스택이 어긋났을 때 고아 항목 하나 남기는 쪽이 페이지 이탈보다 안전. (`lib/hooks/use-dialog-history-back.ts`)
+**남은 한계:** 다이얼로그를 연 채로 창 폭을 768px 경계 너머로 리사이즈하면 여전히 Root가 교체된다(기존부터 있던 엣지). 가드 덕에 사이트 이탈은 안 하고 고아 항목 1개(뒤로가기 한 번 무반응)로 완화됨.
+**원칙:** `useDialogHistoryBack`이 붙은 Root(Dialog/Sheet/Drawer)는 **열린 채로 다른 Root로 갈아끼우면 안 된다.** 반응형 분기 등으로 Root를 조건 교체하는 컴포넌트는 분기 값이 첫 렌더부터 확정돼 있어야 한다.
+
 ## 재사용 패턴
 
 ### 상세 다이얼로그 오픈 = "인스턴트 오픈 + 백필 + 댓글 자체조회" (전 경로 공통 원칙)

--- a/components/common/responsive-drawer.tsx
+++ b/components/common/responsive-drawer.tsx
@@ -22,7 +22,13 @@ import {
 } from "@/components/ui/drawer"
 
 function useMediaQuery(query: string) {
-  const [matches, setMatches] = React.useState(false)
+  // 첫 렌더부터 실제 값이어야 한다 — false로 시작해 이펙트에서 보정하면,
+  // 데스크톱에서 다이얼로그가 open 상태로 마운트될 때 Drawer로 pushState된 뒤
+  // Dialog로 교체(언마운트 back() + 재푸시)되며 useDialogHistoryBack의 히스토리
+  // 스택이 어긋나 닫기 버튼이 사이트 밖(이전 사이트)으로 이탈한다.
+  const [matches, setMatches] = React.useState(
+    () => typeof window !== "undefined" && window.matchMedia(query).matches,
+  )
   React.useEffect(() => {
     const media = window.matchMedia(query)
     // eslint-disable-next-line react-hooks/set-state-in-effect

--- a/lib/hooks/use-dialog-history-back.ts
+++ b/lib/hooks/use-dialog-history-back.ts
@@ -67,7 +67,18 @@ export function useDialogHistoryBack(open: boolean, onClose: () => void) {
       if (popClosedIds.has(id)) {
         // 뒤로가기로 닫힘 — 히스토리 항목은 이미 소비됨
         popClosedIds.delete(id);
-      } else {
+      } else if (
+        // 현재 히스토리 항목이 내 것일 때만 회수한다 — 열린 채로 Root가
+        // 교체(리마운트)되는 등 스택이 어긋난 상태에서 back()을 호출하면
+        // 페이지 진입 이전 사이트까지 이탈할 수 있다. 고아 항목이 하나 남는
+        // 쪽이 페이지를 벗어나는 것보다 안전하다.
+        // 단 pendingProgrammaticBack > 0 이면 같은 커밋에서 위 다이얼로그의
+        // back()이 큐만 되고 아직 착지 전이라 history.state가 잠시 낡은
+        // 값이다(중첩 동시 닫힘). 이때는 큐 순서상 내 항목이 곧 현재가
+        // 되므로 정상 회수한다.
+        pendingProgrammaticBack > 0 ||
+        (history.state as { dialog?: number } | null)?.dialog === id
+      ) {
         // 프로그램적으로 닫힘(X·취소·제출) — 쌓아둔 항목 회수
         pendingProgrammaticBack++;
         history.back();


### PR DESCRIPTION
## 관련 이슈

관련 이슈 없음

## 요약

데스크톱 웹에서 상세 다이얼로그(모임·일정·대회 등)를 처음 열었다 닫기 버튼을 누르면 사이트 진입 이전 페이지(브라우저 최초 페이지)로 튕기는 버그를 수정한다. 모바일에서는 발생하지 않던 데스크톱 전용 버그.

## AS-IS (변경 전)

- `ResponsiveDrawer`의 `useMediaQuery`가 첫 렌더에서 무조건 `false`(모바일)로 시작한 뒤 이펙트에서 보정
- 데스크톱에서 상세 다이얼로그가 **open 상태로 마운트**되면(null 가드 조건부 렌더의 첫 오픈):
  1. 첫 렌더 = Drawer → `useDialogHistoryBack`이 히스토리 항목 push
  2. 직후 데스크톱 판정 → Dialog로 교체: Drawer 언마운트 cleanup이 `history.back()` 회수 + Dialog 재푸시
  3. 비동기 back() 트래버설이 **원래 페이지 항목에 착지** → 다이얼로그는 열려 있는데 히스토리는 이미 소비됨
  4. X 닫기 → 또 `back()` → **사이트 밖으로 이탈**
- 프로덕션 빌드 + Chrome 실측으로 100% 재현 확인 (example.com → 홈 → 모임 클릭 → X → example.com으로 이탈)

## TO-BE (변경 후)

- **근본 수정** (`components/common/responsive-drawer.tsx`): `useMediaQuery` 초기값을 lazy initializer에서 `window.matchMedia()`로 즉시 읽음 → 첫 렌더부터 올바른 Root(Dialog/Drawer)로 마운트, 교체 자체가 사라짐
- **방어 수정** (`lib/hooks/use-dialog-history-back.ts`): cleanup의 회수 `back()`은 현재 히스토리 항목이 자기 것(`history.state.dialog === id`)이거나 같은 커밋에서 형제 back()이 큐된 경우(`pendingProgrammaticBack > 0`, 중첩 동시 닫힘)에만 호출 → 어떤 이유로든 스택이 어긋나도 페이지 이탈은 불가능
- 함정·원칙(`열린 채로 Root 교체 금지`)을 `.claude/docs/KNOWLEDGE.md`에 기록

### 검증 (프로덕션 빌드 실측)

- 데스크톱 X 닫기: push 1회 → back 1회, 페이지 유지 ✅ (수정 전: 사이트 이탈)
- 데스크톱 브라우저 뒤로가기로 닫기 ✅ / 모바일 폭 Drawer 닫기 ✅
- 중첩(상세 → 공유 시트 → 각각 닫기): push 2회 ↔ back 2회 균형 ✅
- `tsc --noEmit`·수정 파일 eslint·vitest 142개 통과
- 다관점 코드리뷰(5에이전트)에서 나온 중첩 동시 닫힘 회귀는 가드 조건 보강으로 반영

### 알려진 한계 (기존부터 존재)

다이얼로그를 연 채로 창 폭을 768px 경계 너머로 리사이즈하면 여전히 Root가 교체된다. 이번 방어 가드 덕에 사이트 이탈 없이 고아 히스토리 항목 1개(뒤로가기 한 번 무반응)로 완화됨.

## 변경 흐름 (Mermaid)

```mermaid
sequenceDiagram
    participant U as 사용자(데스크톱)
    participant R as ResponsiveDrawer
    participant H as History

    rect rgb(255, 235, 235)
    Note over U,H: AS-IS — 첫 오픈
    U->>R: 상세 클릭 (open 마운트)
    R->>H: Drawer push {dialog:1}
    R->>R: 데스크톱 판정 → Dialog 교체
    R->>H: back() 회수 + Dialog push {dialog:2}
    H-->>H: 트래버설이 원래 페이지 항목에 착지
    U->>R: X 닫기
    R->>H: back() → 사이트 밖 이탈 ❌
    end

    rect rgb(235, 255, 235)
    Note over U,H: TO-BE — 첫 오픈
    U->>R: 상세 클릭 (open 마운트)
    R->>R: matchMedia 즉시 판정 → Dialog로 시작
    R->>H: push {dialog:1}
    U->>R: X 닫기
    R->>H: state.dialog===1 확인 → back() → 페이지 유지 ✅
    end
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * 열린 상세 화면에서 뒤로가기 동작이 엉키던 문제를 개선했습니다.
  * 데스크톱/모바일 전환 시 화면 형태가 바뀌어도 더 안정적으로 유지되며, 의도치 않게 한 단계 더 뒤로 이동하는 현상을 줄였습니다.
  * 리사이즈 경계에서 열린 화면이 잘못 전환될 수 있는 상황에 대한 안전장치를 추가했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->