### PR TITLE
fix(notification): 관리자 발송 이력 batch_id 복원

### DIFF
--- a/app/actions/admin/send-notification.ts
+++ b/app/actions/admin/send-notification.ts
@@ -18,6 +18,8 @@ export async function sendNotification(input: {
   return withAdmin(async () => {
     const { teamId } = await getRequestTeamContext();
     const notiTypeEnm = input.notiTypeEnm ?? "adm_cust";
+    // 한 번의 관리자 발송 = 하나의 배치. 발송 이력 화면이 이 값으로 수신자를 묶는다.
+    const batchId = crypto.randomUUID();
 
     try {
       if (input.target === "all") {
@@ -26,6 +28,7 @@ export async function sendNotification(input: {
           notiTypeEnm,
           notiNm: input.notiNm,
           notiCont: input.notiCont ?? null,
+          batchId,
         });
       } else {
         await insertNotiMany({
@@ -34,6 +37,7 @@ export async function sendNotification(input: {
           notiTypeEnm,
           notiNm: input.notiNm,
           notiCont: input.notiCont ?? null,
+          batchId,
         });
       }
     } catch {

--- a/lib/notifications/insert-noti.ts
+++ b/lib/notifications/insert-noti.ts
@@ -116,6 +116,9 @@ type NotiManyInput = {
   notiCont?: string | null;
   refId?: string | null;
   refTypeEnm?: string | null;
+  /** 한 번의 발송을 묶는 배치 식별자. 관리자 수동 발송 이력(발송 이력 화면)이
+   *  이 값으로 수신자를 그룹핑한다. 생략 시 null — 개별 알림은 이력에 묶이지 않는다. */
+  batchId?: string | null;
 };
 
 /**
@@ -152,6 +155,7 @@ export async function insertNotiMany(input: NotiManyInput): Promise<void> {
         noti_cont: input.notiCont ?? null,
         ref_id: input.refId ?? null,
         ref_type_enm: input.refTypeEnm ?? null,
+        batch_id: input.batchId ?? null,
       })),
     )
     .select("noti_id, mem_id");
@@ -189,6 +193,8 @@ type NotiTeamInput = {
   notiCont?: string | null;
   refId?: string | null;
   refTypeEnm?: string | null;
+  /** 발송 이력 그룹핑용 배치 식별자 (insertNotiMany로 그대로 전달). */
+  batchId?: string | null;
 };
 
 /**
@@ -221,5 +227,6 @@ export async function insertNotiForTeam(input: NotiTeamInput): Promise<void> {
     notiCont: input.notiCont ?? null,
     refId: input.refId ?? null,
     refTypeEnm: input.refTypeEnm ?? null,
+    batchId: input.batchId ?? null,
   });
 }


### PR DESCRIPTION
## 관련 이슈

관련 이슈 없음

## 요약

관리자 수동 알림 발송 이력이 6/6 이후로 멈춰 보이던 문제를 수정한다. 발송 이력 화면의 그룹핑 키인 `batch_id`가 알림 저장 경로에서 누락돼 있던 것이 원인이다.

## AS-IS (변경 전)

- 관리자 발송 이력 화면(`발송 이력`)은 `noti_mst.batch_id`로 "한 번의 발송 = 하나의 배치"를 묶어 수신자·수신여부를 보여준다. 조회 쿼리는 `batch_id IS NOT NULL`인 row만 표시한다.
- `PR #347`에서 발송 경로를 `insertNotiForTeam`/`insertNotiMany` 관문으로 통일하며, `insertNotiForTeam`의 **푸시 되조회를 `.select()` RETURNING으로 대체**했다. 이때 되조회 키로만 인식하고 `batch_id` 기록을 함께 제거했다.
- 그러나 `batch_id`는 **발송 이력 그룹핑 키도 겸직**하고 있었다. 그 결과 6/28(PR #347 배포) 이후 모든 관리자 알림이 `batch_id = null`로 저장되고, 이력 쿼리의 `batch_id IS NOT NULL` 필터에 걸려 **6/6 이후 이력이 보이지 않게** 됐다.
- 알림 발송(인앱+푸시) 자체는 정상. 깨진 것은 이력/수신여부 화면뿐.

## TO-BE (변경 후)

- `insert-noti` 관문(`insertNotiMany`, `insertNotiForTeam`)에 **옵셔널 `batchId`** 파라미터를 추가하고, INSERT payload에 `batch_id`로 심는다. 미지정 시 `null` — 기존 개별 알림 발송처(댓글·모임·회비 등)는 **동작 불변**.
- `sendNotification`(관리자 수동 발송)이 발송당 `crypto.randomUUID()`로 `batchId`를 생성해 관문에 전달한다. → 한 번의 발송이 하나의 배치로 묶여 이력이 예전처럼 복원된다.
- 제거됐던 "batch_id 되조회"는 부활하지 않는다(이미 RETURNING으로 대체됨). 그룹핑 키만 복원.
- **데이터 backfill**: 유실 구간(6/28~7/9)의 관리자 알림 3건은 prd에서 migration과 동일한 초 단위 그룹핑 휴리스틱으로 `batch_id`를 채워 이력에 복구 완료(남은 null 0건).

## 변경 흐름 (Mermaid)

```mermaid
flowchart TD
    A[sendNotification] --> B[batchId 생성 crypto.randomUUID]
    B --> C{target}
    C -->|all| D[insertNotiForTeam batchId]
    C -->|select| E[insertNotiMany batchId]
    D --> E
    E --> F[noti_mst INSERT batch_id 포함]
    F --> G[발송 이력 화면 batch_id로 그룹핑]
```
