### PR TITLE
feat(admin): 회원관리 상세에 온보딩 러닝 프로필 컴팩트 표시

### DIFF
--- a/.claude/docs/KNOWLEDGE.md
+++ b/.claude/docs/KNOWLEDGE.md
@@ -119,5 +119,8 @@ dev MCP로 `database.types.ts`를 재생성하면 기존 테이블 블록이 dif
 ### 회원 생성 직후 다중 테이블 INSERT는 트랜잭션이 아니다 — 핵심/부가를 나눠 비치명 처리
 서버 액션은 문장별 실행이라 `mem_mst` INSERT → `team_mem_rel` → `mem_onbd_prf` → 참석 INSERT가 한 트랜잭션으로 묶이지 않는다. 원칙: **가입 성립에 필수인 것**(`mem_mst`+`team_mem_rel`)은 실패 시 service_role로 앞 INSERT를 되돌리고(`mem_mst` DELETE 정책이 없어 admin 클라이언트 필요), **부가 데이터**(`mem_onbd_prf`, 참석 약속 모임 신청)는 실패해도 가입을 롤백하지 않고 `console.error` 로깅만 한다. `mem_onbd_prf` FK가 `ON DELETE CASCADE`라 앞 단계 롤백 시 자동 정리되지만, 이는 "프로필 INSERT는 롤백 지점 뒤"라는 순서에 의존하는 암묵 전제. (선례: `onboardingCreateMember` 2026-07-09)
 
+### 관리자가 타 회원 온보딩 프로필을 볼 때 서버 액션이 필요 없다 (RLS가 이미 허용)
+`mem_onbd_prf`에는 `mem_onbd_prf_select_team_admin` RLS(팀 owner/admin이면 팀원 행 SELECT 허용)가 걸려 있다. 그래서 관리자 회원관리 상세(`admin-members-client.tsx`의 `OnboardingSection`)는 `TitleSection`처럼 **브라우저 클라이언트(`createClient()`)로 직접 조회**하면 된다 — `withAdmin`+`createAdminClient` 서버 액션을 새로 만들 필요 없음(반사적으로 만들기 쉬운 함정). 반대로 본인 편집 경로(`getNearStation`)는 `mem_onbd_prf_select_own`으로 통과. 라벨은 `lib/validations/member.ts` 단일 출처(`PACE_LABELS`/`JOIN_SRC_LABELS`), 관리자 요약용 압축 라벨은 같은 파일 `JOIN_PURP_SHORT_LABELS`. (2026-07-10 회원관리 온보딩 표시 추가)
+
 ### "개편 후 신규 가입자" 식별은 위성 테이블 row 존재가 아니라 전용 플래그로
 `mem_onbd_prf`는 온보딩에서도 생기고 기존 회원이 프로필 편집에서 러닝 프로필을 입력해도 생긴다(upsert). 따라서 "row 존재 = 신규 온보딩 가입자"가 아니다. 넛지 크론 대상 판별은 **`attd_pldg_at IS NOT NULL`**(참석 서약은 온보딩 경로에서만 기록)로 한다. 프로필 편집 서버 액션(`update-running-profile`)은 `attd_pldg_at`/`pldg_gthr_id`/`join_src_cd`/`join_src_txt`를 payload에서 제외해 절대 덮어쓰지 않는다.

--- a/app/(info)/admin/members/admin-members-client.tsx
+++ b/app/(info)/admin/members/admin-members-client.tsx
@@ -14,6 +14,11 @@ import {
 
 import { dayjs } from "@/lib/dayjs";
 import { createClient } from "@/lib/supabase/client";
+import {
+  PACE_LABELS,
+  JOIN_SRC_LABELS,
+  JOIN_PURP_SHORT_LABELS,
+} from "@/lib/validations/member";
 
 import { grantTitle } from "@/app/actions/admin/grant-title";
 import {
@@ -176,6 +181,140 @@ function GrantPanel({
 }
 
 // ---------------------------------------------------------------------------
+// 온보딩(러닝 프로필) 섹션 — 가입 시점 스냅샷을 컴팩트하게 표시
+// ---------------------------------------------------------------------------
+
+type OnboardingProfile = {
+  near_stn_nm: string | null;
+  avg_run_dist_km: number | null;
+  avg_pace_cd: string | null;
+  join_purp_cds: string[] | null;
+  join_purp_txt: string | null;
+  join_src_cd: string | null;
+  join_src_txt: string | null;
+};
+
+/** 라벨-값 미니 pill (역·거리·페이스처럼 짧은 항목 한 줄 나열용) */
+function MiniStat({ label, value }: { label: string; value: string }) {
+  return (
+    <span className="inline-flex items-center gap-1 rounded-md bg-secondary px-2 py-1">
+      <span className="text-[11px] text-muted-foreground">{label}</span>
+      <span className="text-[12px] font-medium text-foreground">{value}</span>
+    </span>
+  );
+}
+
+function OnboardingSection({ memId }: { memId: string }) {
+  const [profile, setProfile] = useState<OnboardingProfile | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    // memId별 remount(호출부 key)라 loading 초기값(true)이 그대로 적용된다 —
+    // effect 안에서 동기 setState를 부르지 않는다.
+    let alive = true;
+    const supabase = createClient();
+    // RLS mem_onbd_prf_select_team_admin 이 팀 관리자에게 팀원 온보딩 조회를 허용한다.
+    supabase
+      .from("mem_onbd_prf")
+      .select(
+        "near_stn_nm, avg_run_dist_km, avg_pace_cd, join_purp_cds, join_purp_txt, join_src_cd, join_src_txt",
+      )
+      .eq("mem_id", memId)
+      .maybeSingle()
+      .then(
+        ({ data }) => {
+          if (!alive) return;
+          setProfile((data as OnboardingProfile) ?? null);
+          setLoading(false);
+        },
+        // 네트워크 실패 등으로 reject 되면 스켈레톤이 영영 안 걷히므로 로딩만 해제
+        () => {
+          if (!alive) return;
+          setLoading(false);
+        },
+      );
+    return () => {
+      alive = false;
+    };
+  }, [memId]);
+
+  const paceLabel = profile?.avg_pace_cd
+    ? (PACE_LABELS[profile.avg_pace_cd as keyof typeof PACE_LABELS] ??
+      profile.avg_pace_cd)
+    : null;
+  const srcLabel = profile?.join_src_cd
+    ? profile.join_src_cd === "ETC" && profile.join_src_txt
+      ? profile.join_src_txt
+      : (JOIN_SRC_LABELS[profile.join_src_cd as keyof typeof JOIN_SRC_LABELS] ??
+        profile.join_src_cd)
+    : null;
+  const purpLabels = (profile?.join_purp_cds ?? []).map(
+    (c) => JOIN_PURP_SHORT_LABELS[c as keyof typeof JOIN_PURP_SHORT_LABELS] ?? c,
+  );
+
+  return (
+    <div className="flex flex-col gap-3">
+      <SectionLabel>러닝 프로필</SectionLabel>
+      {loading ? (
+        <Skeleton className="h-20 w-full rounded-2xl" />
+      ) : !profile ? (
+        <EmptyState variant="inline" message="온보딩 정보 없음" />
+      ) : (
+        <CardItem className="flex flex-col gap-2.5 p-3.5">
+          {/* 역 · 거리 · 페이스 — 한 줄 미니 스탯 */}
+          <div className="flex flex-wrap gap-1.5">
+            <MiniStat label="역" value={profile.near_stn_nm || "-"} />
+            <MiniStat
+              label="거리"
+              value={
+                profile.avg_run_dist_km != null
+                  ? `${profile.avg_run_dist_km}km`
+                  : "-"
+              }
+            />
+            <MiniStat label="페이스" value={paceLabel ?? "-"} />
+          </div>
+
+          {/* 유입 경로 */}
+          {srcLabel && (
+            <div className="flex items-center gap-1.5">
+              <Caption className="text-[11px]">유입</Caption>
+              <Badge variant="secondary" className="text-[11px] px-1.5 py-0">
+                {srcLabel}
+              </Badge>
+            </div>
+          )}
+
+          {/* 가입 목적 */}
+          {purpLabels.length > 0 && (
+            <div className="flex items-start gap-1.5">
+              <Caption className="text-[11px] shrink-0 pt-0.5">목적</Caption>
+              <div className="flex flex-wrap gap-1">
+                {purpLabels.map((label) => (
+                  <span
+                    key={label}
+                    className="rounded-md border border-border px-1.5 py-0.5 text-[11px] font-medium text-foreground"
+                  >
+                    {label}
+                  </span>
+                ))}
+              </div>
+            </div>
+          )}
+
+          {/* 자유 한마디 */}
+          {profile.join_purp_txt && (
+            <p className="rounded-lg bg-secondary/50 px-2.5 py-1.5 text-[12px] leading-snug text-muted-foreground">
+              &ldquo;{profile.join_purp_txt}&rdquo;
+            </p>
+          )}
+        </CardItem>
+      )}
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
 // 칭호 섹션 컴포넌트
 // ---------------------------------------------------------------------------
 
@@ -238,6 +377,8 @@ function TitleSection({
   }, [teamId]);
 
   useEffect(() => {
+    // 마운트 시 칭호 fetch — 외부(네트워크) 동기화 effect라 set-state-in-effect는 오탐
+    // eslint-disable-next-line react-hooks/set-state-in-effect
     loadTitles();
   }, [loadTitles]);
 
@@ -417,6 +558,9 @@ export function AdminMembersClient({ teamId, initialTeamMemId }: { teamId: strin
     if (!initialTeamMemId || loading || initialSelectDone.current) return;
     const found = members.find((m) => m.team_mem_id === initialTeamMemId);
     if (found) {
+      // 딥링크(?memId) 도착 시 목록 로드 완료 후 상세 시트 1회 자동 오픈 — URL 파라미터
+      // 동기화 effect라 set-state-in-effect는 오탐
+      // eslint-disable-next-line react-hooks/set-state-in-effect
       setSelectedMember(found);
       initialSelectDone.current = true;
     }
@@ -761,6 +905,9 @@ export function AdminMembersClient({ teamId, initialTeamMemId }: { teamId: strin
                   />
                 )}
               </div>
+
+              {/* 온보딩 러닝 프로필 — 회원별 remount로 이전 회원 값 잔상 방지 */}
+              <OnboardingSection key={selectedMember.id} memId={selectedMember.id} />
 
               {/* 칭호 관리 */}
               <TitleSection member={selectedMember} teamId={teamId} />

--- a/lib/validations/member.ts
+++ b/lib/validations/member.ts
@@ -96,6 +96,21 @@ export const JOIN_PURP_LABELS: Record<(typeof JOIN_PURP_CODES)[number], string> 
   HABIT: "운동 습관을 만들고 싶어요",
 };
 
+/**
+ * 가입 목적 짧은 라벨 (관리자 회원관리 요약 전용).
+ * 온보딩 위저드의 문장형 라벨(JOIN_PURP_LABELS)은 관리자 요약 화면에 너무 길어,
+ * 컴팩트하게 보여줄 압축 라벨을 같은 단일 출처 파일에 둔다.
+ */
+export const JOIN_PURP_SHORT_LABELS: Record<(typeof JOIN_PURP_CODES)[number], string> = {
+  RUN_MATE: "러닝메이트",
+  COACH: "코칭",
+  TRAINING: "훈련",
+  NEW_SPORT: "새 운동",
+  RACE: "대회",
+  FRIENDS: "친목",
+  HABIT: "운동 습관",
+};
+
 /** 유입 경로 칩 라벨 (설계 §3.5) */
 export const JOIN_SRC_LABELS: Record<(typeof JOIN_SRC_CODES)[number], string> = {
   FRIEND: "지인 소개",


### PR DESCRIPTION
## 관련 이슈

관련 이슈 없음

## 요약

가입 온보딩에서 새로 받기 시작한 러닝 프로필(가까운 역·평균 거리·페이스·유입 경로·가입 목적·한마디)을 **관리자 회원관리 상세 시트**에서 컴팩트하게 볼 수 있게 추가했습니다. 지금까지 이 데이터를 앱 어디에서도 확인할 수 없었습니다.

## AS-IS (변경 전)

- 온보딩에서 수집한 `mem_onbd_prf`(러닝 프로필·가입 목적·유입 경로)를 확인할 화면이 전혀 없음
- 관리자 회원관리 상세에는 연락처·성별·생년월일·가입일·회비잔액·칭호만 표시

## TO-BE (변경 후)

- 회원관리에서 회원 클릭 → 상세 시트 **정보~칭호 사이**에 "러닝 프로필" 섹션 노출
  - 역·거리·페이스 → 한 줄 미니 pill
  - 유입 경로 → 배지 / 가입 목적 → 짧은 칩 / 자유 한마디 → 있을 때만 인용
- 온보딩 안 한 기존 회원 → "온보딩 정보 없음" 표시
- 세로 공간을 적게 쓰는 컴팩트 레이아웃

## 주요 변경 사항

- `app/(info)/admin/members/admin-members-client.tsx`
  - `OnboardingSection` / `MiniStat` 컴포넌트 신설. RLS `mem_onbd_prf_select_team_admin`이 이미 팀 관리자 조회를 허용하므로 `TitleSection`처럼 **브라우저 클라이언트로 직접 조회**(별도 서버 액션 불필요)
  - 회원별 `key`로 remount → 이전 회원 값 잔상 방지, effect 내 동기 setState 회피
  - fetch reject 시 스켈레톤 무한표시 방지(로딩 해제)
  - 같은 파일에 잠복해 있던 lint 에러 2곳(`set-state-in-effect` 오탐 — fetch-on-mount, 딥링크 자동오픈) 사유 명시 후 `eslint-disable`
- `lib/validations/member.ts`: 관리자 요약용 압축 라벨 `JOIN_PURP_SHORT_LABELS` 추가(라벨 단일 출처 파일)
- `.claude/docs/KNOWLEDGE.md`: 관리자 온보딩 조회에 서버 액션이 불필요한 이유(RLS) 기록

## 검증

- `pnpm exec tsc --noEmit` 통과
- lint 신규 에러 0 (오히려 기존 잠복 에러 2건 해소)
- 테스트 149개 통과(pre-commit)
- dev/prd 양쪽 RLS 정책 확인 + 실제 dev 데이터로 라벨 매핑·null 처리 검증
- ⚠️ 실제 브라우저 렌더링(관리자 로그인)은 미확인 — 배포 후 회원 클릭으로 최종 확인 필요

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **새로운 기능**
  - 관리자 회원 상세 화면에서 회원의 온보딩 러닝 프로필을 확인할 수 있습니다.
  - 러닝 거리, 페이스, 가입 경로, 참여 목적, 자유 의견을 보기 쉬운 라벨로 표시합니다.
  - 프로필을 불러오는 동안 로딩 상태를 제공하며, 정보가 없을 때 안내 메시지를 표시합니다.
  - 회원을 전환해 상세 정보를 열 때 이전 회원의 프로필이 남지 않습니다.

- **문서**
  - 관리자용 온보딩 프로필 조회 방식과 표시 라벨 기준을 문서화했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->