### PR TITLE
feat(dues): 자동·제외 행도 일괄 분류로 재분류

### DIFF
--- a/app/(info)/admin/dues/inbox/inbox-table.tsx
+++ b/app/(info)/admin/dues/inbox/inbox-table.tsx
@@ -7,6 +7,7 @@ import { cancelTransaction } from "@/app/actions/dues/cancel-transaction";
 import { confirmAndRecalc } from "@/app/actions/dues/confirm-and-recalc";
 import { deleteTransaction } from "@/app/actions/dues/delete-transaction";
 import { buildConfirmPayload, type Decision, type ItemCd } from "@/lib/dues/confirm-payload";
+import { canReclassify, isDecisionRow, isReclassified } from "@/lib/dues/confirm-scope";
 import { duplicateNames } from "@/lib/dues/homonyms";
 import type { FeeItemOption, InboxTxn, MemberOption, ProcessedTxn, ProjectOption } from "@/lib/queries/dues";
 
@@ -89,9 +90,21 @@ export function InboxTable({
   const rowRefs = useRef<Record<string, HTMLTableRowElement | null>>({});
   const router = useRouter();
 
+  // 분류(itemCd) override 유무 — 자동·제외 행이 일괄 분류로 '재분류'됐는지의 신호.
+  const hasItemCdOverride = (txnId: string) => overrides[txnId]?.itemCd != null;
+  const reclassified = (t: InboxTxn) => isReclassified(t.bucket, hasItemCdOverride(t.txnId));
+  const decisionRow = (t: InboxTxn) => isDecisionRow(t.bucket, hasItemCdOverride(t.txnId));
+
+  // 결정(편집) 대상 행 = 확인필요 + 재분류된 자동·제외. 이들만 분류·회원·프로젝트를 UI에서 정하고
+  // 확정 시 결정 경로(새 값 전송)로 나간다. 건드리지 않은 자동·제외는 종전대로 저장값으로 확정.
+  const decisionRows = useMemo(
+    () => txns.filter((t) => isDecisionRow(t.bucket, overrides[t.txnId]?.itemCd != null)),
+    [txns, overrides],
+  );
+
   const decisions = useMemo<Record<string, Decision>>(
-    () => Object.fromEntries(review.map((t) => [t.txnId, { ...defaultDecision(t), ...overrides[t.txnId] }])),
-    [review, overrides],
+    () => Object.fromEntries(decisionRows.map((t) => [t.txnId, { ...defaultDecision(t), ...overrides[t.txnId] }])),
+    [decisionRows, overrides],
   );
 
   // 필터 + 검색으로 화면에 보일 행. 서버 정렬(txn_dt asc) 유지.
@@ -113,25 +126,30 @@ export function InboxTable({
     );
   }, [processed, filter, query]);
 
-  // 키보드 ↑↓ 이동 대상: 화면에 보이는 needsReview 행 순서.
-  const editableVisible = useMemo(() => visible.filter((t) => t.bucket === "needsReview"), [visible]);
+  // 키보드 ↑↓ 이동 대상: 화면에 보이는 결정 행(확인필요 + 재분류된 자동·제외) 순서.
+  const editableVisible = useMemo(
+    () => visible.filter((t) => isDecisionRow(t.bucket, overrides[t.txnId]?.itemCd != null)),
+    [visible, overrides],
+  );
 
-  // 결정된 확인필요 행: 회비=회원 지정, 프로젝트=귀속 프로젝트 지정(회원은 선택), 제외=분류만.
+  // 결정된 행: 회비=회원 지정, 프로젝트=귀속 프로젝트 지정(회원은 선택), 제외=분류만.
   // 부분 확정 — 미결정 행은 이번 확정에서 빠지고 인박스에 남아 다음에 처리한다.
   // (inbox-row.tsx의 decided 계산과 반드시 같은 규칙을 유지할 것)
-  const decidedReview = review.filter((t) => {
+  const decidedRows = decisionRows.filter((t) => {
     const d = decisions[t.txnId];
     return d && (d.itemCd === "other" || (d.itemCd === "due" ? !!d.memId : !!d.prjId));
   });
-  const undecidedCount = review.length - decidedReview.length;
+  const undecidedCount = decisionRows.length - decidedRows.length;
 
   // 확정 범위: 체크박스로 고른 행이 있으면 **그 중 확정 가능한 행만**, 없으면 전체.
-  // 자동·제외는 판단이 필요 없어 항상 확정 대상, 미결정 확인필요 행은 확정 불가라 빠진다.
+  // 자동·제외는 판단이 필요 없어 항상 확정 대상, 미결정 결정 행은 확정 불가라 빠진다.
+  // 재분류된 자동·제외 행은 저장값 경로(targetAuto/Excluded)에서 빼고 결정 경로(targetReview)로 보낸다
+  // — 안 그러면 새 분류가 무시되고 낡은 저장값으로 확정된다.
   const useSelection = selected.size > 0;
   const inScope = (t: { txnId: string }) => !useSelection || selected.has(t.txnId);
-  const targetAuto = autoDone.filter(inScope);
-  const targetExcluded = excluded.filter(inScope);
-  const targetReview = decidedReview.filter(inScope);
+  const targetAuto = autoDone.filter((t) => !reclassified(t)).filter(inScope);
+  const targetExcluded = excluded.filter((t) => !reclassified(t)).filter(inScope);
+  const targetReview = decidedRows.filter(inScope);
   const confirmCount = targetAuto.length + targetExcluded.length + targetReview.length;
 
   // 체크박스는 확정 범위 지정용 — 화면에 보이는 모든 행(자동·제외 포함)을 선택 대상으로.
@@ -164,7 +182,11 @@ export function InboxTable({
   }
 
   function bulkSetItemCd(itemCd: ItemCd) {
-    const ids = [...selected].filter((id) => review.some((t) => t.txnId === id));
+    // 선택된 '입금' 행만 분류를 바꾼다(출금 제외). 자동·제외 행이면 결정(편집) 흐름에 편입된다.
+    const ids = [...selected].filter((id) => {
+      const t = txns.find((x) => x.txnId === id);
+      return !!t && canReclassify(t.io);
+    });
     setOverrides((prev) => {
       const next = { ...prev };
       for (const id of ids) next[id] = { ...next[id], itemCd };
@@ -346,9 +368,9 @@ export function InboxTable({
                   projects={projects}
                   dupNames={dupNames}
                   nameById={nameById}
-                  decision={t.bucket === "needsReview" ? decisions[t.txnId] : null}
+                  decision={decisionRow(t) ? decisions[t.txnId] : null}
                   selected={selected.has(t.txnId)}
-                  editable={t.bucket === "needsReview"}
+                  editable={decisionRow(t)}
                   onChange={(patch) => setDecision(t.txnId, patch)}
                   onToggleSelect={(checked) => toggleSelect(t.txnId, checked)}
                   rowRef={(el) => {
@@ -374,7 +396,7 @@ export function InboxTable({
             </Button>
           ))}
           <Micro className="text-muted-foreground">
-            선택한 행만 확정됩니다 · 분류 버튼은 확인필요 행에만 적용
+            선택한 행만 확정됩니다 · 분류 버튼은 선택한 입금 행에 적용(자동·제외 포함)
           </Micro>
         </div>
       )}

--- a/lib/__tests__/confirm-scope.test.ts
+++ b/lib/__tests__/confirm-scope.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from "vitest";
+
+import { canReclassify, isDecisionRow, isReclassified } from "@/lib/dues/confirm-scope";
+
+describe("isReclassified", () => {
+  it("자동·제외 행에 분류 override 가 있으면 재분류로 본다", () => {
+    expect(isReclassified("autoDone", true)).toBe(true);
+    expect(isReclassified("excluded", true)).toBe(true);
+  });
+
+  it("override 가 없으면 재분류 아님", () => {
+    expect(isReclassified("autoDone", false)).toBe(false);
+    expect(isReclassified("excluded", false)).toBe(false);
+  });
+
+  it("확인필요 행은 원래 편집 대상이라 재분류로 세지 않는다", () => {
+    expect(isReclassified("needsReview", true)).toBe(false);
+    expect(isReclassified("needsReview", false)).toBe(false);
+  });
+});
+
+describe("isDecisionRow", () => {
+  it("확인필요는 override 유무와 무관하게 항상 결정 경로", () => {
+    expect(isDecisionRow("needsReview", false)).toBe(true);
+    expect(isDecisionRow("needsReview", true)).toBe(true);
+  });
+
+  it("재분류된 자동·제외 행은 결정 경로에 편입", () => {
+    expect(isDecisionRow("autoDone", true)).toBe(true);
+    expect(isDecisionRow("excluded", true)).toBe(true);
+  });
+
+  it("건드리지 않은 자동·제외 행은 저장값 경로(결정 경로 아님)", () => {
+    expect(isDecisionRow("autoDone", false)).toBe(false);
+    expect(isDecisionRow("excluded", false)).toBe(false);
+  });
+});
+
+describe("canReclassify", () => {
+  it("입금만 재분류 허용, 출금은 막는다", () => {
+    expect(canReclassify("deposit")).toBe(true);
+    expect(canReclassify("withdrawal")).toBe(false);
+  });
+});

--- a/lib/dues/confirm-scope.ts
+++ b/lib/dues/confirm-scope.ts
@@ -1,0 +1,35 @@
+import type { Bucket } from "@/lib/dues/upload-bucketize";
+
+/**
+ * 거래내역 처리 인박스의 "재분류/확정 스코프" 판정 (순수 함수).
+ *
+ * 배경: 자동(autoDone)·제외(excluded) 행은 원래 저장값 그대로 확정되는 읽기전용이다.
+ * 하지만 "자동 매칭된 회원이 낸 프로젝트 입금"처럼 자동 버킷에 '회비'로 잠긴 건을
+ * 운영자가 프로젝트/제외로 옮겨야 할 때가 있다. 그래서 하단 일괄 분류 버튼으로 자동·제외
+ * 행을 '재분류'하면, 그 행은 확인필요와 동일한 결정(편집) 흐름에 편입된다.
+ */
+
+/**
+ * 확인필요가 아닌 행(자동·제외)이 일괄 분류로 '재분류'됐는지 판정.
+ * 재분류 신호 = 그 행에 분류(itemCd) override 가 존재. 확인필요 행은 원래 편집 대상이라 제외.
+ */
+export function isReclassified(bucket: Bucket, hasItemCdOverride: boolean): boolean {
+  return bucket !== "needsReview" && hasItemCdOverride;
+}
+
+/**
+ * 확정 시 '결정(review) 경로'로 보낼 행인가 = 확인필요(원래 편집) 또는 재분류된 자동·제외 행.
+ * 결정 경로는 새 분류·회원·프로젝트를 함께 전송하고, 그 외 자동·제외는 저장값(txnId만)으로 확정된다.
+ * 재분류된 자동·제외 행이 저장값 경로로 새면 낡은 '회비' 분류가 그대로 확정되므로 반드시 분리한다.
+ */
+export function isDecisionRow(bucket: Bucket, hasItemCdOverride: boolean): boolean {
+  return bucket === "needsReview" || isReclassified(bucket, hasItemCdOverride);
+}
+
+/**
+ * 일괄 분류(재분류) 가능한 행인가 — 입금만 허용.
+ * 출금을 회비/프로젝트 같은 수입 분류로 바꾸는 사고를 막는다(자동은 항상 입금, 제외엔 출금이 섞임).
+ */
+export function canReclassify(io: "deposit" | "withdrawal"): boolean {
+  return io === "deposit";
+}

--- a/lib/queries/dues.ts
+++ b/lib/queries/dues.ts
@@ -17,6 +17,8 @@ export type InboxTxn = {
   rawName: string;
   memId: string | null;
   matchStatus: "matched" | "unmatched" | "ambiguous";
+  /** 입출금 구분 — 일괄 재분류를 입금 행에만 허용하기 위해 노출(출금→수입 분류 사고 방지) */
+  io: "deposit" | "withdrawal";
   feeItemCd: string | null;
   /** 저장된 프로젝트 귀속 — 수동 등록·확정취소로 재노출된 event_fee 행의 기본값 시드 */
   projectId: string | null;
@@ -89,8 +91,9 @@ export async function getInboxTxns(): Promise<{
   const txns: InboxTxn[] = (rows ?? []).map((r) => {
     const match = matchPayer(r.raw_name, memberRefs, aliasRefs);
     const matchStatus = (r.match_st_cd ?? match.status) as InboxTxn["matchStatus"];
+    const io = r.txn_io_enm as "deposit" | "withdrawal";
     const bucket = bucketOf({
-      io: r.txn_io_enm as "deposit" | "withdrawal",
+      io,
       itemCd: r.fee_item_cd ?? "other",
       matchStatus,
     });
@@ -102,6 +105,7 @@ export async function getInboxTxns(): Promise<{
       rawName: r.raw_name,
       memId: r.mem_id,
       matchStatus,
+      io,
       feeItemCd: r.fee_item_cd,
       projectId: r.project_id,
       bucket,


### PR DESCRIPTION
## AS-IS
거래내역 처리 인박스에서 **자동(autoDone) 버킷 행은 분류가 '회비'로 잠겨** 읽기전용이었다. 자동 매칭된 회원이 낸 **프로젝트성 입금**(예: 단체복·교육비)이 자동으로 '회비'에 갇혀, 프로젝트로 옮길 UI 경로가 없었다. → 실제 운영계에서 운영자가 막힘(임시로 DB에서 `fee_item_cd`를 직접 바꿔 우회).

## TO-BE
선택한 **입금** 행(자동·제외 포함)을 하단 일괄 분류 버튼(회비로/프로젝트로/제외로)으로 **재분류**하면, 그 행이 확인필요와 동일한 결정(편집) 흐름에 편입된다 — 프로젝트 Select 노출, 귀속 프로젝트 선택 후 확정. 기본 흐름(자동 행은 그냥 넘겨 빠르게 확정)은 그대로.

## 구현
- `lib/dues/confirm-scope.ts` (신설): `isReclassified` / `isDecisionRow` / `canReclassify` 순수 함수 + 테스트 7건. 재분류 신호 = `itemCd` override.
- `inbox-table.tsx`: 결정 행 집합을 **확인필요 + 재분류된 자동·제외**로 확장. 재분류 행은 저장값 경로(`targetAuto`/`targetExcluded`)에서 빼고 **결정 경로(`targetReview`)로 전송** — 낡은 분류로 확정되는 것을 방지.
- **출금 보호**: `canReclassify(io)`로 입금 행만 재분류 허용(제외 버킷의 출금은 대상 제외).
- `lib/queries/dues.ts`: `InboxTxn.io` 노출.

## 검증
- `tsc --noEmit` 통과, `vitest` 141건 통과(+7 confirm-scope).
- 서브에이전트(백엔드) 불변식 리뷰 6종 전부 OK — 재분류 행의 결정-경로 분리, buildConfirmPayload 계약, 기본 흐름 무회귀, 출금 보호, 서버 검증 우회 없음, useMemo 의존성.
- 서버 검증(`confirm-transactions.ts`: event_fee→prjId 필수, 팀 소속, 공통코드 유효성)은 그대로 강제.

## 남은 폴리시(후속·P3)
- 재분류된 자동 행의 상태 배지가 여전히 "자동"으로 표시(분류 컬럼은 정확). 시각적 표식은 후속.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * 입금함에서 자동/제외 항목 중 재분류된 행도 확정·편집 대상에 포함되도록 개선했습니다.
  * 대량 분류 변경 시 적용 범위가 더 넓어져, 선택한 입금 행에 자동·제외 항목도 함께 반영됩니다.

* **Bug Fixes**
  * 확정 대상 계산과 선택 안내 문구가 실제 동작과 더 일치하도록 조정했습니다.
  * 입출금 구분에 따라 재분류 가능 여부가 더 정확하게 반영됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->