### PR TITLE
feat(points): 기강 포인트 제도 도입 — 히든 원장 + DB 트리거 자동 적립

### DIFF
--- a/.claude/docs/KNOWLEDGE.md
+++ b/.claude/docs/KNOWLEDGE.md
@@ -83,6 +83,17 @@ Supabase JS `.upsert({ onConflict: "a,b,c" })` 는 `ON CONFLICT (a,b,c)` 만 보
 **남은 한계:** 다이얼로그를 연 채로 창 폭을 768px 경계 너머로 리사이즈하면 여전히 Root가 교체된다(기존부터 있던 엣지). 가드 덕에 사이트 이탈은 안 하고 고아 항목 1개(뒤로가기 한 번 무반응)로 완화됨.
 **원칙:** `useDialogHistoryBack`이 붙은 Root(Dialog/Sheet/Drawer)는 **열린 채로 다른 Root로 갈아끼우면 안 된다.** 반응형 분기 등으로 Root를 조건 교체하는 컴포넌트는 분기 값이 첫 렌더부터 확정돼 있어야 한다.
 
+### public 스키마의 일반 함수는 PostgREST /rpc/로 노출된다 (기본 EXECUTE가 PUBLIC)
+Postgres는 새 함수에 기본적으로 PUBLIC EXECUTE를 부여하고, Supabase는 public 스키마 함수를 `/rpc/<name>`으로 노출한다. `RETURNS trigger`는 RPC 불가라 안전하지만, **트리거가 부르는 헬퍼(RETURNS void/int)나 SECURITY DEFINER 유틸은 클라이언트가 직접 호출 가능**해진다. 또 `ALTER DEFAULT PRIVILEGES` 잔재(20260325 remote_schema)로 **새 테이블에도 anon/authenticated GRANT ALL이 자동 부여**된다 — RLS 정책 0개면 실질 차단되지만 권한 레벨은 열려 있다.
+**원칙:** 내부 전용 함수·비공개 테이블을 만들면 `REVOKE EXECUTE ... FROM PUBLIC, anon, authenticated` / `REVOKE ALL ON TABLE ... FROM anon, authenticated`를 마이그레이션에 항상 동봉한다. (선례: `noti_func_revoke_public`, 포인트 `pt_*` 일괄 REVOKE — 2026-07-04)
+
+### 원천에 유니크 제약이 없는 "존재 확인 후 INSERT"는 advisory lock으로 직렬화
+포인트 원장의 net 판정(§5.2)처럼 **"현재 상태 SELECT → 조건부 INSERT"** 패턴은 원천 테이블 제약이 동시 이벤트를 직렬화해줄 때만 안전하다(참석=UNIQUE(gthr_id,mem_id) 등). 마일리지런 기록처럼 (mem, 날짜) 유니크가 없는 원천은 겹치는 트랜잭션이 서로의 미커밋 INSERT를 못 봐 이중 적립된다. append-only 테이블은 잠글 row도 없어 `FOR UPDATE` 불가.
+**해결:** `pg_advisory_xact_lock(hashtext('<도메인>:'||키)::bigint)`로 논리 키를 직렬화. (선례: `recalc_member_balance`(2026-06-28), `pt_earn_mlg_record`/`recheck_mlg_goal`(2026-07-04))
+
+### MCP generate_typescript_types 결과에는 재정렬 노이즈가 섞인다
+dev MCP로 `database.types.ts`를 재생성하면 기존 테이블 블록이 diff상 삭제+재추가로 보일 수 있다(예: fee_policy_cfg 44줄). 실제 손실인지 이동인지 `git diff | grep "^+" | grep <이름>`으로 반드시 재확인할 것 — dev/prd drift로 진짜 소실될 수도 있다(TODO의 "스키마 drift" 항목 참조).
+
 ## 재사용 패턴
 
 ### 상세 다이얼로그 오픈 = "인스턴트 오픈 + 백필 + 댓글 자체조회" (전 경로 공통 원칙)

--- a/.claude/docs/database-abbreviation-dictionary.md
+++ b/.claude/docs/database-abbreviation-dictionary.md
@@ -38,6 +38,8 @@
 | `sprt` | sport (종목/스포츠) |
 | `ttl` | title (칭호) |
 | `pay` | payment (납부) |
+| `pt` | point (기강 포인트) |
+| `actv` | activity (활동 — 포인트 적립 대상 활동 유형 `actv_type_enm`) |
 | `prj` | project (프로젝트/모금 — `fee_prj_mst`; 단 `fee_txn_hist.project_id`는 P1 선행 컬럼이라 전체 철자) |
 | `attd` | attendance (출석/참석) |
 | `prt` | participation (참가) |

--- a/.claude/docs/database-schema-v2-domains.md
+++ b/.claude/docs/database-schema-v2-domains.md
@@ -434,6 +434,18 @@ RLS:
 트리거:
 - `fdbk_mst_set_upd_at` — UPDATE 시 `set_v2_upd_at()` 호출
 
+## 7) 포인트 도메인 (히든 운영)
+
+> 상세 설계·룰셋·트리거 매트릭스는 `docs/design/2026-07-04-기강포인트제도.md` (source of truth).
+
+### `pt_txn_hist` (포인트 원장, append-only)
+- 멤버 활동(모임 참석·개설, 대회 참가·기록, 마일리지런, 정보등록) 포인트를 기록하는 원장.
+- **적립 주체는 앱이 아니라 원천 테이블 DB 트리거** (`trg_pt_*` — `gthr_attd_rel`, `gthr_mst`, `comp_reg_rel`, `rec_race_hist`, `evt_mlg_act_hist`, `evt_mlg_mth_snap`, `evt_team_prt_rel`, `sch_post_mst`, `comp_mst`).
+- 핵심 컬럼: `pt_amt`(부호 있는 증감), `aply_dt`(귀속 기준일 — 활동일/대회일, KST date), `actv_type_enm`, `txn_type_enm`(earn/revoke/spend/manual_adj), `ref_id`(원천 PK — earn/revoke 짝).
+- 취소·삭제는 row 삭제가 아니라 **역분개(revoke) row 추가**. 멱등은 net(순액) 판정 + advisory lock.
+- **RLS 활성 + 정책 0개 + 테이블/함수 권한 회수** — 클라이언트에서 존재 자체를 알 수 없음(히든). 조회는 관리자 SQL만.
+- 공통 메타 예외: append-only 원장이라 `upd_at`/`del_yn`/`vers` 없음(의도).
+
 ## 8) 관계 요약
 - `mem_mst 1:N team_mem_rel`
 - `team_mst 1:N team_mem_rel`

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -85,6 +85,8 @@ t3-env로 관리되며 `lib/env.ts`에서 import:
 
 > 웹 푸시: `push_sub_rel` 테이블(구독 정보) + `public/sw.js`(수신). 발송은 `insertNoti()`(`lib/notifications/insert-noti.ts`)가 인앱 알림 INSERT 직후 `sendPushToMember`를 fire-and-forget 호출 → 모든 알림 타입 자동 푸시. 설계·함정은 `.claude/docs/push-notification-design.md` / `KNOWLEDGE.md`. VAPID 키는 dev/prd 분리.
 
+> 기강 포인트(**히든 운영 — UI·유저 대상 언급 금지**): `pt_txn_hist` 원장에 원천 테이블(모임·대회·마일리지런·정보) **DB 트리거**가 자동 적립. 앱 코드에 훅 없음 — 새 쓰기 경로를 추가해도 적립은 자동으로 따라온다. 룰·트리거 매트릭스: `docs/design/2026-07-04-기강포인트제도.md`.
+
 # 에이전트 구성
 
 ## 서브에이전트 목록

--- a/docs/design/2026-07-04-기강포인트제도.md
+++ b/docs/design/2026-07-04-기강포인트제도.md
@@ -1,0 +1,320 @@
+# 기강 포인트 제도 설계 문서
+
+> 작성일: 2026-07-04
+> 상태: **dev 구현·QA·대사 검증 완료** (2026-07-04) — prd 미적용, 진행 현황은 `.claude/docs/TODO.md` 참조
+> 구현: 마이그레이션 4개(`supabase/migrations/20260704100000~130000` — 원장/트리거/시드/리뷰수정). 앱 코드 변경 없음(트리거 기반) — `database.types.ts` 재생성만.
+> 관련 문서: `.claude/docs/gathering-design.md`(원안 스케치), `2026-06-28-출석-회비-감면-퀘스트.md`(월 귀속·집계 패턴),
+> `2026-03-19-마일리지런 설계.md`, `2026-03-23-칭호시스템.md`(칭호 포인트는 폐기됨 — 본 제도와 무관)
+
+---
+
+## 1. 개요 — 히든 운영 원칙
+
+멤버의 크루 활동(모임·대회·마일리지런·정보 공유)에 따라 포인트를 적립하는 제도.
+**당분간 유저에게 완전히 비공개**로 운영한다.
+
+| 원칙 | 내용 |
+|------|------|
+| **측정만, 노출 0** | 적립 로직은 실제로 돌지만 UI 어디에도 포인트를 표시하지 않는다. 유저는 적립 사실 자체를 모른다 |
+| **추후 공개 전제** | 공개 시점에 그동안의 이력이 원장에 그대로 살아있어야 한다 → 처음부터 감사 가능한 원장(ledger) 구조 |
+| **도입 시점** | **2026-07부터.** 과거 이력 백필 없음 |
+| **목적** | 참여 독려. 모임 출석이 최고 단가 — "마일리지런만 파는" 것보다 모임에 나오는 게 항상 유리한 구조 |
+
+---
+
+## 2. 적립 룰셋 (확정)
+
+| 활동 | 포인트 | 귀속 기준일(`aply_dt`) | 조건/비고 |
+|------|--------|----------------------|-----------|
+| 정모 참석 | **+30** | 모임 시작일(`stt_at` KST) | `gthr_type_enm='regular'` |
+| 벙 참석 | **+10** | 모임 시작일 | `gthr_type_enm='general'` |
+| 이벤트 참석 | **+20** | 모임 시작일 | `gthr_type_enm='event'` |
+| 벙 개설 | **+5** | 모임 시작일 | `general`만. 개설자는 자동 참석 포함 실질 +15 |
+| 정모/이벤트 개설 | **0** | — | 운영 행위라 미적립 |
+| 대회 참가 | **+20** | **대회 개최일** | 참가 신청 시점에 적립하되 귀속은 대회일 (§4.2) |
+| 대회 기록 등록 | **+20** | **대회 개최일** | **개최일이 2026-07-01 이후인 대회만** (과거 기록 소급 파밍 차단) |
+| 마일리지런 기록 등록 | **+2** | **달린 날짜** | **1일 1건만 인정** (기록 쪼개기 파밍 차단) |
+| 마일리지런 월 목표 달성 | **+10** | 해당 목표 월 1일 | 실시간 판정 — 누적 ≥ 목표가 *처음* 되는 순간 적립 (§5.4) |
+| 정보 등록 | **+5** | 작성일 | `sch_post_mst`. 상한 없음 |
+
+### 밸런스 근거 (월간 기대치 시뮬레이션)
+
+| 페르소나 | 월 포인트 | 해석 |
+|----------|-----------|------|
+| 모임 집중형 (정모1 + 벙4 + 개설2) | ~80 | **크루 취지대로 최상위** |
+| 러닝 집중형 (매일 기록 + 목표달성, 모임 안 나옴) | ~62+10 | 모임형보다 낮음 — 의도된 설계 |
+| 만능형 | ~120 | |
+| 대회 뛰는 달 | +40 | 참가 20 + 기록 20 |
+
+- 정모 30 : 벙 10 = 3:1 가중. 개설자(15) > 참석자(10).
+- 목표달성 +10은 의도적으로 소액 유지 — 마일리지런 과열을 원치 않음 (모임이 더 중요).
+
+---
+
+## 3. 공통 규칙 (확정)
+
+1. **실시간 적립** — 액션 발생 즉시 원장 INSERT. 월 마감 배치 없음.
+2. **회수는 역분개** — 취소/삭제 시 원장 row를 지우지 않고 **음수 회수(-) row를 추가**한다.
+   토글을 100번 반복해도 순액만 수렴. 감사 이력 보존.
+3. **귀속일(`aply_dt`) 기준 집계** — 월 기강지수·랭킹은 전부 `aply_dt`의 월로 GROUP BY.
+   7월에 11월 대회를 신청해도 그 20pt는 11월 랭킹에 잡힌다. 회수 row도 같은 귀속일 → 같은 월에서 상쇄.
+4. **원장은 append-only** — UPDATE/DELETE 금지 (권한 + 정책으로 강제). 정정도 새 row(`manual_adj`)로.
+5. **사용(spend) 대비 규칙** — 추후 사용처가 생기면 사용 가능 잔액은 **`aply_dt` ≤ 오늘**인 적립분만 합산.
+   (미래 귀속 포인트를 미리 쓰는 구멍 차단)
+6. **연초 초기화 — "살아있는 포인트"는 연 단위** (확정)
+   - **살아있는 포인트(활동 잔액)** = `aply_dt`가 **당해 연도(KST)** 에 속하는 순액. 매년 1/1이면 자연히 0부터 시작.
+   - **누적 포인트(lifetime)** = 전체 기간 순액. 초기화와 무관하게 영구 보존·조회 가능.
+   - **초기화 배치는 없다** — 원장은 그대로 두고 집계 윈도우만 연도로 자르면 되므로, 리셋 작업·스냅샷·이월 처리 전부 불필요.
+   - 연도 판정도 귀속일 기준: 12월에 신청한 내년 1월 대회 포인트는 내년 잔액에 귀속 (월 집계와 동일 원리).
+   - spend 도입 시 사용 가능 잔액 = **당해 연도** 순액 ∩ `aply_dt ≤ 오늘`.
+7. **노출 0 보장** — 클라이언트에서 원장 테이블 접근 불가(RLS). 조회는 관리자 전용 (§7).
+
+---
+
+## 4. 적립 방식 — DB 트리거 (확정)
+
+> **결정**: 앱 코드 훅이 아니라 **원천 테이블 트리거**로 적립한다.
+
+### 4.1 왜 트리거인가
+
+| 근거 | 상세 |
+|------|------|
+| 🔴 **쓰기 경로가 흩어져 있음** | 대회 참가(`comp_reg_rel`)는 서버 액션이 아니라 **클라이언트 직접 INSERT/DELETE가 5개+ 컴포넌트**에 산재 (`race-list-view.tsx`, `mini-calendar.tsx`, `competition-detail-dialog.tsx`, `race-record-dialog.tsx`, 관리자 화면). 앱 훅으로는 전부 쫓아다녀야 하고 하나라도 빠지면 조용히 누락 |
+| **hard delete 회수 자동화** | 참석 취소 = `gthr_attd_rel` row 삭제. DELETE 트리거가 회수 row를 원자적으로 남김 — 앱에서 "삭제 전에 회수 먼저" 순서를 강제할 필요 없음 |
+| **유실 없음** | fire-and-forget 앱 훅은 실패 시 포인트 유실 + 히든이라 아무도 눈치 못 챔. 트리거는 원천 변경과 같은 트랜잭션 |
+| **신규 쓰기 경로 자동 커버** | 나중에 새 컴포넌트가 참가 INSERT를 추가해도 적립이 따라옴 |
+
+- **대안(기각)**: 모든 쓰기 경로를 서버 액션으로 리팩터링 후 앱 헬퍼 훅 — 리팩터링 범위가 크고, 이후에도 "새 경로 추가 시 훅 누락" 리스크가 영구 존속.
+- **회비 감면(§3, 규칙은 코드)과의 컨벤션 차이**: 회비 규칙은 배치·퀘스트 카드라는 *코드 소비자*가 같은 함수를 공유해야 했다. 포인트는 소비자 UI가 없고(히든) 적립 지점이 *DB 쓰기 자체*라 트리거가 자연스러운 경계다.
+
+### 4.2 점수 상수 위치
+
+트리거 헬퍼 함수 한 곳(`pt_rule_amt(actv_type)` — CASE 문)에 상수로 둔다.
+값 변경 = 마이그레이션 1건. 관리자가 자주 만지게 되면 설정 테이블(`pt_rule_cfg`)로 승급 (회비 감면 §11과 동일한 승급 경로).
+
+### 4.3 KST 주의 (필수)
+
+`aply_dt`는 **KST date**로 저장한다. timestamptz 원천에서 파생 시 반드시:
+
+```sql
+(stt_at AT TIME ZONE 'Asia/Seoul')::date
+```
+
+날짜가 KST로 정규화된 date라서 월 집계는 타임존 걱정 없이 `date_trunc('month', aply_dt)`로 끝난다.
+
+---
+
+## 5. 스키마
+
+### 5.1 원장 `pt_txn_hist`
+
+```sql
+CREATE TYPE public.pt_txn_type_enm AS ENUM ('earn', 'revoke', 'spend', 'manual_adj');
+CREATE TYPE public.pt_actv_type_enm AS ENUM (
+  'regular_attend',  -- 정모 참석 +30
+  'gthr_attend',     -- 벙 참석 +10
+  'evt_attend',      -- 이벤트 참석 +20
+  'gthr_host',       -- 벙 개설 +5
+  'comp_join',       -- 대회 참가 +20
+  'comp_record',     -- 대회 기록 등록 +20
+  'mlg_record',      -- 마일리지런 기록 +2 (1일 1건)
+  'mlg_goal',        -- 마일리지런 월 목표 달성 +10
+  'sch_post',        -- 정보 등록 +5
+  'manual'           -- 관리자 수동 조정
+);
+
+CREATE TABLE public.pt_txn_hist (
+  pt_txn_id     uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  team_id       uuid NOT NULL,
+  mem_id        uuid NOT NULL,
+  actv_type_enm public.pt_actv_type_enm NOT NULL,
+  txn_type_enm  public.pt_txn_type_enm NOT NULL,
+  pt_amt        integer NOT NULL,          -- earn > 0, revoke/spend < 0 (CHECK)
+  aply_dt       date NOT NULL,             -- 귀속 기준일 (KST, §4.3)
+  ref_type_txt  text,                      -- 원천 종류: 'gthr' | 'comp_reg' | 'race_result' | 'mlg_act' | 'mlg_goal' | 'sch_post'
+  ref_id        uuid,                      -- 원천 PK (earn/revoke 짝 맞춤 키)
+  rsn_txt       text,                      -- 예: "정모 참석: 6월 정기런"
+  crt_at        timestamptz NOT NULL DEFAULT now(),
+  CONSTRAINT ck_pt_amt_sign CHECK (
+    (txn_type_enm = 'earn' AND pt_amt > 0)
+    OR (txn_type_enm IN ('revoke', 'spend') AND pt_amt < 0)
+    OR (txn_type_enm = 'manual_adj')
+  )
+);
+
+-- 월 집계·랭킹용
+CREATE INDEX ix_pt_txn_hist_mem_aply ON public.pt_txn_hist (team_id, mem_id, aply_dt);
+-- 순액 판정(earn/revoke 짝)용
+CREATE INDEX ix_pt_txn_hist_ref ON public.pt_txn_hist (mem_id, actv_type_enm, ref_id);
+```
+
+- `del_yn` 없음 — append-only 원장. 정정은 `manual_adj` row.
+- `vers` 없음 — 스냅샷이 아니라 이력.
+
+### 5.2 순액(net) 규칙 — 멱등의 핵심
+
+같은 원천에 대한 중복 적립/이중 회수를 트리거 내부에서 순액으로 차단한다:
+
+```text
+net(mem, actv, ref) = Σ pt_amt WHERE mem_id, actv_type_enm, ref_id 일치
+
+earn   : net = 0 일 때만 INSERT          (토글 재등록·중복 이벤트 안전)
+revoke : net > 0 일 때만 INSERT(-net)    (이중 회수 안전, 회수액 = 현재 순액)
+```
+
+- 참석 토글 on→off→on→off = earn, revoke, earn, revoke → 순액 0. ✅
+- 같은 참석에 INSERT가 두 번 와도(재시도 등) 두 번째 earn은 net > 0이라 무시. ✅
+
+### 5.3 잔액/집계 (공개 대비 — 지금은 뷰만 예약)
+
+> ⚠️ **모든 유저-노출 집계(랭킹·잔액·히스토리)는 `aply_dt <= 오늘(KST)` 필터 필수.**
+> 월 GROUP BY만 하면 같은 달 안의 미래 귀속(예: 오늘 7/5, 7/21 대회 참가 20pt)이 미리 잡힌다.
+> 포인트는 대회일이 **도래하는 날부터** 획득한 것으로 보여야 함 (배치 불필요 — 날짜가 오면 자동 포함).
+
+```sql
+-- 월 기강지수 (공개 시 랭킹의 원형) — 지금은 관리자 검증용으로만 사용
+SELECT mem_id, date_trunc('month', aply_dt)::date AS ym, SUM(pt_amt) AS pt
+FROM pt_txn_hist
+WHERE team_id = $1
+  AND aply_dt <= (now() AT TIME ZONE 'Asia/Seoul')::date   -- 미래 귀속(미도래 대회) 제외
+GROUP BY mem_id, 2;
+
+-- 살아있는 포인트 (연간 잔액, §3-6): 당해 연도 귀속분만
+SELECT mem_id, SUM(pt_amt) AS live_pt
+FROM pt_txn_hist
+WHERE team_id = $1 AND aply_dt >= date_trunc('year', (now() AT TIME ZONE 'Asia/Seoul'))::date
+GROUP BY mem_id;
+
+-- 누적 포인트 (lifetime): WHERE 연도 조건 없이 전체 합산
+-- 사용 가능 잔액 (spend 도입 시): 당해 연도 ∩ aply_dt <= 오늘(KST) (§3-5·6)
+```
+
+성능은 크루 규모(수십 명 × 월 수십 건)에서 즉석 집계로 충분. 필요해지면 월 스냅샷 테이블로 승급 (회비 §4.2 패턴).
+
+---
+
+## 6. 트리거 매트릭스
+
+| 원천 테이블 | 이벤트 | 동작 |
+|-------------|--------|------|
+| `gthr_attd_rel` | INSERT | 모임 타입 조회 → `regular`: earn 30(`regular_attend`) / `general`: earn 10(`gthr_attend`) / `event`: earn 20(`evt_attend`). ref = `gthr_id` ※ ref_id는 (mem, actv, gthr_id)로 짝이 맞음 |
+| `gthr_attd_rel` | DELETE (참석 취소 = hard delete) | 해당 (mem, actv, gthr_id) net > 0이면 revoke |
+| `gthr_mst` | INSERT | `gthr_type_enm='general'` AND 개설자 → earn 5(`gthr_host`). `regular`/`event`는 0 |
+| `gthr_mst` | UPDATE (`del_yn` false→true, 소프트 삭제) | 개설 포인트 revoke + **그 모임의 모든 참석 적립 revoke** (참석 row는 남지만 모임이 죽었으므로) |
+| `gthr_mst` | UPDATE (`del_yn` true→false, **복원**) | 삭제 때 회수했던 개설·참석 포인트를 현재 타입·일시 기준으로 재적립 (리뷰 발견 — 없으면 복원 시 영구 회수 상태) |
+| `gthr_mst` | UPDATE (`stt_at` 또는 `gthr_type_enm` 변경) | 귀속일/점수가 어긋남 → 해당 gthr ref의 earn 전부 revoke 후 새 `aply_dt`·새 타입 점수로 재적립. 타입 변경 시 개설 포인트(general만 +5)도 함께 재판정 |
+| `comp_mst` | UPDATE (`stt_dt` 변경 — 대회 연기 등) | 해당 대회의 `comp_join` 적립 revoke 후 새 대회일로 재적립 (도입일 가드 재적용 — 새 날짜가 7/1 이전이면 revoke만). `comp_record`는 개별 기록의 `race_dt` 기준이라 무관 |
+| `comp_reg_rel` | INSERT | earn 20(`comp_join`), `aply_dt` = 대회 개최일. ref = `comp_reg_id` |
+| `comp_reg_rel` | DELETE (참가 취소) | revoke (같은 대회일 귀속 → 같은 월에서 상쇄) |
+| `comp_reg_rel` | UPDATE | **mem_id 불변 전제** — 현재 앱 코드는 role/comp_evt_id만 수정. 향후 "참가자 재배정" 기능이 생기면 mem_id 변경 트리거(구 mem revoke + 신 mem earn) 추가 필요 (보안 리뷰 P2, TODO 기록) |
+| `rec_race_hist` | INSERT | **대회일 ≥ 2026-07-01** 이면 earn 20(`comp_record`), `aply_dt` = 대회일. ref = `race_result_id` |
+| `rec_race_hist` | DELETE | revoke |
+| `evt_mlg_act_hist` | INSERT | 해당 (mem, 달린 날짜)의 **첫 유효 기록**일 때만 earn 2(`mlg_record`), `aply_dt` = 달린 날짜. + 목표 달성 재판정(§5.4) |
+| `evt_mlg_act_hist` | UPDATE (날짜/거리 변경) | 변경 전후 날짜 각각 "그날 기록 존재 여부" 재판정 → earn/revoke + 목표 재판정 |
+| `evt_mlg_act_hist` | DELETE | 그날 남은 기록이 없으면 revoke + 목표 재판정 |
+| `evt_mlg_mth_snap` | UPDATE (목표 상향 수정) | 목표 달성 재판정 (달성→미달 전환 시 revoke) |
+| `evt_team_prt_rel` | **BEFORE DELETE** (관리자 참가 거절/삭제) | cascade로 기록·목표가 지워지기 **전에** 그 참가자의 mlg_record·mlg_goal 포인트 일괄 revoke. ⚠️ 자식 테이블 AFTER DELETE 트리거는 cascade 시점에 부모 조인이 실패해 회수를 스킵하므로 부모에서 처리 (리뷰 발견) |
+| `sch_post_mst` | INSERT | earn 5(`sch_post`), `aply_dt` = 작성일(KST). ref = `sch_post_id` |
+| `sch_post_mst` | `del_yn` 소프트 삭제 (구현 확인: soft) | revoke. 복원(true→false) 시 재적립 |
+
+### §5.4 마일리지런 월 목표 달성 — 실시간 판정 함수
+
+기록 INSERT/UPDATE/DELETE와 목표 수정이 전부 같은 재판정 함수를 호출한다.
+**달성 판정은 앱(`lib/mileage.ts` `isMonthAchieved`)과 동일하게 `round(달성치, 소수1) >= 목표`** —
+raw 비교하면 경계값(199.96)에서 UI "달성" 표시와 포인트가 어긋난다 (리뷰 발견, 판정 규칙 이원화 금지).
+
+```text
+recheck_mlg_goal(mem, ym):
+  achieved = (round(해당 월 기록 마일리지 합산, 1) >= evt_mlg_mth_snap 목표)
+  net      = net(mem, 'mlg_goal', ref=해당 월 목표 row id)
+  if achieved and net = 0  → earn 10  (aply_dt = ym 1일)
+  if not achieved and net > 0 → revoke
+```
+
+- 전월 기록 소급 입력(매월 3일까지, 관리자는 이후에도)으로 달성이 월을 넘어 뒤집혀도 같은 로직으로 처리됨.
+- `ref_id` = `evt_mlg_mth_snap`의 해당 월 row PK → 월별로 earn/revoke 짝이 자연히 맞음.
+
+### 마일리지런 1일 1건 판정
+
+```text
+evt_mlg_act_hist INSERT 시:
+  그날(mem, 달린 날짜 KST) 기존 유효 기록 수 = 0 이었을 때만 earn
+DELETE 시:
+  그날 남은 유효 기록 수 = 0 이 될 때만 revoke
+```
+
+`ref_id`를 개별 기록이 아니라 **"그날"을 대표하는 값**으로 관리해야 짝이 맞다 →
+`ref_id`는 NULL로 두고 `(mem, 'mlg_record', aply_dt)` 로 net 판정 (mlg_record만 예외 규칙).
+
+### 트리거 공통 구현 규칙
+
+- 트리거 함수는 **SECURITY DEFINER**(owner: postgres) — RLS로 잠긴 원장에 쓸 수 있어야 함.
+- 트리거 실패가 원천 액션(참석 토글 등)을 깨뜨리면 안 되는가? → **아니다, 같은 트랜잭션이 맞다.**
+  원장 유실(조용한 누락)이 UX 에러 1회보다 나쁘다. 단 트리거 내부는 단순 INSERT라 실패 여지 최소화.
+- 도입일 이전 원천 변경(과거 모임의 참석 토글 등)도 트리거는 타지만, **`aply_dt < '2026-07-01'`이면 적립하지 않는다** (백필 없음 원칙의 트리거판).
+  - ⚠️ 단 회수는 예외 없이 — 도입 후 적립된 것만 회수 대상이므로 net 규칙이 자연히 처리.
+
+---
+
+## 7. 보안 / 노출 0
+
+| 항목 | 정책 |
+|------|------|
+| RLS | `pt_txn_hist` RLS 활성화 + **일반 멤버 정책 없음** (SELECT 불가) |
+| 쓰기 | 트리거(SECURITY DEFINER)만. 클라이언트/서버 액션의 직접 INSERT 금지 |
+| 조회 | 당분간 관리자 SQL(MCP/대시보드)로만. 관리자 화면 노출도 하지 않음 (운영진 입에서 새는 것 방지 — 필요 시 `verifyAdmin` 뒤에 최소 화면) |
+| `database.types.ts` | 재생성하면 타입에는 노출되지만 클라이언트 쿼리는 RLS가 차단 |
+
+---
+
+## 8. 공개 전환 시나리오 (미래, 참고)
+
+1. 집계 뷰/RPC(`월 기강지수`)를 공개 정책으로 오픈
+2. 프로필/랭킹 UI 추가 — 원장은 그대로, 읽기만 열림
+3. 공개 시점에 "그동안 쌓인 포인트"가 첫 화면부터 채워져 있음 (이 제도의 존재 이유)
+4. spend 도입 시: `aply_dt ≤ 오늘` 잔액 규칙(§3-5) + `spend` row
+
+---
+
+## 9. 검증 (히든이라 더 중요)
+
+유저 눈이 0개이므로 적립 누락/중복을 시스템이 스스로 검증해야 한다.
+
+- **대사(reconciliation) 스크립트**: 원천 테이블에서 기대 포인트를 재산출 → 원장 순액과 멤버별 대조.
+  - 참석·개설·대회·정보등록은 원천이 보존되므로 완전 재산출 가능.
+  - 참석 취소(hard delete)·삭제된 기록은 원장에만 남음 — "원장 순액 ≥ 원천 재산출" 형태가 아니라 **원장 net과 현존 원천이 일치**해야 정상 (취소분은 net 0으로 상쇄돼 있으므로).
+- QA 시나리오: 토글 반복 / 모임 소프트 삭제 / 모임 일시 변경 / 11월 대회 참가 후 취소 / 마일리지런 같은 날 2건 / 기록 삭제로 목표 미달 전환 / 전월 소급 입력으로 목표 달성 / 도입일 이전 대회 기록 등록(적립 0 확인).
+
+---
+
+## 10. 작업 분해 (구현 순서)
+
+1. **[BE]** 마이그레이션 ① — enum 2종 + `pt_txn_hist` + 인덱스 + RLS(정책 없음). `database.types.ts` 재생성.
+2. **[BE]** 마이그레이션 ② — 헬퍼(`pt_rule_amt`, net 판정, KST 변환) + 트리거 함수/트리거 일괄 (§6 매트릭스).
+2.5 **[BE]** 마이그레이션 ③ — **도입 시드(백필)**: 트리거는 적용 시점 이후 변경만 잡으므로, 적용 시점에 이미 존재하는 원천 중 **귀속일 ≥ 2026-07-01**인 것을 소급 earn (7월 모임 RSVP·참석, 대회일이 도입 후인 기존 참가 신청, 도입 후 대회 기록, 7월 마일리지런 기록·목표 달성, 7월 정보등록). 원칙: **포인트는 활동일 기준 — 데이터가 언제 쌓였는지는 무관.** net=0 가드로 멱등 (트리거가 이미 적립한 건 스킵) → dev/prd 어느 시점에 실행해도 안전.
+   - 사전 확인: `sch_post_mst` 삭제 방식(hard/soft), `rec_race_hist`의 대회일 컬럼, `comp_reg_rel`→대회일 조인 경로, `evt_mlg_act_hist` 날짜 컬럼.
+3. **[BE]** 대사 스크립트(§9) — 관리자 SQL 또는 `scripts/`.
+4. **[QA]** §9 시나리오 전부 — dev 환경에서 원천 액션 실행 → 원장 대조.
+5. **[OPS]** prd 적용 (2026-07 내 — 도입 월이므로).
+
+---
+
+## 11. 결정 로그
+
+| 결정 | 선택 | 기각된 대안 |
+|------|------|-------------|
+| 적립 시점 | 실시간 (트리거) | 월 마감 배치 — 히든이라 지연 단점은 없었으나 사용자가 배치 원치 않음. 실시간 부하는 크루 규모에서 무시 가능 |
+| 취소 처리 | 역분개(회수 row) | 원장 row 삭제 — 감사 이력 소실 |
+| 원장 성격 | 적립+사용 대비 양방향 원장 | 누적 전용 — 미래 사용처 대비 |
+| 백필 | 도입 월(2026-07)부터만 | 과거 전체 소급 |
+| 귀속 | `aply_dt`(활동 발생일/대회일) 기준 월 집계 | 적립 시각 기준 — 미래 대회 참가가 현재 월에 몰리는 왜곡 |
+| 마일리지런 기록 | 1일 1건 인정 | 건당 무제한 — 쪼개기 파밍 + 마일리지런 과열 방지 |
+| 목표달성 보너스 | +10 유지 | +20~30 상향 — 모임 우위 유지 위해 소액 고수 |
+| 대회 기록 | 개최일 2026-07-01 이후만 | 전체 인정 — 과거 기록 몰아넣기 파밍 |
+| 정보등록 상한 | 없음 | 월 4건 — 도배 실사례 없음 |
+| 이벤트 참석 | +20 (정모 30과 벙 10의 중간) | 벙과 동일 10 |
+| 연초 초기화 | 활동 잔액은 연 단위 윈도우(집계로 처리), 누적은 영구 | 리셋 배치/이월 스냅샷 — 원장 구조상 불필요 |
+| 귀속 원칙 재확인 | **활동일 기준** — 데이터 생성 시점 무관 → 도입 시드(2.5) 필수 | 트리거 적용 시점부터만 — 같은 활동인데 신청 시점으로 점수 갈리는 불공평 |
+| 모임 타입 변경 | 재적립 트리거 (stt_at 트리거에 조건 추가 — 몇 줄) | 수정 차단 — 서버액션+UI 양쪽 수정에 기능 퇴행 |
+| 대회 일정 변경(연기) | 재적립 트리거 (`comp_join`만 — 기록은 race_dt 기준) | 무시 후 수동 조정 — 연초 초기화 경계(12월↔1월)와 충돌 |
+| 적립 지점 | DB 트리거 | 앱 헬퍼 훅 — comp_reg_rel 클라 직접 쓰기가 5곳+ 산재, 누락 리스크 |

--- a/lib/supabase/database.types.ts
+++ b/lib/supabase/database.types.ts
@@ -1143,50 +1143,6 @@ export type Database = {
           },
         ]
       }
-      fee_policy_cfg: {
-        Row: {
-          aply_end_dt: string
-          aply_stt_dt: string
-          crt_at: string
-          del_yn: boolean
-          fee_policy_id: string
-          monthly_fee_amt: number
-          team_id: string
-          upd_at: string
-          vers: number
-        }
-        Insert: {
-          aply_end_dt: string
-          aply_stt_dt: string
-          crt_at?: string
-          del_yn?: boolean
-          fee_policy_id?: string
-          monthly_fee_amt: number
-          team_id: string
-          upd_at?: string
-          vers?: number
-        }
-        Update: {
-          aply_end_dt?: string
-          aply_stt_dt?: string
-          crt_at?: string
-          del_yn?: boolean
-          fee_policy_id?: string
-          monthly_fee_amt?: number
-          team_id?: string
-          upd_at?: string
-          vers?: number
-        }
-        Relationships: [
-          {
-            foreignKeyName: "fk_fee_policy_cfg__team_mst"
-            columns: ["team_id"]
-            isOneToOne: false
-            referencedRelation: "team_mst"
-            referencedColumns: ["team_id"]
-          },
-        ]
-      }
       fee_payer_alias: {
         Row: {
           alias_id: string
@@ -1244,6 +1200,50 @@ export type Database = {
           },
           {
             foreignKeyName: "fk_fee_payer_alias__team_mst"
+            columns: ["team_id"]
+            isOneToOne: false
+            referencedRelation: "team_mst"
+            referencedColumns: ["team_id"]
+          },
+        ]
+      }
+      fee_policy_cfg: {
+        Row: {
+          aply_end_dt: string
+          aply_stt_dt: string
+          crt_at: string
+          del_yn: boolean
+          fee_policy_id: string
+          monthly_fee_amt: number
+          team_id: string
+          upd_at: string
+          vers: number
+        }
+        Insert: {
+          aply_end_dt: string
+          aply_stt_dt: string
+          crt_at?: string
+          del_yn?: boolean
+          fee_policy_id?: string
+          monthly_fee_amt: number
+          team_id: string
+          upd_at?: string
+          vers?: number
+        }
+        Update: {
+          aply_end_dt?: string
+          aply_stt_dt?: string
+          crt_at?: string
+          del_yn?: boolean
+          fee_policy_id?: string
+          monthly_fee_amt?: number
+          team_id?: string
+          upd_at?: string
+          vers?: number
+        }
+        Relationships: [
+          {
+            foreignKeyName: "fk_fee_policy_cfg__team_mst"
             columns: ["team_id"]
             isOneToOne: false
             referencedRelation: "team_mst"
@@ -1832,6 +1832,63 @@ export type Database = {
             isOneToOne: false
             referencedRelation: "mem_mst"
             referencedColumns: ["mem_id"]
+          },
+        ]
+      }
+      pt_txn_hist: {
+        Row: {
+          actv_type_enm: Database["public"]["Enums"]["pt_actv_type_enm"]
+          aply_dt: string
+          crt_at: string
+          mem_id: string
+          pt_amt: number
+          pt_txn_id: string
+          ref_id: string | null
+          ref_type_txt: string | null
+          rsn_txt: string | null
+          team_id: string
+          txn_type_enm: Database["public"]["Enums"]["pt_txn_type_enm"]
+        }
+        Insert: {
+          actv_type_enm: Database["public"]["Enums"]["pt_actv_type_enm"]
+          aply_dt: string
+          crt_at?: string
+          mem_id: string
+          pt_amt: number
+          pt_txn_id?: string
+          ref_id?: string | null
+          ref_type_txt?: string | null
+          rsn_txt?: string | null
+          team_id: string
+          txn_type_enm: Database["public"]["Enums"]["pt_txn_type_enm"]
+        }
+        Update: {
+          actv_type_enm?: Database["public"]["Enums"]["pt_actv_type_enm"]
+          aply_dt?: string
+          crt_at?: string
+          mem_id?: string
+          pt_amt?: number
+          pt_txn_id?: string
+          ref_id?: string | null
+          ref_type_txt?: string | null
+          rsn_txt?: string | null
+          team_id?: string
+          txn_type_enm?: Database["public"]["Enums"]["pt_txn_type_enm"]
+        }
+        Relationships: [
+          {
+            foreignKeyName: "pt_txn_hist_mem_id_fkey"
+            columns: ["mem_id"]
+            isOneToOne: false
+            referencedRelation: "mem_mst"
+            referencedColumns: ["mem_id"]
+          },
+          {
+            foreignKeyName: "pt_txn_hist_team_id_fkey"
+            columns: ["team_id"]
+            isOneToOne: false
+            referencedRelation: "team_mst"
+            referencedColumns: ["team_id"]
           },
         ]
       }
@@ -2455,6 +2512,69 @@ export type Database = {
       }
       migration_v2_norm_email: { Args: { p_input: string }; Returns: string }
       migration_v2_norm_phone: { Args: { p_input: string }; Returns: string }
+      pt_earn: {
+        Args: {
+          p_actv: Database["public"]["Enums"]["pt_actv_type_enm"]
+          p_aply_dt: string
+          p_mem_id: string
+          p_ref_id: string
+          p_ref_type: string
+          p_rsn_txt: string
+          p_team_id: string
+        }
+        Returns: undefined
+      }
+      pt_earn_mlg_record: {
+        Args: {
+          p_aply_dt: string
+          p_mem_id: string
+          p_rsn_txt: string
+          p_team_id: string
+        }
+        Returns: undefined
+      }
+      pt_gthr_actv_type: {
+        Args: { p_gthr_type_enm: string }
+        Returns: Database["public"]["Enums"]["pt_actv_type_enm"]
+      }
+      pt_intro_dt: { Args: never; Returns: string }
+      pt_net_by_ref: {
+        Args: {
+          p_actv: Database["public"]["Enums"]["pt_actv_type_enm"]
+          p_mem_id: string
+          p_ref_id: string
+        }
+        Returns: number
+      }
+      pt_net_mlg_record: {
+        Args: { p_aply_dt: string; p_mem_id: string }
+        Returns: number
+      }
+      pt_revoke: {
+        Args: {
+          p_actv: Database["public"]["Enums"]["pt_actv_type_enm"]
+          p_aply_dt: string
+          p_mem_id: string
+          p_ref_id: string
+          p_ref_type: string
+          p_rsn_txt: string
+          p_team_id: string
+        }
+        Returns: undefined
+      }
+      pt_revoke_mlg_record: {
+        Args: {
+          p_aply_dt: string
+          p_mem_id: string
+          p_rsn_txt: string
+          p_team_id: string
+        }
+        Returns: undefined
+      }
+      pt_rule_amt: {
+        Args: { p_actv: Database["public"]["Enums"]["pt_actv_type_enm"] }
+        Returns: number
+      }
       recalc_member_balance: {
         Args: {
           p_base_bal: number
@@ -2468,6 +2588,7 @@ export type Database = {
         }
         Returns: number
       }
+      recheck_mlg_goal: { Args: { p_goal_id: string }; Returns: undefined }
       rls_is_team_admin: { Args: { p_team_id: string }; Returns: boolean }
       rls_is_team_comp_admin: {
         Args: { p_team_comp_id: string }
@@ -2501,6 +2622,18 @@ export type Database = {
       gender: "male" | "female"
       member_status: "active" | "inactive" | "banned" | "pending"
       participation_role: "participant" | "cheering" | "volunteer"
+      pt_actv_type_enm:
+        | "regular_attend"
+        | "gthr_attend"
+        | "evt_attend"
+        | "gthr_host"
+        | "comp_join"
+        | "comp_record"
+        | "mlg_record"
+        | "mlg_goal"
+        | "sch_post"
+        | "manual"
+      pt_txn_type_enm: "earn" | "revoke" | "spend" | "manual_adj"
       ttl_kind_enm: "auto" | "awarded"
     }
     CompositeTypes: {
@@ -2638,6 +2771,19 @@ export const Constants = {
       gender: ["male", "female"],
       member_status: ["active", "inactive", "banned", "pending"],
       participation_role: ["participant", "cheering", "volunteer"],
+      pt_actv_type_enm: [
+        "regular_attend",
+        "gthr_attend",
+        "evt_attend",
+        "gthr_host",
+        "comp_join",
+        "comp_record",
+        "mlg_record",
+        "mlg_goal",
+        "sch_post",
+        "manual",
+      ],
+      pt_txn_type_enm: ["earn", "revoke", "spend", "manual_adj"],
       ttl_kind_enm: ["auto", "awarded"],
     },
   },

--- a/supabase/migrations/20260704100000_pt_txn_hist.sql
+++ b/supabase/migrations/20260704100000_pt_txn_hist.sql
@@ -1,0 +1,86 @@
+-- ============================================================
+-- 기강 포인트 제도 — enum + 원장 테이블 (pt_txn_hist)
+-- 설계 문서: docs/design/2026-07-04-기강포인트제도.md §5.1
+--
+-- 히든 운영 원칙(§1): 적립 로직은 실제로 돌지만 UI 어디에도 노출하지 않는다.
+--   원장은 처음부터 감사 가능(append-only)해야 추후 공개 시 이력이 그대로 살아있다.
+--   도입 시점은 2026-07부터(과거 이력 백필 없음) — 트리거(마이그레이션 ②)에서 가드.
+-- ============================================================
+
+-- ------------------------------------------------------------
+-- enum
+-- ------------------------------------------------------------
+
+CREATE TYPE public.pt_txn_type_enm AS ENUM ('earn', 'revoke', 'spend', 'manual_adj');
+
+COMMENT ON TYPE public.pt_txn_type_enm IS
+  '포인트 거래 유형: earn(적립) | revoke(회수, 역분개) | spend(사용, 추후 도입) | manual_adj(관리자 수동 조정)';
+
+CREATE TYPE public.pt_actv_type_enm AS ENUM (
+  'regular_attend',  -- 정모 참석 +30
+  'gthr_attend',     -- 벙 참석 +10
+  'evt_attend',      -- 이벤트 참석 +20
+  'gthr_host',       -- 벙 개설 +5
+  'comp_join',       -- 대회 참가 +20
+  'comp_record',     -- 대회 기록 등록 +20
+  'mlg_record',      -- 마일리지런 기록 +2 (1일 1건)
+  'mlg_goal',        -- 마일리지런 월 목표 달성 +10
+  'sch_post',        -- 정보 등록 +5
+  'manual'           -- 관리자 수동 조정
+);
+
+COMMENT ON TYPE public.pt_actv_type_enm IS
+  '포인트 적립 대상 활동 유형. 점수 상수는 public.pt_rule_amt(actv_type) 함수(마이그레이션 ②)에서 관리';
+
+-- ------------------------------------------------------------
+-- 원장 테이블
+-- ------------------------------------------------------------
+
+CREATE TABLE public.pt_txn_hist (
+  pt_txn_id     uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  team_id       uuid NOT NULL REFERENCES public.team_mst(team_id),
+  mem_id        uuid NOT NULL REFERENCES public.mem_mst(mem_id),
+  actv_type_enm public.pt_actv_type_enm NOT NULL,
+  txn_type_enm  public.pt_txn_type_enm NOT NULL,
+  pt_amt        integer NOT NULL,          -- earn > 0, revoke/spend < 0 (CHECK)
+  aply_dt       date NOT NULL,             -- 귀속 기준일 (KST, §4.3) — 월 집계는 이 컬럼으로 GROUP BY
+  ref_type_txt  text,                      -- 원천 종류: 'gthr' | 'comp_reg' | 'race_result' | 'mlg_act' | 'mlg_goal' | 'sch_post'
+  ref_id        uuid,                      -- 원천 PK (earn/revoke 짝 맞춤 키). mlg_record는 예외로 NULL(§5.2)
+  rsn_txt       text,                      -- 사람이 읽을 사유. 예: "정모 참석: 6월 정기런"
+  crt_at        timestamptz NOT NULL DEFAULT now(),
+  CONSTRAINT ck_pt_amt_sign CHECK (
+    (txn_type_enm = 'earn' AND pt_amt > 0)
+    OR (txn_type_enm IN ('revoke', 'spend') AND pt_amt < 0)
+    OR (txn_type_enm = 'manual_adj')
+  )
+);
+
+COMMENT ON TABLE  public.pt_txn_hist               IS '기강 포인트 원장(append-only). UPDATE/DELETE 금지 — 정정은 manual_adj row 추가. 유저 비공개(§1, §7)';
+COMMENT ON COLUMN public.pt_txn_hist.team_id        IS '소속 팀 (team_mst FK)';
+COMMENT ON COLUMN public.pt_txn_hist.mem_id         IS '대상 멤버 (mem_mst FK)';
+COMMENT ON COLUMN public.pt_txn_hist.actv_type_enm  IS '적립 대상 활동 유형';
+COMMENT ON COLUMN public.pt_txn_hist.txn_type_enm   IS '거래 유형 (earn/revoke/spend/manual_adj)';
+COMMENT ON COLUMN public.pt_txn_hist.pt_amt         IS '포인트 증감량. earn>0, revoke/spend<0, manual_adj는 부호 자유';
+COMMENT ON COLUMN public.pt_txn_hist.aply_dt        IS '귀속 기준일(KST date). 월 랭킹·집계는 이 컬럼 기준 GROUP BY (§3-3)';
+COMMENT ON COLUMN public.pt_txn_hist.ref_type_txt   IS '원천 테이블 종류 태그 (감사용)';
+COMMENT ON COLUMN public.pt_txn_hist.ref_id         IS '원천 PK. net(mem, actv, ref) 판정의 짝 맞춤 키(§5.2). mlg_record만 NULL(1일 1건은 aply_dt로 판정)';
+COMMENT ON COLUMN public.pt_txn_hist.rsn_txt        IS '사람이 읽을 수 있는 적립/회수 사유';
+COMMENT ON COLUMN public.pt_txn_hist.crt_at         IS '원장 row 생성 시각(실제 적립 처리 시각, aply_dt와 다를 수 있음)';
+
+-- 월 집계·랭킹용 (팀+멤버+귀속일 범위 조회)
+CREATE INDEX ix_pt_txn_hist_mem_aply ON public.pt_txn_hist (team_id, mem_id, aply_dt);
+
+-- 순액(net) 판정(earn/revoke 짝)용 — 트리거가 매 이벤트마다 조회
+CREATE INDEX ix_pt_txn_hist_ref ON public.pt_txn_hist (mem_id, actv_type_enm, ref_id);
+
+-- ------------------------------------------------------------
+-- RLS — 노출 0 보장(§7). 정책을 하나도 만들지 않아 클라이언트 접근 전면 차단.
+--   쓰기는 SECURITY DEFINER 트리거 함수(마이그레이션 ②)만 가능.
+--   조회는 당분간 관리자 SQL(MCP)로만.
+-- ------------------------------------------------------------
+
+ALTER TABLE public.pt_txn_hist ENABLE ROW LEVEL SECURITY;
+
+-- 방어선 추가: 스키마 기본 GRANT(ALTER DEFAULT PRIVILEGES 잔재)로 부여되는 테이블 권한 자체를 회수.
+-- RLS(정책 0개)만으로도 차단되지만, 권한 레벨에서도 이중 차단(defense in depth).
+REVOKE ALL ON TABLE public.pt_txn_hist FROM anon, authenticated;

--- a/supabase/migrations/20260704110000_pt_txn_hist_triggers.sql
+++ b/supabase/migrations/20260704110000_pt_txn_hist_triggers.sql
@@ -1,0 +1,835 @@
+-- ============================================================
+-- 기강 포인트 제도 — 헬퍼 + 트리거
+-- 설계 문서: docs/design/2026-07-04-기강포인트제도.md §4, §5.2~5.4, §6
+--
+-- 적립 지점을 앱 코드가 아니라 DB 트리거로 둔다(§4.1) — comp_reg_rel 등 클라이언트
+-- 직접 INSERT/DELETE 경로가 여러 컴포넌트에 산재해 앱 훅으로는 누락 위험이 크기 때문.
+-- 트리거 함수는 SECURITY DEFINER + search_path 고정으로 RLS 잠긴 pt_txn_hist에 쓴다.
+-- 실패를 삼키지 않는다(원장 유실이 UX 에러 1회보다 나쁘다는 결정, §6 트리거 공통 구현 규칙).
+--
+-- 도입일 가드: aply_dt < '2026-07-01'이면 earn 하지 않는다(과거 백필 없음, §1).
+--   회수는 가드하지 않는다 — 도입 후 적립된 것만 회수 대상이므로 net 규칙이 자연히 처리(§6 하단 주석).
+-- ============================================================
+
+-- ------------------------------------------------------------
+-- 0. 도입일 상수 — 여러 함수가 공유
+-- ------------------------------------------------------------
+
+CREATE OR REPLACE FUNCTION public.pt_intro_dt()
+RETURNS date LANGUAGE sql IMMUTABLE PARALLEL SAFE AS
+$$ SELECT '2026-07-01'::date; $$;
+
+COMMENT ON FUNCTION public.pt_intro_dt() IS '기강 포인트 제도 도입일(KST). 이 날짜 이전 aply_dt는 earn 적립하지 않는다(백필 없음, §1)';
+
+-- ------------------------------------------------------------
+-- 1. 점수 상수 — 단일 지점(§4.2). 값 변경 = 이 함수만 재정의하는 마이그레이션 1건.
+-- ------------------------------------------------------------
+
+CREATE OR REPLACE FUNCTION public.pt_rule_amt(p_actv public.pt_actv_type_enm)
+RETURNS integer LANGUAGE sql IMMUTABLE PARALLEL SAFE AS
+$$
+  SELECT CASE p_actv
+    WHEN 'regular_attend' THEN 30
+    WHEN 'gthr_attend'    THEN 10
+    WHEN 'evt_attend'     THEN 20
+    WHEN 'gthr_host'      THEN 5
+    WHEN 'comp_join'      THEN 20
+    WHEN 'comp_record'    THEN 20
+    WHEN 'mlg_record'     THEN 2
+    WHEN 'mlg_goal'       THEN 10
+    WHEN 'sch_post'       THEN 5
+    ELSE 0
+  END;
+$$;
+
+COMMENT ON FUNCTION public.pt_rule_amt(public.pt_actv_type_enm) IS
+  '활동 유형별 적립 포인트 상수 (설계 문서 §2 룰셋). manual은 0 반환 — manual_adj는 별도 amt를 직접 지정';
+
+-- ------------------------------------------------------------
+-- 2. net 판정 헬퍼 (§5.2) — ref_id 기반 (기본 케이스)
+-- ------------------------------------------------------------
+
+CREATE OR REPLACE FUNCTION public.pt_net_by_ref(
+  p_mem_id uuid,
+  p_actv   public.pt_actv_type_enm,
+  p_ref_id uuid
+) RETURNS integer LANGUAGE sql STABLE AS
+$$
+  SELECT COALESCE(SUM(pt_amt), 0)::integer
+  FROM public.pt_txn_hist
+  WHERE mem_id = p_mem_id
+    AND actv_type_enm = p_actv
+    AND ref_id IS NOT DISTINCT FROM p_ref_id;
+$$;
+
+COMMENT ON FUNCTION public.pt_net_by_ref(uuid, public.pt_actv_type_enm, uuid) IS
+  'net(mem, actv, ref) — 순액 판정(§5.2). earn은 net=0일 때만, revoke는 net>0일 때만(-net) 적용';
+
+-- mlg_record 전용 net 판정 — ref_id 대신 (mem, actv, aply_dt)로 짝 판정 (1일 1건 규칙, §6 하단)
+CREATE OR REPLACE FUNCTION public.pt_net_mlg_record(
+  p_mem_id  uuid,
+  p_aply_dt date
+) RETURNS integer LANGUAGE sql STABLE AS
+$$
+  SELECT COALESCE(SUM(pt_amt), 0)::integer
+  FROM public.pt_txn_hist
+  WHERE mem_id = p_mem_id
+    AND actv_type_enm = 'mlg_record'
+    AND ref_id IS NULL
+    AND aply_dt = p_aply_dt;
+$$;
+
+COMMENT ON FUNCTION public.pt_net_mlg_record(uuid, date) IS
+  'mlg_record 전용 net 판정 — ref_id를 안 쓰고 (mem, aply_dt=달린 날짜)로 1일 1건 짝을 맞춘다(§5.2, §6)';
+
+-- ------------------------------------------------------------
+-- 3. earn/revoke 삽입 헬퍼 — 도입일 가드 + net 판정을 한 곳에서 처리
+-- ------------------------------------------------------------
+
+-- ref_id 기반 earn: net=0일 때만 삽입. 도입일 이전 aply_dt는 스킵.
+CREATE OR REPLACE FUNCTION public.pt_earn(
+  p_team_id uuid,
+  p_mem_id  uuid,
+  p_actv    public.pt_actv_type_enm,
+  p_aply_dt date,
+  p_ref_type text,
+  p_ref_id  uuid,
+  p_rsn_txt text
+) RETURNS void LANGUAGE plpgsql AS
+$$
+BEGIN
+  IF p_aply_dt < public.pt_intro_dt() THEN
+    RETURN;
+  END IF;
+
+  IF public.pt_net_by_ref(p_mem_id, p_actv, p_ref_id) <> 0 THEN
+    RETURN; -- 이미 적립됨(토글/재시도 안전, §5.2)
+  END IF;
+
+  INSERT INTO public.pt_txn_hist (team_id, mem_id, actv_type_enm, txn_type_enm, pt_amt, aply_dt, ref_type_txt, ref_id, rsn_txt)
+  VALUES (p_team_id, p_mem_id, p_actv, 'earn', public.pt_rule_amt(p_actv), p_aply_dt, p_ref_type, p_ref_id, p_rsn_txt);
+END;
+$$;
+
+COMMENT ON FUNCTION public.pt_earn(uuid, uuid, public.pt_actv_type_enm, date, text, uuid, text) IS
+  'ref_id 기반 earn. net=0일 때만 삽입 + 도입일(pt_intro_dt) 가드';
+
+-- ref_id 기반 revoke: net>0일 때만 -net 삽입. 도입일 가드 없음(회수는 net 규칙이 자연히 처리).
+CREATE OR REPLACE FUNCTION public.pt_revoke(
+  p_team_id uuid,
+  p_mem_id  uuid,
+  p_actv    public.pt_actv_type_enm,
+  p_aply_dt date,
+  p_ref_type text,
+  p_ref_id  uuid,
+  p_rsn_txt text
+) RETURNS void LANGUAGE plpgsql AS
+$$
+DECLARE
+  v_net integer;
+BEGIN
+  v_net := public.pt_net_by_ref(p_mem_id, p_actv, p_ref_id);
+  IF v_net <= 0 THEN
+    RETURN; -- 이미 회수됐거나 애초에 적립 없음(이중 회수 안전, §5.2)
+  END IF;
+
+  INSERT INTO public.pt_txn_hist (team_id, mem_id, actv_type_enm, txn_type_enm, pt_amt, aply_dt, ref_type_txt, ref_id, rsn_txt)
+  VALUES (p_team_id, p_mem_id, p_actv, 'revoke', -v_net, p_aply_dt, p_ref_type, p_ref_id, p_rsn_txt);
+END;
+$$;
+
+COMMENT ON FUNCTION public.pt_revoke(uuid, uuid, public.pt_actv_type_enm, date, text, uuid, text) IS
+  'ref_id 기반 revoke. net>0일 때만 -net 삽입(회수액=현재 순액). 도입일 가드 없음';
+
+-- mlg_record 전용 earn/revoke (ref_id 없이 aply_dt로 짝 판정)
+CREATE OR REPLACE FUNCTION public.pt_earn_mlg_record(
+  p_team_id uuid,
+  p_mem_id  uuid,
+  p_aply_dt date,
+  p_rsn_txt text
+) RETURNS void LANGUAGE plpgsql AS
+$$
+BEGIN
+  IF p_aply_dt < public.pt_intro_dt() THEN
+    RETURN;
+  END IF;
+
+  -- 동시성 직렬화: (mem, 날짜) 짝에 유니크 제약이 없어(같은 날 기록 다건 허용) net 판정이
+  -- 겹치는 트랜잭션에서 레이스 → 이중 earn 가능. advisory xact lock으로 같은 키를 직렬화.
+  PERFORM pg_advisory_xact_lock(hashtext('pt_mlg_record:' || p_mem_id::text || ':' || p_aply_dt::text)::bigint);
+
+  IF public.pt_net_mlg_record(p_mem_id, p_aply_dt) <> 0 THEN
+    RETURN;
+  END IF;
+
+  INSERT INTO public.pt_txn_hist (team_id, mem_id, actv_type_enm, txn_type_enm, pt_amt, aply_dt, ref_type_txt, ref_id, rsn_txt)
+  VALUES (p_team_id, p_mem_id, 'mlg_record', 'earn', public.pt_rule_amt('mlg_record'), p_aply_dt, 'mlg_act', NULL, p_rsn_txt);
+END;
+$$;
+
+COMMENT ON FUNCTION public.pt_earn_mlg_record(uuid, uuid, date, text) IS
+  'mlg_record 전용 earn — ref_id NULL, (mem, aply_dt)로 1일 1건 판정 + 도입일 가드';
+
+CREATE OR REPLACE FUNCTION public.pt_revoke_mlg_record(
+  p_team_id uuid,
+  p_mem_id  uuid,
+  p_aply_dt date,
+  p_rsn_txt text
+) RETURNS void LANGUAGE plpgsql AS
+$$
+DECLARE
+  v_net integer;
+BEGIN
+  -- pt_earn_mlg_record와 같은 키로 직렬화 (동시 earn/revoke 레이스 방지)
+  PERFORM pg_advisory_xact_lock(hashtext('pt_mlg_record:' || p_mem_id::text || ':' || p_aply_dt::text)::bigint);
+
+  v_net := public.pt_net_mlg_record(p_mem_id, p_aply_dt);
+  IF v_net <= 0 THEN
+    RETURN;
+  END IF;
+
+  INSERT INTO public.pt_txn_hist (team_id, mem_id, actv_type_enm, txn_type_enm, pt_amt, aply_dt, ref_type_txt, ref_id, rsn_txt)
+  VALUES (p_team_id, p_mem_id, 'mlg_record', 'revoke', -v_net, p_aply_dt, 'mlg_act', NULL, p_rsn_txt);
+END;
+$$;
+
+COMMENT ON FUNCTION public.pt_revoke_mlg_record(uuid, uuid, date, text) IS
+  'mlg_record 전용 revoke — (mem, aply_dt) 짝의 net>0일 때만 회수';
+
+-- ------------------------------------------------------------
+-- 4. 마일리지런 월 목표 달성 재판정 (§5.4)
+--    기록 INSERT/UPDATE/DELETE, 목표 수정이 전부 이 함수를 호출한다.
+-- ------------------------------------------------------------
+
+CREATE OR REPLACE FUNCTION public.recheck_mlg_goal(p_goal_id uuid)
+RETURNS void LANGUAGE plpgsql SECURITY DEFINER SET search_path = public AS
+$$
+DECLARE
+  v_prt_id    uuid;
+  v_base_dt   date;
+  v_goal_mlg  integer;
+  v_mem_id    uuid;
+  v_team_id   uuid;
+  v_achv_mlg  numeric;
+  v_achieved  boolean;
+  v_net       integer;
+BEGIN
+  SELECT s.prt_id, s.base_dt, s.goal_mlg, s.achv_mlg
+    INTO v_prt_id, v_base_dt, v_goal_mlg, v_achv_mlg
+  FROM public.evt_mlg_mth_snap s
+  WHERE s.goal_id = p_goal_id;
+
+  IF NOT FOUND THEN
+    RETURN;
+  END IF;
+
+  SELECT p.mem_id, t.team_id
+    INTO v_mem_id, v_team_id
+  FROM public.evt_team_prt_rel p
+  JOIN public.evt_team_mst t ON t.evt_id = p.evt_id
+  WHERE p.prt_id = v_prt_id;
+
+  IF NOT FOUND THEN
+    RETURN;
+  END IF;
+
+  -- 동시성 직렬화: 근접 기록 다건 삽입 시 같은 goal_id 재판정이 겹치면 net 레이스 → 이중 earn 가능
+  PERFORM pg_advisory_xact_lock(hashtext('pt_mlg_goal:' || p_goal_id::text)::bigint);
+
+  v_achieved := v_achv_mlg >= v_goal_mlg;
+  v_net := public.pt_net_by_ref(v_mem_id, 'mlg_goal', p_goal_id);
+
+  IF v_achieved AND v_net = 0 THEN
+    PERFORM public.pt_earn(
+      v_team_id, v_mem_id, 'mlg_goal', v_base_dt, 'mlg_goal', p_goal_id,
+      '마일리지런 월 목표 달성 (' || to_char(v_base_dt, 'YYYY-MM') || ')'
+    );
+  ELSIF NOT v_achieved AND v_net > 0 THEN
+    PERFORM public.pt_revoke(
+      v_team_id, v_mem_id, 'mlg_goal', v_base_dt, 'mlg_goal', p_goal_id,
+      '마일리지런 월 목표 미달 전환 (' || to_char(v_base_dt, 'YYYY-MM') || ')'
+    );
+  END IF;
+END;
+$$;
+
+COMMENT ON FUNCTION public.recheck_mlg_goal(uuid) IS
+  '마일리지런 월 목표 달성 실시간 재판정(§5.4). ref_id=evt_mlg_mth_snap.goal_id, aply_dt=해당 월 1일(base_dt)';
+
+-- ------------------------------------------------------------
+-- 5. ①gthr_attd_rel — 참석 적립/회수
+-- ------------------------------------------------------------
+
+CREATE OR REPLACE FUNCTION public.pt_trg_gthr_attd_rel()
+RETURNS trigger LANGUAGE plpgsql SECURITY DEFINER SET search_path = public AS
+$$
+DECLARE
+  v_gthr      record;
+  v_actv      public.pt_actv_type_enm;
+  v_aply_dt   date;
+BEGIN
+  IF TG_OP = 'INSERT' THEN
+    SELECT team_id, gthr_type_enm, gthr_nm, stt_at, del_yn INTO v_gthr
+    FROM public.gthr_mst WHERE gthr_id = NEW.gthr_id;
+
+    IF NOT FOUND OR v_gthr.del_yn THEN
+      RETURN NEW; -- 삭제된 모임에 대한 참석은 적립하지 않음
+    END IF;
+
+    v_actv := CASE v_gthr.gthr_type_enm
+      WHEN 'regular' THEN 'regular_attend'
+      WHEN 'general' THEN 'gthr_attend'
+      WHEN 'event'   THEN 'evt_attend'
+      ELSE NULL
+    END;
+    IF v_actv IS NULL THEN
+      RETURN NEW;
+    END IF;
+
+    v_aply_dt := (v_gthr.stt_at AT TIME ZONE 'Asia/Seoul')::date;
+
+    PERFORM public.pt_earn(
+      v_gthr.team_id, NEW.mem_id, v_actv, v_aply_dt, 'gthr', NEW.gthr_id,
+      CASE v_actv
+        WHEN 'regular_attend' THEN '정모 참석: ' || v_gthr.gthr_nm
+        WHEN 'gthr_attend'    THEN '벙 참석: ' || v_gthr.gthr_nm
+        ELSE '이벤트 참석: ' || v_gthr.gthr_nm
+      END
+    );
+
+    RETURN NEW;
+  END IF;
+
+  IF TG_OP = 'DELETE' THEN
+    SELECT team_id, gthr_type_enm, gthr_nm, stt_at INTO v_gthr
+    FROM public.gthr_mst WHERE gthr_id = OLD.gthr_id;
+
+    IF NOT FOUND THEN
+      RETURN OLD;
+    END IF;
+
+    v_actv := CASE v_gthr.gthr_type_enm
+      WHEN 'regular' THEN 'regular_attend'
+      WHEN 'general' THEN 'gthr_attend'
+      WHEN 'event'   THEN 'evt_attend'
+      ELSE NULL
+    END;
+    IF v_actv IS NULL THEN
+      RETURN OLD;
+    END IF;
+
+    v_aply_dt := (v_gthr.stt_at AT TIME ZONE 'Asia/Seoul')::date;
+
+    PERFORM public.pt_revoke(
+      v_gthr.team_id, OLD.mem_id, v_actv, v_aply_dt, 'gthr', OLD.gthr_id,
+      '참석 취소: ' || v_gthr.gthr_nm
+    );
+
+    RETURN OLD;
+  END IF;
+
+  RETURN NULL;
+END;
+$$;
+
+COMMENT ON FUNCTION public.pt_trg_gthr_attd_rel() IS
+  '모임 참석 등록(INSERT)/취소(hard delete, DELETE) 시 타입별 포인트 적립·회수(§6)';
+
+CREATE TRIGGER trg_pt_gthr_attd_rel
+  AFTER INSERT OR DELETE ON public.gthr_attd_rel
+  FOR EACH ROW EXECUTE FUNCTION public.pt_trg_gthr_attd_rel();
+
+-- ------------------------------------------------------------
+-- 6. ②gthr_mst — 개설 적립 / 소프트 삭제 회수 / 시작일·타입 변경 재적립
+-- ------------------------------------------------------------
+
+CREATE OR REPLACE FUNCTION public.pt_gthr_actv_type(p_gthr_type_enm text)
+RETURNS public.pt_actv_type_enm LANGUAGE sql IMMUTABLE PARALLEL SAFE AS
+$$
+  SELECT CASE p_gthr_type_enm
+    WHEN 'regular' THEN 'regular_attend'::public.pt_actv_type_enm
+    WHEN 'general' THEN 'gthr_attend'::public.pt_actv_type_enm
+    WHEN 'event'   THEN 'evt_attend'::public.pt_actv_type_enm
+    ELSE NULL
+  END;
+$$;
+
+COMMENT ON FUNCTION public.pt_gthr_actv_type(text) IS
+  'gthr_mst.gthr_type_enm → 참석 포인트 pt_actv_type_enm 매핑 (§6)';
+
+CREATE OR REPLACE FUNCTION public.pt_trg_gthr_mst()
+RETURNS trigger LANGUAGE plpgsql SECURITY DEFINER SET search_path = public AS
+$$
+DECLARE
+  v_old_aply_dt date;
+  v_new_aply_dt date;
+  v_attendee    record;
+  v_old_actv    public.pt_actv_type_enm;
+  v_new_actv    public.pt_actv_type_enm;
+BEGIN
+  IF TG_OP = 'INSERT' THEN
+    IF NEW.gthr_type_enm = 'general' THEN
+      PERFORM public.pt_earn(
+        NEW.team_id, NEW.crt_by, 'gthr_host',
+        (NEW.stt_at AT TIME ZONE 'Asia/Seoul')::date,
+        'gthr', NEW.gthr_id, '벙 개설: ' || NEW.gthr_nm
+      );
+    END IF;
+    RETURN NEW;
+  END IF;
+
+  IF TG_OP = 'UPDATE' THEN
+    -- 소프트 삭제(del_yn false→true): 개설 포인트 회수 + 모든 참석 적립 회수
+    IF NEW.del_yn = true AND OLD.del_yn = false THEN
+      IF OLD.gthr_type_enm = 'general' THEN
+        PERFORM public.pt_revoke(
+          OLD.team_id, OLD.crt_by, 'gthr_host',
+          (OLD.stt_at AT TIME ZONE 'Asia/Seoul')::date,
+          'gthr', OLD.gthr_id, '모임 삭제로 개설 포인트 회수: ' || OLD.gthr_nm
+        );
+      END IF;
+
+      v_old_actv := public.pt_gthr_actv_type(OLD.gthr_type_enm);
+
+      IF v_old_actv IS NOT NULL THEN
+        v_old_aply_dt := (OLD.stt_at AT TIME ZONE 'Asia/Seoul')::date;
+        FOR v_attendee IN
+          SELECT mem_id FROM public.gthr_attd_rel WHERE gthr_id = OLD.gthr_id
+        LOOP
+          PERFORM public.pt_revoke(
+            OLD.team_id, v_attendee.mem_id, v_old_actv, v_old_aply_dt,
+            'gthr', OLD.gthr_id, '모임 삭제로 참석 포인트 회수: ' || OLD.gthr_nm
+          );
+        END LOOP;
+      END IF;
+
+      RETURN NEW;
+    END IF;
+
+    -- 시작일(stt_at) 또는 모임 타입(gthr_type_enm) 변경: 귀속일/점수가 어긋나므로
+    -- 해당 gthr ref의 earn 전부(개설+참석) 을 "옛 타입" 기준으로 revoke 후
+    -- "새 타입·새 aply_dt" 기준으로 재적립. 단 모임이 살아있고(del_yn=false) 도입일
+    -- 가드를 통과할 때만 재적립 — 회수는 net 규칙이 자연히 처리하므로 가드 불필요.
+    IF (NEW.gthr_type_enm IS DISTINCT FROM OLD.gthr_type_enm OR NEW.stt_at IS DISTINCT FROM OLD.stt_at)
+       AND NEW.del_yn = false THEN
+      v_old_aply_dt := (OLD.stt_at AT TIME ZONE 'Asia/Seoul')::date;
+      v_new_aply_dt := (NEW.stt_at AT TIME ZONE 'Asia/Seoul')::date;
+
+      -- 개설 포인트: general→비general 전환 시 revoke만, 비general→general 전환 시 earn만,
+      -- general 유지 시 (일시만 바뀐 경우) revoke 후 재적립
+      IF OLD.gthr_type_enm = 'general' THEN
+        PERFORM public.pt_revoke(
+          OLD.team_id, OLD.crt_by, 'gthr_host', v_old_aply_dt,
+          'gthr', OLD.gthr_id, '모임 정보 변경으로 개설 포인트 재조정: ' || OLD.gthr_nm
+        );
+      END IF;
+      IF NEW.gthr_type_enm = 'general' THEN
+        PERFORM public.pt_earn(
+          NEW.team_id, NEW.crt_by, 'gthr_host', v_new_aply_dt,
+          'gthr', NEW.gthr_id, '벙 개설: ' || NEW.gthr_nm
+        );
+      END IF;
+
+      -- 참석 포인트: 옛 타입으로 정확히 회수(ref_id+actv_type 짝) 후 새 타입으로 재적립
+      v_old_actv := public.pt_gthr_actv_type(OLD.gthr_type_enm);
+      v_new_actv := public.pt_gthr_actv_type(NEW.gthr_type_enm);
+
+      FOR v_attendee IN
+        SELECT mem_id FROM public.gthr_attd_rel WHERE gthr_id = NEW.gthr_id
+      LOOP
+        IF v_old_actv IS NOT NULL THEN
+          PERFORM public.pt_revoke(
+            OLD.team_id, v_attendee.mem_id, v_old_actv, v_old_aply_dt,
+            'gthr', NEW.gthr_id, '모임 정보 변경으로 참석 포인트 재조정: ' || OLD.gthr_nm
+          );
+        END IF;
+        IF v_new_actv IS NOT NULL THEN
+          PERFORM public.pt_earn(
+            NEW.team_id, v_attendee.mem_id, v_new_actv, v_new_aply_dt,
+            'gthr', NEW.gthr_id,
+            CASE v_new_actv
+              WHEN 'regular_attend' THEN '정모 참석: ' || NEW.gthr_nm
+              WHEN 'gthr_attend'    THEN '벙 참석: ' || NEW.gthr_nm
+              ELSE '이벤트 참석: ' || NEW.gthr_nm
+            END
+          );
+        END IF;
+      END LOOP;
+    END IF;
+
+    RETURN NEW;
+  END IF;
+
+  RETURN NULL;
+END;
+$$;
+
+COMMENT ON FUNCTION public.pt_trg_gthr_mst() IS
+  '모임 개설(INSERT, general만) 적립 / 소프트삭제(del_yn→true) 회수 / 시작일·타입(stt_at, gthr_type_enm) 변경 시 재적립(§6)';
+
+CREATE TRIGGER trg_pt_gthr_mst
+  AFTER INSERT OR UPDATE ON public.gthr_mst
+  FOR EACH ROW EXECUTE FUNCTION public.pt_trg_gthr_mst();
+
+-- ------------------------------------------------------------
+-- 7. ③comp_reg_rel — 대회 참가 적립/회수 (aply_dt = 대회 개최일)
+--    조인 경로: comp_reg_rel.team_comp_id → team_comp_plan_rel(team_id, comp_id) → comp_mst.stt_dt
+-- ------------------------------------------------------------
+
+CREATE OR REPLACE FUNCTION public.pt_trg_comp_reg_rel()
+RETURNS trigger LANGUAGE plpgsql SECURITY DEFINER SET search_path = public AS
+$$
+DECLARE
+  v_team_id  uuid;
+  v_stt_dt   date;
+  v_comp_nm  text;
+BEGIN
+  IF TG_OP = 'INSERT' THEN
+    SELECT tc.team_id, c.stt_dt, c.comp_nm
+      INTO v_team_id, v_stt_dt, v_comp_nm
+    FROM public.team_comp_plan_rel tc
+    JOIN public.comp_mst c ON c.comp_id = tc.comp_id
+    WHERE tc.team_comp_id = NEW.team_comp_id;
+
+    IF NOT FOUND OR v_stt_dt IS NULL THEN
+      -- 대회 개최일을 알 수 없으면 적립 스킵(§ 보고서 — comp_mst.stt_dt는 NOT NULL이라
+      -- 실무상 발생하지 않지만 방어적으로 처리)
+      RETURN NEW;
+    END IF;
+
+    PERFORM public.pt_earn(
+      v_team_id, NEW.mem_id, 'comp_join', v_stt_dt, 'comp_reg', NEW.comp_reg_id,
+      '대회 참가: ' || v_comp_nm
+    );
+
+    RETURN NEW;
+  END IF;
+
+  IF TG_OP = 'DELETE' THEN
+    SELECT tc.team_id, c.stt_dt, c.comp_nm
+      INTO v_team_id, v_stt_dt, v_comp_nm
+    FROM public.team_comp_plan_rel tc
+    JOIN public.comp_mst c ON c.comp_id = tc.comp_id
+    WHERE tc.team_comp_id = OLD.team_comp_id;
+
+    IF NOT FOUND OR v_stt_dt IS NULL THEN
+      RETURN OLD;
+    END IF;
+
+    PERFORM public.pt_revoke(
+      v_team_id, OLD.mem_id, 'comp_join', v_stt_dt, 'comp_reg', OLD.comp_reg_id,
+      '대회 참가 취소: ' || v_comp_nm
+    );
+
+    RETURN OLD;
+  END IF;
+
+  RETURN NULL;
+END;
+$$;
+
+COMMENT ON FUNCTION public.pt_trg_comp_reg_rel() IS
+  '대회 참가 신청(INSERT)/취소(hard delete, DELETE) 적립·회수. aply_dt=대회 개최일(comp_mst.stt_dt)(§6)';
+
+CREATE TRIGGER trg_pt_comp_reg_rel
+  AFTER INSERT OR DELETE ON public.comp_reg_rel
+  FOR EACH ROW EXECUTE FUNCTION public.pt_trg_comp_reg_rel();
+
+-- ------------------------------------------------------------
+-- 8. ④rec_race_hist — 대회 기록 등록 적립/회수 (대회일 2026-07-01 이후만)
+-- ------------------------------------------------------------
+
+CREATE OR REPLACE FUNCTION public.pt_trg_rec_race_hist()
+RETURNS trigger LANGUAGE plpgsql SECURITY DEFINER SET search_path = public AS
+$$
+DECLARE
+  v_team_id uuid;
+BEGIN
+  IF TG_OP = 'INSERT' THEN
+    SELECT tmr.team_id INTO v_team_id
+    FROM public.team_mem_rel tmr
+    WHERE tmr.mem_id = NEW.mem_id AND tmr.vers = 0 AND tmr.del_yn = false
+    LIMIT 1;
+
+    IF NOT FOUND THEN
+      RETURN NEW;
+    END IF;
+
+    PERFORM public.pt_earn(
+      v_team_id, NEW.mem_id, 'comp_record', NEW.race_dt, 'race_result', NEW.race_result_id,
+      '대회 기록 등록: ' || NEW.race_nm
+    );
+
+    RETURN NEW;
+  END IF;
+
+  IF TG_OP = 'DELETE' THEN
+    SELECT tmr.team_id INTO v_team_id
+    FROM public.team_mem_rel tmr
+    WHERE tmr.mem_id = OLD.mem_id AND tmr.vers = 0 AND tmr.del_yn = false
+    LIMIT 1;
+
+    IF NOT FOUND THEN
+      RETURN OLD;
+    END IF;
+
+    PERFORM public.pt_revoke(
+      v_team_id, OLD.mem_id, 'comp_record', OLD.race_dt, 'race_result', OLD.race_result_id,
+      '대회 기록 삭제: ' || OLD.race_nm
+    );
+
+    RETURN OLD;
+  END IF;
+
+  RETURN NULL;
+END;
+$$;
+
+COMMENT ON FUNCTION public.pt_trg_rec_race_hist() IS
+  '대회 기록 등록(INSERT)/삭제(hard delete, DELETE) 적립·회수. aply_dt=race_dt, pt_earn 내부 도입일 가드가 2026-07-01 이전 대회 기록을 자동 차단(§6)';
+
+CREATE TRIGGER trg_pt_rec_race_hist
+  AFTER INSERT OR DELETE ON public.rec_race_hist
+  FOR EACH ROW EXECUTE FUNCTION public.pt_trg_rec_race_hist();
+
+-- ------------------------------------------------------------
+-- 9. ⑤evt_mlg_act_hist — 마일리지런 기록 1일 1건 적립/회수 + 목표 재판정
+--    mem_id/team_id가 직접 없어 evt_team_prt_rel(→evt_team_mst) 조인 필요.
+--    실제 삭제 방식은 하드 delete(app/actions/mileage-run.ts deleteActivity 확인).
+-- ------------------------------------------------------------
+
+CREATE OR REPLACE FUNCTION public.pt_trg_evt_mlg_act_hist()
+RETURNS trigger LANGUAGE plpgsql SECURITY DEFINER SET search_path = public AS
+$$
+DECLARE
+  v_mem_id   uuid;
+  v_team_id  uuid;
+  v_remain   integer;
+  v_goal     record;
+BEGIN
+  IF TG_OP = 'INSERT' THEN
+    SELECT p.mem_id, t.team_id INTO v_mem_id, v_team_id
+    FROM public.evt_team_prt_rel p JOIN public.evt_team_mst t ON t.evt_id = p.evt_id
+    WHERE p.prt_id = NEW.prt_id;
+
+    IF FOUND THEN
+      PERFORM public.pt_earn_mlg_record(v_team_id, v_mem_id, NEW.act_dt, '마일리지런 기록: ' || to_char(NEW.act_dt, 'YYYY-MM-DD'));
+
+      FOR v_goal IN
+        SELECT goal_id FROM public.evt_mlg_mth_snap
+        WHERE prt_id = NEW.prt_id AND base_dt = date_trunc('month', NEW.act_dt)::date
+      LOOP
+        PERFORM public.recheck_mlg_goal(v_goal.goal_id);
+      END LOOP;
+    END IF;
+
+    RETURN NEW;
+  END IF;
+
+  IF TG_OP = 'DELETE' THEN
+    SELECT p.mem_id, t.team_id INTO v_mem_id, v_team_id
+    FROM public.evt_team_prt_rel p JOIN public.evt_team_mst t ON t.evt_id = p.evt_id
+    WHERE p.prt_id = OLD.prt_id;
+
+    IF FOUND THEN
+      SELECT count(*) INTO v_remain
+      FROM public.evt_mlg_act_hist
+      WHERE prt_id = OLD.prt_id AND act_dt = OLD.act_dt AND act_id <> OLD.act_id;
+
+      IF v_remain = 0 THEN
+        PERFORM public.pt_revoke_mlg_record(v_team_id, v_mem_id, OLD.act_dt, '마일리지런 기록 삭제: ' || to_char(OLD.act_dt, 'YYYY-MM-DD'));
+      END IF;
+
+      FOR v_goal IN
+        SELECT goal_id FROM public.evt_mlg_mth_snap
+        WHERE prt_id = OLD.prt_id AND base_dt = date_trunc('month', OLD.act_dt)::date
+      LOOP
+        PERFORM public.recheck_mlg_goal(v_goal.goal_id);
+      END LOOP;
+    END IF;
+
+    RETURN OLD;
+  END IF;
+
+  IF TG_OP = 'UPDATE' THEN
+    IF NEW.act_dt IS DISTINCT FROM OLD.act_dt THEN
+      SELECT p.mem_id, t.team_id INTO v_mem_id, v_team_id
+      FROM public.evt_team_prt_rel p JOIN public.evt_team_mst t ON t.evt_id = p.evt_id
+      WHERE p.prt_id = NEW.prt_id;
+
+      IF FOUND THEN
+        -- 옛 날짜: 이 기록을 뺀 나머지가 없으면 회수
+        SELECT count(*) INTO v_remain
+        FROM public.evt_mlg_act_hist
+        WHERE prt_id = OLD.prt_id AND act_dt = OLD.act_dt AND act_id <> OLD.act_id;
+
+        IF v_remain = 0 THEN
+          PERFORM public.pt_revoke_mlg_record(v_team_id, v_mem_id, OLD.act_dt, '마일리지런 날짜 변경(이전 날짜 회수): ' || to_char(OLD.act_dt, 'YYYY-MM-DD'));
+        END IF;
+
+        -- 새 날짜: 그날 첫 유효 기록이면 적립(자기 자신 포함 이미 존재하므로 net=0 검사로 충분)
+        PERFORM public.pt_earn_mlg_record(v_team_id, v_mem_id, NEW.act_dt, '마일리지런 기록: ' || to_char(NEW.act_dt, 'YYYY-MM-DD'));
+
+        FOR v_goal IN
+          SELECT goal_id FROM public.evt_mlg_mth_snap
+          WHERE prt_id = OLD.prt_id
+            AND base_dt IN (date_trunc('month', OLD.act_dt)::date, date_trunc('month', NEW.act_dt)::date)
+        LOOP
+          PERFORM public.recheck_mlg_goal(v_goal.goal_id);
+        END LOOP;
+      END IF;
+    ELSE
+      -- 날짜는 그대로, 거리 등 값만 바뀐 경우도 목표 달성 여부가 바뀔 수 있음
+      FOR v_goal IN
+        SELECT goal_id FROM public.evt_mlg_mth_snap
+        WHERE prt_id = NEW.prt_id AND base_dt = date_trunc('month', NEW.act_dt)::date
+      LOOP
+        PERFORM public.recheck_mlg_goal(v_goal.goal_id);
+      END LOOP;
+    END IF;
+
+    RETURN NEW;
+  END IF;
+
+  RETURN NULL;
+END;
+$$;
+
+COMMENT ON FUNCTION public.pt_trg_evt_mlg_act_hist() IS
+  '마일리지런 기록 INSERT/UPDATE/DELETE(hard delete) — 1일 1건 적립/회수(§6 하단) + 월 목표 재판정(recheck_mlg_goal) 호출';
+
+CREATE TRIGGER trg_pt_evt_mlg_act_hist
+  AFTER INSERT OR UPDATE OR DELETE ON public.evt_mlg_act_hist
+  FOR EACH ROW EXECUTE FUNCTION public.pt_trg_evt_mlg_act_hist();
+
+-- ------------------------------------------------------------
+-- 10. ⑥evt_mlg_mth_snap — 목표(goal_mlg) 변경 시 재판정
+--     achv_mlg/achv_yn도 같은 UPDATE로 갱신되므로(recalcGoalsFromMonth) goal_mlg 변경만 훅.
+-- ------------------------------------------------------------
+
+CREATE OR REPLACE FUNCTION public.pt_trg_evt_mlg_mth_snap()
+RETURNS trigger LANGUAGE plpgsql SECURITY DEFINER SET search_path = public AS
+$$
+BEGIN
+  IF NEW.goal_mlg IS DISTINCT FROM OLD.goal_mlg OR NEW.achv_mlg IS DISTINCT FROM OLD.achv_mlg THEN
+    PERFORM public.recheck_mlg_goal(NEW.goal_id);
+  END IF;
+  RETURN NEW;
+END;
+$$;
+
+COMMENT ON FUNCTION public.pt_trg_evt_mlg_mth_snap() IS
+  '월 목표(goal_mlg) 또는 달성 마일리지(achv_mlg) 변경 시 목표 달성 재판정(§6)';
+
+CREATE TRIGGER trg_pt_evt_mlg_mth_snap
+  AFTER UPDATE ON public.evt_mlg_mth_snap
+  FOR EACH ROW EXECUTE FUNCTION public.pt_trg_evt_mlg_mth_snap();
+
+-- ------------------------------------------------------------
+-- 11. ⑦sch_post_mst — 정보 등록 적립 / 소프트 삭제 회수
+-- ------------------------------------------------------------
+
+CREATE OR REPLACE FUNCTION public.pt_trg_sch_post_mst()
+RETURNS trigger LANGUAGE plpgsql SECURITY DEFINER SET search_path = public AS
+$$
+DECLARE
+  v_aply_dt date;
+BEGIN
+  IF TG_OP = 'INSERT' THEN
+    v_aply_dt := (NEW.crt_at AT TIME ZONE 'Asia/Seoul')::date;
+    PERFORM public.pt_earn(
+      NEW.team_id, NEW.crt_by, 'sch_post', v_aply_dt, 'sch_post', NEW.sch_post_id,
+      '정보 등록: ' || NEW.sch_nm
+    );
+    RETURN NEW;
+  END IF;
+
+  IF TG_OP = 'UPDATE' THEN
+    IF NEW.del_yn = true AND OLD.del_yn = false THEN
+      v_aply_dt := (OLD.crt_at AT TIME ZONE 'Asia/Seoul')::date;
+      PERFORM public.pt_revoke(
+        OLD.team_id, OLD.crt_by, 'sch_post', v_aply_dt, 'sch_post', OLD.sch_post_id,
+        '정보 삭제: ' || OLD.sch_nm
+      );
+    END IF;
+    RETURN NEW;
+  END IF;
+
+  RETURN NULL;
+END;
+$$;
+
+COMMENT ON FUNCTION public.pt_trg_sch_post_mst() IS
+  '정보 등록(INSERT) 적립 / 소프트 삭제(del_yn false→true, app/actions/schedule/manage-sch-post.ts deleteSchPost 확인) 회수. aply_dt=작성일(crt_at, KST)(§6)';
+
+CREATE TRIGGER trg_pt_sch_post_mst
+  AFTER INSERT OR UPDATE ON public.sch_post_mst
+  FOR EACH ROW EXECUTE FUNCTION public.pt_trg_sch_post_mst();
+
+-- ------------------------------------------------------------
+-- 12. comp_mst — 대회 개최일(stt_dt) 변경(연기 등) 시 comp_join 재적립
+--     comp_reg_rel(참가 신청)의 aply_dt가 comp_mst.stt_dt에서 파생되므로,
+--     대회일이 바뀌면 그 대회에 연결된 모든 참가 신청을 "옛 날짜"로 revoke 후
+--     "새 날짜"로 재적립한다(도입일 가드 재적용). comp_record(rec_race_hist.race_dt
+--     기준)는 개별 기록의 실제 완주일이라 대회 예정일 변경과 무관 — 건드리지 않음.
+--     조인 경로: comp_mst.comp_id → team_comp_plan_rel.comp_id → comp_reg_rel.team_comp_id
+-- ------------------------------------------------------------
+
+CREATE OR REPLACE FUNCTION public.pt_trg_comp_mst()
+RETURNS trigger LANGUAGE plpgsql SECURITY DEFINER SET search_path = public AS
+$$
+DECLARE
+  v_old_aply_dt date;
+  v_new_aply_dt date;
+  v_reg         record;
+BEGIN
+  IF TG_OP = 'UPDATE' AND NEW.stt_dt IS DISTINCT FROM OLD.stt_dt THEN
+    v_old_aply_dt := OLD.stt_dt;
+    v_new_aply_dt := NEW.stt_dt;
+
+    FOR v_reg IN
+      SELECT r.comp_reg_id, r.mem_id, tc.team_id
+      FROM public.team_comp_plan_rel tc
+      JOIN public.comp_reg_rel r ON r.team_comp_id = tc.team_comp_id
+      WHERE tc.comp_id = NEW.comp_id
+    LOOP
+      PERFORM public.pt_revoke(
+        v_reg.team_id, v_reg.mem_id, 'comp_join', v_old_aply_dt,
+        'comp_reg', v_reg.comp_reg_id, '대회 일정 변경으로 참가 포인트 재조정: ' || NEW.comp_nm
+      );
+      -- pt_earn 내부에서 도입일 가드 재적용 — 새 날짜가 2026-07-01 이전이면 revoke만 되고 재적립 안 됨
+      PERFORM public.pt_earn(
+        v_reg.team_id, v_reg.mem_id, 'comp_join', v_new_aply_dt,
+        'comp_reg', v_reg.comp_reg_id, '대회 참가: ' || NEW.comp_nm
+      );
+    END LOOP;
+  END IF;
+
+  RETURN NEW;
+END;
+$$;
+
+COMMENT ON FUNCTION public.pt_trg_comp_mst() IS
+  '대회 개최일(stt_dt) 변경(연기 등) 시 그 대회의 모든 comp_join 적립을 재조정. comp_record는 무관(§6, §11 결정로그)';
+
+CREATE TRIGGER trg_pt_comp_mst
+  AFTER UPDATE ON public.comp_mst
+  FOR EACH ROW EXECUTE FUNCTION public.pt_trg_comp_mst();
+
+-- ------------------------------------------------------------
+-- 13. API 노출 차단 — public 스키마 함수는 PostgREST /rpc/ 로 호출될 수 있고
+--     Postgres 기본값은 PUBLIC에 EXECUTE 부여. 특히 recheck_mlg_goal은
+--     SECURITY DEFINER(RETURNS void)라 클라이언트가 직접 호출 가능해지므로 전면 회수.
+--     (트리거 함수 RETURNS trigger는 RPC 호출 불가라 대상 아님)
+-- ------------------------------------------------------------
+
+REVOKE EXECUTE ON FUNCTION public.pt_intro_dt() FROM PUBLIC, anon, authenticated;
+REVOKE EXECUTE ON FUNCTION public.pt_rule_amt(public.pt_actv_type_enm) FROM PUBLIC, anon, authenticated;
+REVOKE EXECUTE ON FUNCTION public.pt_net_by_ref(uuid, public.pt_actv_type_enm, uuid) FROM PUBLIC, anon, authenticated;
+REVOKE EXECUTE ON FUNCTION public.pt_net_mlg_record(uuid, date) FROM PUBLIC, anon, authenticated;
+REVOKE EXECUTE ON FUNCTION public.pt_earn(uuid, uuid, public.pt_actv_type_enm, date, text, uuid, text) FROM PUBLIC, anon, authenticated;
+REVOKE EXECUTE ON FUNCTION public.pt_revoke(uuid, uuid, public.pt_actv_type_enm, date, text, uuid, text) FROM PUBLIC, anon, authenticated;
+REVOKE EXECUTE ON FUNCTION public.pt_earn_mlg_record(uuid, uuid, date, text) FROM PUBLIC, anon, authenticated;
+REVOKE EXECUTE ON FUNCTION public.pt_revoke_mlg_record(uuid, uuid, date, text) FROM PUBLIC, anon, authenticated;
+REVOKE EXECUTE ON FUNCTION public.pt_gthr_actv_type(text) FROM PUBLIC, anon, authenticated;
+REVOKE EXECUTE ON FUNCTION public.recheck_mlg_goal(uuid) FROM PUBLIC, anon, authenticated;

--- a/supabase/migrations/20260704120000_pt_seed_backfill.sql
+++ b/supabase/migrations/20260704120000_pt_seed_backfill.sql
@@ -1,0 +1,144 @@
+-- ============================================================
+-- 기강 포인트 제도 — 도입 시드(백필)
+-- 설계 문서: docs/design/2026-07-04-기강포인트제도.md §10 작업분해 2.5
+--
+-- 배경: 트리거(20260704110000)는 "적용 이후" 발생하는 원천 변경만 잡는다.
+--   그런데 이 마이그레이션이 적용되는 시점엔 이미 7월 모임 RSVP, 도입 후 대회일의
+--   기존 참가 신청, 7월 마일리지런 기록 등 "원천은 먼저 존재하지만 트리거는 못 본" 데이터가
+--   있을 수 있다. 원칙: 포인트는 활동일(aply_dt) 기준이지 데이터가 언제 쌓였는지는 무관
+--   (§1, §10) — 따라서 귀속일 ≥ 2026-07-01인 기존 원천을 소급 earn 한다.
+--
+-- 멱등성: 전부 트리거와 동일한 pt_earn/pt_earn_mlg_record 헬퍼(net=0 가드 내장)를 재사용한다.
+--   이미 트리거가 적립해둔 건은 net<>0이라 스킵되므로, 이 마이그레이션은 dev/prd 어느
+--   시점에 실행(재실행 포함)해도 안전하다. 규칙 이원화(시드 전용 로직)를 피하기 위해
+--   새 SQL을 직접 작성하지 않고 반드시 기존 헬퍼를 호출한다.
+--
+-- 회수(revoke)는 시드 대상이 아니다 — 백필은 "아직 없는 적립을 채우는" 단방향 동작이며,
+-- 이미 삭제된 원천(hard delete)은 애초에 이 시드가 순회할 대상 테이블에 남아있지 않다.
+-- ============================================================
+
+DO $$
+DECLARE
+  v_row record;
+BEGIN
+  -- ------------------------------------------------------------
+  -- 1) gthr_attd_rel — 참석 (모임 stt_at KST date >= 7/1, 모임 살아있음)
+  -- ------------------------------------------------------------
+  FOR v_row IN
+    SELECT
+      a.mem_id,
+      g.team_id,
+      g.gthr_id,
+      g.gthr_nm,
+      g.gthr_type_enm,
+      (g.stt_at AT TIME ZONE 'Asia/Seoul')::date AS aply_dt
+    FROM public.gthr_attd_rel a
+    JOIN public.gthr_mst g ON g.gthr_id = a.gthr_id
+    WHERE g.del_yn = false
+      AND (g.stt_at AT TIME ZONE 'Asia/Seoul')::date >= public.pt_intro_dt()
+  LOOP
+    IF public.pt_gthr_actv_type(v_row.gthr_type_enm) IS NOT NULL THEN
+      PERFORM public.pt_earn(
+        v_row.team_id, v_row.mem_id, public.pt_gthr_actv_type(v_row.gthr_type_enm), v_row.aply_dt,
+        'gthr', v_row.gthr_id,
+        '[시드] ' || CASE v_row.gthr_type_enm
+          WHEN 'regular' THEN '정모 참석: '
+          WHEN 'general' THEN '벙 참석: '
+          ELSE '이벤트 참석: '
+        END || v_row.gthr_nm
+      );
+    END IF;
+  END LOOP;
+
+  -- ------------------------------------------------------------
+  -- 2) gthr_mst — 개설 (general만, 살아있음, stt_at KST date >= 7/1)
+  -- ------------------------------------------------------------
+  FOR v_row IN
+    SELECT team_id, gthr_id, gthr_nm, crt_by, (stt_at AT TIME ZONE 'Asia/Seoul')::date AS aply_dt
+    FROM public.gthr_mst
+    WHERE gthr_type_enm = 'general'
+      AND del_yn = false
+      AND (stt_at AT TIME ZONE 'Asia/Seoul')::date >= public.pt_intro_dt()
+  LOOP
+    PERFORM public.pt_earn(
+      v_row.team_id, v_row.crt_by, 'gthr_host',
+      v_row.aply_dt, 'gthr', v_row.gthr_id, '[시드] 벙 개설: ' || v_row.gthr_nm
+    );
+  END LOOP;
+
+  -- ------------------------------------------------------------
+  -- 3) comp_reg_rel — 대회 참가 (대회 개최일 >= 7/1). 11월 등 미래 대회 기신청 포함.
+  -- ------------------------------------------------------------
+  FOR v_row IN
+    SELECT r.comp_reg_id, r.mem_id, tc.team_id, c.stt_dt AS aply_dt, c.comp_nm
+    FROM public.comp_reg_rel r
+    JOIN public.team_comp_plan_rel tc ON tc.team_comp_id = r.team_comp_id
+    JOIN public.comp_mst c ON c.comp_id = tc.comp_id
+    WHERE c.stt_dt >= public.pt_intro_dt()
+  LOOP
+    PERFORM public.pt_earn(
+      v_row.team_id, v_row.mem_id, 'comp_join', v_row.aply_dt,
+      'comp_reg', v_row.comp_reg_id, '[시드] 대회 참가: ' || v_row.comp_nm
+    );
+  END LOOP;
+
+  -- ------------------------------------------------------------
+  -- 4) rec_race_hist — 대회 기록 (대회일 >= 7/1). pt_earn 내부 가드가 이중 방어.
+  -- ------------------------------------------------------------
+  FOR v_row IN
+    SELECT h.race_result_id, h.mem_id, h.race_dt, h.race_nm, tmr.team_id
+    FROM public.rec_race_hist h
+    JOIN public.team_mem_rel tmr ON tmr.mem_id = h.mem_id AND tmr.vers = 0 AND tmr.del_yn = false
+    WHERE h.race_dt >= public.pt_intro_dt()
+  LOOP
+    PERFORM public.pt_earn(
+      v_row.team_id, v_row.mem_id, 'comp_record', v_row.race_dt,
+      'race_result', v_row.race_result_id, '[시드] 대회 기록 등록: ' || v_row.race_nm
+    );
+  END LOOP;
+
+  -- ------------------------------------------------------------
+  -- 5) evt_mlg_act_hist — 마일리지런 기록 (act_dt >= 7/1). 1일 1건만 인정하므로
+  --    (mem, 날짜)별로 한 번만 호출 — pt_earn_mlg_record의 net=0 가드가 자연히
+  --    "그 날짜의 첫 유효 기록"만 적립되게 한다(같은 날 여러 건이어도 중복 없음).
+  -- ------------------------------------------------------------
+  FOR v_row IN
+    SELECT DISTINCT p.mem_id, t.team_id, h.act_dt
+    FROM public.evt_mlg_act_hist h
+    JOIN public.evt_team_prt_rel p ON p.prt_id = h.prt_id
+    JOIN public.evt_team_mst t ON t.evt_id = p.evt_id
+    WHERE h.act_dt >= public.pt_intro_dt()
+  LOOP
+    PERFORM public.pt_earn_mlg_record(
+      v_row.team_id, v_row.mem_id, v_row.act_dt, '[시드] 마일리지런 기록: ' || to_char(v_row.act_dt, 'YYYY-MM-DD')
+    );
+  END LOOP;
+
+  -- ------------------------------------------------------------
+  -- 6) evt_mlg_mth_snap — 월 목표 달성 (base_dt >= 7/1 월, 이미 달성 상태인 것만)
+  --    recheck_mlg_goal은 achv_mlg/goal_mlg를 다시 읽어 판정하므로 그대로 재사용 가능.
+  -- ------------------------------------------------------------
+  FOR v_row IN
+    SELECT goal_id
+    FROM public.evt_mlg_mth_snap
+    WHERE base_dt >= date_trunc('month', public.pt_intro_dt())::date
+      AND achv_mlg >= goal_mlg
+  LOOP
+    PERFORM public.recheck_mlg_goal(v_row.goal_id);
+  END LOOP;
+
+  -- ------------------------------------------------------------
+  -- 7) sch_post_mst — 정보 등록 (살아있음, 작성일 KST >= 7/1)
+  -- ------------------------------------------------------------
+  FOR v_row IN
+    SELECT sch_post_id, team_id, crt_by, sch_nm, (crt_at AT TIME ZONE 'Asia/Seoul')::date AS aply_dt
+    FROM public.sch_post_mst
+    WHERE del_yn = false
+      AND (crt_at AT TIME ZONE 'Asia/Seoul')::date >= public.pt_intro_dt()
+  LOOP
+    PERFORM public.pt_earn(
+      v_row.team_id, v_row.crt_by, 'sch_post', v_row.aply_dt,
+      'sch_post', v_row.sch_post_id, '[시드] 정보 등록: ' || v_row.sch_nm
+    );
+  END LOOP;
+END $$;

--- a/supabase/migrations/20260704130000_pt_review_fixes.sql
+++ b/supabase/migrations/20260704130000_pt_review_fixes.sql
@@ -1,0 +1,467 @@
+-- ============================================================
+-- 기강 포인트 제도 — 결함 점검(8관점 리뷰) 반영 수정
+-- 설계 문서: docs/design/2026-07-04-기강포인트제도.md
+--
+-- 리뷰에서 확정된 결함/개선 8건:
+--  ① [정합] recheck_mlg_goal 달성 판정이 앱(lib/mileage.ts isMonthAchieved)과 반올림 규칙 불일치
+--     — 앱은 소수 첫째 자리 반올림 후 비교(199.96→200.0→달성), DB는 raw 비교라 경계값에서
+--       UI "달성" 표시와 포인트 적립이 어긋남 → round(achv, 1)로 통일
+--  ② [회수 누락] evt_team_prt_rel 삭제(관리자 참가 거절/삭제) 시 evt_mlg_act_hist·evt_mlg_mth_snap이
+--     ON DELETE CASCADE로 지워지는데, cascade 시점엔 부모가 이미 없어 자식 AFTER DELETE 트리거의
+--     조인이 NOT FOUND → 포인트 회수가 조용히 스킵되어 고아 earn이 남음
+--     → 부모(BEFORE DELETE)에서 cascade 전에 일괄 회수
+--  ③ [복원 미처리] gthr_mst·sch_post_mst 소프트 삭제 복원(del_yn true→false) 시 회수만 되고
+--     재적립 경로가 없어 영구 회수 상태로 남음 → 복원 분기 추가
+--  ④ [동시성] 범용 pt_earn/pt_revoke에 advisory lock 부재 — 원천 유니크 제약이 대부분 직렬화해주지만,
+--     gthr_mst UPDATE 트리거의 참석자 순회와 참석 토글이 겹치면 레이스 가능 → mlg 경로와 동일하게 직렬화
+--  ⑤ [중복 제거] pt_trg_gthr_attd_rel의 인라인 타입 CASE 2곳 → pt_gthr_actv_type 헬퍼로 통일
+--  ⑥ [효율] UPDATE OF 절 미사용 트리거 4개 — 무관 컬럼 UPDATE에도 발동하던 것을 관련 컬럼으로 한정
+--     (기존 선례: 20260421180000의 UPDATE OF comp_sprt_cd)
+--  ⑦ [효율] pt_net_mlg_record 조회를 커버하는 부분 인덱스 추가
+--  ⑧ 함수 내부 IS DISTINCT 가드는 그대로 유지(UPDATE OF는 SET 목록 기준이라 값 동일 UPDATE도 발동하므로)
+-- ============================================================
+
+-- ------------------------------------------------------------
+-- ④ pt_earn / pt_revoke — 범용 advisory lock (같은 (mem, actv, ref) 짝 직렬화)
+-- ------------------------------------------------------------
+
+CREATE OR REPLACE FUNCTION public.pt_earn(
+  p_team_id uuid,
+  p_mem_id  uuid,
+  p_actv    public.pt_actv_type_enm,
+  p_aply_dt date,
+  p_ref_type text,
+  p_ref_id  uuid,
+  p_rsn_txt text
+) RETURNS void LANGUAGE plpgsql AS
+$$
+BEGIN
+  IF p_aply_dt < public.pt_intro_dt() THEN
+    RETURN;
+  END IF;
+
+  -- 동시성 직렬화: net 판정(SELECT)과 INSERT 사이 레이스 방지.
+  -- 원천 유니크 제약이 대부분 막아주지만, gthr_mst 변경 트리거의 참석자 순회와
+  -- 참석 토글이 겹치는 경로 등은 제약 밖이라 mlg 경로(선례)와 동일하게 잠근다.
+  PERFORM pg_advisory_xact_lock(
+    hashtext('pt_ref:' || p_mem_id::text || ':' || p_actv::text || ':' || coalesce(p_ref_id::text, ''))::bigint);
+
+  IF public.pt_net_by_ref(p_mem_id, p_actv, p_ref_id) <> 0 THEN
+    RETURN; -- 이미 적립됨(토글/재시도 안전, §5.2)
+  END IF;
+
+  INSERT INTO public.pt_txn_hist (team_id, mem_id, actv_type_enm, txn_type_enm, pt_amt, aply_dt, ref_type_txt, ref_id, rsn_txt)
+  VALUES (p_team_id, p_mem_id, p_actv, 'earn', public.pt_rule_amt(p_actv), p_aply_dt, p_ref_type, p_ref_id, p_rsn_txt);
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION public.pt_revoke(
+  p_team_id uuid,
+  p_mem_id  uuid,
+  p_actv    public.pt_actv_type_enm,
+  p_aply_dt date,
+  p_ref_type text,
+  p_ref_id  uuid,
+  p_rsn_txt text
+) RETURNS void LANGUAGE plpgsql AS
+$$
+DECLARE
+  v_net integer;
+BEGIN
+  -- pt_earn과 같은 키로 직렬화 (동시 earn/revoke 레이스 방지)
+  PERFORM pg_advisory_xact_lock(
+    hashtext('pt_ref:' || p_mem_id::text || ':' || p_actv::text || ':' || coalesce(p_ref_id::text, ''))::bigint);
+
+  v_net := public.pt_net_by_ref(p_mem_id, p_actv, p_ref_id);
+  IF v_net <= 0 THEN
+    RETURN; -- 이미 회수됐거나 애초에 적립 없음(이중 회수 안전, §5.2)
+  END IF;
+
+  INSERT INTO public.pt_txn_hist (team_id, mem_id, actv_type_enm, txn_type_enm, pt_amt, aply_dt, ref_type_txt, ref_id, rsn_txt)
+  VALUES (p_team_id, p_mem_id, p_actv, 'revoke', -v_net, p_aply_dt, p_ref_type, p_ref_id, p_rsn_txt);
+END;
+$$;
+
+-- ------------------------------------------------------------
+-- ① recheck_mlg_goal — 달성 판정을 앱(isMonthAchieved)과 동일한 반올림 규칙으로
+-- ------------------------------------------------------------
+
+CREATE OR REPLACE FUNCTION public.recheck_mlg_goal(p_goal_id uuid)
+RETURNS void LANGUAGE plpgsql SECURITY DEFINER SET search_path = public AS
+$$
+DECLARE
+  v_prt_id    uuid;
+  v_base_dt   date;
+  v_goal_mlg  integer;
+  v_mem_id    uuid;
+  v_team_id   uuid;
+  v_achv_mlg  numeric;
+  v_achieved  boolean;
+  v_net       integer;
+BEGIN
+  SELECT s.prt_id, s.base_dt, s.goal_mlg, s.achv_mlg
+    INTO v_prt_id, v_base_dt, v_goal_mlg, v_achv_mlg
+  FROM public.evt_mlg_mth_snap s
+  WHERE s.goal_id = p_goal_id;
+
+  IF NOT FOUND THEN
+    RETURN;
+  END IF;
+
+  SELECT p.mem_id, t.team_id
+    INTO v_mem_id, v_team_id
+  FROM public.evt_team_prt_rel p
+  JOIN public.evt_team_mst t ON t.evt_id = p.evt_id
+  WHERE p.prt_id = v_prt_id;
+
+  IF NOT FOUND THEN
+    RETURN;
+  END IF;
+
+  -- 동시성 직렬화: 근접 기록 다건 삽입 시 같은 goal_id 재판정이 겹치면 net 레이스 → 이중 earn 가능
+  PERFORM pg_advisory_xact_lock(hashtext('pt_mlg_goal:' || p_goal_id::text)::bigint);
+
+  -- 달성 판정은 앱(lib/mileage.ts isMonthAchieved)과 동일하게
+  -- "소수 첫째 자리 반올림 후 비교" (199.96 → 200.0 → 달성). raw 비교 시 UI와 어긋남.
+  v_achieved := round(v_achv_mlg, 1) >= v_goal_mlg;
+  v_net := public.pt_net_by_ref(v_mem_id, 'mlg_goal', p_goal_id);
+
+  IF v_achieved AND v_net = 0 THEN
+    PERFORM public.pt_earn(
+      v_team_id, v_mem_id, 'mlg_goal', v_base_dt, 'mlg_goal', p_goal_id,
+      '마일리지런 월 목표 달성 (' || to_char(v_base_dt, 'YYYY-MM') || ')'
+    );
+  ELSIF NOT v_achieved AND v_net > 0 THEN
+    PERFORM public.pt_revoke(
+      v_team_id, v_mem_id, 'mlg_goal', v_base_dt, 'mlg_goal', p_goal_id,
+      '마일리지런 월 목표 미달 전환 (' || to_char(v_base_dt, 'YYYY-MM') || ')'
+    );
+  END IF;
+END;
+$$;
+
+-- ------------------------------------------------------------
+-- ⑤ pt_trg_gthr_attd_rel — 인라인 타입 CASE → pt_gthr_actv_type 헬퍼로 통일
+-- ------------------------------------------------------------
+
+CREATE OR REPLACE FUNCTION public.pt_trg_gthr_attd_rel()
+RETURNS trigger LANGUAGE plpgsql SECURITY DEFINER SET search_path = public AS
+$$
+DECLARE
+  v_gthr      record;
+  v_actv      public.pt_actv_type_enm;
+  v_aply_dt   date;
+BEGIN
+  IF TG_OP = 'INSERT' THEN
+    SELECT team_id, gthr_type_enm, gthr_nm, stt_at, del_yn INTO v_gthr
+    FROM public.gthr_mst WHERE gthr_id = NEW.gthr_id;
+
+    IF NOT FOUND OR v_gthr.del_yn THEN
+      RETURN NEW; -- 삭제된 모임에 대한 참석은 적립하지 않음
+    END IF;
+
+    v_actv := public.pt_gthr_actv_type(v_gthr.gthr_type_enm);
+    IF v_actv IS NULL THEN
+      RETURN NEW;
+    END IF;
+
+    v_aply_dt := (v_gthr.stt_at AT TIME ZONE 'Asia/Seoul')::date;
+
+    PERFORM public.pt_earn(
+      v_gthr.team_id, NEW.mem_id, v_actv, v_aply_dt, 'gthr', NEW.gthr_id,
+      CASE v_actv
+        WHEN 'regular_attend' THEN '정모 참석: ' || v_gthr.gthr_nm
+        WHEN 'gthr_attend'    THEN '벙 참석: ' || v_gthr.gthr_nm
+        ELSE '이벤트 참석: ' || v_gthr.gthr_nm
+      END
+    );
+
+    RETURN NEW;
+  END IF;
+
+  IF TG_OP = 'DELETE' THEN
+    SELECT team_id, gthr_type_enm, gthr_nm, stt_at INTO v_gthr
+    FROM public.gthr_mst WHERE gthr_id = OLD.gthr_id;
+
+    IF NOT FOUND THEN
+      RETURN OLD;
+    END IF;
+
+    v_actv := public.pt_gthr_actv_type(v_gthr.gthr_type_enm);
+    IF v_actv IS NULL THEN
+      RETURN OLD;
+    END IF;
+
+    v_aply_dt := (v_gthr.stt_at AT TIME ZONE 'Asia/Seoul')::date;
+
+    PERFORM public.pt_revoke(
+      v_gthr.team_id, OLD.mem_id, v_actv, v_aply_dt, 'gthr', OLD.gthr_id,
+      '참석 취소: ' || v_gthr.gthr_nm
+    );
+
+    RETURN OLD;
+  END IF;
+
+  RETURN NULL;
+END;
+$$;
+
+-- ------------------------------------------------------------
+-- ③-a pt_trg_gthr_mst — 소프트 삭제 복원(del_yn true→false) 분기 추가
+-- ------------------------------------------------------------
+
+CREATE OR REPLACE FUNCTION public.pt_trg_gthr_mst()
+RETURNS trigger LANGUAGE plpgsql SECURITY DEFINER SET search_path = public AS
+$$
+DECLARE
+  v_old_aply_dt date;
+  v_new_aply_dt date;
+  v_attendee    record;
+  v_old_actv    public.pt_actv_type_enm;
+  v_new_actv    public.pt_actv_type_enm;
+BEGIN
+  IF TG_OP = 'INSERT' THEN
+    IF NEW.gthr_type_enm = 'general' THEN
+      PERFORM public.pt_earn(
+        NEW.team_id, NEW.crt_by, 'gthr_host',
+        (NEW.stt_at AT TIME ZONE 'Asia/Seoul')::date,
+        'gthr', NEW.gthr_id, '벙 개설: ' || NEW.gthr_nm
+      );
+    END IF;
+    RETURN NEW;
+  END IF;
+
+  IF TG_OP = 'UPDATE' THEN
+    -- 소프트 삭제(del_yn false→true): 개설 포인트 회수 + 모든 참석 적립 회수
+    IF NEW.del_yn = true AND OLD.del_yn = false THEN
+      IF OLD.gthr_type_enm = 'general' THEN
+        PERFORM public.pt_revoke(
+          OLD.team_id, OLD.crt_by, 'gthr_host',
+          (OLD.stt_at AT TIME ZONE 'Asia/Seoul')::date,
+          'gthr', OLD.gthr_id, '모임 삭제로 개설 포인트 회수: ' || OLD.gthr_nm
+        );
+      END IF;
+
+      v_old_actv := public.pt_gthr_actv_type(OLD.gthr_type_enm);
+
+      IF v_old_actv IS NOT NULL THEN
+        v_old_aply_dt := (OLD.stt_at AT TIME ZONE 'Asia/Seoul')::date;
+        FOR v_attendee IN
+          SELECT mem_id FROM public.gthr_attd_rel WHERE gthr_id = OLD.gthr_id
+        LOOP
+          PERFORM public.pt_revoke(
+            OLD.team_id, v_attendee.mem_id, v_old_actv, v_old_aply_dt,
+            'gthr', OLD.gthr_id, '모임 삭제로 참석 포인트 회수: ' || OLD.gthr_nm
+          );
+        END LOOP;
+      END IF;
+
+      RETURN NEW;
+    END IF;
+
+    -- 복원(del_yn true→false): 삭제 때 회수했던 개설·참석 포인트를 현재 타입·일시 기준으로 재적립
+    -- (없으면 관리자가 복원해도 포인트만 영구 회수 상태로 남는 비대칭 — 리뷰 ③)
+    IF NEW.del_yn = false AND OLD.del_yn = true THEN
+      v_new_aply_dt := (NEW.stt_at AT TIME ZONE 'Asia/Seoul')::date;
+
+      IF NEW.gthr_type_enm = 'general' THEN
+        PERFORM public.pt_earn(
+          NEW.team_id, NEW.crt_by, 'gthr_host', v_new_aply_dt,
+          'gthr', NEW.gthr_id, '모임 복원으로 개설 포인트 재적립: ' || NEW.gthr_nm
+        );
+      END IF;
+
+      v_new_actv := public.pt_gthr_actv_type(NEW.gthr_type_enm);
+      IF v_new_actv IS NOT NULL THEN
+        FOR v_attendee IN
+          SELECT mem_id FROM public.gthr_attd_rel WHERE gthr_id = NEW.gthr_id
+        LOOP
+          PERFORM public.pt_earn(
+            NEW.team_id, v_attendee.mem_id, v_new_actv, v_new_aply_dt,
+            'gthr', NEW.gthr_id, '모임 복원으로 참석 포인트 재적립: ' || NEW.gthr_nm
+          );
+        END LOOP;
+      END IF;
+
+      RETURN NEW;
+    END IF;
+
+    -- 시작일(stt_at) 또는 모임 타입(gthr_type_enm) 변경: 옛 기준 revoke 후 새 기준 재적립
+    IF (NEW.gthr_type_enm IS DISTINCT FROM OLD.gthr_type_enm OR NEW.stt_at IS DISTINCT FROM OLD.stt_at)
+       AND NEW.del_yn = false THEN
+      v_old_aply_dt := (OLD.stt_at AT TIME ZONE 'Asia/Seoul')::date;
+      v_new_aply_dt := (NEW.stt_at AT TIME ZONE 'Asia/Seoul')::date;
+
+      IF OLD.gthr_type_enm = 'general' THEN
+        PERFORM public.pt_revoke(
+          OLD.team_id, OLD.crt_by, 'gthr_host', v_old_aply_dt,
+          'gthr', OLD.gthr_id, '모임 정보 변경으로 개설 포인트 재조정: ' || OLD.gthr_nm
+        );
+      END IF;
+      IF NEW.gthr_type_enm = 'general' THEN
+        PERFORM public.pt_earn(
+          NEW.team_id, NEW.crt_by, 'gthr_host', v_new_aply_dt,
+          'gthr', NEW.gthr_id, '벙 개설: ' || NEW.gthr_nm
+        );
+      END IF;
+
+      v_old_actv := public.pt_gthr_actv_type(OLD.gthr_type_enm);
+      v_new_actv := public.pt_gthr_actv_type(NEW.gthr_type_enm);
+
+      FOR v_attendee IN
+        SELECT mem_id FROM public.gthr_attd_rel WHERE gthr_id = NEW.gthr_id
+      LOOP
+        IF v_old_actv IS NOT NULL THEN
+          PERFORM public.pt_revoke(
+            OLD.team_id, v_attendee.mem_id, v_old_actv, v_old_aply_dt,
+            'gthr', NEW.gthr_id, '모임 정보 변경으로 참석 포인트 재조정: ' || OLD.gthr_nm
+          );
+        END IF;
+        IF v_new_actv IS NOT NULL THEN
+          PERFORM public.pt_earn(
+            NEW.team_id, v_attendee.mem_id, v_new_actv, v_new_aply_dt,
+            'gthr', NEW.gthr_id,
+            CASE v_new_actv
+              WHEN 'regular_attend' THEN '정모 참석: ' || NEW.gthr_nm
+              WHEN 'gthr_attend'    THEN '벙 참석: ' || NEW.gthr_nm
+              ELSE '이벤트 참석: ' || NEW.gthr_nm
+            END
+          );
+        END IF;
+      END LOOP;
+    END IF;
+
+    RETURN NEW;
+  END IF;
+
+  RETURN NULL;
+END;
+$$;
+
+COMMENT ON FUNCTION public.pt_trg_gthr_mst() IS
+  '모임 개설(general) 적립 / 소프트삭제 회수 / 복원 재적립 / 시작일·타입 변경 재조정(§6)';
+
+-- ------------------------------------------------------------
+-- ③-b pt_trg_sch_post_mst — 복원(del_yn true→false) 분기 추가
+-- ------------------------------------------------------------
+
+CREATE OR REPLACE FUNCTION public.pt_trg_sch_post_mst()
+RETURNS trigger LANGUAGE plpgsql SECURITY DEFINER SET search_path = public AS
+$$
+DECLARE
+  v_aply_dt date;
+BEGIN
+  IF TG_OP = 'INSERT' THEN
+    v_aply_dt := (NEW.crt_at AT TIME ZONE 'Asia/Seoul')::date;
+    PERFORM public.pt_earn(
+      NEW.team_id, NEW.crt_by, 'sch_post', v_aply_dt, 'sch_post', NEW.sch_post_id,
+      '정보 등록: ' || NEW.sch_nm
+    );
+    RETURN NEW;
+  END IF;
+
+  IF TG_OP = 'UPDATE' THEN
+    v_aply_dt := (OLD.crt_at AT TIME ZONE 'Asia/Seoul')::date;
+    IF NEW.del_yn = true AND OLD.del_yn = false THEN
+      PERFORM public.pt_revoke(
+        OLD.team_id, OLD.crt_by, 'sch_post', v_aply_dt, 'sch_post', OLD.sch_post_id,
+        '정보 삭제: ' || OLD.sch_nm
+      );
+    ELSIF NEW.del_yn = false AND OLD.del_yn = true THEN
+      PERFORM public.pt_earn(
+        NEW.team_id, NEW.crt_by, 'sch_post', v_aply_dt, 'sch_post', NEW.sch_post_id,
+        '정보 복원으로 재적립: ' || NEW.sch_nm
+      );
+    END IF;
+    RETURN NEW;
+  END IF;
+
+  RETURN NULL;
+END;
+$$;
+
+COMMENT ON FUNCTION public.pt_trg_sch_post_mst() IS
+  '정보 등록 적립 / 소프트 삭제 회수 / 복원 재적립. aply_dt=작성일(crt_at, KST)(§6)';
+
+-- ------------------------------------------------------------
+-- ② evt_team_prt_rel — 참가자 삭제 시 cascade 전에 마일리지 포인트 일괄 회수
+--    (자식 테이블 AFTER DELETE 트리거는 cascade 시점에 부모 조인이 실패해 회수를 스킵)
+-- ------------------------------------------------------------
+
+CREATE OR REPLACE FUNCTION public.pt_trg_evt_team_prt_rel()
+RETURNS trigger LANGUAGE plpgsql SECURITY DEFINER SET search_path = public AS
+$$
+DECLARE
+  v_team_id uuid;
+  v_row     record;
+BEGIN
+  SELECT t.team_id INTO v_team_id
+  FROM public.evt_team_mst t WHERE t.evt_id = OLD.evt_id;
+
+  IF NOT FOUND THEN
+    RETURN OLD;
+  END IF;
+
+  -- 월 목표 달성 포인트 회수 (snap이 cascade로 지워지기 전에)
+  FOR v_row IN
+    SELECT goal_id, base_dt FROM public.evt_mlg_mth_snap WHERE prt_id = OLD.prt_id
+  LOOP
+    PERFORM public.pt_revoke(
+      v_team_id, OLD.mem_id, 'mlg_goal', v_row.base_dt, 'mlg_goal', v_row.goal_id,
+      '마일리지런 참가 삭제로 목표 포인트 회수'
+    );
+  END LOOP;
+
+  -- 기록 포인트 회수 — 날짜별 1건이므로 distinct 날짜 단위로
+  FOR v_row IN
+    SELECT DISTINCT act_dt FROM public.evt_mlg_act_hist WHERE prt_id = OLD.prt_id
+  LOOP
+    PERFORM public.pt_revoke_mlg_record(
+      v_team_id, OLD.mem_id, v_row.act_dt,
+      '마일리지런 참가 삭제로 기록 포인트 회수: ' || to_char(v_row.act_dt, 'YYYY-MM-DD')
+    );
+  END LOOP;
+
+  RETURN OLD;
+END;
+$$;
+
+COMMENT ON FUNCTION public.pt_trg_evt_team_prt_rel() IS
+  '마일리지런 참가자 하드 삭제(관리자 거절/삭제) 시 cascade 전에 기록·목표 포인트 일괄 회수(리뷰 ②)';
+
+CREATE TRIGGER trg_pt_evt_team_prt_rel
+  BEFORE DELETE ON public.evt_team_prt_rel
+  FOR EACH ROW EXECUTE FUNCTION public.pt_trg_evt_team_prt_rel();
+
+-- ------------------------------------------------------------
+-- ⑥ UPDATE OF 절 — 무관 컬럼 UPDATE에 트리거가 발동하지 않도록 한정
+--    (함수 내부 IS DISTINCT 가드는 유지 — UPDATE OF는 SET 목록 기준이라 값 동일 UPDATE도 발동)
+-- ------------------------------------------------------------
+
+DROP TRIGGER trg_pt_gthr_mst ON public.gthr_mst;
+CREATE TRIGGER trg_pt_gthr_mst
+  AFTER INSERT OR UPDATE OF del_yn, stt_at, gthr_type_enm ON public.gthr_mst
+  FOR EACH ROW EXECUTE FUNCTION public.pt_trg_gthr_mst();
+
+DROP TRIGGER trg_pt_evt_mlg_mth_snap ON public.evt_mlg_mth_snap;
+CREATE TRIGGER trg_pt_evt_mlg_mth_snap
+  AFTER UPDATE OF goal_mlg, achv_mlg ON public.evt_mlg_mth_snap
+  FOR EACH ROW EXECUTE FUNCTION public.pt_trg_evt_mlg_mth_snap();
+
+DROP TRIGGER trg_pt_sch_post_mst ON public.sch_post_mst;
+CREATE TRIGGER trg_pt_sch_post_mst
+  AFTER INSERT OR UPDATE OF del_yn ON public.sch_post_mst
+  FOR EACH ROW EXECUTE FUNCTION public.pt_trg_sch_post_mst();
+
+DROP TRIGGER trg_pt_comp_mst ON public.comp_mst;
+CREATE TRIGGER trg_pt_comp_mst
+  AFTER UPDATE OF stt_dt ON public.comp_mst
+  FOR EACH ROW EXECUTE FUNCTION public.pt_trg_comp_mst();
+
+-- ------------------------------------------------------------
+-- ⑦ mlg_record net 판정 전용 부분 인덱스 (ref_id NULL + aply_dt 조회 커버)
+-- ------------------------------------------------------------
+
+CREATE INDEX ix_pt_txn_hist_mlg_daily
+  ON public.pt_txn_hist (mem_id, aply_dt)
+  WHERE actv_type_enm = 'mlg_record' AND ref_id IS NULL;


### PR DESCRIPTION
## 관련 이슈

관련 이슈 없음 (설계 문서: `docs/design/2026-07-04-기강포인트제도.md`)

## 요약

멤버의 크루 활동(모임·대회·마일리지런·정보 공유)에 따라 포인트를 자동 적립하는 **기강 포인트 제도**를 도입합니다.
당분간 **완전 히든 운영** — 적립 로직은 실제로 돌지만 UI 어디에도 노출되지 않고, 유저는 적립 사실 자체를 알 수 없습니다.
추후 공개 시점에 그동안 쌓인 이력이 그대로 살아있도록 처음부터 감사 가능한 원장(ledger) 구조로 설계했습니다.

## AS-IS (변경 전)

- 포인트 제도 없음. `gathering-design.md`에 "기강 포인트 예시 (미구현)" 스케치만 존재
- 칭호 포인트는 2026-05 `drop_title_point_columns`로 폐기된 상태
- 멤버 활동(참석·개설·대회·기록·정보등록)이 정량 지표로 축적되지 않음

## TO-BE (변경 후)

- **`pt_txn_hist` 원장(append-only)**: 모든 적립/회수가 역분개 방식으로 영구 보존 — 취소해도 이력이 남고 순액(net)만 상쇄
- **DB 트리거 자동 적립**: 원천 테이블 9종에 트리거를 걸어, 어떤 경로(앱·관리자·클라 직접 쓰기)로 데이터가 변해도 적립/회수가 자동. 앱 코드 훅 0개
- **노출 0**: RLS 활성+정책 0개, 테이블 권한·함수 EXECUTE 전면 회수 → 클라이언트는 제도의 존재 자체를 알 수 없음
- **귀속일(`aply_dt`) 기준 집계**: 7월에 11월 대회를 신청해도 포인트는 11월에 획득한 것으로 처리 (미래 귀속). 연초 초기화도 집계 윈도우만 연 단위로 자르면 돼 리셋 배치 불필요
- **도입 시드**: "포인트는 활동일 기준" 원칙대로, 이미 존재하는 원천 중 귀속일 ≥ 2026-07-01인 것을 소급 적립 (net 가드로 멱등 — 재실행 안전)

### 적립 룰셋 (확정)

| 활동 | 포인트 | 비고 |
|------|--------|------|
| 정모 참석 | +30 | 최고 단가 — 모임 출석이 크루 최우선 가치 |
| 이벤트 참석 | +20 | |
| 벙 참석 | +10 | |
| 벙 개설 | +5 | 자동 참석 포함 실질 +15. 정모/이벤트 개설은 운영 행위라 0 |
| 대회 참가 | +20 | 귀속 = 대회 개최일 |
| 대회 기록 등록 | +20 | 개최일 2026-07-01 이후 대회만 (과거 기록 파밍 차단) |
| 마일리지런 기록 | +2 | 1일 1건만 인정 (쪼개기 파밍 차단) |
| 마일리지런 월 목표 달성 | +10 | 실시간 판정, 미달 전환 시 자동 회수 |
| 정보 등록 | +5 | |

## 변경 흐름 (Mermaid)

```mermaid
flowchart TD
    A["유저 액션 (참석 토글 · 대회 신청 · 기록 입력 · 정보 등록)"] --> B["원천 테이블 INSERT/UPDATE/DELETE<br/>(앱은 포인트 존재를 모름)"]
    B --> C{"trg_pt_* 트리거<br/>(같은 트랜잭션)"}
    C --> D["도입일 가드<br/>aply_dt < 2026-07-01 → 스킵"]
    D --> E["net 순액 판정 + advisory lock<br/>(중복 적립 · 레이스 차단)"]
    E --> F["pt_txn_hist 원장 INSERT<br/>earn(+) / revoke(-)"]
    F -.->|"RLS 정책 0 + 권한 회수"| G["클라이언트 접근 불가<br/>(노출 0)"]
    F -.->|"공개 전환 시"| H["귀속일 ≤ 오늘 필터로<br/>월 랭킹 · 누적 집계"]
```

## 주요 변경 사항

| 파일 | 내용 |
|------|------|
| `supabase/migrations/20260704100000_pt_txn_hist.sql` | enum 2종 + 원장 테이블 + 인덱스 + RLS(정책 0) + 권한 회수 |
| `supabase/migrations/20260704110000_pt_txn_hist_triggers.sql` | 점수 상수(`pt_rule_amt`)·net 판정·earn/revoke 헬퍼 + 원천 트리거 일괄 + 함수 EXECUTE 회수 |
| `supabase/migrations/20260704120000_pt_seed_backfill.sql` | 도입 시드 — 귀속일 ≥ 7/1 현존 원천 소급 적립 (멱등) |
| `supabase/migrations/20260704130000_pt_review_fixes.sql` | 8관점 결함 리뷰 반영 (아래) |
| `lib/supabase/database.types.ts` | 재생성 (pt 테이블·함수·enum 타입 추가) |
| `docs/design/2026-07-04-기강포인트제도.md` | 설계 문서 (룰셋·트리거 매트릭스·결정 로그) |
| `AGENTS.md` / `.claude/docs/*` | 히든 제도 안내, DB 도메인 문서·약어 사전 등재, 함정 기록 |

### 결함 리뷰(8관점) 반영 — `20260704130000`

- **판정 정합**: 마일리지런 목표 달성 판정을 앱 `isMonthAchieved`와 동일한 `round(달성, 소수1) ≥ 목표`로 통일 (경계값 199.96에서 UI-포인트 불일치 방지)
- **CASCADE 회수**: 관리자가 마일리지런 참가자를 삭제하면 기록·목표가 CASCADE로 지워져 회수가 스킵되던 문제 → 부모 `BEFORE DELETE`에서 일괄 회수
- **복원 재적립**: 모임·정보 소프트 삭제 복원(del_yn true→false) 시 포인트가 영구 회수 상태로 남던 비대칭 해소
- **동시성**: 범용 earn/revoke에도 advisory lock 적용 (net 판정 TOCTOU 레이스 차단)
- **효율**: `UPDATE OF` 절로 무관 컬럼 변경 시 트리거 미발동, mlg 1일 1건 판정 전용 부분 인덱스

## 검증 (dev)

- **QA 시나리오 전부 통과**: 토글 반복 / 벙↔정모 타입 변경 / 도입일 이전 이동(재적립 차단) / 소프트 삭제·복원 / 같은 날 마일리지 2건(1건만 적립) / 목표 달성↔미달 전환 / 반올림 경계(119.96→달성) / 대회 연기(새 날짜 재귀속) / 참가자 삭제(cascade 회수)
- **대사(reconciliation) 검증**: 원천 테이블 재산출 vs 원장 순액 — **37명 전원 일치 (875 = 875)**
- **노출 0 검증**: authenticated 역할로 원장 SELECT 0행, 헬퍼 RPC 실행 불가, 테이블 권한 없음
- `tsc --noEmit` 클린, vitest 142개 통과 (pre-commit)

## 배포 참고

- **dev**: 마이그레이션 4개 + 시드 적용 완료, 트리거 8종 가동 중
- **prd**: 이 PR과 별개로 동일 마이그레이션 적용 예정 (도입 월인 7월 내 — 트리거 공백 중 hard delete된 참석·기록은 소급 불가하므로 빠를수록 좋음)
- ⚠️ **히든 운영 원칙**: 이 제도는 유저에게 언급·노출 금지. UI 코드 0줄이 의도된 상태입니다

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * 포인트 적립·회수 내역을 기준으로 한 새 포인트 원장 기능이 추가됐습니다.
  * 활동 유형별 포인트 집계와 월별 목표 달성 재판정이 자동으로 반영됩니다.
  * 기존 데이터에 대한 포인트 이력 소급 반영이 지원됩니다.

* **Bug Fixes**
  * 중복 적립과 동시성 문제를 줄이도록 처리 방식이 강화됐습니다.
  * 삭제/복원/변경 시 포인트 상태가 일관되게 다시 계산되도록 개선됐습니다.

* **Documentation**
  * 포인트 운영 규칙, 집계 기준, 보안 주의사항 문서가 추가·보강됐습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->