### PR TITLE
feat(gatherings): 임박 개설(12시간 미만) 정보성 안내

### DIFF
--- a/app/(info)/gatherings/new/gathering-form.tsx
+++ b/app/(info)/gatherings/new/gathering-form.tsx
@@ -5,10 +5,12 @@ import { useEffect, useState } from "react";
 import { useRouter } from "next/navigation";
 
 import { zodResolver } from "@hookform/resolvers/zod";
+import { Info } from "lucide-react";
 import { useForm } from "react-hook-form";
 import { z } from "zod";
 
 import { dayjs } from "@/lib/dayjs";
+import { isImminentGathering } from "@/lib/gathering/imminent";
 import { GTHR_TYPES, gthrTypeLabels, createGthrSchema, type CreateGthrInput } from "@/lib/validations/gathering";
 
 import { createGathering, updateGathering } from "@/app/actions/gathering/manage-gathering";
@@ -31,6 +33,7 @@ import {
   SelectValue,
 } from "@/components/ui/select";
 import { AutoGrowTextarea } from "@/components/common/auto-grow-textarea";
+import { Caption } from "@/components/common/typography";
 
 const formSchema = createGthrSchema.omit({ team_id: true });
 type FormValues = z.infer<typeof formSchema>;
@@ -84,6 +87,10 @@ export function GatheringForm(props: Props) {
   });
 
   const { isSubmitting } = form.formState;
+
+  // 시작까지 12시간 미만이면 정보성 안내 노출 — 개설을 막지는 않는다.
+  const sttAt = form.watch("stt_at");
+  const isImminent = isImminentGathering(sttAt);
 
   useEffect(() => {
     if (props.mode !== "edit") return;
@@ -204,6 +211,16 @@ export function GatheringForm(props: Props) {
             )}
           />
         </div>
+
+        {/* 임박 개설 안내 — 정보성, 제출은 막지 않음 */}
+        {isImminent && (
+          <div className="flex items-start gap-2 rounded-lg bg-info/10 px-3 py-2">
+            <Info className="mt-0.5 size-4 shrink-0 text-info" />
+            <Caption className="text-info">
+              시작까지 12시간이 채 남지 않았어요. 당일에 오픈한 일정은 참석자가 없을 수 있어요.
+            </Caption>
+          </div>
+        )}
 
         {/* 장소 */}
         <FormField

--- a/components/schedule/gathering-form-dialog.tsx
+++ b/components/schedule/gathering-form-dialog.tsx
@@ -2,7 +2,7 @@
 
 import { useEffect, useState } from "react";
 
-import { History } from "lucide-react";
+import { History, Info } from "lucide-react";
 
 import { zodResolver } from "@hookform/resolvers/zod";
 import { useForm } from "react-hook-form";
@@ -13,6 +13,7 @@ import { z } from "zod";
 import { dayjs } from "@/lib/dayjs";
 import type { RecentGathering } from "@/lib/gathering/dedupe-recent";
 import { REGULAR_GATHERING_TEMPLATE } from "@/lib/gathering/templates";
+import { isImminentGathering } from "@/lib/gathering/imminent";
 import {
   GTHR_TYPES,
   GTHR_SPRT_TYPES,
@@ -50,6 +51,7 @@ import {
 } from "@/components/ui/select";
 import { Separator } from "@/components/ui/separator";
 import { AutoGrowTextarea } from "@/components/common/auto-grow-textarea";
+import { Caption } from "@/components/common/typography";
 
 const formSchema = createGthrSchema.omit({ team_id: true });
 type FormValues = z.infer<typeof formSchema>;
@@ -379,6 +381,16 @@ export function GatheringFormDialog({
                 )}
               />
             </div>
+
+            {/* 시작까지 12시간 미만이면 정보성 안내 노출 — 개설을 막지는 않는다. */}
+            {isImminentGathering(form.watch("stt_at")) && (
+              <div className="flex items-start gap-2 rounded-lg bg-info/10 px-3 py-2">
+                <Info className="mt-0.5 size-4 shrink-0 text-info" />
+                <Caption className="text-info">
+                  시작까지 12시간이 채 남지 않았어요. 당일에 오픈한 일정은 참석자가 없을 수 있어요.
+                </Caption>
+              </div>
+            )}
 
             {/* 장소 */}
             <FormField

--- a/lib/__tests__/imminent.test.ts
+++ b/lib/__tests__/imminent.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from "vitest";
+
+import { dayjs } from "@/lib/dayjs";
+import { isImminentGathering } from "@/lib/gathering/imminent";
+
+// 기준 시각: 2026-07-20 12:00 KST
+const NOW = "2026-07-20T12:00:00+09:00";
+
+describe("isImminentGathering", () => {
+  it("11시간 59분 남았으면 임박(true)", () => {
+    expect(isImminentGathering("2026-07-20T23:59", NOW)).toBe(true);
+  });
+
+  it("정확히 12시간 남았으면 임박 아님(false) — 경계값", () => {
+    expect(isImminentGathering("2026-07-21T00:00", NOW)).toBe(false);
+  });
+
+  it("12시간 1분 남았으면 임박 아님(false)", () => {
+    expect(isImminentGathering("2026-07-21T00:01", NOW)).toBe(false);
+  });
+
+  it("1시간만 남았으면 임박(true)", () => {
+    expect(isImminentGathering("2026-07-20T13:00", NOW)).toBe(true);
+  });
+
+  it("정확히 지금 시작이면 임박 아님(false) — 이미 시작한 것으로 취급", () => {
+    expect(isImminentGathering("2026-07-20T12:00", NOW)).toBe(false);
+  });
+
+  it("이미 지난 시각이면 임박 아님(false) — 지난 모임 수정 시 오탐 방지", () => {
+    expect(isImminentGathering("2026-07-19T10:00", NOW)).toBe(false);
+  });
+
+  it("충분히 미래(며칠 뒤)면 임박 아님(false)", () => {
+    expect(isImminentGathering("2026-07-25T12:00", NOW)).toBe(false);
+  });
+
+  it("값이 없으면 false", () => {
+    expect(isImminentGathering(null, NOW)).toBe(false);
+    expect(isImminentGathering(undefined, NOW)).toBe(false);
+    expect(isImminentGathering("", NOW)).toBe(false);
+  });
+
+  it("유효하지 않은 날짜 문자열이면 false", () => {
+    expect(isImminentGathering("not-a-date", NOW)).toBe(false);
+  });
+
+  it("now를 생략하면 실제 현재 시각 기준으로 동작한다", () => {
+    const soon = dayjs().tz("Asia/Seoul").add(1, "hour").format("YYYY-MM-DDTHH:mm");
+    expect(isImminentGathering(soon)).toBe(true);
+
+    const far = dayjs().tz("Asia/Seoul").add(3, "day").format("YYYY-MM-DDTHH:mm");
+    expect(isImminentGathering(far)).toBe(false);
+  });
+});

--- a/lib/gathering/imminent.ts
+++ b/lib/gathering/imminent.ts
@@ -1,0 +1,31 @@
+import { dayjs } from "@/lib/dayjs";
+
+import type { Dayjs } from "dayjs";
+
+const KST = "Asia/Seoul";
+
+/** 이 시간(시) 미만으로 시작까지 남으면 "임박 개설"로 본다. */
+export const IMMINENT_THRESHOLD_HOURS = 12;
+
+/**
+ * 모임 시작 시각이 "현재로부터 12시간 미만"인지 판정 — 임박 개설 안내 노출 기준.
+ *
+ * `sttAt`은 개설 폼의 datetime-local 값(오프셋 없는 "YYYY-MM-DDTHH:mm", KST 벽시계 기준)을
+ * 그대로 받는다. 서버 액션의 `toUtcIso`와 동일하게 `dayjs.tz(sttAt, "Asia/Seoul")`로 해석한다.
+ *
+ * 이미 시작 시각이 지난 경우(diff <= 0)는 "임박"이 아니라 별개 케이스이므로 false —
+ * 지난/이미 임박했던 모임을 수정할 때 뒤늦게 안내가 뜨는 오탐을 막는다.
+ */
+export function isImminentGathering(
+  sttAt: string | null | undefined,
+  now: Dayjs | string = dayjs(),
+): boolean {
+  if (!sttAt || !dayjs(sttAt).isValid()) return false;
+
+  const target = dayjs.tz(sttAt, KST);
+
+  const nowDayjs = typeof now === "string" ? dayjs(now) : now;
+  const diffHours = target.diff(nowDayjs, "hour", true);
+
+  return diffHours > 0 && diffHours < IMMINENT_THRESHOLD_HOURS;
+}


### PR DESCRIPTION
## AS-IS
- 모임 시작까지 얼마 안 남은 시점에 개설해도 아무 안내가 없어, 당일 오픈 모임이 참석자 없이 진행되는 상황을 개설자가 예상하지 못함 (2026-07-19 사건 후속, #427 / Linear EES-87)

## TO-BE
- 개설/수정 폼에서 시작까지 **12시간 미만**이면 정보성 안내 노출: "시작까지 12시간이 채 남지 않았어요. 당일에 오픈한 일정은 참석자가 없을 수 있어요."
- 개설을 막지 않음(제출 버튼과 무관), 지난 모임 수정 시 오탐 없음
- 판정은 `lib/gathering/imminent.ts` 순수 함수(KST, `@/lib/dayjs`) — 경계값 포함 단위 테스트 10개

## 검증
- vitest 182/182 PASS, tsc 클린
- 독립 코드리뷰 통과 (경계값 의미·디자인 토큰·dayjs 규칙 확인)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018fYh2XfDUiNTNRGiqTLw9p

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새 기능**
  * 모임 개설 화면에서 시작 시각 기준 12시간 이내인 경우 ‘임박 개설’ 안내가 조건부로 표시됩니다.
  * 시작 시간이 이미 지났거나 12시간 이상 남은 경우에는 안내가 표시되지 않습니다.
* **테스트**
  * 11시간 59분/12시간/12시간 1분 경계값, 과거·미래, 빈 값·유효하지 않은 입력, 그리고 타임존 기준 동작까지 임박 판정을 검증하는 테스트를 추가했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->