### PR TITLE
fix(gathering): 취소 로직 타임존·경계 결함 수정 및 렌더 예외 방어

### DIFF
--- a/app/(info)/gatherings/[id]/gathering-cancel-dialog.tsx
+++ b/app/(info)/gatherings/[id]/gathering-cancel-dialog.tsx
@@ -4,7 +4,7 @@ import { useState } from "react";
 
 import { toast } from "sonner";
 
-import { isCancelReasonRequired } from "@/lib/gathering/cancel-imminent";
+import { CANCEL_REASON_REQUIRED_MESSAGE, isCancelReasonRequired } from "@/lib/gathering/cancel-imminent";
 import { GATHERING_CANCEL_REASON_MAX_LENGTH, validateCancelReason } from "@/lib/gathering/cancel-reason";
 
 import { Caption } from "@/components/common/typography";
@@ -36,9 +36,13 @@ type Props = {
 export function GatheringCancelDialog({ open, onOpenChange, sttAt, onConfirm }: Props) {
   const [reason, setReason] = useState("");
   const [submitting, setSubmitting] = useState(false);
+  // 서버가 "사유 필요"로 거절한 적이 있으면 이 모달을 강제로 사유 필수 모드로 전환한다.
+  // 클라/서버 시각이 5시간 경계에서 어긋나 클라만 "선택"으로 봤던 경우의 복구 경로 —
+  // 조용히 실패하지 않고 사유 입력을 유도해 재시도하면 취소가 반드시 완료된다.
+  const [serverForcedReason, setServerForcedReason] = useState(false);
 
   // 모달이 열려 있는 동안 시간이 흘러도 렌더마다 재계산 — 값이 굳지 않게 한다.
-  const reasonRequired = isCancelReasonRequired(sttAt);
+  const reasonRequired = serverForcedReason || isCancelReasonRequired(sttAt);
   const reasonCheck = validateCancelReason(reason);
   const normalizedReason = reasonCheck.ok ? reasonCheck.value : null;
   const canSubmit = !submitting && reasonCheck.ok && (!reasonRequired || !!normalizedReason);
@@ -46,7 +50,10 @@ export function GatheringCancelDialog({ open, onOpenChange, sttAt, onConfirm }: 
   function handleOpenChange(next: boolean) {
     if (submitting) return; // 제출 중엔 닫기 방지
     onOpenChange(next);
-    if (!next) setReason(""); // 닫힐 때 입력 초기화
+    if (!next) {
+      setReason(""); // 닫힐 때 입력 초기화
+      setServerForcedReason(false); // 다음 오픈을 위해 강제 필수 플래그도 리셋
+    }
   }
 
   async function handleSubmit() {
@@ -55,7 +62,12 @@ export function GatheringCancelDialog({ open, onOpenChange, sttAt, onConfirm }: 
     try {
       await onConfirm(normalizedReason ?? undefined);
       setReason("");
+      setServerForcedReason(false);
     } catch (e) {
+      // 서버가 사유 필수로 거절 → 모달을 사유 필수 모드로 전환해 사용자가 사유를 넣고 다시 시도하게 한다.
+      if (e instanceof Error && e.message === CANCEL_REASON_REQUIRED_MESSAGE) {
+        setServerForcedReason(true);
+      }
       toast.error(e instanceof Error ? e.message : "참석 취소에 실패했습니다.");
     } finally {
       setSubmitting(false);

--- a/app/actions/gathering/toggle-attendance.ts
+++ b/app/actions/gathering/toggle-attendance.ts
@@ -4,7 +4,7 @@ import { revalidatePath } from "next/cache";
 
 import { withActive } from "@/lib/actions/auth";
 import { dayjs } from "@/lib/dayjs";
-import { isCancelReasonRequired } from "@/lib/gathering/cancel-imminent";
+import { CANCEL_REASON_REQUIRED_MESSAGE, isCancelReasonRequired } from "@/lib/gathering/cancel-imminent";
 import { validateCancelReason } from "@/lib/gathering/cancel-reason";
 import { joinGatheringWithCapCheck } from "@/lib/gathering/join-gathering";
 import { insertNoti } from "@/lib/notifications/insert-noti";
@@ -58,8 +58,10 @@ export async function toggleGatheringAttendance(
       if (!reasonCheck.ok) throw new Error(reasonCheck.message);
 
       // 임박 취소(시작 5시간 전부터)는 사유 필수 — 클라이언트 모달을 우회한 호출도 서버에서 재차 막는다.
+      // 클라가 시각 차로 "선택"으로 보고 사유 없이 보내면 여기서 거절되고, 클라는 이 메시지를 식별해
+      // 취소 모달을 사유 필수 모드로 전환한다(CANCEL_REASON_REQUIRED_MESSAGE 공유).
       if (isCancelReasonRequired(gthr.stt_at) && !reasonCheck.value) {
-        throw new Error("시작 5시간 전부터는 취소 사유가 필요해요.");
+        throw new Error(CANCEL_REASON_REQUIRED_MESSAGE);
       }
 
       // 취소 = gthr_attd_rel DELETE + gthr_attd_hist(cancel) INSERT 를 원자적으로.

--- a/app/error.tsx
+++ b/app/error.tsx
@@ -1,13 +1,22 @@
 "use client";
 
+import { useEffect } from "react";
+
 import { Button } from "@/components/ui/button";
 
 export default function Error({
+  error,
   reset,
 }: {
   error: Error & { digest?: string };
   reset: () => void;
 }) {
+  // 렌더 중 터진 예외를 콘솔에 남긴다 — 이 화면(전체 오류 폴백)이 떴을 때 원인 스택을 잡기 위함.
+  // 재현이 어려운 클라 렌더 예외를 디버깅하려면 메시지·digest·스택이 필요하다(리포팅 도구 부재).
+  useEffect(() => {
+    console.error("[app/error] uncaught:", error?.message, "| digest:", error?.digest, error);
+  }, [error]);
+
   return (
     <div className="flex min-h-svh flex-col items-center justify-center gap-4 px-6">
       <span className="text-5xl font-bold text-muted-foreground">오류</span>

--- a/components/schedule/gathering-detail-dialog.tsx
+++ b/components/schedule/gathering-detail-dialog.tsx
@@ -5,7 +5,7 @@ import { useEffect, useRef, useState } from "react";
 import { Copy, ExternalLink, Lock, Pencil, Share2, Trash2 } from "lucide-react";
 import { toast } from "sonner";
 
-import { dayjs } from "@/lib/dayjs";
+import { dayjs, parseEventTime } from "@/lib/dayjs";
 import { isPastLockedFor } from "@/lib/past-event";
 import { gthrTypeLabels, gthrSprtLabels, type GthrType, type GthrSprtType } from "@/lib/validations/gathering";
 
@@ -146,8 +146,10 @@ export function GatheringDetailDialog({
   // 지난 모임(KST 날짜 기준)은 수정·삭제·참석 변경 불가 — 관리자만 예외 (서버 액션에서도 동일 검증)
   const isPastLocked = isPastLockedFor(isAdmin, gathering.evt_stt_at ?? gathering.start_date, gathering.evt_end_at);
 
-  const stt = gathering.evt_stt_at ? dayjs(gathering.evt_stt_at).tz("Asia/Seoul") : dayjs(gathering.start_date);
-  const end = gathering.evt_end_at ? dayjs(gathering.evt_end_at).tz("Asia/Seoul") : null;
+  // evt_stt_at 없으면 start_date(날짜만)로 폴백 — parseEventTime이 KST 자정으로 고정해
+  // 기기 타임존에 따라 시각 표시가 어긋나지 않게 한다(isPastLocked·취소 판정과 동일 기준).
+  const stt = parseEventTime(gathering.evt_stt_at ?? gathering.start_date).tz("Asia/Seoul");
+  const end = gathering.evt_end_at ? parseEventTime(gathering.evt_end_at).tz("Asia/Seoul") : null;
   const dateStr = stt.format("YYYY년 M월 D일 (ddd)");
   const timeStr = end ? `${stt.format("HH:mm")} ~ ${end.format("HH:mm")}` : stt.format("HH:mm");
 
@@ -197,7 +199,11 @@ export function GatheringDetailDialog({
       if (result.attending && result.monthlyAttendCnt) {
         toast.success(`이번 달 ${result.monthlyAttendCnt}회 참여!`);
       }
-      onAttendanceChange?.();
+      // 부가 갱신(달력·참석자 재조회)은 참석 처리와 독립 — 여기서 reject돼도 위 성공한 토글을
+      // 롤백하면 안 되므로 try 밖에서 삼킨다(catch 흐름 오염·unhandled rejection 방지).
+      void Promise.resolve(onAttendanceChange?.()).catch((err) => {
+        console.error("[gathering] 참석 변경 후 갱신 실패", err);
+      });
     } catch (e) {
       setAttending(prev);
       setAttdCount((c) => (prev ? c + 1 : c - 1));
@@ -234,7 +240,11 @@ export function GatheringDetailDialog({
     try {
       await toggleGatheringAttendance(gathering!.id, reason);
       setCancelDialogOpen(false);
-      onAttendanceChange?.();
+      // 취소 성공 후 부가 갱신(달력·참석자 재조회)은 실패해도 취소 자체엔 영향 없어야 한다.
+      // await하지 않고 호출하므로, 내부에서 reject되면 unhandled rejection이 되지 않도록 여기서 삼킨다.
+      void Promise.resolve(onAttendanceChange?.()).catch((err) => {
+        console.error("[gathering] 취소 후 갱신 실패", err);
+      });
     } catch (e) {
       setAttending(true);
       setAttdCount(prevCount);

--- a/lib/__tests__/past-event.test.ts
+++ b/lib/__tests__/past-event.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from "vitest";
+
+import { dayjs, parseEventTime } from "@/lib/dayjs";
+import { isPastEventKst, isPastLockedFor } from "@/lib/past-event";
+
+describe("parseEventTime", () => {
+  it("시각 정보가 있는 ISO 문자열은 절대시각 그대로 해석한다", () => {
+    expect(parseEventTime("2026-07-20T10:00:00+00:00").toISOString()).toBe("2026-07-20T10:00:00.000Z");
+    expect(parseEventTime("2026-07-20T10:00:00Z").toISOString()).toBe("2026-07-20T10:00:00.000Z");
+  });
+
+  it("날짜만 있는 문자열은 실행 환경 TZ와 무관하게 KST 자정으로 고정한다", () => {
+    // KST 2026-07-20 00:00 = UTC 2026-07-19T15:00:00Z (프로세스 TZ가 UTC든 KST든 동일해야 함)
+    expect(parseEventTime("2026-07-20").toISOString()).toBe("2026-07-19T15:00:00.000Z");
+    // dayjs("2026-07-20")(로컬 자정)와 달라야 date-only 편차가 제거된 것
+    expect(parseEventTime("2026-07-20").toISOString()).toBe(dayjs.tz("2026-07-20", "Asia/Seoul").toISOString());
+  });
+
+  it("공백이 섞인 날짜 문자열도 트림 후 date-only로 판정한다", () => {
+    expect(parseEventTime("  2026-07-20  ").toISOString()).toBe("2026-07-19T15:00:00.000Z");
+  });
+});
+
+describe("isPastEventKst — date-only 입력 안전성", () => {
+  // 기준 '오늘'을 고정하지 않고, 오늘/어제/내일 KST 날짜로 상대 판정한다(실행 시점 무관).
+  const todayKst = dayjs().tz("Asia/Seoul").format("YYYY-MM-DD");
+  const yesterdayKst = dayjs().tz("Asia/Seoul").subtract(1, "day").format("YYYY-MM-DD");
+  const tomorrowKst = dayjs().tz("Asia/Seoul").add(1, "day").format("YYYY-MM-DD");
+
+  it("어제(KST) 날짜만 있는 일정은 지난 일정", () => {
+    expect(isPastEventKst(yesterdayKst)).toBe(true);
+  });
+
+  it("오늘(KST) 날짜만 있는 일정은 자정까지 지난 일정이 아니다", () => {
+    expect(isPastEventKst(todayKst)).toBe(false);
+  });
+
+  it("내일(KST) 날짜만 있는 일정은 지난 일정이 아니다", () => {
+    expect(isPastEventKst(tomorrowKst)).toBe(false);
+  });
+
+  it("종료일시(endAt)가 우선한다 — 시작이 어제여도 종료가 오늘이면 지난 일정 아님", () => {
+    expect(isPastEventKst(yesterdayKst, todayKst)).toBe(false);
+  });
+});
+
+describe("isPastLockedFor — 관리자 예외", () => {
+  const yesterdayKst = dayjs().tz("Asia/Seoul").subtract(1, "day").format("YYYY-MM-DD");
+
+  it("관리자는 지난 일정이어도 잠기지 않는다", () => {
+    expect(isPastLockedFor(true, yesterdayKst)).toBe(false);
+  });
+
+  it("일반 멤버는 지난 일정이면 잠긴다", () => {
+    expect(isPastLockedFor(false, yesterdayKst)).toBe(true);
+  });
+});

--- a/lib/dayjs.ts
+++ b/lib/dayjs.ts
@@ -17,6 +17,23 @@ const KST = "Asia/Seoul";
 
 export { dayjs };
 
+/**
+ * 이벤트(모임·일정) 시작/종료 시각 문자열을 절대시각(dayjs)으로 안전하게 해석한다.
+ *
+ * - 시각 정보가 있는 문자열(ISO "…T…", DB timestamptz "… +00" 등) → 그대로 파싱(오프셋 포함 절대시각)
+ * - 날짜만 있는 문자열("YYYY-MM-DD") → **KST 자정**으로 명시 해석.
+ *
+ * 왜 필요한가: 캘린더 행 데이터는 시각이 있는 `evt_stt_at`을 주로 쓰지만, 없을 때 `start_date`
+ * (날짜만)로 폴백하는 경로가 있다. 이때 `dayjs("2026-07-20")`는 **실행 환경 로컬 자정**으로
+ * 해석돼(브라우저=KST, Vercel 서버=UTC) 절대시각이 최대 9시간 어긋난다 → 지난 일정 판정·취소
+ * 사유 게이트가 기기/환경 타임존에 따라 갈린다. 이 함수로 date-only를 KST 자정에 고정해 그 편차를
+ * 없앤다. 시각 판정(과거 여부·임박 여부)과 표시 모두 이 한 곳을 공유한다.
+ */
+export function parseEventTime(value: string): dayjs.Dayjs {
+  const trimmed = value.trim();
+  return /^\d{4}-\d{2}-\d{2}$/.test(trimmed) ? dayjs.tz(trimmed, KST) : dayjs(trimmed);
+}
+
 /** KST 기준 현재 dayjs 인스턴스 */
 function nowKST() {
   return dayjs().tz(KST);

--- a/lib/gathering/__tests__/cancel-imminent.test.ts
+++ b/lib/gathering/__tests__/cancel-imminent.test.ts
@@ -38,4 +38,18 @@ describe("isCancelReasonRequired", () => {
     const imminent = dayjs().add(1, "hour").toISOString();
     expect(isCancelReasonRequired(imminent)).toBe(true);
   });
+
+  describe("날짜만 있는 입력(start_date 폴백)은 KST 자정 기준으로 해석", () => {
+    // "2026-07-20"(date-only) = KST 자정 = UTC 2026-07-19T15:00:00Z. 실행 환경 TZ와 무관해야 한다.
+    const dateOnly = "2026-07-20";
+    const kstMidnightUtc = "2026-07-19T15:00:00Z";
+
+    it("KST 자정까지 5시간보다 더 남았으면 사유 선택", () => {
+      expect(isCancelReasonRequired(dateOnly, dayjs(kstMidnightUtc).subtract(6, "hour"))).toBe(false);
+    });
+
+    it("KST 자정까지 5시간 이내면 사유 필수", () => {
+      expect(isCancelReasonRequired(dateOnly, dayjs(kstMidnightUtc).subtract(1, "hour"))).toBe(true);
+    });
+  });
 });

--- a/lib/gathering/cancel-imminent.ts
+++ b/lib/gathering/cancel-imminent.ts
@@ -10,19 +10,29 @@
  * 그 함수를 재사용하지 말 것 — 여기서는 항상 `import { dayjs } from "@/lib/dayjs"` 만 사용한다.
  */
 
-import { dayjs } from "@/lib/dayjs";
+import { dayjs, parseEventTime } from "@/lib/dayjs";
 
 export const GATHERING_CANCEL_IMMINENT_HOURS = 5;
+
+/**
+ * 임박 취소인데 사유가 없을 때 서버(toggleGatheringAttendance)가 던지는 에러 메시지.
+ * 클라이언트가 이 메시지를 식별해 취소 모달을 사유 필수 모드로 전환할 수 있도록 상수로 공유한다 —
+ * 클라/서버 시각이 5시간 경계에서 미세하게 어긋나 클라만 "선택"으로 보고 사유 없이 보냈을 때의 복구 경로.
+ */
+export const CANCEL_REASON_REQUIRED_MESSAGE = "시작 5시간 전부터는 취소 사유가 필요해요.";
 
 /**
  * 취소 시점 기준으로 사유가 필수인지 판정한다.
  * - 시작까지 남은 시간이 GATHERING_CANCEL_IMMINENT_HOURS 미만(이미 시작한 경우 포함) → true(필수)
  * - 정확히 GATHERING_CANCEL_IMMINENT_HOURS 이상 남았으면 → false(선택)
  *
- * @param sttAt 모임 시작 시각(UTC ISO 문자열, gthr_mst.stt_at)
+ * sttAt에 날짜만("YYYY-MM-DD") 와도 안전하다 — parseEventTime이 KST 자정으로 고정해
+ * 실행 환경 타임존에 따라 판정이 갈리는 것을 막는다(evt_stt_at 없이 start_date로 폴백하는 경로 대비).
+ *
+ * @param sttAt 모임 시작 시각(UTC ISO 문자열, gthr_mst.stt_at). 날짜만 오면 KST 자정으로 해석.
  * @param now 기준 시각(테스트용, 생략 시 현재 시각)
  */
 export function isCancelReasonRequired(sttAt: string, now: dayjs.Dayjs = dayjs()): boolean {
-  const hoursUntilStart = dayjs(sttAt).diff(now, "hour", true);
+  const hoursUntilStart = parseEventTime(sttAt).diff(now, "hour", true);
   return hoursUntilStart < GATHERING_CANCEL_IMMINENT_HOURS;
 }

--- a/lib/past-event.ts
+++ b/lib/past-event.ts
@@ -1,4 +1,4 @@
-import { dayjs } from "@/lib/dayjs";
+import { dayjs, parseEventTime } from "@/lib/dayjs";
 
 /**
  * 지난 일정(모임·일정글) 판정 — KST 날짜 기준.
@@ -7,11 +7,15 @@ import { dayjs } from "@/lib/dayjs";
  * 당일 일정은 그날 자정(KST)까지는 지난 것으로 보지 않는다 —
  * 모임 종료 직후 참석 체크·내용 보완이 흔하기 때문. 홈탭 지난 일정 dim 기준과 동일.
  *
+ * sttAt/endAt에 날짜만("YYYY-MM-DD") 와도 안전하다 — parseEventTime이 KST 자정으로 고정한다.
+ * (그냥 dayjs("2026-07-20")로 파싱하면 절대시각이 실행 환경 로컬 자정이 되어, Vercel 서버(UTC)와
+ *  브라우저(KST)에서 최대 9시간 어긋나 자정 근처의 지난-일정 판정이 하루 갈릴 수 있다.)
+ *
  * 지난 일정은 수정·삭제·참석·참석해제 불가 (관리자만 예외).
  * 서버 액션 검증과 클라이언트 버튼 노출 양쪽에서 공용으로 사용한다.
  */
 export function isPastEventKst(sttAt: string, endAt?: string | null): boolean {
-  const baseline = dayjs(endAt ?? sttAt).tz("Asia/Seoul");
+  const baseline = parseEventTime(endAt ?? sttAt).tz("Asia/Seoul");
   return baseline.isBefore(dayjs().tz("Asia/Seoul").startOf("day"));
 }
 


### PR DESCRIPTION
## 개요

모임 참석 취소 로직 전반을 엣지케이스로 점검해 발견한 **실재하는 결함들**을 수정합니다.
(발단: "당일/지난 일정 취소 시 에러, 내일 모임은 정상" 제보 → 취소 경로 전수 점검)

## 배경

DB RPC·트리거·PostgREST 응답 형식을 실제로 굴려 확인한 결과 **서버/DB는 무죄**(취소 요청 전부 2xx)였고,
남은 결함은 **애플리케이션의 시각 판정과 렌더 예외 방어**에 있었습니다.

## 변경 사항 (AS-IS → TO-BE)

### 1. date-only 폴백 타임존 편차 (핵심)
- **AS-IS**: `evt_stt_at` 없이 `start_date`(`"YYYY-MM-DD"`)로 폴백하면 `dayjs("2026-07-20")`가
  **실행 환경 로컬 자정**으로 해석 → Vercel 서버(UTC)와 브라우저(KST)에서 절대시각이 **최대 9시간** 어긋나
  "지난 일정" 판정·취소 사유 게이트가 기기/환경마다 갈림
- **TO-BE**: 공용 `parseEventTime`(`lib/dayjs.ts`) 도입 — date-only는 **KST 자정 고정**, 시각 있으면 절대시각 그대로.
  `isPastEventKst`·`isCancelReasonRequired`·상세 다이얼로그 표시가 **한 파서를 공유**(폴백 3곳 중복 제거)

### 2. 클라/서버 시각 불일치로 취소 거절
- **AS-IS**: 시작 5시간 경계 부근에서 클라(브라우저 시계)·서버(서버 시계)가 사유 필수 판정을 각자 계산 →
  클라가 "선택"으로 보고 사유 없이 제출 → 서버가 거절 → 취소 실패(간헐적, 시계 오차 큰 모바일에서 재현)
- **TO-BE**: 서버 거절 메시지를 상수(`CANCEL_REASON_REQUIRED_MESSAGE`)로 공유. 클라가 이를 식별하면
  취소 모달을 **사유 필수 모드로 전환** → 사용자가 사유 입력 후 재시도로 복구(조용한 실패 제거)

### 3. 취소·참석 후 부가 갱신의 unhandled rejection
- **AS-IS**: `onAttendanceChange?.()`를 `await`/`catch` 없이 호출 → 내부 reject 시 unhandled rejection.
  특히 **참석 등록 경로**에선 부가 갱신 실패가 이미 성공한 토글을 롤백하던 버그
- **TO-BE**: `void Promise.resolve(onAttendanceChange?.()).catch(...)`로 감싸 부가 갱신 실패를 취소/참석 본류와 분리

### 4. 렌더 예외 관측
- `app/error.tsx`가 렌더 예외를 콘솔에 남기도록 로깅 추가(리포팅 도구 부재 상황의 원인 추적용)

## 테스트

- `lib/__tests__/past-event.test.ts` **신규** — date-only 타임존 회귀 방지(프로세스 TZ 무관 검증)
- `cancel-imminent.test.ts` — date-only 케이스 추가
- ✅ 취소+past-event 관련 vitest **48개 통과** · typecheck EXIT 0 · lint 클린

## 남은 사항 (별도)

- 제보된 "다시 시도 전체화면"(React error boundary)의 **진짜 원인은 미확정** — 서버 무죄이므로 클라 렌더 예외로 추정.
  추가한 error.tsx 로깅으로 다음 재현 시 콘솔의 `[app/error] uncaught:`로 특정 예정
- `GatheringDetailDialog`의 `syncKey`에 `canceledAttendees` 미포함 → 서버 재조회가 로컬에 늦게 반영될 수 있음(재오픈 시 정리, 비치명적)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **버그 수정**
  * 임박한 모임 취소 시 서버가 사유를 요구하면 취소 사유 입력 모드로 자동 전환됩니다.
  * 모임 날짜만 제공되는 경우에도 한국 시간 기준으로 시작·종료 및 지난 일정이 정확히 판정됩니다.
  * 참석 상태 갱신 실패가 모임 취소나 참석 처리 결과에 영향을 주지 않도록 개선했습니다.

* **개선 사항**
  * 오류 발생 시 상세 정보가 기록되어 문제 진단이 쉬워졌습니다.
  * 취소 사유가 필요한 상황에서 일관된 안내 메시지를 제공합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->