### PR TITLE
fix(security): 상태이력 RPC anon/authenticated EXECUTE 회수 (IDOR 차단)

### DIFF
--- a/supabase/migrations/20260715121000_apply_team_mem_rel_change_rpc.sql
+++ b/supabase/migrations/20260715121000_apply_team_mem_rel_change_rpc.sql
@@ -76,6 +76,8 @@ comment on function public.apply_team_mem_rel_change(uuid, jsonb, timestamptz) i
 
 -- 앱의 모든 호출 경로가 service_role(createAdminClient)이므로 service_role 만 허용한다.
 -- (온보딩 자기 가입은 이 RPC 를 쓰지 않고 team_mem_rel 직접 INSERT — GRANT 불필요.)
--- 기본 PUBLIC EXECUTE 를 회수해 authenticated 가 /rpc/ 로 직접 호출하는 IDOR 경로를 차단한다.
-revoke all on function public.apply_team_mem_rel_change(uuid, jsonb, timestamptz) from public;
+-- PUBLIC 뿐 아니라 authenticated·anon 의 EXECUTE 도 명시 회수해야 한다 — `from public` 만으로는
+-- authenticated 에 준 명시적 GRANT 가 안 지워지고, SECURITY DEFINER + auth.uid()=null 우회로
+-- anon 이 /rpc/ 로 남의 회원을 조작하는 IDOR 가 열린다.
+revoke all on function public.apply_team_mem_rel_change(uuid, jsonb, timestamptz) from public, authenticated, anon;
 grant execute on function public.apply_team_mem_rel_change(uuid, jsonb, timestamptz) to service_role;

--- a/supabase/migrations/20260715122000_apply_team_mem_rel_delete_rpc.sql
+++ b/supabase/migrations/20260715122000_apply_team_mem_rel_delete_rpc.sql
@@ -62,8 +62,9 @@ $$;
 comment on function public.apply_team_mem_rel_delete(uuid, timestamptz) is
   '회원 소속 삭제 = 정본(vers=0)을 vers=max+1·del_yn=true 이력으로 밀어 vers=0 슬롯을 비운다. 재가입 시 새 정본 INSERT 가능. team_mem_id(PK) 유지로 칭호 FK 보존.';
 
--- 기본 PUBLIC EXECUTE 회수 후 service_role 만 허용(관리자 삭제 액션 전용).
-revoke all on function public.apply_team_mem_rel_delete(uuid, timestamptz) from public;
+-- PUBLIC·authenticated·anon EXECUTE 모두 회수 후 service_role 만 허용(관리자 삭제 액션 전용).
+-- (`from public` 만으로는 authenticated 명시 GRANT·anon 이 남아 IDOR 가 열린다 — change RPC 주석 참조)
+revoke all on function public.apply_team_mem_rel_delete(uuid, timestamptz) from public, authenticated, anon;
 grant execute on function public.apply_team_mem_rel_delete(uuid, timestamptz) to service_role;
 
 -- 기존 삭제분(del_yn=true, vers=0) 백필: 슬롯을 비워 재가입 가능하게. 대상 없으면 no-op(멱등).

--- a/supabase/migrations/20260716100000_rpc_perm_revoke_authenticated_anon.sql
+++ b/supabase/migrations/20260716100000_rpc_perm_revoke_authenticated_anon.sql
@@ -1,0 +1,15 @@
+-- 보안 핫픽스 — apply_team_mem_rel_change/delete 의 authenticated·anon EXECUTE 회수
+-- 설계: docs/superpowers/specs/2026-07-15-회원상태이력-비활성회비제외-design.md §4.3
+--
+-- 문제: 최초 두 RPC 마이그레이션이 `grant to authenticated` 로 명시 권한을 줬고, 이후 강화가
+--   `revoke all from public` 만 해서 authenticated 명시 GRANT + 기본 anon 이 남았다. 두 함수는
+--   SECURITY DEFINER 이고 내부 auth 가드가 `auth.uid() is not null AND not owner_admin` 이라,
+--   anon(auth.uid()=null)은 가드를 통과한다 → 비로그인 anon key 로 /rpc/ 직접 호출 시 임의 회원
+--   상태 변경(권한 승격 team_role_cd='owner' 포함)·삭제가 가능한 IDOR/권한상승 취약점.
+--
+-- 조치: 두 함수의 authenticated·anon EXECUTE 를 명시 회수한다. 앱의 모든 호출 경로는
+--   service_role(createAdminClient)이라 서버 동작에는 영향이 없다. (fresh DB 는 각 RPC 파일이
+--   이미 `from public, authenticated, anon` 으로 회수하므로 이 백필은 no-op.)
+
+revoke execute on function public.apply_team_mem_rel_change(uuid, jsonb, timestamptz) from authenticated, anon;
+revoke execute on function public.apply_team_mem_rel_delete(uuid, timestamptz) from authenticated, anon;


### PR DESCRIPTION
## 관련 이슈

- 관련 이슈 없음 (보안 핫픽스)

## 요약

`apply_team_mem_rel_change`/`apply_team_mem_rel_delete`(SECURITY DEFINER)의 `authenticated`·`anon` EXECUTE 권한을 회수해, 비로그인 상태로 임의 회원을 조작할 수 있던 IDOR/권한상승 취약점을 막습니다.

## 취약점

- 두 RPC는 `SECURITY DEFINER`(RLS 우회)이고 내부 가드가 `auth.uid() is not null AND not owner_admin`.
- **`anon`은 `auth.uid()`가 null이라 가드를 통과** → 공개 anon key로 `/rpc/` 직접 호출 시 임의 `team_mem_id`에 대해 상태 변경(`team_role_cd='owner'` 권한 승격 포함)·삭제 가능.
- 근본 원인: 권한 회수가 `revoke ... from public`만이라, 최초 마이그레이션이 `grant to authenticated`로 준 명시적 권한 + 기본 `anon`이 남아있었음.

## 조치

- 두 RPC 파일의 revoke를 `from public, authenticated, anon`으로 완전화 (fresh DB는 처음부터 안전).
- `20260716100000_rpc_perm_revoke_authenticated_anon.sql`: 이미 배포된 dev/prd의 잔여 권한을 소급 회수하는 백필.

## 적용·검증

- **prd·dev 양쪽 적용 완료.** 두 함수의 `grantees`가 `postgres, service_role`만 남음(anon/authenticated 제거) 확인.
- 앱의 모든 호출은 `service_role`(createAdminClient) 경로라 서버 동작 영향 없음.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **보안**
  * 팀 멤버십 변경 및 삭제 작업의 RPC 실행 권한을 제한했습니다.
  * 인증 및 비인증 요청에서 해당 작업을 직접 호출할 수 없도록 접근 제어를 강화했습니다.
  * 해당 기능은 승인된 내부 서비스 권한으로만 실행됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->