### PR TITLE
feat(admin): 회원관리 참여현황 탭·상세 참여 섹션 추가

### DIFF
--- a/.claude/docs/KNOWLEDGE.md
+++ b/.claude/docs/KNOWLEDGE.md
@@ -98,6 +98,9 @@ Postgres는 새 함수에 기본적으로 PUBLIC EXECUTE를 부여하고, Supaba
 관리자 서버 액션이 `createAdminClient()`(service role)를 쓰는 순간 RLS가 전부 무력화되므로, "어느 팀의 무엇을 대상으로 하는가"를 **액션 안에서 직접 검증**해야 한다. 안 하면 임의 id를 넘겨 타 팀 데이터를 조작하는 IDOR이 된다 (모임 참가자 관리 리뷰에서 발견 — 초안이 gthr_id 팀 소속 확인 없이 DELETE).
 **패턴:** `getRequestTeamContext()`로 teamId → 대상 row를 teamId 조건 포함해 조회(없으면 거부) → 변경. 선례: `manage-member.ts`의 `.eq("team_id", teamId)`, `manage-gathering-attendance.ts`의 `verifyGatheringInTeam()`. 클라이언트 필터(활성 멤버만 셀렉트 등)는 UI 편의일 뿐 서버 검증을 대체하지 않는다.
 
+### 관리자 화면 브라우저 QA는 dev0X 이메일 계정으로 불가 (전부 일반 회원)
+dev DB의 이메일 로그인 테스트 계정(dev01~05@dev.com)은 모두 비관리자 멤버라 `/admin/*` 화면 QA에 못 쓴다. 관리자 권한 계정은 전부 OAuth(카카오/구글)라 자동화 세션 확보 불가. 관리자 화면을 에이전트가 브라우저로 검증하려면 dev 환경에서 dev 계정 하나에 admin 역할(`team_mem_rel.team_role_cd`)을 부여해 둬야 한다(운영자 결정 필요). 그 전까지는 임베드 쿼리 REST 스모크(200/400) + SQL 기대값 대조 + 라우트 컴파일 확인이 최선의 proxy. (2026-07-14 참여현황 기능에서 확인)
+
 ### MCP generate_typescript_types 결과에는 재정렬 노이즈가 섞인다
 dev MCP로 `database.types.ts`를 재생성하면 기존 테이블 블록이 diff상 삭제+재추가로 보일 수 있다(예: fee_policy_cfg 44줄). 실제 손실인지 이동인지 `git diff | grep "^+" | grep <이름>`으로 반드시 재확인할 것 — dev/prd drift로 진짜 소실될 수도 있다(TODO의 "스키마 drift" 항목 참조).
 

--- a/app/(info)/admin/members/admin-members-client.tsx
+++ b/app/(info)/admin/members/admin-members-client.tsx
@@ -30,6 +30,9 @@ import {
 } from "@/app/actions/admin/manage-member";
 import { revokeTitle } from "@/app/actions/admin/revoke-title";
 
+import { ParticipationSection } from "./participation-section";
+import { ParticipationTab } from "./participation-tab";
+
 import { Avatar } from "@/components/common/avatar";
 import { EmptyState } from "@/components/common/empty-state";
 import { InfoRow } from "@/components/common/info-row";
@@ -481,6 +484,7 @@ function TitleSection({
 export function AdminMembersClient({ teamId, initialTeamMemId }: { teamId: string; initialTeamMemId?: string }) {
   const [members, setMembers] = useState<Member[]>([]);
   const [loading, setLoading] = useState(true);
+  const [tab, setTab] = useState<"members" | "participation">("members");
   const [search, setSearch] = useState("");
   const [selectedMember, setSelectedMember] = useState<Member | null>(null);
   const [actioning, setActioning] = useState(false);
@@ -694,6 +698,32 @@ export function AdminMembersClient({ teamId, initialTeamMemId }: { teamId: strin
     <div className="flex flex-col gap-4 px-6 pb-6 pt-4">
       <H2>회원 관리</H2>
 
+      {/* 회원 목록 ↔ 참여 통계 탭 */}
+      <SegmentControl
+        segments={[
+          { value: "members", label: "회원" },
+          { value: "participation", label: "참여" },
+        ]}
+        value={tab}
+        onValueChange={(v) => {
+          setTab(v as "members" | "participation");
+          // 참여 탭에선 배치 액션 바가 안 보이므로, 보이지 않는 선택 상태가 남지 않게 해제
+          setSelectedIds(new Set());
+        }}
+      />
+
+      {tab === "participation" && (
+        <ParticipationTab
+          members={members}
+          onSelectMember={(memId) => {
+            const found = members.find((m) => m.id === memId);
+            if (found) setSelectedMember(found);
+          }}
+        />
+      )}
+
+      {tab === "members" && (
+        <>
       {/* 검색 */}
       <div className="relative">
         <Search className="absolute left-3.5 top-1/2 size-4 -translate-y-1/2 text-muted-foreground" />
@@ -833,6 +863,8 @@ export function AdminMembersClient({ teamId, initialTeamMemId }: { teamId: strin
           </TableBody>
         </Table>
       </div>
+        </>
+      )}
 
       {/* 회원 상세 시트 */}
       {selectedMember && (
@@ -908,6 +940,13 @@ export function AdminMembersClient({ teamId, initialTeamMemId }: { teamId: strin
 
               {/* 온보딩 러닝 프로필 — 회원별 remount로 이전 회원 값 잔상 방지 */}
               <OnboardingSection key={selectedMember.id} memId={selectedMember.id} />
+
+              {/* 참여 현황 — 모임·대회 참여 요약/월별/최근 활동 */}
+              <ParticipationSection
+                key={`participation-${selectedMember.id}`}
+                memId={selectedMember.id}
+                teamId={teamId}
+              />
 
               {/* 칭호 관리 */}
               <TitleSection member={selectedMember} teamId={teamId} />

--- a/app/(info)/admin/members/participation-section.tsx
+++ b/app/(info)/admin/members/participation-section.tsx
@@ -1,0 +1,417 @@
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+
+import {
+  INACTIVE_WARN_DAYS,
+  MONTHLY_WINDOW,
+} from "@/lib/constants/participation";
+import { dayjs, recentMonthBucketsKST, secondsToTime } from "@/lib/dayjs";
+import { createClient } from "@/lib/supabase/client";
+
+import { EmptyState } from "@/components/common/empty-state";
+import { Caption, SectionLabel } from "@/components/common/typography";
+import { CardItem } from "@/components/ui/card";
+import { Skeleton } from "@/components/ui/skeleton";
+
+// ---------------------------------------------------------------------------
+// 회원 상세 시트 — 참여 현황 섹션
+//
+// 서버 액션 없이 브라우저 클라이언트로 직접 조회한다. RLS가 이미 팀 멤버에게
+// 조회를 허용하기 때문(gthr_attd_rel_select / comp_reg_rel_select_teammate /
+// rec_race_hist_select_public). KNOWLEDGE.md "관리자가 타 회원 온보딩 프로필을
+// 볼 때 서버 액션이 필요 없다" 항목과 같은 원칙.
+//
+// 색 규칙(설계안): 모임 계열 = primary(파랑), 대회 계열 = sport-road-run(주황).
+// "대회 신청"과 "완주 기록"은 다른 사실이므로 합산하지 않는다.
+// ---------------------------------------------------------------------------
+
+const KST = "Asia/Seoul";
+/** 타임라인 기본 표시 건수 ("전체 보기"로 확장) */
+const TIMELINE_PREVIEW_COUNT = 4;
+
+type GthrAttdRow = {
+  gthr_id: string;
+  gthr_mst: {
+    gthr_nm: string;
+    stt_at: string;
+    gthr_type_enm: string;
+    crt_by: string | null;
+  };
+};
+
+type CompRegRow = {
+  comp_reg_id: string;
+  crt_at: string;
+  comp_evt_cfg: { comp_evt_type: string } | null;
+  team_comp_plan_rel: {
+    comp_mst: { comp_nm: string; stt_dt: string } | null;
+  };
+};
+
+type RaceRow = {
+  race_result_id: string;
+  race_nm: string | null;
+  race_dt: string;
+  rec_time_sec: number | null;
+};
+
+type TimelineItem = {
+  id: string;
+  kind: "gthr" | "comp" | "rec";
+  /** 정렬·표시 기준 시각 (모임=모임 시작, 대회=신청 시각, 기록=대회일) */
+  date: string;
+  label: string;
+  hosted?: boolean;
+  future?: boolean;
+};
+
+type Participation = {
+  attendCnt: number;
+  regularCnt: number;
+  hostedCnt: number;
+  compRegCnt: number;
+  raceRecCnt: number;
+  /** 최근 6개월 월별 참석 수 (과거 오래된 달 → 이번 달 순) */
+  monthly: { ym: string; label: string; count: number }[];
+  timeline: TimelineItem[];
+  /** 마지막 참여(모임 참석·완주 기록) 시점. 신청은 몸으로 한 참여가 아니라 제외 */
+  lastAt: string | null;
+};
+
+/** 값 강조형 미니 pill — 모임(파랑)/대회(주황) 계열 색 고정 */
+function CountPill({
+  tone,
+  label,
+  value,
+}: {
+  tone: "gthr" | "comp";
+  label: string;
+  value: number;
+}) {
+  const toneCls =
+    tone === "gthr"
+      ? "bg-primary/10 text-primary"
+      : "bg-sport-road-run/10 text-sport-road-run";
+  return (
+    <span className={`inline-flex items-baseline gap-1 rounded-md px-2 py-1 ${toneCls}`}>
+      <span className="text-[11px]">{label}</span>
+      <span className="text-[13px] font-bold tabular-nums text-foreground">{value}</span>
+    </span>
+  );
+}
+
+/** 타임라인 종류 뱃지 */
+function KindBadge({ kind }: { kind: TimelineItem["kind"] }) {
+  const cls =
+    kind === "gthr"
+      ? "bg-primary/10 text-primary"
+      : "bg-sport-road-run/10 text-sport-road-run";
+  const text = kind === "gthr" ? "모임" : kind === "comp" ? "대회" : "기록";
+  return (
+    <span className={`shrink-0 rounded-md px-1.5 py-0.5 text-[10px] font-bold ${cls}`}>
+      {text}
+    </span>
+  );
+}
+
+export function ParticipationSection({
+  memId,
+  teamId,
+}: {
+  memId: string;
+  teamId: string;
+}) {
+  const [data, setData] = useState<Participation | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [failed, setFailed] = useState(false);
+  const [expanded, setExpanded] = useState(false);
+
+  useEffect(() => {
+    // memId별 remount(호출부 key)라 loading 초기값(true)이 그대로 적용된다.
+    let alive = true;
+    const supabase = createClient();
+
+    Promise.all([
+      // 1) 모임 참석 (팀 스코프는 gthr_mst 임베드 필터로)
+      supabase
+        .from("gthr_attd_rel")
+        .select(
+          "gthr_id, gthr_mst!inner(gthr_nm, stt_at, gthr_type_enm, crt_by, team_id, del_yn)",
+        )
+        .eq("mem_id", memId)
+        .eq("gthr_mst.team_id", teamId)
+        .eq("gthr_mst.del_yn", false),
+      // 2) 개설 수 (참석 여부 무관 — get_member_monthly_activity의 hosted_cnt와 동일 기준)
+      supabase
+        .from("gthr_mst")
+        .select("gthr_id", { count: "exact", head: true })
+        .eq("crt_by", memId)
+        .eq("team_id", teamId)
+        .eq("del_yn", false),
+      // 3) 팀 대회 신청
+      supabase
+        .from("comp_reg_rel")
+        .select(
+          "comp_reg_id, crt_at, comp_evt_cfg(comp_evt_type), team_comp_plan_rel!inner(team_id, del_yn, comp_mst!inner(comp_nm, stt_dt))",
+        )
+        .eq("mem_id", memId)
+        .eq("vers", 0)
+        .eq("del_yn", false)
+        .eq("team_comp_plan_rel.team_id", teamId)
+        .eq("team_comp_plan_rel.del_yn", false),
+      // 4) 대회 완주 기록 (수기 기록 포함)
+      supabase
+        .from("rec_race_hist")
+        .select("race_result_id, race_nm, race_dt, rec_time_sec")
+        .eq("mem_id", memId)
+        .eq("vers", 0)
+        .eq("del_yn", false)
+        .order("race_dt", { ascending: false }),
+    ]).then(
+      ([attdRes, hostedRes, regRes, raceRes]) => {
+        if (!alive) return;
+        // supabase 쿼리는 실패해도 reject 대신 { error }로 resolve — 무시하면
+        // "참여 기록 없음"으로 오인 표시되므로 명시적으로 에러 상태를 켠다.
+        if (attdRes.error || hostedRes.error || regRes.error || raceRes.error) {
+          setFailed(true);
+          setLoading(false);
+          return;
+        }
+        const attends = (attdRes.data ?? []) as unknown as GthrAttdRow[];
+        const regs = (regRes.data ?? []) as unknown as CompRegRow[];
+        const races = (raceRes.data ?? []) as RaceRow[];
+
+        const now = dayjs().tz(KST);
+        const pastAttends = attends.filter((a) =>
+          dayjs(a.gthr_mst.stt_at).isBefore(now),
+        );
+        // 미래 날짜 수기 기록은 아직 "완주"가 아님 — 카운트·마지막 참여에서 제외
+        const pastRaces = races.filter(
+          (r) => !dayjs.tz(r.race_dt, KST).isAfter(now),
+        );
+
+        const monthly = recentMonthBucketsKST(MONTHLY_WINDOW).map((m) => ({
+          ...m,
+          count: 0,
+        }));
+        const bucket = new Map(monthly.map((m) => [m.ym, m]));
+        for (const a of pastAttends) {
+          const ym = dayjs(a.gthr_mst.stt_at).tz(KST).format("YYYY-MM");
+          const b = bucket.get(ym);
+          if (b) b.count += 1;
+        }
+
+        const timeline: TimelineItem[] = [
+          ...attends.map((a): TimelineItem => ({
+            id: `g-${a.gthr_id}`,
+            kind: "gthr",
+            date: a.gthr_mst.stt_at,
+            label: a.gthr_mst.gthr_nm,
+            hosted: a.gthr_mst.crt_by === memId,
+            future: dayjs(a.gthr_mst.stt_at).isAfter(now),
+          })),
+          ...regs.map((r): TimelineItem => ({
+            id: `c-${r.comp_reg_id}`,
+            kind: "comp",
+            date: r.crt_at,
+            label: `${r.team_comp_plan_rel.comp_mst?.comp_nm ?? "대회"} 신청${
+              r.comp_evt_cfg?.comp_evt_type ? ` · ${r.comp_evt_cfg.comp_evt_type}` : ""
+            }`,
+          })),
+          ...races.map((r): TimelineItem => {
+            const dt = dayjs.tz(r.race_dt, KST); // date 컬럼 → KST 자정 앵커로 정규화
+            return {
+              id: `r-${r.race_result_id}`,
+              kind: "rec",
+              date: dt.toISOString(),
+              label: `${r.race_nm ?? "대회 기록"}${
+                r.rec_time_sec != null ? ` · ${secondsToTime(r.rec_time_sec)}` : ""
+              }`,
+              future: dt.isAfter(now),
+            };
+          }),
+        ].sort((a, b) => dayjs(b.date).valueOf() - dayjs(a.date).valueOf());
+
+        const lastCandidates = [
+          ...pastAttends.map((a) => a.gthr_mst.stt_at),
+          ...pastRaces.map((r) => dayjs.tz(r.race_dt, KST).toISOString()),
+        ].sort((a, b) => dayjs(b).valueOf() - dayjs(a).valueOf());
+
+        setData({
+          attendCnt: pastAttends.length,
+          regularCnt: pastAttends.filter((a) => a.gthr_mst.gthr_type_enm === "regular")
+            .length,
+          hostedCnt: hostedRes.count ?? 0,
+          compRegCnt: regs.length,
+          raceRecCnt: pastRaces.length,
+          monthly,
+          timeline,
+          lastAt: lastCandidates[0] ?? null,
+        });
+        setLoading(false);
+      },
+      // 네트워크 실패 등으로 reject 되면 스켈레톤이 영영 안 걷히므로 로딩만 해제
+      () => {
+        if (!alive) return;
+        setLoading(false);
+      },
+    );
+    return () => {
+      alive = false;
+    };
+  }, [memId, teamId]);
+
+  const maxMonthly = useMemo(
+    () => Math.max(1, ...(data?.monthly.map((m) => m.count) ?? [1])),
+    [data],
+  );
+
+  const isEmpty =
+    data &&
+    data.attendCnt === 0 &&
+    data.hostedCnt === 0 &&
+    data.compRegCnt === 0 &&
+    data.raceRecCnt === 0 &&
+    data.timeline.length === 0;
+
+  const daysSinceLast = data?.lastAt
+    ? dayjs().tz(KST).startOf("day").diff(dayjs(data.lastAt).tz(KST).startOf("day"), "day")
+    : null;
+
+  const visibleTimeline = expanded
+    ? data?.timeline
+    : data?.timeline.slice(0, TIMELINE_PREVIEW_COUNT);
+
+  return (
+    <div className="flex flex-col gap-3">
+      <div className="flex items-baseline gap-2">
+        <SectionLabel>참여 현황</SectionLabel>
+        {/* 참여 탭(기간 필터)과 달리 시트는 전체 기간 집계 — 기준을 명시해 혼동 방지 */}
+        <Caption className="text-[11px]">전체 기간</Caption>
+      </div>
+
+      {loading ? (
+        <Skeleton className="h-32 w-full rounded-2xl" />
+      ) : failed ? (
+        <EmptyState variant="inline" message="참여 정보를 불러오지 못했습니다" />
+      ) : !data || isEmpty ? (
+        <EmptyState variant="inline" message="참여 기록 없음" />
+      ) : (
+        <CardItem className="flex flex-col gap-3.5 p-3.5">
+          {/* 요약 pill — 모임 계열(파랑) / 대회 계열(주황) */}
+          <div className="flex flex-col gap-1.5">
+            <div className="flex flex-wrap gap-1.5">
+              <CountPill tone="gthr" label="모임 참석" value={data.attendCnt} />
+              <CountPill tone="gthr" label="정모" value={data.regularCnt} />
+              <CountPill tone="gthr" label="개설" value={data.hostedCnt} />
+            </div>
+            <div className="flex flex-wrap gap-1.5">
+              <CountPill tone="comp" label="대회 신청" value={data.compRegCnt} />
+              <CountPill tone="comp" label="완주 기록" value={data.raceRecCnt} />
+            </div>
+          </div>
+
+          {/* 월별 참석 — 최근 6개월 미니 바 */}
+          <div className="flex flex-col gap-1">
+            <Caption className="text-[11px]">월별 참석 · 최근 6개월</Caption>
+            <div className="flex items-end gap-2 px-1 pt-1">
+              {data.monthly.map((m, i) => {
+                const isCurrent = i === data.monthly.length - 1;
+                return (
+                  <div
+                    key={m.ym}
+                    className="flex flex-1 flex-col items-center gap-0.5"
+                    title={`${m.label} ${m.count}회`}
+                  >
+                    {isCurrent && (
+                      <span className="text-[11px] font-bold tabular-nums text-foreground">
+                        {m.count}
+                      </span>
+                    )}
+                    {m.count === 0 ? (
+                      <div className="h-[3px] w-full max-w-6 rounded-sm bg-border" />
+                    ) : (
+                      <div
+                        className="w-full max-w-6 rounded-t-[3px] bg-primary"
+                        style={{ height: `${6 + (m.count / maxMonthly) * 30}px` }}
+                      />
+                    )}
+                    <span
+                      className={`text-[10px] tabular-nums ${
+                        isCurrent
+                          ? "font-semibold text-foreground"
+                          : "text-muted-foreground"
+                      }`}
+                    >
+                      {m.label}
+                    </span>
+                  </div>
+                );
+              })}
+            </div>
+          </div>
+
+          {/* 최근 활동 타임라인 */}
+          {data.timeline.length > 0 && (
+            <div className="flex flex-col">
+              <Caption className="text-[11px]">최근 활동</Caption>
+              {visibleTimeline?.map((t) => (
+                <div
+                  key={t.id}
+                  className={`flex items-center gap-2 border-b border-border py-2 last:border-b-0 ${
+                    t.future ? "opacity-55" : ""
+                  }`}
+                >
+                  <KindBadge kind={t.kind} />
+                  <span className="min-w-0 flex-1 truncate text-[13px] text-foreground">
+                    {t.label}
+                    {t.hosted && (
+                      <span className="text-muted-foreground"> · 개설</span>
+                    )}
+                    {t.future && (
+                      <span className="text-muted-foreground"> · 예정</span>
+                    )}
+                  </span>
+                  <span className="shrink-0 text-[11px] tabular-nums text-muted-foreground">
+                    {dayjs(t.date).tz(KST).format("M.D")}
+                  </span>
+                </div>
+              ))}
+              {data.timeline.length > TIMELINE_PREVIEW_COUNT && (
+                <button
+                  onClick={() => setExpanded((v) => !v)}
+                  className="pt-2 text-center text-[12px] font-semibold text-primary"
+                >
+                  {expanded ? "접기" : `전체 활동 보기 (${data.timeline.length})`}
+                </button>
+              )}
+            </div>
+          )}
+
+          {/* 마지막 참여 — 4주 이상 무참여면 이탈 신호로 경고색 */}
+          {daysSinceLast != null && (
+            <div className="flex items-center gap-1.5">
+              <span
+                className={`size-1.5 rounded-full ${
+                  daysSinceLast >= INACTIVE_WARN_DAYS ? "bg-warning" : "bg-success"
+                }`}
+              />
+              <Caption
+                className={`text-[12px] ${
+                  daysSinceLast >= INACTIVE_WARN_DAYS ? "text-warning" : ""
+                }`}
+              >
+                {daysSinceLast >= INACTIVE_WARN_DAYS
+                  ? `${Math.floor(daysSinceLast / 7)}주째 참여 없음`
+                  : daysSinceLast === 0
+                    ? "오늘 참여함"
+                    : `마지막 참여 ${daysSinceLast}일 전`}
+              </Caption>
+            </div>
+          )}
+        </CardItem>
+      )}
+    </div>
+  );
+}

--- a/app/(info)/admin/members/participation-tab.tsx
+++ b/app/(info)/admin/members/participation-tab.tsx
@@ -1,0 +1,466 @@
+"use client";
+
+import Link from "next/link";
+import { useEffect, useMemo, useRef, useState } from "react";
+
+import { ArrowDownWideNarrow, ArrowUpNarrowWide, X } from "lucide-react";
+
+import {
+  HOT_THRESHOLD,
+  PARTICIPATION_DATA_EPOCH,
+  RECENT_WINDOW_DAYS,
+} from "@/lib/constants/participation";
+import { dayjs } from "@/lib/dayjs";
+
+import {
+  getParticipationStats,
+  type MemberParticipationStat,
+  type ParticipationStats,
+} from "@/app/actions/admin/get-participation-stats";
+
+import { Avatar } from "@/components/common/avatar";
+import { EmptyState } from "@/components/common/empty-state";
+import { StatCard } from "@/components/common/stat-card";
+import { Caption, SectionLabel } from "@/components/common/typography";
+import { CardItem } from "@/components/ui/card";
+import { Skeleton } from "@/components/ui/skeleton";
+
+// ---------------------------------------------------------------------------
+// 참여 탭 — 팀 요약 통계 + 회원별 참여 명단
+//
+// 인터랙션 규칙(설계안): 사람 수가 적힌 것(카드·온도 세그먼트·미참여 카드)을
+// 탭하면 아래 명단이 그 조건으로 필터되고 명단 위에 해제 칩이 붙는다.
+// 새 화면·다이얼로그 없음. 예외는 모임당 평균(모임 지표 → 모임 관리로 이동)뿐.
+// 행 클릭 → 부모(AdminMembersClient)의 상세 시트를 그대로 연다.
+// ---------------------------------------------------------------------------
+
+const KST = "Asia/Seoul";
+
+type Period = "month" | "3m" | "all";
+
+const PERIOD_LABELS: Record<Period, string> = {
+  month: "이번 달",
+  "3m": "최근 3개월",
+  all: "전체",
+};
+
+type Temperature = "hot" | "warm" | "cold" | "new";
+
+const TEMP_META: Record<Temperature, { label: string; pillCls: string; dotCls: string }> = {
+  hot: { label: "열심", pillCls: "bg-success/10 text-success", dotCls: "bg-success" },
+  warm: { label: "보통", pillCls: "bg-primary/10 text-primary", dotCls: "bg-primary" },
+  cold: { label: "조용", pillCls: "bg-muted text-muted-foreground", dotCls: "bg-border" },
+  new: { label: "신규", pillCls: "border border-border text-muted-foreground", dotCls: "bg-border" },
+};
+
+type ListFilter =
+  | { key: "participated"; label: string }
+  | { key: "upcoming"; label: string }
+  | { key: "never"; label: string }
+  | { key: "temp"; temp: Temperature; label: string };
+
+export type ParticipationTabMember = {
+  id: string;
+  full_name: string | null;
+  avatar_url: string | null;
+  status: string | null;
+  joined_at: string | null;
+};
+
+const EMPTY_STAT: Omit<MemberParticipationStat, "memId"> = {
+  attendCnt: 0,
+  regularCnt: 0,
+  hostedCnt: 0,
+  compRegCnt: 0,
+  attendAllCnt: 0,
+  recentAttendCnt: 0,
+  upcomingReg: false,
+  lastAt: null,
+};
+
+function periodRange(period: Period): { from: string; to: string } {
+  const now = dayjs().tz(KST);
+  const nextMonth = now.add(1, "month").startOf("month").format("YYYY-MM-DD");
+  if (period === "month")
+    return { from: now.startOf("month").format("YYYY-MM-DD"), to: nextMonth };
+  if (period === "3m")
+    return {
+      from: now.startOf("month").subtract(2, "month").format("YYYY-MM-DD"),
+      to: nextMonth,
+    };
+  return { from: PARTICIPATION_DATA_EPOCH, to: nextMonth };
+}
+
+export function ParticipationTab({
+  members,
+  onSelectMember,
+}: {
+  members: ParticipationTabMember[];
+  onSelectMember: (memId: string) => void;
+}) {
+  const [period, setPeriod] = useState<Period>("month");
+  // 기간별 조회 결과 — stats=null 은 실패. loading/error 는 파생값으로 계산해
+  // 이펙트 안 동기 setState(cascading render)를 피한다.
+  const [result, setResult] = useState<{
+    period: Period;
+    stats: ParticipationStats | null;
+  } | null>(null);
+  const [filter, setFilter] = useState<ListFilter | null>(null);
+  const [sortAsc, setSortAsc] = useState(false);
+  const [retryTick, setRetryTick] = useState(0);
+  const listRef = useRef<HTMLDivElement>(null);
+  // 기간별 결과 캐시 — 이미 본 기간 재선택 시 동일 원시 데이터 재조회를 생략.
+  // 키에 실제 날짜 범위를 포함해, 자정/월 경계를 넘긴 뒤 낡은 범위 결과가 재사용되지 않게 한다.
+  const cacheRef = useRef(new Map<string, ParticipationStats>());
+  const cacheKey = (p: Period) => {
+    const { from, to } = periodRange(p);
+    return `${p}|${from}|${to}`;
+  };
+
+  const stats = result?.period === period ? result.stats : null;
+  const loading = result?.period !== period;
+  const error = result?.period === period && result.stats === null;
+
+  /** 기간 선택 — 캐시 히트면 이벤트 핸들러에서 즉시 반영(이펙트 내 동기 setState 회피) */
+  const selectPeriod = (p: Period) => {
+    setPeriod(p);
+    const cached = cacheRef.current.get(cacheKey(p));
+    if (cached) setResult({ period: p, stats: cached });
+  };
+
+  /** 조회 실패 후 재시도 — 실패는 캐시에 없으므로 이펙트가 다시 fetch 한다 */
+  const retry = () => {
+    setResult(null);
+    setRetryTick((t) => t + 1);
+  };
+
+  useEffect(() => {
+    const key = cacheKey(period);
+    if (cacheRef.current.has(key)) return; // 캐시 히트 — selectPeriod에서 이미 반영
+    let alive = true;
+    const { from, to } = periodRange(period);
+    getParticipationStats(from, to).then(
+      (res) => {
+        if (!alive) return;
+        cacheRef.current.set(key, res);
+        setResult({ period, stats: res });
+      },
+      () => {
+        if (alive) setResult({ period, stats: null });
+      },
+    );
+    return () => {
+      alive = false;
+    };
+  }, [period, retryTick]);
+
+  const now = dayjs().tz(KST);
+
+  const rows = useMemo(() => {
+    const statMap = new Map((stats?.members ?? []).map((s) => [s.memId, s]));
+    return members
+      .filter((m) => m.status === "active")
+      .map((m) => {
+        const stat = statMap.get(m.id) ?? { memId: m.id, ...EMPTY_STAT };
+        const isNew =
+          !!m.joined_at &&
+          now.diff(dayjs.tz(m.joined_at, KST), "day") < RECENT_WINDOW_DAYS;
+        const temp: Temperature = isNew
+          ? "new"
+          : stat.recentAttendCnt >= HOT_THRESHOLD
+            ? "hot"
+            : stat.recentAttendCnt >= 1
+              ? "warm"
+              : "cold";
+        return { member: m, stat, temp };
+      });
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [members, stats]);
+
+  const summary = useMemo(() => {
+    const activeCnt = rows.length;
+    const participated = rows.filter((r) => r.stat.attendCnt > 0).length;
+    const tempCnt = { hot: 0, warm: 0, cold: 0, new: 0 };
+    for (const r of rows) tempCnt[r.temp] += 1;
+    const never = rows.filter((r) => r.stat.attendAllCnt === 0).length;
+    // 카드 값과 클릭 시 필터 결과가 같은 모집단(active rows)을 보도록 여기서 파생
+    const upcoming = rows.filter((r) => r.stat.upcomingReg).length;
+    return { activeCnt, participated, tempCnt, never, upcoming };
+  }, [rows]);
+
+  const filteredRows = useMemo(() => {
+    let list = rows;
+    if (filter?.key === "participated") list = list.filter((r) => r.stat.attendCnt > 0);
+    else if (filter?.key === "upcoming") list = list.filter((r) => r.stat.upcomingReg);
+    else if (filter?.key === "never") list = list.filter((r) => r.stat.attendAllCnt === 0);
+    else if (filter?.key === "temp") list = list.filter((r) => r.temp === filter.temp);
+    return [...list].sort((a, b) => {
+      const diff = a.stat.attendCnt - b.stat.attendCnt;
+      if (diff !== 0) return sortAsc ? diff : -diff;
+      return (a.member.full_name ?? "").localeCompare(b.member.full_name ?? "", "ko");
+    });
+  }, [rows, filter, sortAsc]);
+
+  /** 카드/세그먼트 탭 → 명단 필터 적용 + 명단으로 스크롤 */
+  const applyFilter = (next: ListFilter) => {
+    setFilter((prev) => {
+      const same =
+        prev?.key === next.key &&
+        (prev?.key !== "temp" || next.key !== "temp" || prev.temp === next.temp);
+      return same ? null : next;
+    });
+    listRef.current?.scrollIntoView({ behavior: "smooth", block: "start" });
+  };
+
+  const avgAttend =
+    stats && stats.gthrCnt > 0 ? (stats.attendTotal / stats.gthrCnt).toFixed(1) : null;
+  const maxMonthly = Math.max(1, ...(stats?.monthly.map((m) => m.attendCnt) ?? [1]));
+
+  return (
+    <div className="flex flex-col gap-5">
+      {/* 기간 필터 — 모든 요약 카드·명단 수치의 분모 */}
+      <div className="flex gap-1.5">
+        {(Object.keys(PERIOD_LABELS) as Period[]).map((p) => (
+          <button
+            key={p}
+            onClick={() => selectPeriod(p)}
+            aria-pressed={period === p}
+            className={`rounded-full border px-3 py-1.5 text-[12px] font-semibold transition-colors ${
+              period === p
+                ? "border-foreground bg-foreground text-background"
+                : "border-border text-muted-foreground"
+            }`}
+          >
+            {PERIOD_LABELS[p]}
+            {p === "all" && " (7월~)"}
+          </button>
+        ))}
+      </div>
+
+      {error ? (
+        // 기간 셀렉터는 위에 그대로 남아 다른 기간으로 전환하거나 재시도할 수 있다
+        <div className="flex flex-col gap-3">
+          <EmptyState variant="card" message="통계를 불러오지 못했습니다." />
+          <button
+            onClick={retry}
+            className="self-center rounded-full border border-border px-4 py-2 text-[13px] font-semibold text-primary"
+          >
+            다시 시도
+          </button>
+        </div>
+      ) : loading || !stats ? (
+        <div className="flex flex-col gap-4">
+          <div className="grid grid-cols-2 gap-3">
+            {Array.from({ length: 4 }).map((_, i) => (
+              <Skeleton key={i} className="h-20 w-full rounded-2xl" />
+            ))}
+          </div>
+          <Skeleton className="h-24 w-full rounded-2xl" />
+          <Skeleton className="h-48 w-full rounded-2xl" />
+        </div>
+      ) : (
+        <>
+          {/* 요약 카드 — 사람 수 카드는 탭하면 명단 필터 */}
+          <div className="grid grid-cols-2 gap-3">
+            <StatCard
+              value={`${summary.participated}명`}
+              label={`${PERIOD_LABELS[period]} 모임 참여 · 활동 ${summary.activeCnt}명 중`}
+              className="cursor-pointer transition-transform active:scale-[0.98]"
+              onClick={() => applyFilter({ key: "participated", label: "기간 내 참여" })}
+            />
+            <Link href="/admin/gatherings" className="contents">
+              <StatCard
+                value={avgAttend ? `${avgAttend}명` : "-"}
+                label={`모임당 평균 참석 · ${stats.gthrCnt}회 기준`}
+                className="cursor-pointer transition-transform active:scale-[0.98]"
+              />
+            </Link>
+            <StatCard
+              value={`${summary.upcoming}명`}
+              label="예정 대회 신청"
+              className="cursor-pointer transition-transform active:scale-[0.98]"
+              onClick={() => applyFilter({ key: "upcoming", label: "예정 대회 신청자" })}
+            />
+            <StatCard
+              value={`${summary.tempCnt.cold}명`}
+              label="4주 이상 모임 무참석"
+              valueClassName="text-warning"
+              className="cursor-pointer transition-transform active:scale-[0.98]"
+              onClick={() =>
+                applyFilter({ key: "temp", temp: "cold", label: "4주+ 무참석" })
+              }
+            />
+          </div>
+
+          {/* 참여 온도 — 세그먼트 탭 → 해당 온도 필터 */}
+          <CardItem className="flex flex-col gap-2.5 p-4">
+            <SectionLabel>참여 온도</SectionLabel>
+            <div className="flex h-3.5 gap-0.5 overflow-hidden rounded-full">
+              {(["hot", "warm", "cold"] as const).map((t) =>
+                summary.tempCnt[t] > 0 ? (
+                  <button
+                    key={t}
+                    aria-label={`${TEMP_META[t].label} ${summary.tempCnt[t]}명 필터`}
+                    onClick={() =>
+                      applyFilter({ key: "temp", temp: t, label: TEMP_META[t].label })
+                    }
+                    className={TEMP_META[t].dotCls}
+                    style={{ flex: summary.tempCnt[t] }}
+                  />
+                ) : null,
+              )}
+            </div>
+            <div className="flex flex-wrap gap-x-4 gap-y-1">
+              {(["hot", "warm", "cold"] as const).map((t) => (
+                <button
+                  key={t}
+                  onClick={() =>
+                    applyFilter({ key: "temp", temp: t, label: TEMP_META[t].label })
+                  }
+                  className="flex items-center gap-1.5"
+                >
+                  <span className={`size-2 rounded-full ${TEMP_META[t].dotCls}`} />
+                  <Caption className="text-[12px]">
+                    {TEMP_META[t].label}{" "}
+                    <span className="font-bold text-foreground tabular-nums">
+                      {summary.tempCnt[t]}
+                    </span>
+                  </Caption>
+                </button>
+              ))}
+            </div>
+            <Caption className="text-[11px]">
+              열심 4주 {HOT_THRESHOLD}회+ · 보통 1~3회 · 조용 4주+ 무참석 · 신규(가입 4주
+              미만) {summary.tempCnt.new}명은 판정 제외
+            </Caption>
+          </CardItem>
+
+          {/* 월별 참석 연인원 — 최근 6개월 */}
+          <CardItem className="flex flex-col gap-2 p-4">
+            <SectionLabel>월별 참석 연인원</SectionLabel>
+            <div className="flex items-end gap-2 px-1 pt-1">
+              {stats.monthly.map((m, i) => {
+                const isCurrent = i === stats.monthly.length - 1;
+                return (
+                  <div
+                    key={m.ym}
+                    className="flex flex-1 flex-col items-center gap-0.5"
+                    title={`${m.label} 참석 ${m.attendCnt}명 · 모임 ${m.gthrCnt}회`}
+                  >
+                    <span
+                      className={`text-[11px] font-bold tabular-nums ${
+                        m.attendCnt === 0 ? "text-transparent" : "text-foreground"
+                      }`}
+                    >
+                      {m.attendCnt}
+                    </span>
+                    {m.attendCnt === 0 ? (
+                      <div className="h-[3px] w-full max-w-8 rounded-sm bg-border" />
+                    ) : (
+                      <div
+                        className="w-full max-w-8 rounded-t-[3px] bg-primary"
+                        style={{ height: `${6 + (m.attendCnt / maxMonthly) * 44}px` }}
+                      />
+                    )}
+                    <span
+                      className={`text-[10px] tabular-nums ${
+                        isCurrent
+                          ? "font-semibold text-foreground"
+                          : "text-muted-foreground"
+                      }`}
+                    >
+                      {m.label}
+                    </span>
+                    <span className="text-[9px] text-muted-foreground">
+                      {m.gthrCnt > 0 ? `${m.gthrCnt}회` : ""}
+                    </span>
+                  </div>
+                );
+              })}
+            </div>
+          </CardItem>
+
+          {/* 회원별 참여 명단 */}
+          <div ref={listRef} className="flex scroll-mt-16 flex-col gap-3">
+            <div className="flex items-center justify-between">
+              <SectionLabel>회원별 참여</SectionLabel>
+              <button
+                onClick={() => setSortAsc((v) => !v)}
+                className="flex items-center gap-1 rounded-full border border-border px-2.5 py-1 text-[12px] text-muted-foreground"
+              >
+                {sortAsc ? (
+                  <ArrowUpNarrowWide className="size-3" />
+                ) : (
+                  <ArrowDownWideNarrow className="size-3" />
+                )}
+                {sortAsc ? "참석 적은순" : "참석 많은순"}
+              </button>
+            </div>
+
+            {/* 활성 필터 칩 */}
+            {filter && (
+              <button
+                onClick={() => setFilter(null)}
+                className="flex w-fit items-center gap-1.5 rounded-full bg-foreground px-3 py-1.5 text-[12px] font-semibold text-background"
+              >
+                {filter.label} · {filteredRows.length}명
+                <X className="size-3" />
+              </button>
+            )}
+
+            {filteredRows.length === 0 ? (
+              <EmptyState variant="card" message="조건에 맞는 회원이 없습니다." />
+            ) : (
+              <CardItem className="flex flex-col px-4 py-1">
+                {filteredRows.map(({ member, stat, temp }) => (
+                  <button
+                    key={member.id}
+                    onClick={() => onSelectMember(member.id)}
+                    className="flex items-center gap-3 border-b border-border py-2.5 text-left last:border-b-0"
+                  >
+                    <Avatar src={member.avatar_url} seed={member.id} size="sm" />
+                    <div className="min-w-0 flex-1">
+                      <div className="truncate text-[14px] font-semibold text-foreground">
+                        {member.full_name ?? "이름 없음"}
+                      </div>
+                      <Caption className="text-[11.5px] tabular-nums">
+                        모임 {stat.attendCnt} · 정모 {stat.regularCnt} · 대회{" "}
+                        {stat.compRegCnt}
+                        {stat.hostedCnt > 0 && ` · 개설 ${stat.hostedCnt}`}
+                      </Caption>
+                    </div>
+                    <div className="flex shrink-0 flex-col items-end gap-1">
+                      <span
+                        className={`rounded-full px-2 py-0.5 text-[10.5px] font-semibold ${TEMP_META[temp].pillCls}`}
+                      >
+                        {TEMP_META[temp].label}
+                      </span>
+                      <span className="text-[11px] tabular-nums text-muted-foreground">
+                        {stat.lastAt ? dayjs(stat.lastAt).tz(KST).format("M.D") : "—"}
+                      </span>
+                    </div>
+                  </button>
+                ))}
+              </CardItem>
+            )}
+          </div>
+
+          {/* 액션 리스트 — 가입 후 모임 미참여 */}
+          {summary.never > 0 && (
+            <button
+              onClick={() => applyFilter({ key: "never", label: "가입 후 미참여" })}
+              className="flex items-center gap-2.5 rounded-2xl border border-warning/40 bg-warning/5 px-4 py-3 text-left"
+            >
+              <span className="text-[14px] text-warning">⚠</span>
+              <span className="flex-1 text-[13px] text-foreground">
+                가입 후 모임 참여가 없는 회원{" "}
+                <b className="font-bold tabular-nums">{summary.never}명</b>
+              </span>
+              <span className="text-muted-foreground">›</span>
+            </button>
+          )}
+        </>
+      )}
+    </div>
+  );
+}

--- a/app/actions/admin/get-participation-stats.ts
+++ b/app/actions/admin/get-participation-stats.ts
@@ -1,0 +1,221 @@
+"use server";
+
+import { withAdminOrThrow } from "@/lib/actions/auth";
+import {
+  MONTHLY_WINDOW,
+  RECENT_WINDOW_DAYS,
+} from "@/lib/constants/participation";
+import { dayjs, recentMonthBucketsKST } from "@/lib/dayjs";
+import { getRequestTeamContext } from "@/lib/queries/request-team";
+
+// ---------------------------------------------------------------------------
+// 참여 탭 집계 — 지표 정의의 단일 출처
+//
+// 원천(참석 44·신청 116·기록 172건)이 작아 RPC 없이 원시 행을 받아 TS로 집계한다.
+// 규모가 커지면 이 함수 "속만" RPC 호출로 교체한다(호출부 불변 —
+// get_member_monthly_activity 마이그레이션 주석의 원칙과 동일).
+//
+// 쿼리는 호출자 세션(supabase)로 실행 — RLS(팀 멤버 조회 허용)가 그대로 적용되고
+// 명시적 team 필터를 이중으로 건다. RLS 우회(createAdminClient)가 필요 없다.
+// ---------------------------------------------------------------------------
+
+const KST = "Asia/Seoul";
+
+export type MemberParticipationStat = {
+  memId: string;
+  /** 기간 내 지난 모임 참석 수 */
+  attendCnt: number;
+  /** 기간 내 정모(regular) 참석 수 */
+  regularCnt: number;
+  /** 기간 내 열린 모임 중 개설 수 (참석 여부 무관) */
+  hostedCnt: number;
+  /** 기간 내 팀 대회 신청 수 (신청 시각 기준) */
+  compRegCnt: number;
+  /** 전체 기간 모임 참석 수 (가입 후 미참여 판정용) */
+  attendAllCnt: number;
+  /** 최근 28일 모임 참석 수 (참여 온도 판정용, 기간 필터 무관) */
+  recentAttendCnt: number;
+  /** 예정 대회 신청 보유 여부 */
+  upcomingReg: boolean;
+  /** 마지막 참여 시각 — 모임 참석·완주 기록 중 최신 (신청은 제외, 전체 기간) */
+  lastAt: string | null;
+};
+
+export type ParticipationStats = {
+  members: MemberParticipationStat[];
+  /** 기간 내 열린(이미 지난) 모임 수 */
+  gthrCnt: number;
+  /** 기간 내 참석 연인원 */
+  attendTotal: number;
+  /** 최근 6개월 월별 참석 연인원·모임 수 (기간 필터 무관, 오래된 달 → 이번 달) */
+  monthly: { ym: string; label: string; attendCnt: number; gthrCnt: number }[];
+};
+
+type RegRow = {
+  mem_id: string;
+  crt_at: string;
+  team_comp_plan_rel: { comp_mst: { stt_dt: string } | null };
+};
+
+/**
+ * 팀 전체 회원별 참여 집계.
+ * @param fromISO 기간 시작 'YYYY-MM-DD' (KST, 포함)
+ * @param toISO   기간 끝 'YYYY-MM-DD' (KST, 미포함)
+ */
+export async function getParticipationStats(
+  fromISO: string,
+  toISO: string,
+): Promise<ParticipationStats> {
+  return withAdminOrThrow(async ({ supabase }) => {
+    const from = dayjs.tz(fromISO, KST);
+    const to = dayjs.tz(toISO, KST);
+    if (!from.isValid() || !to.isValid()) throw new Error("잘못된 기간입니다");
+
+    const { teamId } = await getRequestTeamContext();
+
+    const [memRes, gthrRes, attdRes, regRes, raceRes] = await Promise.all([
+      supabase
+        .from("team_mem_rel")
+        .select("mem_id")
+        .eq("team_id", teamId)
+        .eq("vers", 0)
+        .eq("del_yn", false),
+      supabase
+        .from("gthr_mst")
+        .select("gthr_id, stt_at, gthr_type_enm, crt_by")
+        .eq("team_id", teamId)
+        .eq("del_yn", false),
+      supabase
+        .from("gthr_attd_rel")
+        .select("mem_id, gthr_id, gthr_mst!inner(team_id, del_yn)")
+        .eq("gthr_mst.team_id", teamId)
+        .eq("gthr_mst.del_yn", false),
+      supabase
+        .from("comp_reg_rel")
+        .select(
+          "mem_id, crt_at, team_comp_plan_rel!inner(team_id, del_yn, comp_mst!inner(stt_dt))",
+        )
+        .eq("vers", 0)
+        .eq("del_yn", false)
+        .eq("team_comp_plan_rel.team_id", teamId)
+        .eq("team_comp_plan_rel.del_yn", false),
+      supabase
+        .from("rec_race_hist")
+        .select("mem_id, race_dt")
+        .eq("vers", 0)
+        .eq("del_yn", false),
+    ]);
+
+    // supabase 쿼리는 실패해도 reject 대신 { error }로 resolve — 하나라도 실패면
+    // "0으로 집계된 가짜 성공"이 되므로 여기서 명시적으로 throw 한다.
+    const failed = [memRes, gthrRes, attdRes, regRes, raceRes].find((r) => r.error);
+    if (failed?.error) throw new Error(`참여 통계 조회 실패: ${failed.error.message}`);
+
+    const now = dayjs().tz(KST);
+    const recentFrom = now.subtract(RECENT_WINDOW_DAYS, "day");
+    const today = now.startOf("day");
+
+    const monthly = recentMonthBucketsKST(MONTHLY_WINDOW).map((m) => ({
+      ...m,
+      attendCnt: 0,
+      gthrCnt: 0,
+    }));
+    const monthBucket = new Map(monthly.map((m) => [m.ym, m]));
+
+    const stats = new Map<string, MemberParticipationStat>(
+      (memRes.data ?? []).map((m) => [
+        m.mem_id,
+        {
+          memId: m.mem_id,
+          attendCnt: 0,
+          regularCnt: 0,
+          hostedCnt: 0,
+          compRegCnt: 0,
+          attendAllCnt: 0,
+          recentAttendCnt: 0,
+          upcomingReg: false,
+          lastAt: null,
+        },
+      ]),
+    );
+
+    const bumpLast = (s: MemberParticipationStat, at: string) => {
+      if (!s.lastAt || dayjs(at).isAfter(dayjs(s.lastAt))) s.lastAt = at;
+    };
+
+    // 모임 인덱스 — 이미 지난 모임만 "열린 모임"으로 센다 (예정 신청은 참석이 아님)
+    const gthrMap = new Map(
+      (gthrRes.data ?? []).map((g) => {
+        const stt = dayjs(g.stt_at);
+        const past = stt.isBefore(now);
+        return [
+          g.gthr_id,
+          {
+            sttAt: g.stt_at,
+            ym: stt.tz(KST).format("YYYY-MM"),
+            regular: g.gthr_type_enm === "regular",
+            crtBy: g.crt_by,
+            past,
+            inRange: past && !stt.isBefore(from) && stt.isBefore(to),
+            recent: past && stt.isAfter(recentFrom),
+          },
+        ];
+      }),
+    );
+
+    let gthrCnt = 0;
+    let attendTotal = 0;
+    for (const g of gthrMap.values()) {
+      if (g.past) {
+        const mb = monthBucket.get(g.ym);
+        if (mb) mb.gthrCnt += 1;
+      }
+      if (!g.inRange) continue;
+      gthrCnt += 1;
+      const host = g.crtBy ? stats.get(g.crtBy) : undefined;
+      if (host) host.hostedCnt += 1;
+    }
+
+    for (const a of attdRes.data ?? []) {
+      const g = gthrMap.get(a.gthr_id);
+      if (!g || !g.past) continue;
+      // 팀 연인원·월별 집계는 회원 재적 여부와 무관 — 모임에 실제 온 사람 수가 사실
+      const mb = monthBucket.get(g.ym);
+      if (mb) mb.attendCnt += 1;
+      if (g.inRange) attendTotal += 1;
+      const s = stats.get(a.mem_id);
+      if (!s) continue;
+      s.attendAllCnt += 1;
+      bumpLast(s, g.sttAt);
+      if (g.recent) s.recentAttendCnt += 1;
+      if (g.inRange) {
+        s.attendCnt += 1;
+        if (g.regular) s.regularCnt += 1;
+      }
+    }
+
+    for (const r of (regRes.data ?? []) as unknown as RegRow[]) {
+      const s = stats.get(r.mem_id);
+      if (!s) continue;
+      const crt = dayjs(r.crt_at);
+      if (!crt.isBefore(from) && crt.isBefore(to)) s.compRegCnt += 1;
+      const sttDt = r.team_comp_plan_rel.comp_mst?.stt_dt;
+      if (sttDt && !dayjs.tz(sttDt, KST).isBefore(today)) s.upcomingReg = true;
+    }
+
+    for (const r of raceRes.data ?? []) {
+      const s = stats.get(r.mem_id);
+      if (!s) continue; // 팀 외 기록(전역 public select) 제외
+      const dt = dayjs.tz(r.race_dt, KST); // date 컬럼 → KST 자정 앵커로 정규화
+      if (dt.isAfter(now)) continue; // 미래 날짜 수기 기록은 "참여"가 아님
+      bumpLast(s, dt.toISOString());
+    }
+
+    return {
+      members: [...stats.values()],
+      gthrCnt,
+      attendTotal,
+      monthly,
+    };
+  });
+}

--- a/lib/constants/participation.ts
+++ b/lib/constants/participation.ts
@@ -1,0 +1,18 @@
+// 참여 지표 정의 상수 — 단일 출처.
+// 서버 집계(get-participation-stats)와 클라이언트 판정(participation-tab/-section)이
+// 같은 값을 쓰도록 여기서만 정의한다 (선례: lib/constants/dues-quest.ts).
+
+/** 참여 온도·무활동·신규 판정 기준 일수 (설계: 4주) */
+export const RECENT_WINDOW_DAYS = 28;
+
+/** 열심 기준: 최근 4주 모임 참석 횟수 */
+export const HOT_THRESHOLD = 4;
+
+/** 이 일수 이상 참여가 없으면 이탈 신호로 경고 표시 */
+export const INACTIVE_WARN_DAYS = RECENT_WINDOW_DAYS;
+
+/** 모임 데이터 실질 시작일 — "전체" 기간도 이 이전은 집계에서 제외 */
+export const PARTICIPATION_DATA_EPOCH = "2026-07-01";
+
+/** 월별 참석 미니 차트의 창 크기(개월) */
+export const MONTHLY_WINDOW = 6;

--- a/lib/dayjs.ts
+++ b/lib/dayjs.ts
@@ -42,6 +42,15 @@ export function currentMonthKST(): string {
   return nowKST().startOf("month").format("YYYY-MM-DD");
 }
 
+/** KST 기준 최근 n개월 월 버킷 (오래된 달 → 이번 달 순). ym='YYYY-MM', label='M월' */
+export function recentMonthBucketsKST(n: number): { ym: string; label: string }[] {
+  const start = nowKST().startOf("month");
+  return Array.from({ length: n }, (_, i) => {
+    const m = start.subtract(n - 1 - i, "month");
+    return { ym: m.format("YYYY-MM"), label: m.format("M월") };
+  });
+}
+
 /** Date를 KST 기준 'YYYY-MM-01'로 변환 */
 export function toMonthStart(date: Date): string {
   return dayjs(date).tz(KST).startOf("month").format("YYYY-MM-DD");


### PR DESCRIPTION
## 관련 이슈

관련 이슈 없음

## 요약

관리자 회원관리에 참여현황 기능을 추가한다. `회원 | 참여` 탭으로 팀 전체 참여 통계를 보고, 회원 상세 시트에서 개인의 모임·대회 참여 이력을 확인할 수 있다.

## AS-IS (변경 전)

- 회원관리에서 회원의 모임 참석·대회 참여 이력을 볼 방법이 없음 — 모임 관리/대회 관리 화면을 오가며 수동 대조해야 함
- 크루 전체의 참여도(누가 활발하고 누가 조용한지, 이탈 징후)를 한눈에 볼 화면이 없음

## TO-BE (변경 후)

**참여 탭** (`/admin/members` → 참여)
- 기간 필터(이번 달 / 최근 3개월 / 전체·7월~) — 모임 데이터 시작(7/1) 이전은 집계 제외
- 요약 StatCard 4종: 기간 내 참여 회원 · 모임당 평균 참석 · 예정 대회 신청 · 4주+ 무참석
- 참여 온도: 열심(4주 4회+) / 보통(1~3회) / 조용(4주+ 무참석), 신규(가입 4주 미만) 판정 제외
- 월별 참석 연인원(최근 6개월) 미니 차트
- 회원별 참여 명단(참석 많은/적은순 정렬) — **사람 수가 적힌 카드·온도 세그먼트를 탭하면 명단이 그 조건으로 필터**되고 해제 칩이 붙음. 행 탭 → 기존 상세 시트
- "가입 후 모임 미참여 N명" 액션 카드

**상세 시트 참여 현황 섹션** (러닝 프로필 아래)
- 요약 pill: 모임 참석·정모·개설(파랑) / 대회 신청·완주 기록(주황) — 신청과 완주는 합산하지 않음
- 최근 6개월 월별 참석 미니 바(0인 달은 스텁, 이번 달만 값 표시)
- 최근 활동 타임라인(모임/대회/기록 배지, 예정은 흐림) + 전체 보기
- 마지막 참여 상대시간 — 4주+ 무참여 시 경고색

## 주요 설계 결정

- **집계 = 서버 액션 TS 집계** (`app/actions/admin/get-participation-stats.ts`): 원천이 참석 44·신청 116·기록 172건으로 작아 RPC 마이그레이션 없이 구현. 지표 정의가 이 파일 한 곳에 모여 있어 규모가 커지면 내부만 RPC로 교체 (기존 `get_member_monthly_activity` 주석의 원칙)
- **상세 시트 = 클라이언트 직접 조회**: RLS가 팀 멤버 조회를 이미 허용 (KNOWLEDGE.md 온보딩 프로필 항목과 동일 원칙)
- **지표 상수 단일 출처**: `lib/constants/participation.ts` (4주 창·열심 4회·데이터 시작일), 월 버킷 헬퍼는 `lib/dayjs.ts`의 `recentMonthBucketsKST`로 공용화

## 변경 흐름 (Mermaid)

```mermaid
flowchart TD
    A["/admin/members"] --> B{SegmentControl}
    B -->|회원| C[기존 회원 목록·검색·배치]
    B -->|참여| D[ParticipationTab]
    D -->|기간 선택| E["getParticipationStats(from, to)<br/>withAdminOrThrow · RLS 세션 · TS 집계"]
    E --> F[요약 카드 · 온도 · 월별 · 명단]
    F -->|카드/온도 탭| G[명단 필터 + 해제 칩]
    F -->|행 탭| H[회원 상세 시트]
    C -->|행 탭| H
    H --> I["ParticipationSection<br/>클라 직접 조회 (RLS 허용 4테이블)"]
```

## 검증

- `tsc --noEmit` · ESLint · vitest 149개 통과
- 컴포넌트가 쓰는 PostgREST 임베드 쿼리를 REST로 직접 실행해 문법 검증, SQL로 기대값 대조 (예: 참석 최다 회원 — 참석 8·정모 1·개설 7·신청 7·기록 13)
- xhigh 결함 점검(10관점 파인더 + 검증 + 스윕): 15건 발견 → 13건 수정 반영 (supabase error 미체크로 인한 가짜 0 통계, 미래 완주 기록의 lastAt 오염, date-only 타임존 하루 밀림, 캐시 stale, 카드-명단 모집단 불일치 등)
- ⚠️ 관리자 로그인 후 실제 UI 렌더는 미관찰 — dev 이메일 테스트 계정이 전부 비관리자라 세션 확보 불가 (KNOWLEDGE.md에 기록). 머지 전 dev 환경에서 한 번 눈으로 확인 권장

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새 기능**
  * 관리자 회원 관리 화면에 회원 참여 통계 탭을 추가했습니다.
  * 회원별 참여 횟수, 최근 활동, 월별 참석 현황, 대회 참여 기록을 확인할 수 있습니다.
  * 참여 상태·활동량별 필터와 참석 횟수순 정렬을 지원합니다.
  * 회원 상세 화면에서 참여 요약과 최근 활동 타임라인을 확인할 수 있습니다.
  * 데이터 로딩, 오류, 기록 없음 상태를 구분해 안내합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->