### PR TITLE
feat(gathering): 취소 사유 입력 — 시작 5시간 전부터 필수, 그 전 선택

### DIFF
--- a/app/(info)/gatherings/[id]/gathering-attend-button.tsx
+++ b/app/(info)/gatherings/[id]/gathering-attend-button.tsx
@@ -11,31 +11,42 @@ import { toggleGatheringAttendance } from "@/app/actions/gathering/toggle-attend
 
 import { Button } from "@/components/ui/button";
 
+import { GatheringCancelDialog } from "./gathering-cancel-dialog";
+
 type Props = {
   gthrId: string;
   initialAttending: boolean;
   maxPrtCnt: number | null;
   currentAttdCount: number;
+  /** 모임 시작 시각(UTC ISO) — 취소 사유 필수 여부(시작 5시간 전부터) 판정용 */
+  sttAt: string;
   /** 지난 모임(KST) — 참석/해제 잠금 (관리자는 서버 페이지에서 false로 내려옴) */
   pastLocked?: boolean;
 };
 
-export function GatheringAttendButton({ gthrId, initialAttending, maxPrtCnt, currentAttdCount, pastLocked }: Props) {
+export function GatheringAttendButton({
+  gthrId,
+  initialAttending,
+  maxPrtCnt,
+  currentAttdCount,
+  sttAt,
+  pastLocked,
+}: Props) {
   const [attending, setAttending] = useState(initialAttending);
   const [attdCount, setAttdCount] = useState(currentAttdCount);
+  const [cancelDialogOpen, setCancelDialogOpen] = useState(false);
   const [, startTransition] = useTransition();
   // 동기적 재진입 가드 — isPending(리렌더 의존)은 같은 렌더 내 연타를 못 막으므로 ref로 막는다.
   const togglingRef = useRef(false);
 
   const isFull = !attending && maxPrtCnt !== null && attdCount >= maxPrtCnt;
 
-  function handleToggle() {
-    if (isFull || pastLocked || togglingRef.current) return; // 처리 중이면 재클릭 무시(중복 방지) — 버튼은 흐려지지 않음
+  // 참석 등록 — 기존과 동일하게 원탭 즉시 처리(낙관적 업데이트).
+  function handleJoin() {
     togglingRef.current = true;
     startTransition(async () => {
-      const prev = attending;
-      setAttending(!prev);
-      setAttdCount((c) => (!prev ? c + 1 : c - 1));
+      setAttending(true);
+      setAttdCount((c) => c + 1);
       try {
         const result = await toggleGatheringAttendance(gthrId);
         setAttending(result.attending);
@@ -44,9 +55,8 @@ export function GatheringAttendButton({ gthrId, initialAttending, maxPrtCnt, cur
           toast.success(`이번 달 ${result.monthlyAttendCnt}회 참여!`);
         }
       } catch (e) {
-        setAttending(prev);
-        // 낙관적 업데이트(!prev ? +1 : -1)의 역방향으로 롤백
-        setAttdCount((c) => (prev ? c + 1 : c - 1));
+        setAttending(false);
+        setAttdCount((c) => c - 1);
         // 서버 거절 사유(지난 모임·인원 마감 등)를 안내 — 무음 롤백이면 버튼 고장으로 오인한다
         toast.error(e instanceof Error ? e.message : "참석 처리에 실패했습니다.");
       } finally {
@@ -55,21 +65,59 @@ export function GatheringAttendButton({ gthrId, initialAttending, maxPrtCnt, cur
     });
   }
 
+  // 참석 취소 — 확인 모달에서 호출. 실패 시 에러를 다시 던져 모달이 자체 토스트를 띄우고
+  // 제출 상태를 풀되(모달은 열린 채) 낙관적 업데이트만 롤백한다.
+  async function handleCancelConfirm(reason?: string) {
+    togglingRef.current = true;
+    const prevAttdCount = attdCount;
+    setAttending(false);
+    setAttdCount((c) => c - 1);
+    try {
+      await toggleGatheringAttendance(gthrId, reason);
+      setCancelDialogOpen(false);
+    } catch (e) {
+      setAttending(true);
+      setAttdCount(prevAttdCount);
+      throw e;
+    } finally {
+      togglingRef.current = false;
+    }
+  }
+
+  function handleClick() {
+    if (isFull || pastLocked || togglingRef.current) return; // 처리 중이면 재클릭 무시(중복 방지) — 버튼은 흐려지지 않음
+    if (attending) {
+      // 참석 취소는 원탭 즉시 처리 대신 사유 확인 모달을 거친다(참석 등록 경로는 그대로 1탭).
+      setCancelDialogOpen(true);
+      return;
+    }
+    handleJoin();
+  }
+
   return (
-    <Button
-      onClick={handleToggle}
-      // 처리 중(isPending)엔 disabled 대신 handleToggle 가드로 재클릭만 막아 버튼이 흐려지지 않게 한다.
-      // 낙관적 업데이트로 색이 즉시 바뀌므로 사용자는 "바로 눌렸다"고 느낀다.
-      disabled={isFull || pastLocked}
-      variant={attending ? "default" : "outline"}
-      className={cn(
-        "w-full",
-        attending && "bg-success hover:bg-success/90 border-success",
-      )}
-    >
-      {/* 지난 모임: 문구 변경 없이 잠금 아이콘 + disabled 흐림으로만 표시 */}
-      {pastLocked && <Lock className="size-3.5" />}
-      {!pastLocked && isFull ? "인원 마감" : attending ? "✅ 참석" : "참석하기"}
-    </Button>
+    <>
+      <Button
+        onClick={handleClick}
+        // 처리 중(isPending)엔 disabled 대신 handleClick 가드로 재클릭만 막아 버튼이 흐려지지 않게 한다.
+        // 낙관적 업데이트로 색이 즉시 바뀌므로 사용자는 "바로 눌렸다"고 느낀다.
+        disabled={isFull || pastLocked}
+        variant={attending ? "default" : "outline"}
+        className={cn(
+          "w-full",
+          attending && "bg-success hover:bg-success/90 border-success",
+        )}
+      >
+        {/* 지난 모임: 문구 변경 없이 잠금 아이콘 + disabled 흐림으로만 표시 */}
+        {pastLocked && <Lock className="size-3.5" />}
+        {!pastLocked && isFull ? "인원 마감" : attending ? "✅ 참석" : "참석하기"}
+      </Button>
+
+      <GatheringCancelDialog
+        open={cancelDialogOpen}
+        onOpenChange={setCancelDialogOpen}
+        sttAt={sttAt}
+        onConfirm={handleCancelConfirm}
+      />
+    </>
   );
 }

--- a/app/(info)/gatherings/[id]/gathering-cancel-dialog.tsx
+++ b/app/(info)/gatherings/[id]/gathering-cancel-dialog.tsx
@@ -1,0 +1,105 @@
+"use client";
+
+import { useState } from "react";
+
+import { toast } from "sonner";
+
+import { isCancelReasonRequired } from "@/lib/gathering/cancel-imminent";
+import { GATHERING_CANCEL_REASON_MAX_LENGTH, validateCancelReason } from "@/lib/gathering/cancel-reason";
+
+import { Caption } from "@/components/common/typography";
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Textarea } from "@/components/ui/textarea";
+
+type Props = {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  /** 모임 시작 시각(UTC ISO) — 사유 필수 여부(시작 5시간 전부터) 판정용 */
+  sttAt: string;
+  /** 취소 확정 — 실패 시 throw 하면 이 모달이 에러 토스트를 띄우고 제출 상태를 푼다(모달은 열린 채 유지) */
+  onConfirm: (reason?: string) => Promise<void>;
+};
+
+/**
+ * 참석 취소 확인 모달.
+ * 임박(모임 시작 5시간 이내) 여부에 따라 사유 필수/선택 안내와 제출 가능 여부가 달라진다.
+ * 판정은 서버(toggleGatheringAttendance)에서도 동일 기준으로 재검증한다 — 여기 값은 UX용.
+ */
+export function GatheringCancelDialog({ open, onOpenChange, sttAt, onConfirm }: Props) {
+  const [reason, setReason] = useState("");
+  const [submitting, setSubmitting] = useState(false);
+
+  // 모달이 열려 있는 동안 시간이 흘러도 렌더마다 재계산 — 값이 굳지 않게 한다.
+  const reasonRequired = isCancelReasonRequired(sttAt);
+  const reasonCheck = validateCancelReason(reason);
+  const normalizedReason = reasonCheck.ok ? reasonCheck.value : null;
+  const canSubmit = !submitting && reasonCheck.ok && (!reasonRequired || !!normalizedReason);
+
+  function handleOpenChange(next: boolean) {
+    if (submitting) return; // 제출 중엔 닫기 방지
+    onOpenChange(next);
+    if (!next) setReason(""); // 닫힐 때 입력 초기화
+  }
+
+  async function handleSubmit() {
+    if (!canSubmit) return;
+    setSubmitting(true);
+    try {
+      await onConfirm(normalizedReason ?? undefined);
+      setReason("");
+    } catch (e) {
+      toast.error(e instanceof Error ? e.message : "참석 취소에 실패했습니다.");
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={handleOpenChange}>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>참석을 취소할까요?</DialogTitle>
+          <DialogDescription>
+            취소하면 벙주에게 기록이 남아요. 미리 알려주면 더 좋아요 :)
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="flex flex-col gap-2">
+          <Caption className={reasonRequired ? "text-destructive" : "text-muted-foreground"}>
+            {reasonRequired
+              ? "지금은 시작이 얼마 안 남아서 사유가 꼭 필요해요"
+              : "(선택) 벙주님의 멘탈을 위해 사유를 남겨주세요🥹"}
+          </Caption>
+          <Textarea
+            value={reason}
+            onChange={(e) => setReason(e.target.value)}
+            placeholder="예) 몸살 기운이 있어서 쉬어야 할 것 같아요"
+            maxLength={GATHERING_CANCEL_REASON_MAX_LENGTH}
+            rows={3}
+            disabled={submitting}
+          />
+          <Caption className="self-end text-muted-foreground">
+            {reason.length}/{GATHERING_CANCEL_REASON_MAX_LENGTH}
+          </Caption>
+        </div>
+
+        <DialogFooter>
+          <Button variant="outline" onClick={() => handleOpenChange(false)} disabled={submitting}>
+            닫기
+          </Button>
+          <Button variant="destructive" onClick={handleSubmit} disabled={!canSubmit}>
+            {submitting ? "취소 처리 중..." : "취소하기"}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/app/(info)/gatherings/[id]/page.tsx
+++ b/app/(info)/gatherings/[id]/page.tsx
@@ -151,6 +151,7 @@ export default async function GatheringDetailPage({
             initialAttending={isAttending}
             maxPrtCnt={gthr.max_prt_cnt ?? null}
             currentAttdCount={attendees?.length ?? 0}
+            sttAt={gthr.stt_at}
             pastLocked={isPastLocked}
           />
         )}

--- a/app/actions/__tests__/gathering-cancel-reason-required.test.ts
+++ b/app/actions/__tests__/gathering-cancel-reason-required.test.ts
@@ -1,0 +1,105 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { GATHERING_CANCEL_IMMINENT_HOURS } from "@/lib/gathering/cancel-imminent";
+
+// 임박 취소(모임 시작 GATHERING_CANCEL_IMMINENT_HOURS 시간 전부터) 사유 필수 서버 강제 검증(SG-02).
+// 클라이언트 모달을 우회해 reason 없이 호출해도 서버가 거부하는지가 핵심 — 클라이언트를 신뢰하지 않는다.
+// vi.mock 패턴은 gathering-cancel-history.test.ts 를 따른다.
+
+const h = vi.hoisted(() => {
+  const rpc = vi.fn();
+
+  const queryStub = (result: unknown) => {
+    const p = Promise.resolve(result);
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const proxy: any = new Proxy(function () {}, {
+      get(_t, prop) {
+        if (prop === "then") return p.then.bind(p);
+        if (prop === "catch") return p.catch.bind(p);
+        if (prop === "finally") return p.finally.bind(p);
+        return () => proxy;
+      },
+      apply: () => proxy,
+    });
+    return proxy;
+  };
+
+  // 매 테스트에서 stt_at 을 바꿔치기할 수 있도록 mutable 객체로 보관.
+  const cfg = {
+    gthr: { data: { max_prt_cnt: null, stt_at: "" as string, end_at: null as string | null } },
+    existing: { data: { attd_id: "attd-1" } },
+    selfMember: { id: "mem-self", admin: false, status: "active" },
+  };
+
+  return { rpc, queryStub, cfg };
+});
+
+vi.mock("next/cache", () => ({ revalidatePath: vi.fn() }));
+vi.mock("@/lib/past-event", () => ({ isPastLockedFor: () => false }));
+vi.mock("@/lib/queries/request-team", () => ({
+  getRequestTeamContext: async () => ({ teamId: "team-1" }),
+}));
+vi.mock("@/lib/gathering/join-gathering", () => ({
+  joinGatheringWithCapCheck: async () => ({ joined: true }),
+}));
+vi.mock("@/lib/actions/auth", () => ({
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  withActive: async (fn: any) =>
+    fn({ member: h.cfg.selfMember, supabase: { from: () => h.queryStub(h.cfg.existing) } }),
+}));
+vi.mock("@/lib/supabase/admin", () => ({
+  createUntypedAdminClient: () => ({ from: () => h.queryStub(h.cfg.gthr), rpc: h.rpc }),
+}));
+
+import { dayjs } from "@/lib/dayjs";
+
+import { toggleGatheringAttendance } from "@/app/actions/gathering/toggle-attendance";
+
+beforeEach(() => {
+  h.rpc.mockReset();
+  h.rpc.mockResolvedValue({ error: null });
+});
+
+describe("toggleGatheringAttendance — 임박 취소 사유 필수 서버 강제", () => {
+  it("AC-05: 시작이 5시간 이내로 임박했는데 사유가 빈 값이면 RPC 호출 없이 거부한다", async () => {
+    h.cfg.gthr.data.stt_at = dayjs().add(2, "hour").toISOString();
+
+    await expect(toggleGatheringAttendance("gthr-1")).rejects.toThrow(
+      "시작 5시간 전부터는 취소 사유가 필요해요.",
+    );
+    expect(h.rpc).not.toHaveBeenCalled();
+  });
+
+  it("AC-05: 임박 취소에 공백만 있는 사유를 보내도 거부한다(trim 후 빈 값 취급)", async () => {
+    h.cfg.gthr.data.stt_at = dayjs().add(1, "hour").toISOString();
+
+    await expect(toggleGatheringAttendance("gthr-1", "   ")).rejects.toThrow(
+      "시작 5시간 전부터는 취소 사유가 필요해요.",
+    );
+    expect(h.rpc).not.toHaveBeenCalled();
+  });
+
+  it("AC-05: 임박 취소라도 사유가 있으면 RPC 를 호출한다", async () => {
+    h.cfg.gthr.data.stt_at = dayjs().add(1, "hour").toISOString();
+
+    const result = await toggleGatheringAttendance("gthr-1", "몸살이 나서 못 갈 것 같아요");
+
+    expect(result).toEqual({ attending: false });
+    expect(h.rpc).toHaveBeenCalledWith(
+      "cancel_gthr_attendance",
+      expect.objectContaining({ p_reason: "몸살이 나서 못 갈 것 같아요" }),
+    );
+  });
+
+  it(`AC-06: 시작까지 ${GATHERING_CANCEL_IMMINENT_HOURS}시간보다 많이 남았으면 사유 없이도 취소된다`, async () => {
+    h.cfg.gthr.data.stt_at = dayjs().add(10, "hour").toISOString();
+
+    const result = await toggleGatheringAttendance("gthr-1");
+
+    expect(result).toEqual({ attending: false });
+    expect(h.rpc).toHaveBeenCalledWith(
+      "cancel_gthr_attendance",
+      expect.objectContaining({ p_reason: null }),
+    );
+  });
+});

--- a/app/actions/gathering/toggle-attendance.ts
+++ b/app/actions/gathering/toggle-attendance.ts
@@ -4,6 +4,7 @@ import { revalidatePath } from "next/cache";
 
 import { withActive } from "@/lib/actions/auth";
 import { dayjs } from "@/lib/dayjs";
+import { isCancelReasonRequired } from "@/lib/gathering/cancel-imminent";
 import { validateCancelReason } from "@/lib/gathering/cancel-reason";
 import { joinGatheringWithCapCheck } from "@/lib/gathering/join-gathering";
 import { isPastLockedFor } from "@/lib/past-event";
@@ -15,8 +16,9 @@ import { createUntypedAdminClient } from "@/lib/supabase/admin";
  * 참석 등록 시 `monthlyAttendCnt`(그 모임 stt_at 월 기준 본인 총참석 횟수)를 함께 반환해,
  * 클라이언트가 "이번 달 N회 참석" 토스트를 띄울 수 있게 한다. 취소 시엔 undefined.
  *
- * 취소 시 `reason`(선택)을 넘기면 취소 이력(gthr_attd_hist)에 사유로 저장된다.
- * SG-01 은 저장만 지원 — 사유 필수 강제는 후속 과제(SG-02). 등록 토글 시 reason 은 무시.
+ * 취소 시 `reason`(선택 또는 필수)을 넘기면 취소 이력(gthr_attd_hist)에 사유로 저장된다.
+ * 모임 시작 GATHERING_CANCEL_IMMINENT_HOURS 시간 전부터의 취소는 사유가 필수다(클라이언트 모달
+ * 뿐 아니라 여기서도 재검증 — 클라이언트를 신뢰하지 않음). 등록 토글 시 reason 은 무시.
  */
 export async function toggleGatheringAttendance(
   gthr_id: string,
@@ -53,6 +55,11 @@ export async function toggleGatheringAttendance(
       // 사유 길이 상한(500자) 서버 강제 — 초과 시 잘라내지 않고 거부.
       const reasonCheck = validateCancelReason(reason);
       if (!reasonCheck.ok) throw new Error(reasonCheck.message);
+
+      // 임박 취소(시작 5시간 전부터)는 사유 필수 — 클라이언트 모달을 우회한 호출도 서버에서 재차 막는다.
+      if (isCancelReasonRequired(gthr.stt_at) && !reasonCheck.value) {
+        throw new Error("시작 5시간 전부터는 취소 사유가 필요해요.");
+      }
 
       // 취소 = gthr_attd_rel DELETE + gthr_attd_hist(cancel) INSERT 를 원자적으로.
       // cancel_gthr_attendance RPC 는 service_role 전용(authenticated·anon EXECUTE 회수)이라

--- a/lib/gathering/__tests__/cancel-imminent.test.ts
+++ b/lib/gathering/__tests__/cancel-imminent.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from "vitest";
+
+import { dayjs } from "@/lib/dayjs";
+import { GATHERING_CANCEL_IMMINENT_HOURS, isCancelReasonRequired } from "@/lib/gathering/cancel-imminent";
+
+describe("isCancelReasonRequired", () => {
+  const sttAt = "2026-07-20T10:00:00Z";
+
+  it("정확히 5시간 전이면 아직 임박 아님(사유 선택)", () => {
+    const now = dayjs(sttAt).subtract(GATHERING_CANCEL_IMMINENT_HOURS, "hour");
+    expect(isCancelReasonRequired(sttAt, now)).toBe(false);
+  });
+
+  it("5시간에서 1분 모자라면 임박(사유 필수)", () => {
+    const now = dayjs(sttAt).subtract(GATHERING_CANCEL_IMMINENT_HOURS, "hour").add(1, "minute");
+    expect(isCancelReasonRequired(sttAt, now)).toBe(true);
+  });
+
+  it("5시간보다 많이 남았으면 임박 아님(사유 선택)", () => {
+    const now = dayjs(sttAt).subtract(6, "hour");
+    expect(isCancelReasonRequired(sttAt, now)).toBe(false);
+  });
+
+  it("시작 직전(몇 분 전)이면 임박(사유 필수)", () => {
+    const now = dayjs(sttAt).subtract(10, "minute");
+    expect(isCancelReasonRequired(sttAt, now)).toBe(true);
+  });
+
+  it("이미 시작 시각이 지났어도 임박(사유 필수) 취급", () => {
+    const now = dayjs(sttAt).add(30, "minute");
+    expect(isCancelReasonRequired(sttAt, now)).toBe(true);
+  });
+
+  it("now 생략 시 현재 시각 기준으로 판단한다", () => {
+    const farFuture = dayjs().add(10, "hour").toISOString();
+    expect(isCancelReasonRequired(farFuture)).toBe(false);
+
+    const imminent = dayjs().add(1, "hour").toISOString();
+    expect(isCancelReasonRequired(imminent)).toBe(true);
+  });
+});

--- a/lib/gathering/cancel-imminent.ts
+++ b/lib/gathering/cancel-imminent.ts
@@ -1,0 +1,28 @@
+/**
+ * 모임 취소 시점에 따른 사유 필수 여부 판정.
+ *
+ * 정책(오너 확정): 모임 시작 GATHERING_CANCEL_IMMINENT_HOURS 시간 전부터의 취소는 사유 필수,
+ * 그 전까지는 사유 선택. 클라이언트(취소 모달)와 서버(toggleGatheringAttendance) 양쪽에서
+ * 이 함수를 재사용해 판정 기준을 일치시킨다(클라이언트만 믿지 않음).
+ *
+ * 주의: sttAt 은 DB(gthr_mst.stt_at)에서 온 UTC ISO 문자열이다.
+ * SG-04 의 `imminent.ts` 가 다루는 datetime-local(로컬 오프셋 없는) 문자열과는 형식이 다르므로
+ * 그 함수를 재사용하지 말 것 — 여기서는 항상 `import { dayjs } from "@/lib/dayjs"` 만 사용한다.
+ */
+
+import { dayjs } from "@/lib/dayjs";
+
+export const GATHERING_CANCEL_IMMINENT_HOURS = 5;
+
+/**
+ * 취소 시점 기준으로 사유가 필수인지 판정한다.
+ * - 시작까지 남은 시간이 GATHERING_CANCEL_IMMINENT_HOURS 미만(이미 시작한 경우 포함) → true(필수)
+ * - 정확히 GATHERING_CANCEL_IMMINENT_HOURS 이상 남았으면 → false(선택)
+ *
+ * @param sttAt 모임 시작 시각(UTC ISO 문자열, gthr_mst.stt_at)
+ * @param now 기준 시각(테스트용, 생략 시 현재 시각)
+ */
+export function isCancelReasonRequired(sttAt: string, now: dayjs.Dayjs = dayjs()): boolean {
+  const hoursUntilStart = dayjs(sttAt).diff(now, "hour", true);
+  return hoursUntilStart < GATHERING_CANCEL_IMMINENT_HOURS;
+}


### PR DESCRIPTION
## AS-IS
- 참석 취소가 원탭 즉시 실행 — 사유를 남길 방법이 없고, 임박 취소도 무언으로 가능 (Linear EES-88)

## TO-BE
- **취소만 확인 모달**로 변경 (참석 등록은 기존 1탭 그대로 — 운영진 합의: 참여 허들 불변)
- **시작 5시간 전부터: 사유 필수** (클라이언트 + 서버 이중 강제 — 서버 액션 직접 호출 우회도 차단), 그 전: 선택
- 말랑한 안내: "취소하면 벙주에게 기록이 남아요. 미리 알려주면 더 좋아요 :)" / "(선택) 벙주님의 멘탈을 위해 사유를 남겨주세요🥹"
- 판정 헬퍼 `lib/gathering/cancel-imminent.ts` (UTC ISO용 — 개설 폼용 12h 헬퍼와 의도적 분리), 500자 카운터

## 검증
- vitest 195/195 PASS (신규 10: 경계값 6 + 서버 강제 4), tsc 클린
- 독립 코드리뷰 통과: 서버 우회 방어·연타 가드·지난모임 잠금 회귀 없음·경계값 의미 확인

## 참고
- base가 #430(취소 이력)입니다 — **#430 머지 후 자동으로 dev 대상으로 전환**됩니다 (스택 PR)
- 정확히 5시간 시점은 "선택"으로 구현(exclusive) — 포함으로 바꾸려면 한 글자 수정입니다

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018fYh2XfDUiNTNRGiqTLw9p