### PR TITLE
feat(admin): 모임 관리 화면 — 월별 리스트 + 참가자 취소/추가

### DIFF
--- a/app/(info)/admin/gatherings/admin-gatherings-client.tsx
+++ b/app/(info)/admin/gatherings/admin-gatherings-client.tsx
@@ -2,12 +2,11 @@
 
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 
-import { CalendarDays, Check, ChevronLeft, ChevronRight, ChevronsUpDown, Plus, Users, X } from "lucide-react";
+import { CalendarDays, ChevronLeft, ChevronRight, ChevronsUpDown, Plus, Users, X } from "lucide-react";
 import { toast } from "sonner";
 
 import { currentMonthKST, dayjs, nextMonthStr, prevMonthStr } from "@/lib/dayjs";
 import { createClient } from "@/lib/supabase/client";
-import { cn } from "@/lib/utils";
 import { gthrTypeLabels, type GthrType } from "@/lib/validations/gathering";
 
 import {
@@ -78,7 +77,6 @@ export function AdminGatheringsClient({ teamId }: { teamId: string }) {
   const [attendeesLoading, setAttendeesLoading] = useState(false);
 
   const [activeMembers, setActiveMembers] = useState<ActiveMember[]>([]);
-  const [addingMemId, setAddingMemId] = useState("");
   const [addOpen, setAddOpen] = useState(false);
   const [adding, setAdding] = useState(false);
   const [removingMemId, setRemovingMemId] = useState<string | null>(null);
@@ -173,7 +171,6 @@ export function AdminGatheringsClient({ teamId }: { teamId: string }) {
   const openGathering = (g: Gathering) => {
     setSelected(g);
     setDialogOpen(true);
-    setAddingMemId("");
     loadAttendees(g.gthr_id);
     loadActiveMembers();
   };
@@ -213,22 +210,21 @@ export function AdminGatheringsClient({ teamId }: { teamId: string }) {
     setRemovingMemId(null);
   };
 
-  const handleAddAttendee = async () => {
-    if (!selected || !addingMemId) return;
-    const member = activeMembers.find((m) => m.mem_id === addingMemId);
-    if (!member) return;
+  const handleAddAttendee = async (member: ActiveMember) => {
+    if (!selected || adding) return;
 
     setAdding(true);
     const prevAttendees = attendees;
     setAttendees((prev) => [...prev, member]);
     syncGatheringCount(selected.gthr_id, 1);
-    setAddingMemId("");
 
     const result = await addGatheringAttendance(selected.gthr_id, member.mem_id);
     if (!result.ok) {
       setAttendees(prevAttendees);
       syncGatheringCount(selected.gthr_id, -1);
       toast.error(result.message ?? "참석 추가에 실패했습니다");
+    } else {
+      toast.success(`${member.mem_nm ?? "이름 없음"}님을 참석 처리했습니다`);
     }
     setAdding(false);
   };
@@ -322,67 +318,52 @@ export function AdminGatheringsClient({ teamId }: { teamId: string }) {
 
           <div className="flex-1 overflow-y-auto px-4 pb-6 pt-4">
             <div className="flex flex-col gap-4">
-              {/* 참가자 추가 — 이름 타이핑으로 검색 가능한 콤보박스 (member-combobox.tsx 패턴) */}
-              <div className="flex gap-2">
-                <Popover open={addOpen} onOpenChange={setAddOpen}>
-                  <PopoverTrigger asChild>
-                    <Button
-                      type="button"
-                      variant="outline"
-                      role="combobox"
-                      aria-expanded={addOpen}
-                      className="h-10 flex-1 justify-between rounded-xl font-normal"
-                    >
-                      {addingMemId
-                        ? (activeMembers.find((m) => m.mem_id === addingMemId)?.mem_nm ?? "이름 없음")
-                        : "추가할 멤버 검색…"}
-                      <ChevronsUpDown className="ml-1 size-3.5 shrink-0 opacity-50" />
-                    </Button>
-                  </PopoverTrigger>
-                  <PopoverContent className="w-[--radix-popover-trigger-width] p-0" align="start">
-                    <Command>
-                      <CommandInput placeholder="이름 검색…" />
-                      <CommandList>
-                        <CommandEmpty>
-                          {availableMembers.length === 0
-                            ? "추가할 수 있는 멤버가 없습니다"
-                            : "검색 결과가 없습니다"}
-                        </CommandEmpty>
-                        <CommandGroup>
-                          {availableMembers.map((m) => (
-                            <CommandItem
-                              key={m.mem_id}
-                              value={`${m.mem_nm ?? "이름 없음"} ${m.mem_id}`}
-                              onSelect={() => {
-                                setAddingMemId(m.mem_id);
-                                setAddOpen(false);
-                              }}
-                            >
-                              <Check
-                                className={cn(
-                                  "mr-2 size-4",
-                                  addingMemId === m.mem_id ? "opacity-100" : "opacity-0",
-                                )}
-                              />
-                              {m.mem_nm ?? "이름 없음"}
-                            </CommandItem>
-                          ))}
-                        </CommandGroup>
-                      </CommandList>
-                    </Command>
-                  </PopoverContent>
-                </Popover>
-                <Button
-                  variant="outline"
-                  size="sm"
-                  disabled={!addingMemId || adding}
-                  onClick={handleAddAttendee}
-                  className="h-10"
-                >
-                  <Plus className="size-3.5" />
-                  추가
-                </Button>
-              </div>
+              {/* 참가자 추가 — 검색해서 선택하면 바로 참석 처리 (별도 추가 버튼 없음) */}
+              <Popover open={addOpen} onOpenChange={setAddOpen}>
+                <PopoverTrigger asChild>
+                  <Button
+                    type="button"
+                    variant="outline"
+                    role="combobox"
+                    aria-expanded={addOpen}
+                    disabled={adding}
+                    className="h-10 w-full justify-between rounded-xl font-normal text-muted-foreground"
+                  >
+                    <span className="flex items-center gap-1.5">
+                      <Plus className="size-3.5" />
+                      {adding ? "추가 중…" : "참가자 추가 — 이름 검색"}
+                    </span>
+                    <ChevronsUpDown className="ml-1 size-3.5 shrink-0 opacity-50" />
+                  </Button>
+                </PopoverTrigger>
+                <PopoverContent className="w-[--radix-popover-trigger-width] p-0" align="start">
+                  <Command>
+                    <CommandInput placeholder="이름 검색…" />
+                    <CommandList>
+                      <CommandEmpty>
+                        {availableMembers.length === 0
+                          ? "추가할 수 있는 멤버가 없습니다"
+                          : "검색 결과가 없습니다"}
+                      </CommandEmpty>
+                      <CommandGroup>
+                        {availableMembers.map((m) => (
+                          <CommandItem
+                            key={m.mem_id}
+                            value={`${m.mem_nm ?? "이름 없음"} ${m.mem_id}`}
+                            onSelect={() => {
+                              setAddOpen(false);
+                              handleAddAttendee(m);
+                            }}
+                          >
+                            <Plus className="mr-2 size-3.5 text-muted-foreground" />
+                            {m.mem_nm ?? "이름 없음"}
+                          </CommandItem>
+                        ))}
+                      </CommandGroup>
+                    </CommandList>
+                  </Command>
+                </PopoverContent>
+              </Popover>
 
               {/* 참가자 목록 */}
               <div className="flex flex-col gap-2">

--- a/app/(info)/admin/gatherings/admin-gatherings-client.tsx
+++ b/app/(info)/admin/gatherings/admin-gatherings-client.tsx
@@ -2,11 +2,12 @@
 
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 
-import { CalendarDays, ChevronLeft, ChevronRight, Plus, Users, X } from "lucide-react";
+import { CalendarDays, Check, ChevronLeft, ChevronRight, ChevronsUpDown, Plus, Users, X } from "lucide-react";
 import { toast } from "sonner";
 
 import { currentMonthKST, dayjs, nextMonthStr, prevMonthStr } from "@/lib/dayjs";
 import { createClient } from "@/lib/supabase/client";
+import { cn } from "@/lib/utils";
 import { gthrTypeLabels, type GthrType } from "@/lib/validations/gathering";
 
 import {
@@ -28,12 +29,14 @@ import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { CardItem } from "@/components/ui/card";
 import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from "@/components/ui/select";
+  Command,
+  CommandEmpty,
+  CommandGroup,
+  CommandInput,
+  CommandItem,
+  CommandList,
+} from "@/components/ui/command";
+import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
 import { Skeleton } from "@/components/ui/skeleton";
 
 type Gathering = {
@@ -76,6 +79,7 @@ export function AdminGatheringsClient({ teamId }: { teamId: string }) {
 
   const [activeMembers, setActiveMembers] = useState<ActiveMember[]>([]);
   const [addingMemId, setAddingMemId] = useState("");
+  const [addOpen, setAddOpen] = useState(false);
   const [adding, setAdding] = useState(false);
   const [removingMemId, setRemovingMemId] = useState<string | null>(null);
 
@@ -318,31 +322,62 @@ export function AdminGatheringsClient({ teamId }: { teamId: string }) {
 
           <div className="flex-1 overflow-y-auto px-4 pb-6 pt-4">
             <div className="flex flex-col gap-4">
-              {/* 참가자 추가 */}
+              {/* 참가자 추가 — 이름 타이핑으로 검색 가능한 콤보박스 (member-combobox.tsx 패턴) */}
               <div className="flex gap-2">
-                <Select value={addingMemId} onValueChange={setAddingMemId}>
-                  <SelectTrigger className="h-10 flex-1 rounded-xl border text-[13px]">
-                    <SelectValue placeholder="추가할 멤버 선택" />
-                  </SelectTrigger>
-                  <SelectContent>
-                    {availableMembers.length === 0 ? (
-                      <div className="px-2 py-1.5">
-                        <Caption className="text-muted-foreground">추가할 수 있는 멤버가 없습니다</Caption>
-                      </div>
-                    ) : (
-                      availableMembers.map((m) => (
-                        <SelectItem key={m.mem_id} value={m.mem_id}>
-                          {m.mem_nm ?? "이름 없음"}
-                        </SelectItem>
-                      ))
-                    )}
-                  </SelectContent>
-                </Select>
+                <Popover open={addOpen} onOpenChange={setAddOpen}>
+                  <PopoverTrigger asChild>
+                    <Button
+                      type="button"
+                      variant="outline"
+                      role="combobox"
+                      aria-expanded={addOpen}
+                      className="h-10 flex-1 justify-between rounded-xl font-normal"
+                    >
+                      {addingMemId
+                        ? (activeMembers.find((m) => m.mem_id === addingMemId)?.mem_nm ?? "이름 없음")
+                        : "추가할 멤버 검색…"}
+                      <ChevronsUpDown className="ml-1 size-3.5 shrink-0 opacity-50" />
+                    </Button>
+                  </PopoverTrigger>
+                  <PopoverContent className="w-[--radix-popover-trigger-width] p-0" align="start">
+                    <Command>
+                      <CommandInput placeholder="이름 검색…" />
+                      <CommandList>
+                        <CommandEmpty>
+                          {availableMembers.length === 0
+                            ? "추가할 수 있는 멤버가 없습니다"
+                            : "검색 결과가 없습니다"}
+                        </CommandEmpty>
+                        <CommandGroup>
+                          {availableMembers.map((m) => (
+                            <CommandItem
+                              key={m.mem_id}
+                              value={`${m.mem_nm ?? "이름 없음"} ${m.mem_id}`}
+                              onSelect={() => {
+                                setAddingMemId(m.mem_id);
+                                setAddOpen(false);
+                              }}
+                            >
+                              <Check
+                                className={cn(
+                                  "mr-2 size-4",
+                                  addingMemId === m.mem_id ? "opacity-100" : "opacity-0",
+                                )}
+                              />
+                              {m.mem_nm ?? "이름 없음"}
+                            </CommandItem>
+                          ))}
+                        </CommandGroup>
+                      </CommandList>
+                    </Command>
+                  </PopoverContent>
+                </Popover>
                 <Button
                   variant="outline"
                   size="sm"
                   disabled={!addingMemId || adding}
                   onClick={handleAddAttendee}
+                  className="h-10"
                 >
                   <Plus className="size-3.5" />
                   추가

--- a/app/(info)/admin/gatherings/admin-gatherings-client.tsx
+++ b/app/(info)/admin/gatherings/admin-gatherings-client.tsx
@@ -86,6 +86,10 @@ export function AdminGatheringsClient({ teamId }: { teamId: string }) {
   // 월 이동 stale-response 가드 — 응답 도착 시점의 month가 요청 시점과 다르면(빠른 연속 이동) 무시한다.
   const latestMonthRequestRef = useRef<string>(month);
 
+  // 참가자 다이얼로그 가드 — 모임 A를 열자마자 닫고 B를 열면 A의 늦은 응답/실패 롤백이
+  // B 화면을 덮을 수 있다. 현재 열린 모임 id를 ref로 추적해 다르면 상태 반영을 건너뛴다.
+  const currentGthrRef = useRef<string | null>(null);
+
   const loadGatherings = useCallback(async (targetMonth: string) => {
     latestMonthRequestRef.current = targetMonth;
     setLoading(true);
@@ -131,6 +135,8 @@ export function AdminGatheringsClient({ teamId }: { teamId: string }) {
       .select("mem_id, mem_mst(mem_id, mem_nm, avatar_url)")
       .eq("gthr_id", gthrId);
 
+    if (currentGthrRef.current !== gthrId) return; // 다른 모임으로 전환됨 — 늦은 응답 폐기
+
     setAttendees(
       (data ?? []).map((row) => {
         const m = Array.isArray(row.mem_mst) ? row.mem_mst[0] : row.mem_mst;
@@ -169,10 +175,16 @@ export function AdminGatheringsClient({ teamId }: { teamId: string }) {
   }, [teamId]);
 
   const openGathering = (g: Gathering) => {
+    currentGthrRef.current = g.gthr_id;
     setSelected(g);
     setDialogOpen(true);
     loadAttendees(g.gthr_id);
     loadActiveMembers();
+  };
+
+  const handleDialogOpenChange = (open: boolean) => {
+    setDialogOpen(open);
+    if (!open) currentGthrRef.current = null; // 닫힌 뒤 도착하는 응답/롤백 무효화
   };
 
   const attendeeIds = useMemo(() => new Set(attendees.map((a) => a.mem_id)), [attendees]);
@@ -189,6 +201,7 @@ export function AdminGatheringsClient({ teamId }: { teamId: string }) {
 
   const handleRemoveAttendee = async (memId: string) => {
     if (!selected || removingMemId) return;
+    const gthrId = selected.gthr_id;
     const target = attendees.find((a) => a.mem_id === memId);
     const memName = target?.mem_nm ?? "이름 없음";
     const gDate = dayjs(selected.stt_at).tz("Asia/Seoul").format("M/D(ddd)");
@@ -197,12 +210,13 @@ export function AdminGatheringsClient({ teamId }: { teamId: string }) {
     setRemovingMemId(memId);
     const prevAttendees = attendees;
     setAttendees((prev) => prev.filter((a) => a.mem_id !== memId));
-    syncGatheringCount(selected.gthr_id, -1);
+    syncGatheringCount(gthrId, -1);
 
-    const result = await removeGatheringAttendance(selected.gthr_id, memId);
+    const result = await removeGatheringAttendance(gthrId, memId);
     if (!result.ok) {
-      setAttendees(prevAttendees);
-      syncGatheringCount(selected.gthr_id, 1);
+      // 참가자 목록 롤백은 아직 같은 모임을 보고 있을 때만 (전환됐으면 이미 새 목록으로 교체됨)
+      if (currentGthrRef.current === gthrId) setAttendees(prevAttendees);
+      syncGatheringCount(gthrId, 1); // 리스트 카운트는 gthr_id 기준이라 항상 안전
       toast.error(result.message ?? "참석 취소에 실패했습니다");
     } else {
       toast.success(`${memName}님 참석을 취소했습니다`);
@@ -212,16 +226,17 @@ export function AdminGatheringsClient({ teamId }: { teamId: string }) {
 
   const handleAddAttendee = async (member: ActiveMember) => {
     if (!selected || adding) return;
+    const gthrId = selected.gthr_id;
 
     setAdding(true);
     const prevAttendees = attendees;
     setAttendees((prev) => [...prev, member]);
-    syncGatheringCount(selected.gthr_id, 1);
+    syncGatheringCount(gthrId, 1);
 
-    const result = await addGatheringAttendance(selected.gthr_id, member.mem_id);
+    const result = await addGatheringAttendance(gthrId, member.mem_id);
     if (!result.ok) {
-      setAttendees(prevAttendees);
-      syncGatheringCount(selected.gthr_id, -1);
+      if (currentGthrRef.current === gthrId) setAttendees(prevAttendees);
+      syncGatheringCount(gthrId, -1);
       toast.error(result.message ?? "참석 추가에 실패했습니다");
     } else {
       toast.success(`${member.mem_nm ?? "이름 없음"}님을 참석 처리했습니다`);
@@ -304,7 +319,7 @@ export function AdminGatheringsClient({ teamId }: { teamId: string }) {
       )}
 
       {/* 참가자 관리 다이얼로그 */}
-      <ResponsiveDrawer open={dialogOpen} onOpenChange={setDialogOpen}>
+      <ResponsiveDrawer open={dialogOpen} onOpenChange={handleDialogOpenChange}>
         <ResponsiveDrawerContent
           dialogClassName="max-w-md max-h-[85dvh] flex flex-col gap-0 p-0 overflow-hidden"
           drawerClassName="h-[85dvh] max-h-[85dvh]"

--- a/app/(info)/admin/gatherings/admin-gatherings-client.tsx
+++ b/app/(info)/admin/gatherings/admin-gatherings-client.tsx
@@ -1,0 +1,395 @@
+"use client";
+
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+
+import { CalendarDays, ChevronLeft, ChevronRight, Plus, Users, X } from "lucide-react";
+import { toast } from "sonner";
+
+import { currentMonthKST, dayjs, nextMonthStr, prevMonthStr } from "@/lib/dayjs";
+import { createClient } from "@/lib/supabase/client";
+import { gthrTypeLabels, type GthrType } from "@/lib/validations/gathering";
+
+import {
+  addGatheringAttendance,
+  removeGatheringAttendance,
+} from "@/app/actions/admin/manage-gathering-attendance";
+
+import { Avatar } from "@/components/common/avatar";
+import {
+  ResponsiveDrawer,
+  ResponsiveDrawerContent,
+  ResponsiveDrawerDescription,
+  ResponsiveDrawerHeader,
+  ResponsiveDrawerTitle,
+} from "@/components/common/responsive-drawer";
+import { H2, Body, Caption, Micro } from "@/components/common/typography";
+import { EmptyState } from "@/components/common/empty-state";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { CardItem } from "@/components/ui/card";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { Skeleton } from "@/components/ui/skeleton";
+
+type Gathering = {
+  gthr_id: string;
+  gthr_nm: string;
+  gthr_type_enm: string;
+  stt_at: string;
+  loc_txt: string | null;
+  attd_count: number;
+};
+
+type Attendee = {
+  mem_id: string;
+  mem_nm: string | null;
+  avatar_url: string | null;
+};
+
+type ActiveMember = {
+  mem_id: string;
+  mem_nm: string | null;
+  avatar_url: string | null;
+};
+
+/** 모임 타입 배지 스타일 — 시맨틱 토큰만 사용 (하드코딩 색 금지). */
+const TYPE_BADGE_CLASS: Record<string, string> = {
+  regular: "border-transparent bg-primary/10 text-primary",
+  event: "border-transparent bg-warning/10 text-warning",
+  general: "border-transparent bg-muted text-muted-foreground",
+};
+
+export function AdminGatheringsClient({ teamId }: { teamId: string }) {
+  const [month, setMonth] = useState(() => currentMonthKST());
+  const [gatherings, setGatherings] = useState<Gathering[]>([]);
+  const [loading, setLoading] = useState(true);
+
+  const [selected, setSelected] = useState<Gathering | null>(null);
+  const [dialogOpen, setDialogOpen] = useState(false);
+  const [attendees, setAttendees] = useState<Attendee[]>([]);
+  const [attendeesLoading, setAttendeesLoading] = useState(false);
+
+  const [activeMembers, setActiveMembers] = useState<ActiveMember[]>([]);
+  const [addingMemId, setAddingMemId] = useState("");
+  const [adding, setAdding] = useState(false);
+  const [removingMemId, setRemovingMemId] = useState<string | null>(null);
+
+  const monthLabel = dayjs(month).format("YYYY년 M월");
+
+  // 월 이동 stale-response 가드 — 응답 도착 시점의 month가 요청 시점과 다르면(빠른 연속 이동) 무시한다.
+  const latestMonthRequestRef = useRef<string>(month);
+
+  const loadGatherings = useCallback(async (targetMonth: string) => {
+    latestMonthRequestRef.current = targetMonth;
+    setLoading(true);
+    const supabase = createClient();
+    const monthStartIso = dayjs.tz(targetMonth, "Asia/Seoul").toISOString();
+    const monthEndIso = dayjs.tz(nextMonthStr(targetMonth), "Asia/Seoul").toISOString();
+
+    const { data } = await supabase
+      .from("gthr_mst")
+      .select("gthr_id, gthr_nm, gthr_type_enm, stt_at, loc_txt, gthr_attd_rel(count)")
+      .eq("team_id", teamId)
+      .eq("del_yn", false)
+      .gte("stt_at", monthStartIso)
+      .lt("stt_at", monthEndIso)
+      .order("stt_at", { ascending: true });
+
+    // 응답 도착 시점에 이미 다른 달로 이동했다면 이 응답은 버린다 (더 빠른 요청이 늦게 도착하는 경우 대비).
+    if (latestMonthRequestRef.current !== targetMonth) return;
+
+    setGatherings(
+      (data ?? []).map((g) => ({
+        gthr_id: g.gthr_id,
+        gthr_nm: g.gthr_nm,
+        gthr_type_enm: g.gthr_type_enm,
+        stt_at: g.stt_at,
+        loc_txt: g.loc_txt,
+        attd_count: (g.gthr_attd_rel as unknown as { count: number }[] | null)?.[0]?.count ?? 0,
+      })),
+    );
+    setLoading(false);
+  }, [teamId]);
+
+  useEffect(() => {
+    // eslint-disable-next-line react-hooks/set-state-in-effect
+    loadGatherings(month);
+  }, [loadGatherings, month]);
+
+  const loadAttendees = useCallback(async (gthrId: string) => {
+    setAttendeesLoading(true);
+    const supabase = createClient();
+    const { data } = await supabase
+      .from("gthr_attd_rel")
+      .select("mem_id, mem_mst(mem_id, mem_nm, avatar_url)")
+      .eq("gthr_id", gthrId);
+
+    setAttendees(
+      (data ?? []).map((row) => {
+        const m = Array.isArray(row.mem_mst) ? row.mem_mst[0] : row.mem_mst;
+        return {
+          mem_id: row.mem_id,
+          mem_nm: m?.mem_nm ?? null,
+          avatar_url: m?.avatar_url ?? null,
+        };
+      }),
+    );
+    setAttendeesLoading(false);
+  }, []);
+
+  const loadActiveMembers = useCallback(async () => {
+    const supabase = createClient();
+    const { data } = await supabase
+      .from("team_mem_rel")
+      .select("mem_id, mem_mst!inner(mem_id, mem_nm, avatar_url)")
+      .eq("team_id", teamId)
+      .eq("vers", 0)
+      .eq("del_yn", false)
+      .eq("mem_st_cd", "active")
+      .eq("mem_mst.vers", 0)
+      .eq("mem_mst.del_yn", false);
+
+    setActiveMembers(
+      (data ?? []).map((row) => {
+        const m = Array.isArray(row.mem_mst) ? row.mem_mst[0] : row.mem_mst;
+        return {
+          mem_id: row.mem_id,
+          mem_nm: m?.mem_nm ?? null,
+          avatar_url: m?.avatar_url ?? null,
+        };
+      }),
+    );
+  }, [teamId]);
+
+  const openGathering = (g: Gathering) => {
+    setSelected(g);
+    setDialogOpen(true);
+    setAddingMemId("");
+    loadAttendees(g.gthr_id);
+    loadActiveMembers();
+  };
+
+  const attendeeIds = useMemo(() => new Set(attendees.map((a) => a.mem_id)), [attendees]);
+  const availableMembers = useMemo(
+    () => activeMembers.filter((m) => !attendeeIds.has(m.mem_id)),
+    [activeMembers, attendeeIds],
+  );
+
+  const syncGatheringCount = (gthrId: string, delta: number) => {
+    setGatherings((prev) =>
+      prev.map((g) => (g.gthr_id === gthrId ? { ...g, attd_count: g.attd_count + delta } : g)),
+    );
+  };
+
+  const handleRemoveAttendee = async (memId: string) => {
+    if (!selected || removingMemId) return;
+    const target = attendees.find((a) => a.mem_id === memId);
+    const memName = target?.mem_nm ?? "이름 없음";
+    const gDate = dayjs(selected.stt_at).tz("Asia/Seoul").format("M/D(ddd)");
+    if (!window.confirm(`${memName}님의 ${gDate} "${selected.gthr_nm}" 참석을 취소합니다. 계속할까요?`)) return;
+
+    setRemovingMemId(memId);
+    const prevAttendees = attendees;
+    setAttendees((prev) => prev.filter((a) => a.mem_id !== memId));
+    syncGatheringCount(selected.gthr_id, -1);
+
+    const result = await removeGatheringAttendance(selected.gthr_id, memId);
+    if (!result.ok) {
+      setAttendees(prevAttendees);
+      syncGatheringCount(selected.gthr_id, 1);
+      toast.error(result.message ?? "참석 취소에 실패했습니다");
+    } else {
+      toast.success(`${memName}님 참석을 취소했습니다`);
+    }
+    setRemovingMemId(null);
+  };
+
+  const handleAddAttendee = async () => {
+    if (!selected || !addingMemId) return;
+    const member = activeMembers.find((m) => m.mem_id === addingMemId);
+    if (!member) return;
+
+    setAdding(true);
+    const prevAttendees = attendees;
+    setAttendees((prev) => [...prev, member]);
+    syncGatheringCount(selected.gthr_id, 1);
+    setAddingMemId("");
+
+    const result = await addGatheringAttendance(selected.gthr_id, member.mem_id);
+    if (!result.ok) {
+      setAttendees(prevAttendees);
+      syncGatheringCount(selected.gthr_id, -1);
+      toast.error(result.message ?? "참석 추가에 실패했습니다");
+    }
+    setAdding(false);
+  };
+
+  return (
+    <div className="flex flex-col gap-4 px-6 pb-6 pt-4">
+      <H2>모임 관리</H2>
+
+      {/* 월 이동 */}
+      <div className="flex items-center justify-center gap-4">
+        <Button
+          variant="ghost"
+          size="icon-sm"
+          onClick={() => setMonth((m) => prevMonthStr(m))}
+          className="text-muted-foreground active:bg-secondary"
+          aria-label="이전 달"
+        >
+          <ChevronLeft className="size-5" />
+        </Button>
+        <Body className="min-w-[8rem] text-center text-lg font-bold">
+          {monthLabel}
+        </Body>
+        <Button
+          variant="ghost"
+          size="icon-sm"
+          onClick={() => setMonth((m) => nextMonthStr(m))}
+          className="text-muted-foreground active:bg-secondary"
+          aria-label="다음 달"
+        >
+          <ChevronRight className="size-5" />
+        </Button>
+      </div>
+
+      {/* 모임 목록 */}
+      {loading ? (
+        <div className="flex flex-col gap-3">
+          {Array.from({ length: 3 }).map((_, i) => (
+            <Skeleton key={i} className="h-20 w-full rounded-2xl" />
+          ))}
+        </div>
+      ) : gatherings.length === 0 ? (
+        <EmptyState
+          variant="card"
+          icon={CalendarDays}
+          message="이번 달 등록된 모임이 없습니다."
+        />
+      ) : (
+        <div className="flex flex-col gap-3">
+          {gatherings.map((g) => {
+            const stt = dayjs(g.stt_at).tz("Asia/Seoul");
+            const typeLabel = gthrTypeLabels[g.gthr_type_enm as GthrType] ?? g.gthr_type_enm;
+            const typeBadgeClass = TYPE_BADGE_CLASS[g.gthr_type_enm] ?? TYPE_BADGE_CLASS.general;
+            return (
+              <CardItem asChild key={g.gthr_id} className="flex flex-col gap-2">
+                <button
+                  onClick={() => openGathering(g)}
+                  className="text-left transition-colors active:bg-secondary"
+                >
+                  <div className="flex items-center gap-2">
+                    <Badge variant="outline" className={typeBadgeClass}>
+                      {typeLabel}
+                    </Badge>
+                    <Caption>{stt.format("M.D(ddd) HH:mm")}</Caption>
+                  </div>
+                  <Body className="font-semibold">
+                    {g.gthr_nm}
+                  </Body>
+                  <Micro className="flex items-center gap-1">
+                    <Users className="size-3" />
+                    <span>참석 {g.attd_count}명</span>
+                  </Micro>
+                </button>
+              </CardItem>
+            );
+          })}
+        </div>
+      )}
+
+      {/* 참가자 관리 다이얼로그 */}
+      <ResponsiveDrawer open={dialogOpen} onOpenChange={setDialogOpen}>
+        <ResponsiveDrawerContent
+          dialogClassName="max-w-md max-h-[85dvh] flex flex-col gap-0 p-0 overflow-hidden"
+          drawerClassName="h-[85dvh] max-h-[85dvh]"
+        >
+          <ResponsiveDrawerHeader className="shrink-0 border-b border-border px-4 py-4 text-left">
+            <ResponsiveDrawerTitle>{selected?.gthr_nm ?? "참가자 관리"}</ResponsiveDrawerTitle>
+            <ResponsiveDrawerDescription className="sr-only">
+              모임 참가자 관리
+            </ResponsiveDrawerDescription>
+          </ResponsiveDrawerHeader>
+
+          <div className="flex-1 overflow-y-auto px-4 pb-6 pt-4">
+            <div className="flex flex-col gap-4">
+              {/* 참가자 추가 */}
+              <div className="flex gap-2">
+                <Select value={addingMemId} onValueChange={setAddingMemId}>
+                  <SelectTrigger className="h-10 flex-1 rounded-xl border text-[13px]">
+                    <SelectValue placeholder="추가할 멤버 선택" />
+                  </SelectTrigger>
+                  <SelectContent>
+                    {availableMembers.length === 0 ? (
+                      <div className="px-2 py-1.5">
+                        <Caption className="text-muted-foreground">추가할 수 있는 멤버가 없습니다</Caption>
+                      </div>
+                    ) : (
+                      availableMembers.map((m) => (
+                        <SelectItem key={m.mem_id} value={m.mem_id}>
+                          {m.mem_nm ?? "이름 없음"}
+                        </SelectItem>
+                      ))
+                    )}
+                  </SelectContent>
+                </Select>
+                <Button
+                  variant="outline"
+                  size="sm"
+                  disabled={!addingMemId || adding}
+                  onClick={handleAddAttendee}
+                >
+                  <Plus className="size-3.5" />
+                  추가
+                </Button>
+              </div>
+
+              {/* 참가자 목록 */}
+              <div className="flex flex-col gap-2">
+                <Caption className="text-muted-foreground">
+                  참석자 ({attendees.length}명)
+                </Caption>
+                {attendeesLoading ? (
+                  Array.from({ length: 3 }).map((_, i) => (
+                    <Skeleton key={i} className="h-12 w-full rounded-xl" />
+                  ))
+                ) : attendees.length === 0 ? (
+                  <EmptyState message="참석자가 없습니다." />
+                ) : (
+                  attendees.map((a) => (
+                    <div
+                      key={a.mem_id}
+                      className="flex items-center justify-between rounded-xl border border-border px-3 py-2.5"
+                    >
+                      <div className="flex items-center gap-2.5">
+                        <Avatar src={a.avatar_url} seed={a.mem_id} alt={a.mem_nm ?? ""} size="sm" />
+                        <Body className="font-medium">
+                          {a.mem_nm ?? "이름 없음"}
+                        </Body>
+                      </div>
+                      <Button
+                        variant="ghost"
+                        size="icon-sm"
+                        onClick={() => handleRemoveAttendee(a.mem_id)}
+                        disabled={removingMemId === a.mem_id}
+                        aria-label={`${a.mem_nm ?? "이름 없음"} 참석 취소`}
+                        className="text-muted-foreground active:text-destructive"
+                      >
+                        <X className="size-3.5" />
+                      </Button>
+                    </div>
+                  ))
+                )}
+              </div>
+            </div>
+          </div>
+        </ResponsiveDrawerContent>
+      </ResponsiveDrawer>
+    </div>
+  );
+}

--- a/app/(info)/admin/gatherings/page.tsx
+++ b/app/(info)/admin/gatherings/page.tsx
@@ -1,0 +1,27 @@
+import { Suspense } from "react";
+
+import { getRequestTeamContext } from "@/lib/queries/request-team";
+
+import { Skeleton } from "@/components/ui/skeleton";
+
+import { AdminGatheringsClient } from "./admin-gatherings-client";
+
+function GatheringsFallback() {
+  return (
+    <div className="flex flex-col gap-4 px-6 pt-4">
+      <Skeleton className="h-8 w-32 rounded" />
+      {Array.from({ length: 4 }).map((_, i) => (
+        <Skeleton key={i} className="h-20 w-full rounded-2xl" />
+      ))}
+    </div>
+  );
+}
+
+export default async function AdminGatheringsPage() {
+  const { teamId } = await getRequestTeamContext();
+  return (
+    <Suspense fallback={<GatheringsFallback />}>
+      <AdminGatheringsClient teamId={teamId} />
+    </Suspense>
+  );
+}

--- a/app/(info)/admin/page.tsx
+++ b/app/(info)/admin/page.tsx
@@ -17,6 +17,7 @@ import {
   Bell,
   Wallet,
   MessageSquare,
+  CalendarDays,
 } from "lucide-react";
 
 import {
@@ -53,6 +54,13 @@ const generalCards: Card[] = [
     icon: Wallet,
     getValue: (s) => s.unpaidMemberCount,
     getAccentValue: (s) => s.unpaidMemberCount,
+  },
+  {
+    key: "gatherings",
+    label: "모임 관리",
+    href: "/admin/gatherings",
+    icon: CalendarDays,
+    getValue: (s) => s.monthlyGatheringCount,
   },
   {
     key: "competitions",

--- a/app/actions/admin/get-admin-stats.ts
+++ b/app/actions/admin/get-admin-stats.ts
@@ -1,7 +1,7 @@
 "use server";
 
 import { withAdminOrThrow } from "@/lib/actions/auth";
-import { currentMonthKST, nextMonthStr } from "@/lib/dayjs";
+import { currentMonthKST, dayjs, nextMonthStr } from "@/lib/dayjs";
 import { env } from "@/lib/env";
 import { getRequestTeamContext } from "@/lib/queries/request-team";
 import { createAdminClient } from "@/lib/supabase/admin";
@@ -10,6 +10,7 @@ export type AdminStats = {
   totalCount: number;
   activeCount: number;
   monthlyCompetitionCount: number;
+  monthlyGatheringCount: number;
   recentRecordCount: number;
   activeProjectCount: number;
   pendingParticipationCount: number;
@@ -27,7 +28,7 @@ export async function getAdminStats(): Promise<AdminStats> {
     const keyPrefix = env.SUPABASE_SERVICE_ROLE_KEY.slice(0, 20);
     console.log("[getAdminStats] teamId:", teamId, "keyPrefix:", keyPrefix, "noFilterCount:", noFilter.count, "noFilterError:", noFilter.error);
 
-    const [total, active, competitions, records, activeProjects, pendingPrt, unpaidResult, openFeedback] = await Promise.all([
+    const [total, active, competitions, gatherings, records, activeProjects, pendingPrt, unpaidResult, openFeedback] = await Promise.all([
       admin.from("team_mem_rel").select("*", { count: "exact", head: true }).eq("team_id", teamId).eq("vers", 0).eq("del_yn", false)
         .then((res) => { if (res.error) console.error("[getAdminStats] team_mem_rel error:", res.error, "teamId:", teamId); return res; }),
       admin.from("team_mem_rel").select("*", { count: "exact", head: true }).eq("team_id", teamId).eq("vers", 0).eq("del_yn", false).eq("mem_st_cd", "active"),
@@ -35,6 +36,14 @@ export async function getAdminStats(): Promise<AdminStats> {
         const monthStart = currentMonthKST();
         const monthEnd = nextMonthStr(monthStart);
         return admin.from("comp_mst").select("*", { count: "exact", head: true }).eq("vers", 0).eq("del_yn", false).gte("stt_dt", monthStart).lt("stt_dt", monthEnd);
+      })(),
+      (() => {
+        // stt_at은 timestamptz — KST 월 경계를 명시적 ISO(UTC)로 변환해 gte/lt 비교한다.
+        const monthStart = currentMonthKST();
+        const monthEnd = nextMonthStr(monthStart);
+        const monthStartIso = dayjs.tz(monthStart, "Asia/Seoul").toISOString();
+        const monthEndIso = dayjs.tz(monthEnd, "Asia/Seoul").toISOString();
+        return admin.from("gthr_mst").select("*", { count: "exact", head: true }).eq("team_id", teamId).eq("del_yn", false).gte("stt_at", monthStartIso).lt("stt_at", monthEndIso);
       })(),
       admin.from("rec_race_hist").select("*", { count: "exact", head: true }).eq("vers", 0).eq("del_yn", false),
       admin.from("evt_team_mst").select("*", { count: "exact", head: true }).eq("team_id", teamId).eq("stts_enm", "ACTIVE"),
@@ -50,6 +59,7 @@ export async function getAdminStats(): Promise<AdminStats> {
       totalCount: total.count ?? 0,
       activeCount: active.count ?? 0,
       monthlyCompetitionCount: competitions.count ?? 0,
+      monthlyGatheringCount: gatherings.count ?? 0,
       recentRecordCount: records.count ?? 0,
       activeProjectCount: activeProjects.count ?? 0,
       pendingParticipationCount: pendingPrt.count ?? 0,

--- a/app/actions/admin/manage-gathering-attendance.ts
+++ b/app/actions/admin/manage-gathering-attendance.ts
@@ -1,0 +1,68 @@
+"use server";
+
+import { withAdmin } from "@/lib/actions/auth";
+import { getRequestTeamContext } from "@/lib/queries/request-team";
+import { createAdminClient } from "@/lib/supabase/admin";
+
+/** createAdminClient는 RLS를 우회하므로, 대상 모임이 현재 팀 소속인지 서버에서 직접 확인한다 (IDOR 방지). */
+async function verifyGatheringInTeam(
+  db: ReturnType<typeof createAdminClient>,
+  gthrId: string,
+  teamId: string,
+): Promise<boolean> {
+  const { data } = await db
+    .from("gthr_mst")
+    .select("gthr_id")
+    .eq("gthr_id", gthrId)
+    .eq("team_id", teamId)
+    .eq("del_yn", false)
+    .maybeSingle();
+  return !!data;
+}
+
+/** 관리자가 특정 모임에서 특정 멤버의 참석을 취소한다 (RLS 우회 — 본인 외 삭제 허용). */
+export async function removeGatheringAttendance(gthrId: string, memId: string) {
+  return withAdmin(async () => {
+    const { teamId } = await getRequestTeamContext();
+    const db = createAdminClient();
+
+    const inTeam = await verifyGatheringInTeam(db, gthrId, teamId);
+    if (!inTeam) return { ok: false, message: "모임을 찾을 수 없습니다" };
+
+    const { error } = await db
+      .from("gthr_attd_rel")
+      .delete()
+      .eq("gthr_id", gthrId)
+      .eq("mem_id", memId);
+    if (error) return { ok: false, message: "참석 취소에 실패했습니다" };
+    return { ok: true, message: null };
+  });
+}
+
+/** 관리자가 특정 모임에 특정 멤버의 참석을 등록한다 (RLS 우회 — 본인 외 등록 허용). */
+export async function addGatheringAttendance(gthrId: string, memId: string) {
+  return withAdmin(async () => {
+    const { teamId } = await getRequestTeamContext();
+    const db = createAdminClient();
+
+    const inTeam = await verifyGatheringInTeam(db, gthrId, teamId);
+    if (!inTeam) return { ok: false, message: "모임을 찾을 수 없습니다" };
+
+    const { data: memRel } = await db
+      .from("team_mem_rel")
+      .select("team_mem_id")
+      .eq("mem_id", memId)
+      .eq("team_id", teamId)
+      .eq("vers", 0)
+      .eq("del_yn", false)
+      .eq("mem_st_cd", "active")
+      .maybeSingle();
+    if (!memRel) return { ok: false, message: "추가할 수 없는 멤버입니다" };
+
+    const { error } = await db
+      .from("gthr_attd_rel")
+      .upsert({ gthr_id: gthrId, mem_id: memId }, { onConflict: "gthr_id,mem_id", ignoreDuplicates: true });
+    if (error) return { ok: false, message: "참석 추가에 실패했습니다" };
+    return { ok: true, message: null };
+  });
+}


### PR DESCRIPTION
## 관련 이슈

관련 이슈 없음

## 요약

관리자용 **모임 관리** 화면을 추가합니다. 지금까지 관리자가 모임 삭제·수정은 할 수 있었지만 **다른 멤버의 참석을 취소/추가할 방법이 없었던** 운영 공백을 해소합니다. 관리 대시보드 일반 섹션 3번째(회비 관리 ↔ 대회 관리 사이)에 진입 카드가 생깁니다.

## AS-IS (변경 전)

- `gthr_attd_rel` RLS가 본인만 INSERT/DELETE 허용 → 노쇼 멤버 참석 정리, 대리 참석 처리 등 운영 요청을 관리자가 처리할 수 없음
- 관리 화면에 모임 도메인 진입점 자체가 없음

## TO-BE (변경 후)

- **관리 대시보드**: "모임 관리" 카드 (이번 달 모임 수 표시, `monthlyGatheringCount` 통계 추가)
- **`/admin/gatherings`**: ‹ 월 이동 › + 해당 월 모임 리스트(타입 배지·일시·참석 N명) → 행 클릭 시 참가자 관리 드로어
  - **참석 취소**: X 버튼 → confirm(멤버 이름·모임명·날짜 명시) → 낙관적 업데이트 + 성공 토스트
  - **참석 추가**: 검색형 콤보박스(이름 타이핑 검색, 회비 인박스 member-combobox 패턴) — **선택 즉시 참석 처리** (별도 추가 버튼 없음, 2탭 완결)
- 서버 액션(`manage-gathering-attendance.ts`): `withAdmin` + service role. RLS 우회이므로 **팀 스코프 검증(verifyGatheringInTeam)** 과 **멤버 소속·활성 상태 재검증**을 서버에서 강제

## 변경 흐름 (Mermaid)

```mermaid
flowchart TD
    A["관리 대시보드<br/>모임 관리 카드 (이번 달 N개)"] --> B["/admin/gatherings<br/>‹ 월 이동 › + 모임 리스트"]
    B -->|행 클릭| C["참가자 관리 드로어"]
    C -->|X 버튼 + confirm| D["removeGatheringAttendance<br/>(withAdmin + 팀 스코프 검증)"]
    C -->|이름 검색 → 선택 즉시| E["addGatheringAttendance<br/>(+ 멤버 활성 상태 서버 검증)"]
    D --> F["gthr_attd_rel DELETE"]
    E --> G["gthr_attd_rel INSERT<br/>(UNIQUE 충돌 무해 처리)"]
    F & G -.-> H["낙관적 업데이트 + 리스트 카운트 동기화<br/>실패 시 롤백 + 토스트"]
```

## 주요 변경 사항

| 파일 | 내용 |
|------|------|
| `app/(info)/admin/gatherings/page.tsx` · `admin-gatherings-client.tsx` (신규) | 월별 리스트 + 참가자 관리 UI |
| `app/actions/admin/manage-gathering-attendance.ts` (신규) | 참석 취소/추가 서버 액션 (팀 스코프·멤버 검증) |
| `app/(info)/admin/page.tsx` | 일반 섹션 3번째 모임 관리 카드 |
| `app/actions/admin/get-admin-stats.ts` | `monthlyGatheringCount` (KST 월 경계) |

## 리뷰 반영 (3관점 결함·개선 + 부하 점검)

- **P0**: 팀 스코프 검증 누락(IDOR — service role이 RLS를 우회하므로 임의 gthr_id로 타 팀 조작 가능했음), 추가 시 멤버 소속·활성 서버 검증 누락 → 수정
- **P1**: 월 빠른 이동 stale-response 가드 / 참가자 다이얼로그 빠른 전환 시 늦은 응답·실패 롤백이 다른 모임 화면을 덮는 레이스(현재 모임 ref 가드) / confirm 문구 대상 특정 / 성공 토스트 / 디자인 토큰 위반 정리(violet 하드코딩 → 시맨틱 토큰, 매직넘버 → 타이포 컴포넌트)
- **P2**: 제거 버튼 연타 방지, aria-label
- **부하 점검**: 월 이동 쿼리(모임+참석수 집계 1회)·통계 추가 쿼리·인덱스 커버(`ix_gthr_mst_team_stt_at` 등) 모두 크루 규모에서 이상 없음 확인

## 검증

- `tsc --noEmit` 클린, 변경 파일 ESLint 클린, pre-commit vitest 142개 통과
- ⚠️ 브라우저 실동작 QA 미완 (구현 세션에서 관리자 로그인 자격증명 없음) — dev에서 월 이동/취소/추가 한 번 확인 권장
- 후속(TODO 기록): 참가자 검색 Input, "이번 달로" 복귀 버튼

🤖 Generated with [Claude Code](https://claude.com/claude-code)