### PR TITLE
feat(gathering): 홈 캘린더 모달에도 취소자·사유 표시

### DIFF
--- a/components/home/mini-calendar.tsx
+++ b/components/home/mini-calendar.tsx
@@ -78,6 +78,8 @@ const GatheringFormDialog = dynamic<GatheringFormDialogProps>(
   { ssr: false }
 );
 
+import type { CanceledAttendee } from "@/app/(info)/gatherings/[id]/gathering-canceled-attendees";
+import { fetchGatheringCancelHistoryRowsClient, deriveCanceledFromRows } from "@/lib/queries/gathering-cancel-history-client";
 import type { GatheringDetailDialogProps, GatheringAttendee } from "@/components/schedule/gathering-detail-dialog";
 const GatheringDetailDialog = dynamic<GatheringDetailDialogProps>(
   () =>
@@ -230,7 +232,7 @@ export function MiniCalendar({
 
   // 모임 상세 다이얼로그 상태
   const [gthrDetailOpen, setGthrDetailOpen] = useState(false);
-  const [gthrDetailRace, setGthrDetailRace] = useState<(CalendarRace & { maxPrtCnt?: number | null; attendees?: GatheringAttendee[]; sprt_cd?: string | null }) | null>(null);
+  const [gthrDetailRace, setGthrDetailRace] = useState<(CalendarRace & { maxPrtCnt?: number | null; attendees?: GatheringAttendee[]; canceledAttendees?: CanceledAttendee[]; sprt_cd?: string | null }) | null>(null);
   const [gthrDetailAttending, setGthrDetailAttending] = useState(false);
   // 상세를 "즉시 열고" 참석자/정원을 뒤에서 채우는 동안 true — 다이얼로그가 스켈레톤을 그린다
   const [gthrDetailLoading, setGthrDetailLoading] = useState(false);
@@ -332,11 +334,13 @@ export function MiniCalendar({
     try {
       type GthrDetail = { max_prt_cnt: number | null; sprt_cd: string | null; attendees: GatheringAttendee[] };
       // 댓글은 함께 기다리지 않는다 — undefined로 넘기면 CommentSection이 스스로 조회·로딩 표시한다.
-      const [attdResult, gthrDetailResult] = await Promise.all([
+      // 취소 이력은 참석자 RPC와 병렬로 받아 지연 없이 취소자 판정에 합친다(판정엔 현재 참석자 집합 필요).
+      const [attdResult, gthrDetailResult, cancelRows] = await Promise.all([
         memberId
           ? supabase.from("gthr_attd_rel").select("attd_id").eq("gthr_id", race.id).eq("mem_id", memberId).maybeSingle()
           : Promise.resolve({ data: null }),
         supabase.rpc("get_gathering_detail", { p_gthr_id: race.id, p_team_id: teamId }),
+        fetchGatheringCancelHistoryRowsClient(supabase, race.id),
       ]);
       if (gthrDetailResult.error) {
         // 이미 열린 다이얼로그는 유지 — 행 데이터만으로도 핵심 정보는 보인다
@@ -347,8 +351,9 @@ export function MiniCalendar({
       if (reqId !== gthrOpenReqRef.current) return;
       const gthrData = gthrDetailResult.data as GthrDetail | null;
       const attendees: GatheringAttendee[] = gthrData?.attendees ?? [];
+      const canceledAttendees = deriveCanceledFromRows(cancelRows, attendees.map((a) => a.mem_id));
       setGthrDetailRace((prev) => prev && prev.id === race.id
-        ? { ...prev, regCount: attendees.length, maxPrtCnt: gthrData?.max_prt_cnt ?? null, attendees, sprt_cd: gthrData?.sprt_cd ?? prev.sprt_cd ?? null }
+        ? { ...prev, regCount: attendees.length, maxPrtCnt: gthrData?.max_prt_cnt ?? null, attendees, canceledAttendees, sprt_cd: gthrData?.sprt_cd ?? prev.sprt_cd ?? null }
         : prev);
       // 등록 직후(justCreated)엔 작성자가 자동 참석되므로 무조건 참석 상태로 확정한다.
       // (자동 참석 INSERT 직후라 attd 조회가 read-after-write 지연으로 null을 반환할 수 있어
@@ -386,7 +391,8 @@ export function MiniCalendar({
           memberId
             ? supabase.from("gthr_attd_rel").select("attd_id").eq("gthr_id", deepLinkGthrId).eq("mem_id", memberId).maybeSingle()
             : Promise.resolve({ data: null }),
-        ]).then(([masterRes, detailRes, attdRes]) => {
+          fetchGatheringCancelHistoryRowsClient(supabase, deepLinkGthrId),
+        ]).then(([masterRes, detailRes, attdRes, cancelRows]) => {
           if (cancelled) return
           // 그 사이 다른 모임이 열렸으면 늦게 온 딥링크 응답을 버린다
           if (reqId !== gthrOpenReqRef.current) return
@@ -397,6 +403,7 @@ export function MiniCalendar({
           }
           const gthrData = detailRes.data as GthrDetail | null
           const attendees: GatheringAttendee[] = gthrData?.attendees ?? []
+          const canceledAttendees = deriveCanceledFromRows(cancelRows, attendees.map((a) => a.mem_id))
           setGthrJustCreated(false)
           setGthrDetailRace({
             id: data.gthr_id,
@@ -413,6 +420,7 @@ export function MiniCalendar({
             regCount: attendees.length,
             maxPrtCnt: gthrData?.max_prt_cnt ?? null,
             attendees,
+            canceledAttendees,
             sprt_cd: gthrData?.sprt_cd ?? null,
           })
           setGthrDetailAttending(!!attdRes.data)
@@ -1636,7 +1644,7 @@ export function MiniCalendar({
         onDelete={refreshMonthData}
         onAttendanceChange={async () => {
           type GthrDetail = { max_prt_cnt: number | null; sprt_cd: string | null; attendees: GatheringAttendee[] };
-          const [, gthrDetailResult, attdResult] = await Promise.all([
+          const [, gthrDetailResult, attdResult, cancelRows] = await Promise.all([
             refreshMonthData(),
             gthrDetailRace
               ? supabase.rpc("get_gathering_detail", { p_gthr_id: gthrDetailRace.id, p_team_id: teamId })
@@ -1644,11 +1652,15 @@ export function MiniCalendar({
             gthrDetailRace && memberId
               ? supabase.from("gthr_attd_rel").select("attd_id").eq("gthr_id", gthrDetailRace.id).eq("mem_id", memberId).maybeSingle()
               : Promise.resolve({ data: null }),
+            gthrDetailRace
+              ? fetchGatheringCancelHistoryRowsClient(supabase, gthrDetailRace.id)
+              : Promise.resolve([]),
           ]);
           if (gthrDetailRace && gthrDetailResult.data) {
             const gthrData = gthrDetailResult.data as GthrDetail;
             const attendees: GatheringAttendee[] = gthrData.attendees ?? [];
-            setGthrDetailRace((prev) => prev ? { ...prev, regCount: attendees.length, attendees } : prev);
+            const canceledAttendees = deriveCanceledFromRows(cancelRows, attendees.map((a) => a.mem_id));
+            setGthrDetailRace((prev) => prev ? { ...prev, regCount: attendees.length, attendees, canceledAttendees } : prev);
             setGthrDetailAttending(!!attdResult.data);
           }
         }}

--- a/components/schedule/gathering-detail-dialog.tsx
+++ b/components/schedule/gathering-detail-dialog.tsx
@@ -12,6 +12,10 @@ import { gthrTypeLabels, gthrSprtLabels, type GthrType, type GthrSprtType } from
 import { deleteGathering } from "@/app/actions/gathering/manage-gathering";
 import { toggleGatheringAttendance } from "@/app/actions/gathering/toggle-attendance";
 import { GatheringCancelDialog } from "@/app/(info)/gatherings/[id]/gathering-cancel-dialog";
+import {
+  GatheringCanceledAttendees,
+  type CanceledAttendee,
+} from "@/app/(info)/gatherings/[id]/gathering-canceled-attendees";
 
 
 import type { CmntRow } from "@/components/comment/comment-item";
@@ -44,6 +48,7 @@ export interface GatheringDetailDialogProps {
   gathering: (CalendarRace & {
     maxPrtCnt?: number | null;
     attendees?: GatheringAttendee[];
+    canceledAttendees?: CanceledAttendee[];
     sprt_cd?: string | null;
   }) | null;
   open: boolean;
@@ -97,6 +102,7 @@ export function GatheringDetailDialog({
   const [cancelDialogOpen, setCancelDialogOpen] = useState(false);
   const [attdCount, setAttdCount] = useState(gathering?.regCount ?? 0);
   const [attendees, setAttendees] = useState(gathering?.attendees ?? []);
+  const [canceledAttendees, setCanceledAttendees] = useState<CanceledAttendee[]>(gathering?.canceledAttendees ?? []);
   // 참석 토글 재진입 가드 — 동기 ref로 같은 렌더 내 연타까지 막는다(리렌더 의존 state는 못 막음).
   // 버튼 흐림 없이 재클릭만 무시하므로 UI에 노출할 state는 불필요.
   const togglingRef = useRef(false);
@@ -119,6 +125,7 @@ export function GatheringDetailDialog({
     setAttending(initialIsAttending ?? false);
     setAttdCount(gathering?.regCount ?? 0);
     setAttendees(gathering?.attendees ?? []);
+    setCanceledAttendees(gathering?.canceledAttendees ?? []);
     setShowShareHint(justCreated ?? false);
   }
 
@@ -176,10 +183,14 @@ export function GatheringDetailDialog({
     }
     togglingRef.current = true;
     const prev = attending;
+    const prevCanceled = canceledAttendees;
     const myEntry = { mem_id: currentMemberId, mem_nm: currentMemberName ?? null, avatar_url: currentMemberAvatarUrl ?? null };
     setAttending(!prev);
     setAttdCount((c) => (!prev ? c + 1 : c - 1));
     setAttendees((list) => !prev ? [...list, myEntry] : list.filter((a) => a.mem_id !== currentMemberId));
+    // 재참석(!prev=참석 등록)이면 취소자 목록에서 본인을 즉시 뺀다 — 안 그러면 같은 모달 안에서
+    // 취소→재참석 시 참석·취소 양쪽에 동시에 보인다(재오픈 전까지). 재오픈하면 rel 우선 파생으로 자동 정리.
+    if (!prev) setCanceledAttendees((list) => list.filter((c) => c.mem_id !== currentMemberId));
     try {
       const result = await toggleGatheringAttendance(gathering!.id);
       setAttending(result.attending);
@@ -191,6 +202,7 @@ export function GatheringDetailDialog({
       setAttending(prev);
       setAttdCount((c) => (prev ? c + 1 : c - 1));
       setAttendees(gathering!.attendees ?? []);
+      setCanceledAttendees(prevCanceled);
       // 서버 거절 사유(지난 모임·인원 마감 등)를 안내 — 무음 롤백이면 버튼 고장으로 오인한다
       toast.error(e instanceof Error ? e.message : "참석 처리에 실패했습니다.");
     } finally {
@@ -204,9 +216,21 @@ export function GatheringDetailDialog({
     togglingRef.current = true;
     const prevCount = attdCount;
     const prevAttendees = attendees;
+    const prevCanceled = canceledAttendees;
     setAttending(false);
     setAttdCount((c) => c - 1);
     setAttendees((list) => list.filter((a) => a.mem_id !== currentMemberId));
+    // 취소 즉시 취소자 목록에 본인을 낙관적으로 올려 "흔적 없음"을 없앤다(재오픈·재조회 전에도 바로 보이게).
+    setCanceledAttendees((list) => [
+      {
+        mem_id: currentMemberId,
+        mem_nm: currentMemberName ?? "",
+        avatar_url: currentMemberAvatarUrl ?? null,
+        evt_at: dayjs().toISOString(),
+        reason_txt: reason ?? null,
+      },
+      ...list.filter((c) => c.mem_id !== currentMemberId),
+    ]);
     try {
       await toggleGatheringAttendance(gathering!.id, reason);
       setCancelDialogOpen(false);
@@ -215,6 +239,7 @@ export function GatheringDetailDialog({
       setAttending(true);
       setAttdCount(prevCount);
       setAttendees(prevAttendees);
+      setCanceledAttendees(prevCanceled);
       throw e;
     } finally {
       togglingRef.current = false;
@@ -368,6 +393,9 @@ export function GatheringDetailDialog({
                 ))}
               </div>
             ) : null}
+
+            {/* 취소자 목록 — 상세 페이지(SG-03)와 동등한 회색 표시(취소 시각·사유). 카운트엔 미포함. */}
+            <GatheringCanceledAttendees attendees={canceledAttendees} />
 
             {/* 등록 직후 공유 유도 안내 */}
             {showShareHint && (

--- a/lib/queries/gathering-cancel-history-client.ts
+++ b/lib/queries/gathering-cancel-history-client.ts
@@ -1,0 +1,79 @@
+import type { SupabaseClient } from "@supabase/supabase-js";
+
+import { deriveCanceledAttendees } from "@/lib/gathering/derive-canceled-attendees";
+
+import type { CanceledAttendee } from "@/app/(info)/gatherings/[id]/gathering-canceled-attendees";
+
+/** 취소자 판정에 필요한 필드 + 표시용 멤버 정보를 한 행에 담은 클라이언트 조회 결과. */
+type CancelHistClientRow = CanceledAttendee & { evt_cd: "register" | "cancel" };
+
+/**
+ * 브라우저(클라이언트)에서 특정 모임의 참석 이벤트 이력(gthr_attd_hist)을 최신순으로 조회한다.
+ *
+ * 서버 경로({@link import("./gathering-cancel-history").getGatheringAttendanceHistory})는
+ * `server-only`라 클라이언트 번들에서 못 쓴다. 홈 캘린더 상세 모달(gathering-detail-dialog)은
+ * 클라이언트 컴포넌트라 여기서 RLS를 타는 브라우저 supabase 클라이언트로 직접 조회한다.
+ *
+ * 보안: 취소 사유는 팀 멤버 전체 공개·비멤버 차단(A-03 오너 확정)이며, 이는 RLS 정책
+ * `gthr_attd_hist_select`가 DB에서 강제한다 — SECURITY DEFINER RPC(get_gathering_detail,
+ * anon 허용)에 사유를 실으면 비멤버에 노출되므로 절대 그 경로로 내리지 않는다.
+ *
+ * 취소자 "판정"(재참석 제외·멤버별 최신 1건)은 하지 않는다 — 그건 현재 참석자 집합이 필요하므로
+ * 순수 함수 {@link deriveCanceledFromRows}로 분리해, 참석자 RPC와 이 조회를 병렬로 돌린 뒤 합친다.
+ * gthr_attd_hist는 database.types.ts 미생성 테이블(SG-01)이라 클라이언트가 loosely-typed로 조회한다.
+ */
+export async function fetchGatheringCancelHistoryRowsClient(
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  supabase: SupabaseClient<any, any, any>,
+  gthrId: string,
+): Promise<CancelHistClientRow[]> {
+  const { data, error } = await supabase
+    .from("gthr_attd_hist")
+    .select(
+      // mem_mst FK가 둘(mem_id·actor_mem_id) → 임베드 관계를 FK 이름으로 명시해야
+      // PostgREST "more than one relationship" 에러를 피한다. 취소 대상은 mem_id.
+      "mem_id, evt_cd, reason_txt, evt_at, mem_mst!gthr_attd_hist_mem_id_fkey(mem_id, mem_nm, avatar_url)",
+    )
+    .eq("gthr_id", gthrId)
+    .order("evt_at", { ascending: false });
+
+  if (error) {
+    console.error("[gathering] 취소 이력 조회 실패", error.message);
+    return [];
+  }
+
+  type RawRow = {
+    mem_id: string;
+    evt_cd: "register" | "cancel";
+    reason_txt: string | null;
+    evt_at: string;
+    mem_mst:
+      | { mem_id: string; mem_nm: string; avatar_url: string | null }
+      | { mem_id: string; mem_nm: string; avatar_url: string | null }[]
+      | null;
+  };
+
+  return ((data ?? []) as RawRow[]).map((h) => {
+    const mem = Array.isArray(h.mem_mst) ? h.mem_mst[0] : h.mem_mst;
+    return {
+      mem_id: h.mem_id,
+      mem_nm: mem?.mem_nm ?? "",
+      avatar_url: mem?.avatar_url ?? null,
+      evt_at: h.evt_at,
+      reason_txt: h.reason_txt,
+      evt_cd: h.evt_cd,
+    };
+  });
+}
+
+/**
+ * 조회된 이력 행에서 현재 취소자만 뽑는다(재참석자 제외·멤버별 최신 1건).
+ * `attendingMemIds`는 gthr_attd_rel 현재 참석자 — 재참석 시 rel 존재로 자동 제외된다.
+ */
+export function deriveCanceledFromRows(
+  rows: readonly CancelHistClientRow[],
+  attendingMemIds: readonly string[],
+): CanceledAttendee[] {
+  // deriveCanceledAttendees는 제네릭이라 evt_cd를 포함한 행 모양을 그대로 보존해 돌려준다.
+  return deriveCanceledAttendees(rows, attendingMemIds);
+}


### PR DESCRIPTION
## 배경
참가 취소 이력(취소자·사유)이 **상세 페이지**에만 보이고, 실제로 취소가 자주 일어나는 **홈 캘린더 상세 모달**에는 안 보였다. → 사용자 실피드백: "홈에서 취소하면 그냥 취소되고 흔적도 없음". (기존 목표 EES-109 / 관련 #427)

## AS-IS
- 홈 캘린더에서 모임을 열어 취소하면 취소는 되지만 취소자·사유가 화면에 안 남음
- 취소자 노출은 `app/(info)/gatherings/[id]` 상세 페이지에만 존재(SG-03)

## TO-BE
- 홈 캘린더 상세 모달(`gathering-detail-dialog`)에 **취소자 섹션**(회색 아바타·취소 시각 KST·사유) 추가 — 상세 페이지와 동일 컴포넌트 재사용
- 재참석자는 취소 목록에서 자동 제외(참석 목록에 표시), 참석 수·정원 카운트엔 취소자 미포함
- 본인이 홈에서 취소하면 즉시 취소자 목록에 반영(낙관적)

## 보안 (중요)
취소 **사유**는 `anon`에 GRANT된 `SECURITY DEFINER` RPC `get_gathering_detail`(RLS 우회)에 **싣지 않는다**. 반드시 RLS 정책 `gthr_attd_hist_select`(팀 멤버 SELECT)를 타는 `gthr_attd_hist` 클라이언트 직접 조회로만 노출 → 비멤버·비로그인 차단을 DB가 강제.

## 변경
- `lib/queries/gathering-cancel-history-client.ts` (신규) — 브라우저 RLS 클라이언트 취소 이력 조회 헬퍼
- `components/schedule/gathering-detail-dialog.tsx` — 취소자 섹션 + 낙관적 self-add/롤백
- `components/home/mini-calendar.tsx` — 3개 진입 경로에서 참석자 RPC와 병렬로 취소 이력 조회 후 파생

## 검증
- `tsc --noEmit` 0 · `eslint`(변경 파일) 0 · `pnpm test` 221/221 · `pnpm build` 통과
- 로컬 프로덕션 빌드 + headless 시각 QA: 홈 모달에 취소자(회색·시각·사유) 노출, 재참석자 제외, 홈에서 취소→취소자 노출 재현 확인
- 독립 리뷰(opus) ACCEPT — AC/보안(A-03)/가드레일(M-03) 전부 PASS

> ⚠️ prd 반영 시 마이그레이션 2건(`gthr_attd_hist`, `gthr_cncl_noti_type`) 선적용 필요(기존 스택과 동일).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **새 기능**
  - 모임 상세 화면에서 참석 취소 이력을 별도 목록으로 확인할 수 있습니다.
  - 현재 참석 중인 사람과 취소한 사람을 구분해 표시합니다.
  - 참석을 다시 신청하면 취소자 목록에서 자동으로 제외됩니다.
  - 모임 상세를 새로 열거나 참석 상태를 변경할 때 최신 취소 현황이 반영됩니다.

- **버그 수정**
  - 참석 취소 또는 재참여 처리 중 오류가 발생하면 화면 상태가 이전 상태로 복원됩니다.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->