### PR TITLE
feat(gathering): 참가자 취소 시 벙주에게 알림 발송

### DIFF
--- a/app/actions/__tests__/gathering-cancel-history.test.ts
+++ b/app/actions/__tests__/gathering-cancel-history.test.ts
@@ -42,6 +42,9 @@ vi.mock("@/lib/queries/request-team", () => ({
 vi.mock("@/lib/gathering/join-gathering", () => ({
   joinGatheringWithCapCheck: async () => ({ joined: true }),
 }));
+// toggle-attendance.ts가 취소 성공 후 벙주 알림을 위해 import한다(SG-05) — 이 테스트는 알림 발송
+// 자체를 검증 대상으로 하지 않으므로 no-op으로 스텁(실제 발송 검증은 gathering-cancel-notify.test.ts).
+vi.mock("@/lib/notifications/insert-noti", () => ({ insertNoti: vi.fn() }));
 vi.mock("@/lib/actions/auth", () => ({
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   withActive: async (fn: any) =>

--- a/app/actions/__tests__/gathering-cancel-notify.test.ts
+++ b/app/actions/__tests__/gathering-cancel-notify.test.ts
@@ -1,0 +1,114 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// 참가자 취소 시 벙주(개설자)에게 알림이 가는지 검증(SG-05).
+// - AC-14: 본인 취소 시 벙주에게 신규 알림 타입(gthr_cncl)으로 insertNoti 발송
+// - AC-15: 벙주 본인이 자기 모임을 취소한 경우엔 자기 자신에게 발송하지 않음
+// vi.mock 패턴은 gathering-cancel-history.test.ts 를 따른다.
+
+const h = vi.hoisted(() => {
+  const rpc = vi.fn();
+  const insertNoti = vi.fn();
+
+  const queryStub = (result: unknown) => {
+    const p = Promise.resolve(result);
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const proxy: any = new Proxy(function () {}, {
+      get(_t, prop) {
+        if (prop === "then") return p.then.bind(p);
+        if (prop === "catch") return p.catch.bind(p);
+        if (prop === "finally") return p.finally.bind(p);
+        return () => proxy;
+      },
+      apply: () => proxy,
+    });
+    return proxy;
+  };
+
+  const cfg = {
+    gthr: {
+      data: {
+        max_prt_cnt: null,
+        stt_at: "2026-08-01T10:00:00Z",
+        end_at: null as string | null,
+        gthr_nm: "양재천 저녁런",
+        crt_by: "mem-organizer",
+      },
+    },
+    existing: { data: { attd_id: "attd-1" } },
+    selfMember: { id: "mem-self", admin: false, status: "active", full_name: "홍길동" },
+  };
+
+  return { rpc, insertNoti, queryStub, cfg };
+});
+
+vi.mock("next/cache", () => ({ revalidatePath: vi.fn() }));
+vi.mock("@/lib/past-event", () => ({ isPastLockedFor: () => false }));
+vi.mock("@/lib/queries/request-team", () => ({
+  getRequestTeamContext: async () => ({ teamId: "team-1" }),
+}));
+vi.mock("@/lib/gathering/join-gathering", () => ({
+  joinGatheringWithCapCheck: async () => ({ joined: true }),
+}));
+vi.mock("@/lib/notifications/insert-noti", () => ({ insertNoti: h.insertNoti }));
+vi.mock("@/lib/actions/auth", () => ({
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  withActive: async (fn: any) =>
+    fn({ member: h.cfg.selfMember, supabase: { from: () => h.queryStub(h.cfg.existing) } }),
+}));
+vi.mock("@/lib/supabase/admin", () => ({
+  createUntypedAdminClient: () => ({ from: () => h.queryStub(h.cfg.gthr), rpc: h.rpc }),
+}));
+
+import { toggleGatheringAttendance } from "@/app/actions/gathering/toggle-attendance";
+
+beforeEach(() => {
+  h.rpc.mockReset();
+  h.rpc.mockResolvedValue({ error: null });
+  h.insertNoti.mockReset();
+  h.cfg.gthr.data.crt_by = "mem-organizer";
+});
+
+describe("toggleGatheringAttendance — 참가자 취소 시 벙주 알림", () => {
+  it("AC-14: 본인 취소 시 벙주에게 gthr_cncl 타입으로 인앱+푸시 알림을 발송한다(수신거부는 gthr_upd로 판단)", async () => {
+    const result = await toggleGatheringAttendance("gthr-1", "몸살이 나서 못 갈 것 같아요");
+
+    expect(result).toEqual({ attending: false });
+    expect(h.insertNoti).toHaveBeenCalledTimes(1);
+    expect(h.insertNoti).toHaveBeenCalledWith({
+      teamId: "team-1",
+      memId: "mem-organizer",
+      notiTypeEnm: "gthr_cncl",
+      prefTypeEnm: "gthr_upd",
+      notiNm: "홍길동님이 '양재천 저녁런' 참석을 취소했어요",
+      notiCont: "사유: 몸살이 나서 못 갈 것 같아요",
+      refId: "gthr-1",
+      refTypeEnm: "gathering",
+    });
+  });
+
+  it("AC-14: 사유 없이 취소하면 notiCont는 null이다", async () => {
+    h.cfg.gthr.data.stt_at = "2026-08-01T10:00:00Z";
+    await toggleGatheringAttendance("gthr-1");
+
+    expect(h.insertNoti).toHaveBeenCalledWith(
+      expect.objectContaining({ notiCont: null }),
+    );
+  });
+
+  it("AC-15: 벙주 본인이 자기 모임을 취소하면 자기 자신에게 알림을 보내지 않는다", async () => {
+    h.cfg.gthr.data.crt_by = "mem-self"; // 개설자 = 취소하는 본인
+
+    const result = await toggleGatheringAttendance("gthr-1", "일정 변경");
+
+    expect(result).toEqual({ attending: false });
+    expect(h.insertNoti).not.toHaveBeenCalled();
+  });
+
+  it("알림 발송(insertNoti)이 실패해도 취소 자체는 성공으로 처리한다", async () => {
+    h.insertNoti.mockRejectedValue(new Error("push down"));
+
+    const result = await toggleGatheringAttendance("gthr-1", "부상");
+
+    expect(result).toEqual({ attending: false });
+  });
+});

--- a/app/actions/__tests__/gathering-cancel-reason-required.test.ts
+++ b/app/actions/__tests__/gathering-cancel-reason-required.test.ts
@@ -42,6 +42,9 @@ vi.mock("@/lib/queries/request-team", () => ({
 vi.mock("@/lib/gathering/join-gathering", () => ({
   joinGatheringWithCapCheck: async () => ({ joined: true }),
 }));
+// toggle-attendance.ts가 취소 성공 후 벙주 알림을 위해 import한다(SG-05) — 이 테스트는 알림 발송
+// 자체를 검증 대상으로 하지 않으므로 no-op으로 스텁(실제 발송 검증은 gathering-cancel-notify.test.ts).
+vi.mock("@/lib/notifications/insert-noti", () => ({ insertNoti: vi.fn() }));
 vi.mock("@/lib/actions/auth", () => ({
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   withActive: async (fn: any) =>

--- a/app/actions/gathering/toggle-attendance.ts
+++ b/app/actions/gathering/toggle-attendance.ts
@@ -7,6 +7,7 @@ import { dayjs } from "@/lib/dayjs";
 import { isCancelReasonRequired } from "@/lib/gathering/cancel-imminent";
 import { validateCancelReason } from "@/lib/gathering/cancel-reason";
 import { joinGatheringWithCapCheck } from "@/lib/gathering/join-gathering";
+import { insertNoti } from "@/lib/notifications/insert-noti";
 import { isPastLockedFor } from "@/lib/past-event";
 import { getRequestTeamContext } from "@/lib/queries/request-team";
 import { createUntypedAdminClient } from "@/lib/supabase/admin";
@@ -31,7 +32,7 @@ export async function toggleGatheringAttendance(
     const [{ data: gthr }, { data: existing }] = await Promise.all([
       admin
         .from("gthr_mst")
-        .select("max_prt_cnt, stt_at, end_at")
+        .select("max_prt_cnt, stt_at, end_at, gthr_nm, crt_by")
         .eq("gthr_id", gthr_id)
         .eq("team_id", teamId)
         .eq("del_yn", false)
@@ -72,6 +73,29 @@ export async function toggleGatheringAttendance(
         p_reason: reasonCheck.value,
       });
       if (cancelError) throw new Error("참석 취소에 실패했습니다.");
+
+      // 벙주(개설자)에게 취소 알림 — 본인이 자기 모임을 취소한 경우엔 자기 자신에게 보내지 않는다.
+      // 알림은 부가 기능이라 실패해도 이미 완료된 취소 자체는 되돌리지 않는다(insertNoti 실패는 내부에서 로깅만).
+      // 수신거부는 gthr_upd(모임 수정·삭제)와 같은 설정 항목으로 묶어 판단한다 — gthr_del이
+      // gthr_upd 설정을 공유하는 기존 전례를 따른 것으로, 별도 설정 UI 항목을 새로 추가하지 않고도
+      // 사용자가 기존 "참가 모임 수정·삭제" 토글로 즉시 제어할 수 있게 한다.
+      if (gthr.crt_by && gthr.crt_by !== member.id) {
+        try {
+          await insertNoti({
+            teamId,
+            memId: gthr.crt_by,
+            notiTypeEnm: "gthr_cncl",
+            prefTypeEnm: "gthr_upd",
+            notiNm: `${member.full_name}님이 '${gthr.gthr_nm}' 참석을 취소했어요`,
+            notiCont: reasonCheck.value ? `사유: ${reasonCheck.value}` : null,
+            refId: gthr_id,
+            refTypeEnm: "gathering",
+          });
+        } catch (e) {
+          console.error("[gthr_cncl] 알림 발송 실패", e);
+        }
+      }
+
       // 홈(/)은 dynamic 렌더(getCurrentMember가 cookies 사용)라 매 요청 새로 조회되므로
       // revalidatePath("/")는 무효화할 캐시가 없어 불필요 — 모임 상세 직접 URL만 무효화한다.
       revalidatePath(`/gatherings/${gthr_id}`);

--- a/components/notifications/notification-item.tsx
+++ b/components/notifications/notification-item.tsx
@@ -29,6 +29,7 @@ const NOTI_ICON: Record<string, React.ElementType> = {
   gthr_new: Users,
   gthr_upd: Users,
   gthr_del: Users,
+  gthr_cncl: Users,
   gthr_cmnt: MessageCircle,
   gthr_reply: MessageCircle,
   gthr_mention: MessageCircle,

--- a/lib/notifications/__tests__/insert-noti.test.ts
+++ b/lib/notifications/__tests__/insert-noti.test.ts
@@ -1,0 +1,102 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// insertNoti의 prefTypeEnm 필터링 검증(SG-05 AC-16 근거).
+// gthr_cncl처럼 notiTypeEnm과 수신거부 판단 타입(prefTypeEnm)이 다른 알림도
+// noti_pref_cfg 관문(insertNoti)에서 올바르게 걸러지는지 확인한다.
+
+const h = vi.hoisted(() => {
+  const prefEqArgs: [string, string][] = [];
+  const prefRow: { data: { enabled_yn: boolean } | null } = { data: null };
+  const insertMock = vi.fn(() => ({
+    select: () => ({
+      single: async () => ({ data: { noti_id: "noti-1" }, error: null }),
+    }),
+  }));
+
+  const from = vi.fn((table: string) => {
+    if (table === "noti_pref_cfg") {
+      return {
+        select: () => ({
+          eq: (col: string, val: string) => {
+            prefEqArgs.push([col, val]);
+            return {
+              eq: (col2: string, val2: string) => {
+                prefEqArgs.push([col2, val2]);
+                return { maybeSingle: async () => prefRow };
+              },
+            };
+          },
+        }),
+      };
+    }
+    if (table === "noti_mst") {
+      return { insert: insertMock };
+    }
+    throw new Error(`unexpected table ${table}`);
+  });
+
+  return { from, insertMock, prefRow, prefEqArgs };
+});
+
+vi.mock("@/lib/supabase/admin", () => ({
+  createUntypedAdminClient: () => ({ from: h.from }),
+}));
+vi.mock("@/lib/push/send-push", () => ({
+  sendPushToMember: vi.fn(),
+  sendPushToMembers: vi.fn(),
+}));
+
+import { insertNoti } from "@/lib/notifications/insert-noti";
+
+beforeEach(() => {
+  h.insertMock.mockClear();
+  h.from.mockClear();
+  h.prefRow.data = null;
+  h.prefEqArgs.length = 0;
+});
+
+describe("insertNoti — prefTypeEnm 수신거부 판단", () => {
+  it("AC-16: prefTypeEnm으로 지정한 타입이 수신거부(enabled_yn=false)면 notiTypeEnm이 달라도 발송하지 않는다", async () => {
+    h.prefRow.data = { enabled_yn: false };
+
+    await insertNoti({
+      teamId: "team-1",
+      memId: "mem-organizer",
+      notiTypeEnm: "gthr_cncl",
+      prefTypeEnm: "gthr_upd",
+      notiNm: "취소 알림",
+    });
+
+    // 수신거부 여부는 prefTypeEnm("gthr_upd") 기준으로 조회해야 한다 — notiTypeEnm이 아니라.
+    expect(h.prefEqArgs).toContainEqual(["noti_type_enm", "gthr_upd"]);
+    expect(h.insertMock).not.toHaveBeenCalled();
+  });
+
+  it("AC-16: prefTypeEnm 수신이 허용(enabled_yn=true)이면 notiTypeEnm 그대로 발송한다", async () => {
+    h.prefRow.data = { enabled_yn: true };
+
+    await insertNoti({
+      teamId: "team-1",
+      memId: "mem-organizer",
+      notiTypeEnm: "gthr_cncl",
+      prefTypeEnm: "gthr_upd",
+      notiNm: "취소 알림",
+    });
+
+    expect(h.insertMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("prefTypeEnm 미지정 시 notiTypeEnm 기준으로 수신거부를 판단한다(기존 동작 유지)", async () => {
+    h.prefRow.data = { enabled_yn: false };
+
+    await insertNoti({
+      teamId: "team-1",
+      memId: "mem-1",
+      notiTypeEnm: "gthr_upd",
+      notiNm: "수정 알림",
+    });
+
+    expect(h.prefEqArgs).toContainEqual(["noti_type_enm", "gthr_upd"]);
+    expect(h.insertMock).not.toHaveBeenCalled();
+  });
+});

--- a/lib/notifications/deep-link.ts
+++ b/lib/notifications/deep-link.ts
@@ -31,6 +31,7 @@ const NOTI_ROUTE: Record<
   gthr_new: (refId) => (refId ? `/?gthr=${refId}` : "/"),
   gthr_upd: (refId) => (refId ? `/?gthr=${refId}` : "/"),
   gthr_del: () => "/",
+  gthr_cncl: (refId) => (refId ? `/?gthr=${refId}` : "/"),
   gthr_cmnt: (refId) => (refId ? `/?gthr=${refId}` : "/"),
   gthr_reply: (refId) => (refId ? `/?gthr=${refId}` : "/"),
   gthr_mention: (refId) => (refId ? `/?gthr=${refId}` : "/"),

--- a/lib/notifications/insert-noti.ts
+++ b/lib/notifications/insert-noti.ts
@@ -25,6 +25,9 @@ type NotiInput = {
   teamId: string;
   memId: string;
   notiTypeEnm: string;
+  /** 수신거부(noti_pref_cfg) 판단에 쓸 타입. 생략 시 notiTypeEnm 사용.
+   *  예: gthr_cncl 알림이지만 수신거부는 gthr_upd 설정으로 묶어 판단할 때. */
+  prefTypeEnm?: string;
   notiNm: string;
   notiCont?: string | null;
   refId?: string | null;
@@ -56,12 +59,12 @@ function toPushPayload(
 export async function insertNoti(input: NotiInput): Promise<void> {
   const admin = createUntypedAdminClient();
 
-  // 수신 설정 확인 — enabled_yn=false 인 row가 있으면 발송 안 함
+  // 수신 설정 확인 — enabled_yn=false 인 row가 있으면 발송 안 함 (prefTypeEnm 지정 시 그 타입으로 판단)
   const { data: pref } = await admin
     .from("noti_pref_cfg")
     .select("enabled_yn")
     .eq("mem_id", input.memId)
-    .eq("noti_type_enm", input.notiTypeEnm)
+    .eq("noti_type_enm", input.prefTypeEnm ?? input.notiTypeEnm)
     .maybeSingle();
 
   if (pref?.enabled_yn === false) return;

--- a/supabase/migrations/20260720063220_gthr_cncl_noti_type.sql
+++ b/supabase/migrations/20260720063220_gthr_cncl_noti_type.sql
@@ -1,0 +1,27 @@
+-- ============================================================
+-- gthr_cncl_noti_type — 모임 참석 취소 알림 타입 추가
+-- 참가자가 모임 참석을 취소하면 벙주(개설자)에게 알림이 발송된다.
+-- 기준: gigang-gathering-cancel-accountability-v1 SG-05
+--
+-- 추가 타입: gthr_cncl — 참가자 참석 취소(벙주 알림)
+-- ============================================================
+
+ALTER TABLE public.noti_mst
+  DROP CONSTRAINT IF EXISTS noti_mst_noti_type_enm_check;
+
+-- NOT VALID로 추가 — 기존 행 전체 스캔(쓰기 블록)을 피한다.
+ALTER TABLE public.noti_mst
+  ADD CONSTRAINT noti_mst_noti_type_enm_check
+  CHECK (noti_type_enm IN (
+    'ttl_grnt', 'adm_cust', 'dues_check_req', 'dues_notice',
+    'cmnt_reply', 'cmnt_mention', 'sch_post_cmnt', 'sch_post_new',
+    'gthr_new', 'gthr_upd', 'gthr_del',
+    'gthr_cmnt', 'gthr_reply', 'gthr_mention', 'gthr_cncl',
+    'fdbk_new', 'fdbk_rspd',
+    'newbie_nudge_14', 'newbie_nudge_28',
+    'reactivate_req'
+  )) NOT VALID;
+
+-- 기존 행 검증(공유 락만 잡아 쓰기를 막지 않는다).
+ALTER TABLE public.noti_mst
+  VALIDATE CONSTRAINT noti_mst_noti_type_enm_check;


### PR DESCRIPTION
## AS-IS
- 참가자가 취소해도 벙주는 명단을 직접 보기 전까지 알 수 없음 (Linear EES-90)

## TO-BE
- 취소 성공 시 벙주에게 인앱+푸시 알림 (신규 타입 `gthr_cncl`): "OO님이 '모임명' 참석을 취소했어요" + 사유(있으면)
- 벙주 본인이 자기 모임 취소 시 미발송, 수신거부는 기존 "참가 모임 수정·삭제" 토글 공유(gthr_del 전례)
- 알림 실패는 취소를 실패시키지 않음 (try-catch 격리 + insertNoti 무throw 이중 보호)
- 푸시 딥링크 `/?gthr=<id>` 라우팅 추가

## DB
- `20260720063220_gthr_cncl_noti_type.sql` — noti_type allowlist에 gthr_cncl 추가 (NOT VALID→VALIDATE로 쓰기 무중단). **dev 적용·실측 완료, prd는 main 릴리스 시 적용 필요**

## 검증
- vitest 202/202 PASS, tsc·eslint 클린
- 독립 코드리뷰 통과: 비차단성·전 도메인 호출부 회귀 없음·dev DB 제약 실측

## 참고
- base가 #431(사유 UX)입니다 — 스택 최상단. 머지 순서: #430 → #431 → 이 PR (#432는 병렬)
- 후속 소소한 개선(비차단): 알림 목록 아이콘에 gthr_cncl 한 줄 추가, 발송을 after()로 이동

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018fYh2XfDUiNTNRGiqTLw9p