### PR TITLE
feat(gathering): 모임 참가 취소를 삭제 대신 이력으로 기록

### DIFF
--- a/app/actions/__tests__/gathering-cancel-history.test.ts
+++ b/app/actions/__tests__/gathering-cancel-history.test.ts
@@ -1,0 +1,114 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// 취소 이력(gthr_attd_hist) 배선 검증:
+// 본인/관리자 두 취소 경로가 모두 cancel_gthr_attendance RPC 를 올바른 actor 구분·사유로
+// 호출하는지 확인한다. 실제 원자성/RLS/재참석은 dev DB SQL 로 별도 검증(AC-03/04).
+
+const h = vi.hoisted(() => {
+  const rpc = vi.fn();
+
+  // Supabase 쿼리 빌더 스텁: 어떤 체이닝 메서드도 자기 자신을 반환하고, await 시 result 로 resolve.
+  const queryStub = (result: unknown) => {
+    const p = Promise.resolve(result);
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const proxy: any = new Proxy(function () {}, {
+      get(_t, prop) {
+        if (prop === "then") return p.then.bind(p);
+        if (prop === "catch") return p.catch.bind(p);
+        if (prop === "finally") return p.finally.bind(p);
+        return () => proxy;
+      },
+      apply: () => proxy,
+    });
+    return proxy;
+  };
+
+  const cfg = {
+    gthr: { data: { max_prt_cnt: null, stt_at: "2026-08-01T10:00:00Z", end_at: null } },
+    existing: { data: { attd_id: "attd-1" } },
+    verify: { data: { gthr_id: "gthr-1" } },
+    selfMember: { id: "mem-self", admin: false, status: "active" },
+    adminMember: { id: "admin-1", admin: true, status: "active" },
+  };
+
+  return { rpc, queryStub, cfg };
+});
+
+vi.mock("next/cache", () => ({ revalidatePath: vi.fn() }));
+vi.mock("@/lib/past-event", () => ({ isPastLockedFor: () => false }));
+vi.mock("@/lib/queries/request-team", () => ({
+  getRequestTeamContext: async () => ({ teamId: "team-1" }),
+}));
+vi.mock("@/lib/gathering/join-gathering", () => ({
+  joinGatheringWithCapCheck: async () => ({ joined: true }),
+}));
+vi.mock("@/lib/actions/auth", () => ({
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  withActive: async (fn: any) =>
+    fn({ member: h.cfg.selfMember, supabase: { from: () => h.queryStub(h.cfg.existing) } }),
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  withAdmin: async (fn: any) =>
+    fn({ member: h.cfg.adminMember, supabase: { from: () => h.queryStub(h.cfg.existing) } }),
+}));
+vi.mock("@/lib/supabase/admin", () => ({
+  createUntypedAdminClient: () => ({ from: () => h.queryStub(h.cfg.gthr), rpc: h.rpc }),
+  createAdminClient: () => ({ from: () => h.queryStub(h.cfg.verify), rpc: h.rpc }),
+}));
+
+import { removeGatheringAttendance } from "@/app/actions/admin/manage-gathering-attendance";
+import { toggleGatheringAttendance } from "@/app/actions/gathering/toggle-attendance";
+
+beforeEach(() => {
+  h.rpc.mockReset();
+  h.rpc.mockResolvedValue({ error: null });
+});
+
+describe("본인 참석 취소 (toggleGatheringAttendance)", () => {
+  it("취소 시 cancel_gthr_attendance RPC 를 actor_kind='self' + 사유로 호출한다", async () => {
+    const result = await toggleGatheringAttendance("gthr-1", "부상으로 불참");
+
+    expect(result).toEqual({ attending: false });
+    expect(h.rpc).toHaveBeenCalledWith("cancel_gthr_attendance", {
+      p_gthr_id: "gthr-1",
+      p_mem_id: "mem-self",
+      p_actor_kind: "self",
+      p_actor_mem_id: "mem-self",
+      p_reason: "부상으로 불참",
+    });
+  });
+
+  it("사유 미지정 시 p_reason 은 null 로 전달된다", async () => {
+    await toggleGatheringAttendance("gthr-1");
+
+    expect(h.rpc).toHaveBeenCalledWith(
+      "cancel_gthr_attendance",
+      expect.objectContaining({ p_actor_kind: "self", p_reason: null }),
+    );
+  });
+
+  it("RPC 실패 시 참석 취소 에러를 던진다", async () => {
+    h.rpc.mockResolvedValue({ error: { message: "boom" } });
+    await expect(toggleGatheringAttendance("gthr-1")).rejects.toThrow("참석 취소에 실패했습니다.");
+  });
+});
+
+describe("관리자 참석 취소 (removeGatheringAttendance)", () => {
+  it("취소 시 cancel_gthr_attendance RPC 를 actor_kind='admin' + 관리자 mem_id 로 호출한다", async () => {
+    const result = await removeGatheringAttendance("gthr-1", "mem-2", "노쇼 처리");
+
+    expect(result).toEqual({ ok: true, message: null });
+    expect(h.rpc).toHaveBeenCalledWith("cancel_gthr_attendance", {
+      p_gthr_id: "gthr-1",
+      p_mem_id: "mem-2",
+      p_actor_kind: "admin",
+      p_actor_mem_id: "admin-1",
+      p_reason: "노쇼 처리",
+    });
+  });
+
+  it("RPC 실패 시 ok:false 를 반환한다", async () => {
+    h.rpc.mockResolvedValue({ error: { message: "boom" } });
+    const result = await removeGatheringAttendance("gthr-1", "mem-2");
+    expect(result).toEqual({ ok: false, message: "참석 취소에 실패했습니다" });
+  });
+});

--- a/app/actions/__tests__/gathering-cancel-history.test.ts
+++ b/app/actions/__tests__/gathering-cancel-history.test.ts
@@ -64,14 +64,14 @@ beforeEach(() => {
 });
 
 describe("본인 참석 취소 (toggleGatheringAttendance)", () => {
-  it("취소 시 cancel_gthr_attendance RPC 를 actor_kind='self' + 사유로 호출한다", async () => {
+  it("취소 시 cancel_gthr_attendance RPC 를 actor_cd='self' + 사유로 호출한다", async () => {
     const result = await toggleGatheringAttendance("gthr-1", "부상으로 불참");
 
     expect(result).toEqual({ attending: false });
     expect(h.rpc).toHaveBeenCalledWith("cancel_gthr_attendance", {
       p_gthr_id: "gthr-1",
       p_mem_id: "mem-self",
-      p_actor_kind: "self",
+      p_actor_cd: "self",
       p_actor_mem_id: "mem-self",
       p_reason: "부상으로 불참",
     });
@@ -82,8 +82,16 @@ describe("본인 참석 취소 (toggleGatheringAttendance)", () => {
 
     expect(h.rpc).toHaveBeenCalledWith(
       "cancel_gthr_attendance",
-      expect.objectContaining({ p_actor_kind: "self", p_reason: null }),
+      expect.objectContaining({ p_actor_cd: "self", p_reason: null }),
     );
+  });
+
+  it("사유가 500자를 초과하면 RPC 호출 없이 거부한다", async () => {
+    const tooLong = "가".repeat(501);
+    await expect(toggleGatheringAttendance("gthr-1", tooLong)).rejects.toThrow(
+      "취소 사유는 500자 이내로 입력해주세요.",
+    );
+    expect(h.rpc).not.toHaveBeenCalled();
   });
 
   it("RPC 실패 시 참석 취소 에러를 던진다", async () => {
@@ -93,17 +101,24 @@ describe("본인 참석 취소 (toggleGatheringAttendance)", () => {
 });
 
 describe("관리자 참석 취소 (removeGatheringAttendance)", () => {
-  it("취소 시 cancel_gthr_attendance RPC 를 actor_kind='admin' + 관리자 mem_id 로 호출한다", async () => {
+  it("취소 시 cancel_gthr_attendance RPC 를 actor_cd='admin' + 관리자 mem_id 로 호출한다", async () => {
     const result = await removeGatheringAttendance("gthr-1", "mem-2", "노쇼 처리");
 
     expect(result).toEqual({ ok: true, message: null });
     expect(h.rpc).toHaveBeenCalledWith("cancel_gthr_attendance", {
       p_gthr_id: "gthr-1",
       p_mem_id: "mem-2",
-      p_actor_kind: "admin",
+      p_actor_cd: "admin",
       p_actor_mem_id: "admin-1",
       p_reason: "노쇼 처리",
     });
+  });
+
+  it("사유가 500자를 초과하면 RPC 호출 없이 ok:false 를 반환한다", async () => {
+    const tooLong = "노".repeat(501);
+    const result = await removeGatheringAttendance("gthr-1", "mem-2", tooLong);
+    expect(result).toEqual({ ok: false, message: "취소 사유는 500자 이내로 입력해주세요." });
+    expect(h.rpc).not.toHaveBeenCalled();
   });
 
   it("RPC 실패 시 ok:false 를 반환한다", async () => {

--- a/app/actions/admin/manage-gathering-attendance.ts
+++ b/app/actions/admin/manage-gathering-attendance.ts
@@ -2,7 +2,7 @@
 
 import { withAdmin } from "@/lib/actions/auth";
 import { getRequestTeamContext } from "@/lib/queries/request-team";
-import { createAdminClient } from "@/lib/supabase/admin";
+import { createAdminClient, createUntypedAdminClient } from "@/lib/supabase/admin";
 
 /** createAdminClient는 RLS를 우회하므로, 대상 모임이 현재 팀 소속인지 서버에서 직접 확인한다 (IDOR 방지). */
 async function verifyGatheringInTeam(
@@ -20,20 +20,29 @@ async function verifyGatheringInTeam(
   return !!data;
 }
 
-/** 관리자가 특정 모임에서 특정 멤버의 참석을 취소한다 (RLS 우회 — 본인 외 삭제 허용). */
-export async function removeGatheringAttendance(gthrId: string, memId: string) {
-  return withAdmin(async () => {
+/**
+ * 관리자가 특정 모임에서 특정 멤버의 참석을 취소한다 (RLS 우회 — 본인 외 삭제 허용).
+ * 취소 = gthr_attd_rel DELETE + gthr_attd_hist(cancel) INSERT 를 원자적으로 처리한다.
+ * `reason`(선택)을 넘기면 취소 사유로 이력에 저장된다(저장만, 필수 강제는 후속 SG-02).
+ */
+export async function removeGatheringAttendance(gthrId: string, memId: string, reason?: string) {
+  return withAdmin(async ({ member }) => {
     const { teamId } = await getRequestTeamContext();
     const db = createAdminClient();
 
     const inTeam = await verifyGatheringInTeam(db, gthrId, teamId);
     if (!inTeam) return { ok: false, message: "모임을 찾을 수 없습니다" };
 
-    const { error } = await db
-      .from("gthr_attd_rel")
-      .delete()
-      .eq("gthr_id", gthrId)
-      .eq("mem_id", memId);
+    // cancel_gthr_attendance RPC 는 service_role 전용. actor 는 처리한 관리자(admin).
+    // 신규 RPC 라 아직 DB 타입 미생성 → untyped 관리자 클라이언트로 호출(gen types 후 교체 예정).
+    const untyped = createUntypedAdminClient();
+    const { error } = await untyped.rpc("cancel_gthr_attendance", {
+      p_gthr_id: gthrId,
+      p_mem_id: memId,
+      p_actor_kind: "admin",
+      p_actor_mem_id: member.id,
+      p_reason: reason ?? null,
+    });
     if (error) return { ok: false, message: "참석 취소에 실패했습니다" };
     return { ok: true, message: null };
   });

--- a/app/actions/admin/manage-gathering-attendance.ts
+++ b/app/actions/admin/manage-gathering-attendance.ts
@@ -1,6 +1,7 @@
 "use server";
 
 import { withAdmin } from "@/lib/actions/auth";
+import { validateCancelReason } from "@/lib/gathering/cancel-reason";
 import { getRequestTeamContext } from "@/lib/queries/request-team";
 import { createAdminClient, createUntypedAdminClient } from "@/lib/supabase/admin";
 
@@ -33,15 +34,19 @@ export async function removeGatheringAttendance(gthrId: string, memId: string, r
     const inTeam = await verifyGatheringInTeam(db, gthrId, teamId);
     if (!inTeam) return { ok: false, message: "모임을 찾을 수 없습니다" };
 
+    // 사유 길이 상한(500자) 서버 강제 — 초과 시 잘라내지 않고 거부.
+    const reasonCheck = validateCancelReason(reason);
+    if (!reasonCheck.ok) return { ok: false, message: reasonCheck.message };
+
     // cancel_gthr_attendance RPC 는 service_role 전용. actor 는 처리한 관리자(admin).
     // 신규 RPC 라 아직 DB 타입 미생성 → untyped 관리자 클라이언트로 호출(gen types 후 교체 예정).
     const untyped = createUntypedAdminClient();
     const { error } = await untyped.rpc("cancel_gthr_attendance", {
       p_gthr_id: gthrId,
       p_mem_id: memId,
-      p_actor_kind: "admin",
+      p_actor_cd: "admin",
       p_actor_mem_id: member.id,
-      p_reason: reason ?? null,
+      p_reason: reasonCheck.value,
     });
     if (error) return { ok: false, message: "참석 취소에 실패했습니다" };
     return { ok: true, message: null };

--- a/app/actions/gathering/toggle-attendance.ts
+++ b/app/actions/gathering/toggle-attendance.ts
@@ -13,9 +13,13 @@ import { createUntypedAdminClient } from "@/lib/supabase/admin";
  * 모임 참석 토글.
  * 참석 등록 시 `monthlyAttendCnt`(그 모임 stt_at 월 기준 본인 총참석 횟수)를 함께 반환해,
  * 클라이언트가 "이번 달 N회 참석" 토스트를 띄울 수 있게 한다. 취소 시엔 undefined.
+ *
+ * 취소 시 `reason`(선택)을 넘기면 취소 이력(gthr_attd_hist)에 사유로 저장된다.
+ * SG-01 은 저장만 지원 — 사유 필수 강제는 후속 과제(SG-02). 등록 토글 시 reason 은 무시.
  */
 export async function toggleGatheringAttendance(
   gthr_id: string,
+  reason?: string,
 ): Promise<{ attending: boolean; monthlyAttendCnt?: number }> {
   return withActive(async ({ member, supabase }) => {
     // 모임 검증용 조회와 내 참석 여부 조회는 독립적 — 병렬 1 RTT로 (직렬 2 RTT 방지)
@@ -45,8 +49,17 @@ export async function toggleGatheringAttendance(
     }
 
     if (existing) {
-      const { error: deleteError } = await supabase.from("gthr_attd_rel").delete().eq("attd_id", existing.attd_id);
-      if (deleteError) throw new Error("참석 취소에 실패했습니다.");
+      // 취소 = gthr_attd_rel DELETE + gthr_attd_hist(cancel) INSERT 를 원자적으로.
+      // cancel_gthr_attendance RPC 는 service_role 전용(authenticated·anon EXECUTE 회수)이라
+      // 본인 인가가 끝난 admin 클라이언트로 호출한다. actor 는 본인(self).
+      const { error: cancelError } = await admin.rpc("cancel_gthr_attendance", {
+        p_gthr_id: gthr_id,
+        p_mem_id: member.id,
+        p_actor_kind: "self",
+        p_actor_mem_id: member.id,
+        p_reason: reason ?? null,
+      });
+      if (cancelError) throw new Error("참석 취소에 실패했습니다.");
       // 홈(/)은 dynamic 렌더(getCurrentMember가 cookies 사용)라 매 요청 새로 조회되므로
       // revalidatePath("/")는 무효화할 캐시가 없어 불필요 — 모임 상세 직접 URL만 무효화한다.
       revalidatePath(`/gatherings/${gthr_id}`);

--- a/app/actions/gathering/toggle-attendance.ts
+++ b/app/actions/gathering/toggle-attendance.ts
@@ -4,6 +4,7 @@ import { revalidatePath } from "next/cache";
 
 import { withActive } from "@/lib/actions/auth";
 import { dayjs } from "@/lib/dayjs";
+import { validateCancelReason } from "@/lib/gathering/cancel-reason";
 import { joinGatheringWithCapCheck } from "@/lib/gathering/join-gathering";
 import { isPastLockedFor } from "@/lib/past-event";
 import { getRequestTeamContext } from "@/lib/queries/request-team";
@@ -49,15 +50,19 @@ export async function toggleGatheringAttendance(
     }
 
     if (existing) {
+      // 사유 길이 상한(500자) 서버 강제 — 초과 시 잘라내지 않고 거부.
+      const reasonCheck = validateCancelReason(reason);
+      if (!reasonCheck.ok) throw new Error(reasonCheck.message);
+
       // 취소 = gthr_attd_rel DELETE + gthr_attd_hist(cancel) INSERT 를 원자적으로.
       // cancel_gthr_attendance RPC 는 service_role 전용(authenticated·anon EXECUTE 회수)이라
       // 본인 인가가 끝난 admin 클라이언트로 호출한다. actor 는 본인(self).
       const { error: cancelError } = await admin.rpc("cancel_gthr_attendance", {
         p_gthr_id: gthr_id,
         p_mem_id: member.id,
-        p_actor_kind: "self",
+        p_actor_cd: "self",
         p_actor_mem_id: member.id,
-        p_reason: reason ?? null,
+        p_reason: reasonCheck.value,
       });
       if (cancelError) throw new Error("참석 취소에 실패했습니다.");
       // 홈(/)은 dynamic 렌더(getCurrentMember가 cookies 사용)라 매 요청 새로 조회되므로

--- a/lib/__tests__/cancel-reason.test.ts
+++ b/lib/__tests__/cancel-reason.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  GATHERING_CANCEL_REASON_MAX_LENGTH,
+  validateCancelReason,
+} from "@/lib/gathering/cancel-reason";
+
+describe("validateCancelReason", () => {
+  it("null/undefined 는 사유 없음(null)", () => {
+    expect(validateCancelReason()).toEqual({ ok: true, value: null });
+    expect(validateCancelReason(null)).toEqual({ ok: true, value: null });
+  });
+
+  it("공백만 있으면 trim 후 null", () => {
+    expect(validateCancelReason("   ")).toEqual({ ok: true, value: null });
+  });
+
+  it("일반 사유는 trim 된 값 반환", () => {
+    expect(validateCancelReason("  부상  ")).toEqual({ ok: true, value: "부상" });
+  });
+
+  it("정확히 500자는 허용", () => {
+    const exact = "가".repeat(GATHERING_CANCEL_REASON_MAX_LENGTH);
+    expect(validateCancelReason(exact)).toEqual({ ok: true, value: exact });
+  });
+
+  it("501자는 거부(잘라내지 않음)", () => {
+    const tooLong = "가".repeat(GATHERING_CANCEL_REASON_MAX_LENGTH + 1);
+    const result = validateCancelReason(tooLong);
+    expect(result.ok).toBe(false);
+    expect(result).toMatchObject({ ok: false, message: "취소 사유는 500자 이내로 입력해주세요." });
+  });
+
+  it("앞뒤 공백 제외 500자면 허용(공백 포함 502자)", () => {
+    const padded = ` ${"나".repeat(GATHERING_CANCEL_REASON_MAX_LENGTH)} `;
+    expect(validateCancelReason(padded)).toEqual({
+      ok: true,
+      value: "나".repeat(GATHERING_CANCEL_REASON_MAX_LENGTH),
+    });
+  });
+});

--- a/lib/gathering/cancel-reason.ts
+++ b/lib/gathering/cancel-reason.ts
@@ -1,0 +1,32 @@
+/**
+ * 모임 참석 취소 사유(reason) 검증.
+ *
+ * 서버 액션은 "use server" 엔드포인트라 임의 인자로 호출될 수 있어(예: 수 MB 텍스트),
+ * RPC 호출 전에 길이 상한을 서버에서 강제한다. DB 측에도 동일한 상한(char_length <= 500)
+ * CHECK 제약이 있어 이중 방어. 초과 시 잘라내지 않고 명시적으로 거부한다(잘림보다 명확).
+ */
+
+export const GATHERING_CANCEL_REASON_MAX_LENGTH = 500;
+
+export const GATHERING_CANCEL_REASON_TOO_LONG_MESSAGE = `취소 사유는 ${GATHERING_CANCEL_REASON_MAX_LENGTH}자 이내로 입력해주세요.`;
+
+export type CancelReasonResult =
+  | { ok: true; value: string | null }
+  | { ok: false; message: string };
+
+/**
+ * 취소 사유를 정규화·검증한다.
+ * - null/undefined 또는 trim 후 빈 문자열 → 사유 없음(null)
+ * - trim 후 500자 초과 → 거부(잘라내지 않음)
+ * - 그 외 → trim 된 값
+ */
+export function validateCancelReason(reason?: string | null): CancelReasonResult {
+  if (reason == null) return { ok: true, value: null };
+
+  const trimmed = reason.trim();
+  if (trimmed.length === 0) return { ok: true, value: null };
+  if (trimmed.length > GATHERING_CANCEL_REASON_MAX_LENGTH) {
+    return { ok: false, message: GATHERING_CANCEL_REASON_TOO_LONG_MESSAGE };
+  }
+  return { ok: true, value: trimmed };
+}

--- a/supabase/migrations/20260720100000_gthr_attd_hist.sql
+++ b/supabase/migrations/20260720100000_gthr_attd_hist.sql
@@ -1,0 +1,118 @@
+-- ============================================================
+-- gthr_attd_hist — 모임 참석 취소 이력 (append-only)
+-- 목적: 참석 취소를 gthr_attd_rel 에서 하드 삭제하던 것을 이력으로 남긴다.
+--   현재상태 테이블(gthr_attd_rel)은 그대로 유지(UNIQUE(gthr_id,mem_id) 재등록 충돌 회피),
+--   취소 이벤트만 이 이력 테이블에 append 한다. 취소 = rel DELETE + hist INSERT 는
+--   원자적이어야 하므로 SECURITY DEFINER RPC(cancel_gthr_attendance)로 묶는다.
+-- 노출 정책(오너 결정): 취소 이력(사유 포함) SELECT = 팀 멤버 전체 공개
+--   (gthr_attd_rel_select 와 동일 수준). 비멤버·anon 차단. 컬럼 분리/뷰 불필요.
+-- ============================================================
+
+CREATE TABLE public.gthr_attd_hist (
+  hist_id      uuid        PRIMARY KEY DEFAULT gen_random_uuid(),
+  gthr_id      uuid        NOT NULL REFERENCES public.gthr_mst(gthr_id),
+  mem_id       uuid        NOT NULL REFERENCES public.mem_mst(mem_id),
+  evt_cd       text        NOT NULL DEFAULT 'cancel' CHECK (evt_cd IN ('register', 'cancel')),
+  actor_kind   text        NOT NULL CHECK (actor_kind IN ('self', 'admin')),
+  actor_mem_id uuid        REFERENCES public.mem_mst(mem_id),
+  reason_txt   text,
+  evt_at       timestamptz NOT NULL DEFAULT now()
+);
+
+COMMENT ON TABLE  public.gthr_attd_hist              IS '모임 참석 이벤트 이력 (append-only). 현재는 취소(cancel) 이벤트만 기록. 재참석은 gthr_attd_rel upsert 로 처리되며 이 이력은 보존된다.';
+COMMENT ON COLUMN public.gthr_attd_hist.hist_id      IS 'PK';
+COMMENT ON COLUMN public.gthr_attd_hist.gthr_id      IS '모임 ID (gthr_mst FK)';
+COMMENT ON COLUMN public.gthr_attd_hist.mem_id       IS '대상 참석자 mem_id (mem_mst FK)';
+COMMENT ON COLUMN public.gthr_attd_hist.evt_cd       IS '이벤트 종류: register|cancel. 현재 cancel 만 기록(register 로깅은 후속 과제).';
+COMMENT ON COLUMN public.gthr_attd_hist.actor_kind   IS '취소 주체 구분: self(본인)|admin(관리자).';
+COMMENT ON COLUMN public.gthr_attd_hist.actor_mem_id IS '실제 행위자 mem_id. self 면 mem_id 와 동일, admin 이면 처리한 관리자 mem_id.';
+COMMENT ON COLUMN public.gthr_attd_hist.reason_txt   IS '취소 사유(nullable). SG-01 은 저장만, 필수 강제는 후속 SG-02.';
+COMMENT ON COLUMN public.gthr_attd_hist.evt_at       IS '이벤트(취소) 발생 시각.';
+
+-- 특정 모임의 취소 이력 조회용
+CREATE INDEX ix_gthr_attd_hist_gthr ON public.gthr_attd_hist(gthr_id);
+-- 특정 멤버의 취소 이력 조회용
+CREATE INDEX ix_gthr_attd_hist_mem  ON public.gthr_attd_hist(mem_id);
+
+-- ============================================================
+-- RLS — SELECT 만 팀 멤버에게 허용. INSERT/UPDATE/DELETE 정책 없음
+--   → authenticated 는 직접 쓰기 불가(append-only 불변). 쓰기는 SECURITY DEFINER
+--   RPC(service_role, RLS 우회)만 수행.
+-- ============================================================
+
+ALTER TABLE public.gthr_attd_hist ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY gthr_attd_hist_select ON public.gthr_attd_hist
+  FOR SELECT TO authenticated
+  USING (
+    EXISTS (
+      SELECT 1 FROM public.gthr_mst g
+      WHERE g.gthr_id = gthr_attd_hist.gthr_id
+        AND g.del_yn = false
+        AND public.v2_rls_auth_in_team(g.team_id)
+    )
+  );
+
+COMMENT ON POLICY gthr_attd_hist_select ON public.gthr_attd_hist
+  IS '팀 멤버만 취소 이력(사유 포함) 조회. 비멤버·anon 차단.';
+
+-- ============================================================
+-- cancel_gthr_attendance — 참석 취소를 원자적으로 이력화하는 RPC
+--   ① gthr_attd_rel 현재상태 행 DELETE → ② gthr_attd_hist 에 cancel 이벤트 INSERT.
+--   한 트랜잭션(함수)으로 묶어 부분 실패 방지.
+-- 보안: 앱의 모든 호출 경로가 service_role(createAdminClient/createUntypedAdminClient)이므로
+--   service_role 에만 EXECUTE 를 주고 authenticated·anon 은 명시 회수한다.
+--   (SECURITY DEFINER + `from public` 만으론 authenticated 명시 GRANT·기본 anon 이 남아
+--    /rpc/ 직접 호출로 남의 참석을 취소하는 IDOR 가 열린다 — 사고 #425 전례.)
+-- 인가(누가 취소할 자격이 있는지)는 호출부 서버 액션(withMember/withAdmin)에서 이미 검증한다.
+-- ============================================================
+
+CREATE OR REPLACE FUNCTION public.cancel_gthr_attendance(
+  p_gthr_id      uuid,
+  p_mem_id       uuid,
+  p_actor_kind   text,
+  p_actor_mem_id uuid DEFAULT NULL,
+  p_reason       text DEFAULT NULL
+)
+RETURNS void
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  v_deleted int;
+  v_reason  text;
+BEGIN
+  IF p_actor_kind NOT IN ('self', 'admin') THEN
+    RAISE EXCEPTION 'actor_kind 는 self|admin 만 허용: %', p_actor_kind;
+  END IF;
+
+  -- ① 현재상태(gthr_attd_rel) 행 삭제
+  DELETE FROM public.gthr_attd_rel
+  WHERE gthr_id = p_gthr_id AND mem_id = p_mem_id;
+  GET DIAGNOSTICS v_deleted = ROW_COUNT;
+  IF v_deleted = 0 THEN
+    RAISE EXCEPTION '참석 기록이 없습니다';
+  END IF;
+
+  -- 빈 문자열/공백은 사유 없음(NULL)으로 정규화
+  v_reason := NULLIF(btrim(COALESCE(p_reason, '')), '');
+
+  -- ② 취소 이벤트 이력 append
+  INSERT INTO public.gthr_attd_hist (gthr_id, mem_id, evt_cd, actor_kind, actor_mem_id, reason_txt)
+  VALUES (p_gthr_id, p_mem_id, 'cancel', p_actor_kind, p_actor_mem_id, v_reason);
+END;
+$$;
+
+COMMENT ON FUNCTION public.cancel_gthr_attendance(uuid, uuid, text, uuid, text)
+  IS '참석 취소를 원자적으로 이력화: gthr_attd_rel DELETE + gthr_attd_hist(cancel) INSERT. service_role 전용.';
+
+REVOKE ALL ON FUNCTION public.cancel_gthr_attendance(uuid, uuid, text, uuid, text) FROM public, authenticated, anon;
+GRANT EXECUTE ON FUNCTION public.cancel_gthr_attendance(uuid, uuid, text, uuid, text) TO service_role;
+
+-- ============================================================
+-- REVERT (수동 롤백용 — 이 마이그레이션을 되돌리려면 아래를 실행)
+-- ------------------------------------------------------------
+-- DROP FUNCTION IF EXISTS public.cancel_gthr_attendance(uuid, uuid, text, uuid, text);
+-- DROP TABLE IF EXISTS public.gthr_attd_hist;
+-- ============================================================

--- a/supabase/migrations/20260720100000_gthr_attd_hist.sql
+++ b/supabase/migrations/20260720100000_gthr_attd_hist.sql
@@ -13,10 +13,13 @@ CREATE TABLE public.gthr_attd_hist (
   gthr_id      uuid        NOT NULL REFERENCES public.gthr_mst(gthr_id),
   mem_id       uuid        NOT NULL REFERENCES public.mem_mst(mem_id),
   evt_cd       text        NOT NULL DEFAULT 'cancel' CHECK (evt_cd IN ('register', 'cancel')),
-  actor_kind   text        NOT NULL CHECK (actor_kind IN ('self', 'admin')),
+  actor_cd     text        NOT NULL CHECK (actor_cd IN ('self', 'admin')),
   actor_mem_id uuid        REFERENCES public.mem_mst(mem_id),
   reason_txt   text,
-  evt_at       timestamptz NOT NULL DEFAULT now()
+  evt_at       timestamptz NOT NULL DEFAULT now(),
+  -- reason_txt 길이 상한(문자수). "use server" 엔드포인트가 임의 인자로 대용량 텍스트를
+  -- 저장하는 것을 DB 레벨에서 이중 차단. 서버 액션에서도 동일 상한(500)을 강제한다.
+  CONSTRAINT gthr_attd_hist_reason_len CHECK (char_length(reason_txt) <= 500)
 );
 
 COMMENT ON TABLE  public.gthr_attd_hist              IS '모임 참석 이벤트 이력 (append-only). 현재는 취소(cancel) 이벤트만 기록. 재참석은 gthr_attd_rel upsert 로 처리되며 이 이력은 보존된다.';
@@ -24,9 +27,9 @@ COMMENT ON COLUMN public.gthr_attd_hist.hist_id      IS 'PK';
 COMMENT ON COLUMN public.gthr_attd_hist.gthr_id      IS '모임 ID (gthr_mst FK)';
 COMMENT ON COLUMN public.gthr_attd_hist.mem_id       IS '대상 참석자 mem_id (mem_mst FK)';
 COMMENT ON COLUMN public.gthr_attd_hist.evt_cd       IS '이벤트 종류: register|cancel. 현재 cancel 만 기록(register 로깅은 후속 과제).';
-COMMENT ON COLUMN public.gthr_attd_hist.actor_kind   IS '취소 주체 구분: self(본인)|admin(관리자).';
+COMMENT ON COLUMN public.gthr_attd_hist.actor_cd     IS '취소 주체 구분: self(본인)|admin(관리자).';
 COMMENT ON COLUMN public.gthr_attd_hist.actor_mem_id IS '실제 행위자 mem_id. self 면 mem_id 와 동일, admin 이면 처리한 관리자 mem_id.';
-COMMENT ON COLUMN public.gthr_attd_hist.reason_txt   IS '취소 사유(nullable). SG-01 은 저장만, 필수 강제는 후속 SG-02.';
+COMMENT ON COLUMN public.gthr_attd_hist.reason_txt   IS '취소 사유(nullable, 최대 500자). SG-01 은 저장만, 필수 강제는 후속 SG-02.';
 COMMENT ON COLUMN public.gthr_attd_hist.evt_at       IS '이벤트(취소) 발생 시각.';
 
 -- 특정 모임의 취소 이력 조회용
@@ -70,7 +73,7 @@ COMMENT ON POLICY gthr_attd_hist_select ON public.gthr_attd_hist
 CREATE OR REPLACE FUNCTION public.cancel_gthr_attendance(
   p_gthr_id      uuid,
   p_mem_id       uuid,
-  p_actor_kind   text,
+  p_actor_cd     text,
   p_actor_mem_id uuid DEFAULT NULL,
   p_reason       text DEFAULT NULL
 )
@@ -83,8 +86,8 @@ DECLARE
   v_deleted int;
   v_reason  text;
 BEGIN
-  IF p_actor_kind NOT IN ('self', 'admin') THEN
-    RAISE EXCEPTION 'actor_kind 는 self|admin 만 허용: %', p_actor_kind;
+  IF p_actor_cd NOT IN ('self', 'admin') THEN
+    RAISE EXCEPTION 'actor_cd 는 self|admin 만 허용: %', p_actor_cd;
   END IF;
 
   -- ① 현재상태(gthr_attd_rel) 행 삭제
@@ -95,12 +98,12 @@ BEGIN
     RAISE EXCEPTION '참석 기록이 없습니다';
   END IF;
 
-  -- 빈 문자열/공백은 사유 없음(NULL)으로 정규화
+  -- 빈 문자열/공백은 사유 없음(NULL)으로 정규화. 길이 상한(<=500)은 컬럼 CHECK 가 강제.
   v_reason := NULLIF(btrim(COALESCE(p_reason, '')), '');
 
   -- ② 취소 이벤트 이력 append
-  INSERT INTO public.gthr_attd_hist (gthr_id, mem_id, evt_cd, actor_kind, actor_mem_id, reason_txt)
-  VALUES (p_gthr_id, p_mem_id, 'cancel', p_actor_kind, p_actor_mem_id, v_reason);
+  INSERT INTO public.gthr_attd_hist (gthr_id, mem_id, evt_cd, actor_cd, actor_mem_id, reason_txt)
+  VALUES (p_gthr_id, p_mem_id, 'cancel', p_actor_cd, p_actor_mem_id, v_reason);
 END;
 $$;
 


### PR DESCRIPTION
## AS-IS
- 참가 취소가 `gthr_attd_rel` 하드 DELETE라 누가 언제 왜 취소했는지 흔적이 전혀 없음 → 조용취소에 벙주 무방비 (2026-07-19 양재천런 사건, #427 / Linear EES-86)

## TO-BE
- **append-only 이력 테이블 `gthr_attd_hist`**: 취소자·취소 시각·사유(선택)·행위자 구분(self/admin) 영구 기록. 쓰기 정책 없음(불변), SELECT는 팀 멤버 전체(사유 포함 — 운영진 결정)
- **SECURITY DEFINER RPC `cancel_gthr_attendance`**: rel 삭제+이력 삽입 원자화. EXECUTE는 service_role 전용(REVOKE — #425 IDOR 전례 준수)
- 취소 경로 2개(본인 토글·관리자 제거) 전수 배선, optional `reason` 저장(UI 필수화는 후속 EES-88)
- 사유 500자 상한: DB CHECK + 서버 액션 명시 거부(공유 검증기 `lib/gathering/cancel-reason.ts`)
- 취소 후 재참석 정상(UNIQUE 충돌 없음, 이력 보존)

## DB
- 마이그레이션 `20260720100000_gthr_attd_hist.sql` (revert SQL 동봉, 기존 데이터 무파괴) — **dev 적용 완료·검증됨, prd는 main 릴리스 시 별도 적용 필요**
- database.types.ts 미갱신(신규 RPC untyped 클라이언트 사용) — dev/origin 동기화 후 gen types 권장

## 검증
- vitest 185/185 PASS(신규 13), tsc 클린
- 독립 코드리뷰 2회: IDOR(self는 member.id 하드코딩·admin은 withAdmin+팀스코프)·RPC ACL 실측·원자성·RLS·길이 상한 enforcement(dev DB 501자 거부 실측) 전부 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018fYh2XfDUiNTNRGiqTLw9p