### PR TITLE
feat(board): 게시판 SSG + 태그 기반 on-demand revalidation 전환

### DIFF
--- a/app/(board)/board/[id]/page.tsx
+++ b/app/(board)/board/[id]/page.tsx
@@ -1,8 +1,8 @@
-import { notFound, redirect } from "next/navigation";
-import { getCurrentMember } from "@/lib/queries/member";
-import { getBoardPost, recordBoardPostRead } from "@/lib/queries/board";
+import { notFound } from "next/navigation";
+import { getCachedBoardPost } from "@/lib/queries/board";
 import { PostDetail } from "@/components/board/post-detail";
 
+// 게시판 상세는 공개 온디맨드 캐시 페이지. 읽음 처리·권한 계산은 클라에서 서버액션으로 수행한다.
 export default async function BoardPostPage({
   params,
 }: {
@@ -10,19 +10,8 @@ export default async function BoardPostPage({
 }) {
   const { id } = await params;
 
-  const { user, member } = await getCurrentMember();
-  if (!user) redirect("/auth/login");
-
-  const post = await getBoardPost(id);
+  const post = await getCachedBoardPost(id);
   if (!post) notFound();
 
-  if (member) {
-    await recordBoardPostRead(id, member.id);
-  }
-
-  const canEdit = Boolean(
-    member && (member.admin || member.id === post.writ_mem_id),
-  );
-
-  return <PostDetail post={post} canEdit={canEdit} />;
+  return <PostDetail post={post} />;
 }

--- a/app/(board)/board/board-client.tsx
+++ b/app/(board)/board/board-client.tsx
@@ -1,9 +1,11 @@
 "use client";
 
+import { useEffect, useState } from "react";
 import { useSearchParams, useRouter } from "next/navigation";
 import Link from "next/link";
 import { PenLine } from "lucide-react";
 import type { BoardPostSummary } from "@/lib/queries/board";
+import { checkBoardPermission } from "@/app/actions/check-board-permission";
 import { PostList } from "@/components/board/post-list";
 import { SegmentControl } from "@/components/common/segment-control";
 import { analytics } from "@/lib/analytics";
@@ -11,13 +13,20 @@ import { analytics } from "@/lib/analytics";
 type BoardClientProps = {
   initialNotices: BoardPostSummary[];
   initialUpdates: BoardPostSummary[];
-  canWrite: boolean;
 };
 
-export function BoardClient({ initialNotices, initialUpdates, canWrite }: BoardClientProps) {
+export function BoardClient({ initialNotices, initialUpdates }: BoardClientProps) {
   const searchParams = useSearchParams();
   const router = useRouter();
   const tab = (searchParams.get("tab") === "update" ? "update" : "notice") as "notice" | "update";
+
+  // SSG라 서버에서 권한을 알 수 없으므로 작성 버튼 노출 권한은 클라에서 조회한다.
+  const [canWrite, setCanWrite] = useState(false);
+  useEffect(() => {
+    checkBoardPermission()
+      .then((p) => setCanWrite(p.canWrite))
+      .catch(() => setCanWrite(false));
+  }, []);
 
   function handleTabChange(value: "notice" | "update") {
     analytics.boardTabSwitch(value);

--- a/app/(board)/board/page.tsx
+++ b/app/(board)/board/page.tsx
@@ -1,32 +1,24 @@
-import { redirect } from "next/navigation";
-import { getCurrentMember } from "@/lib/queries/member";
-import { getRequestTeamContext } from "@/lib/queries/request-team";
-import { getBoardPosts } from "@/lib/queries/board";
+import { DEFAULT_FALLBACK_TEAM_ID } from "@/lib/constants/gigang-team";
+import { getCachedBoardPosts } from "@/lib/queries/board";
 import { BackHeader } from "@/components/back-header";
 import { BoardClient } from "./board-client";
 
 export const metadata = { title: "게시판" };
 
+// 게시판은 공개 정적 페이지(SSG). 로그인·팀 컨텍스트에 의존하지 않는다.
+// 팀은 단일 팀(gigang)이라 상수로 고정 — 멀티팀이 생기면 request-team 기반으로 되살린다.
+const TEAM_ID = DEFAULT_FALLBACK_TEAM_ID;
+
 export default async function BoardPage() {
-  const { user, member } = await getCurrentMember();
-  if (!user) redirect("/auth/login");
-  const { teamId } = await getRequestTeamContext();
-
   const [notices, updates] = await Promise.all([
-    getBoardPosts(teamId, "notice", { limit: 20 }),
-    getBoardPosts(teamId, "update", { limit: 20 }),
+    getCachedBoardPosts(TEAM_ID, "notice"),
+    getCachedBoardPosts(TEAM_ID, "update"),
   ]);
-
-  const canWrite = member?.admin ?? false;
 
   return (
     <div className="flex flex-col">
       <BackHeader title="게시판" href="/" />
-      <BoardClient
-        initialNotices={notices}
-        initialUpdates={updates}
-        canWrite={canWrite}
-      />
+      <BoardClient initialNotices={notices} initialUpdates={updates} />
     </div>
   );
 }

--- a/app/actions/check-board-permission.ts
+++ b/app/actions/check-board-permission.ts
@@ -1,0 +1,37 @@
+"use server";
+
+import { getCurrentMember } from "@/lib/queries/member";
+
+export type BoardPermission = {
+  /** 로그인 + 가입 완료 여부 */
+  authed: boolean;
+  /** 글 작성 권한 (관리자) */
+  canWrite: boolean;
+  /** 특정 글 수정/삭제 권한 (관리자 또는 작성자). writMemId 미전달 시 항상 false */
+  canEdit: boolean;
+};
+
+/**
+ * 게시판 권한을 클라이언트에서 조회한다.
+ * 게시판은 SSG라 서버 렌더에서 멤버를 조회할 수 없으므로, 버튼 노출용 권한만 이 액션으로 뺀다.
+ * (실제 쓰기/수정/삭제 인가는 create/update/delete-post 액션이 서버에서 다시 검증하므로,
+ *  이 값은 UI 노출 판단용이며 보안 경계가 아니다.)
+ *
+ * @param writMemId 상세 페이지에서 canEdit(작성자 여부) 계산에 쓸 글 작성자 id. 목록에서는 생략.
+ */
+export async function checkBoardPermission(
+  writMemId?: string | null,
+): Promise<BoardPermission> {
+  const { member } = await getCurrentMember();
+
+  if (!member) {
+    return { authed: false, canWrite: false, canEdit: false };
+  }
+
+  const canWrite = member.admin;
+  const canEdit = Boolean(
+    writMemId && (member.admin || member.id === writMemId),
+  );
+
+  return { authed: true, canWrite, canEdit };
+}

--- a/app/actions/create-post.ts
+++ b/app/actions/create-post.ts
@@ -1,9 +1,10 @@
 "use server";
 
-import { revalidatePath } from "next/cache";
+import { revalidateTag } from "next/cache";
 import { createUntypedAdminClient } from "@/lib/supabase/admin";
 import { withAdminOrThrow } from "@/lib/actions/auth";
 import { getRequestTeamContext } from "@/lib/queries/request-team";
+import { BOARD_POSTS_CACHE_TAG } from "@/lib/queries/board";
 import { createPostSchema } from "@/lib/validations/board";
 
 export async function createPost(input: {
@@ -30,7 +31,9 @@ export async function createPost(input: {
 
     if (error || !post) throw new Error("게시글 등록에 실패했습니다.");
 
-    revalidatePath("/board");
+    // 목록 캐시 무효화 (새 글이라 상세 태그는 아직 없음). DB 트리거도 동일 태그를 치지만
+    // 앱에서 즉시 무효화해 작성 직후 목록에 바로 반영되도록 한다(트리거 웹훅은 비동기).
+    revalidateTag(BOARD_POSTS_CACHE_TAG, "max");
     return { post_id: post.post_id };
   });
 }

--- a/app/actions/delete-post.ts
+++ b/app/actions/delete-post.ts
@@ -1,14 +1,17 @@
 "use server";
 
-import { revalidatePath } from "next/cache";
+import { revalidateTag } from "next/cache";
 import { createUntypedAdminClient } from "@/lib/supabase/admin";
 import { withAdminOrThrow } from "@/lib/actions/auth";
+import { BOARD_POSTS_CACHE_TAG, boardPostCacheTag } from "@/lib/queries/board";
 
 export async function deletePost(postId: string) {
   return withAdminOrThrow(async () => {
     const admin = createUntypedAdminClient();
     const { error } = await admin.from("brd_post_mst").update({ del_yn: true }).eq("post_id", postId);
     if (error) throw new Error("게시글 삭제에 실패했습니다.");
-    revalidatePath("/board");
+    // 목록 + 해당 글 상세 캐시 무효화 (삭제된 글의 상세는 다음 조회 시 notFound 처리됨)
+    revalidateTag(BOARD_POSTS_CACHE_TAG, "max");
+    revalidateTag(boardPostCacheTag(postId), "max");
   });
 }

--- a/app/actions/record-board-read.ts
+++ b/app/actions/record-board-read.ts
@@ -1,0 +1,17 @@
+"use server";
+
+import { getCurrentMember } from "@/lib/queries/member";
+import { recordBoardPostRead } from "@/lib/queries/board";
+
+/**
+ * 게시글 읽음 이력을 기록한다.
+ * 게시판 상세는 SSG라 서버 렌더에서 멤버를 조회할 수 없으므로 읽음 처리를 이 액션으로 뺐다.
+ * 비로그인/미가입이면 조용히 no-op (게시판은 공개, 읽음 이력은 로그인 멤버만 의미가 있음).
+ * 홈 화면의 미읽음 표시(hasUnreadBoardPosts)가 이 이력을 소비한다.
+ */
+export async function recordBoardReadAction(postId: string): Promise<void> {
+  const { member } = await getCurrentMember();
+  if (!member) return;
+
+  await recordBoardPostRead(postId, member.id);
+}

--- a/app/actions/update-post.ts
+++ b/app/actions/update-post.ts
@@ -1,8 +1,9 @@
 "use server";
 
-import { revalidatePath } from "next/cache";
+import { revalidateTag } from "next/cache";
 import { createUntypedAdminClient } from "@/lib/supabase/admin";
 import { withMember } from "@/lib/actions/auth";
+import { BOARD_POSTS_CACHE_TAG, boardPostCacheTag } from "@/lib/queries/board";
 import { updatePostSchema } from "@/lib/validations/board";
 import { getKSTDate } from "@/lib/dayjs";
 
@@ -37,7 +38,8 @@ export async function updatePost(input: {
 
     if (error) throw new Error("게시글 수정에 실패했습니다.");
 
-    revalidatePath("/board");
-    revalidatePath(`/board/${input.post_id}`);
+    // 목록 + 해당 글 상세 캐시 무효화 (앱 내 수정 경로)
+    revalidateTag(BOARD_POSTS_CACHE_TAG, "max");
+    revalidateTag(boardPostCacheTag(input.post_id), "max");
   });
 }

--- a/app/api/revalidate/route.ts
+++ b/app/api/revalidate/route.ts
@@ -2,6 +2,7 @@ import { revalidateTag } from "next/cache";
 import { NextRequest, NextResponse } from "next/server";
 import { COMMON_CODES_CACHE_TAG } from "@/lib/common-codes-cache-tag";
 import { env } from "@/lib/env";
+import { BOARD_POSTS_CACHE_TAG } from "@/lib/queries/board";
 import { HOME_CALENDAR_CACHE_TAG } from "@/lib/queries/home-calendar";
 
 /** 홈 캘린더 데이터에 반영되는 테이블 (모임·참석·일정포스트·댓글 카운트) */
@@ -12,6 +13,8 @@ const COMP_TABLES = new Set(["comp_mst", "team_comp_plan_rel", "comp_reg_rel"]);
 const RECORDS_TABLES = new Set(["personal_best", "utmb_profile"]);
 /** 공통코드 캐시에 반영되는 테이블 */
 const CMM_CD_TABLES = new Set(["cmm_cd_mst"]);
+/** 게시판(/board 목록·상세)에 반영되는 테이블 */
+const BOARD_TABLES = new Set(["brd_post_mst"]);
 
 // 홈(/)·랭킹(/records)은 dynamic 렌더라 revalidatePath는 no-op — 태그 무효화만 수행
 function revalidateHomeCalendar() {
@@ -27,6 +30,11 @@ function revalidateCompetitions() {
 function revalidateRecords() {
   // /records 의 unstable_cache(tags: "records", `records:${teamId}`)
   revalidateTag("records", "max");
+}
+
+function revalidateBoard() {
+  // /board 목록 + 상세 (getCachedBoardPost가 board-posts 태그도 공유하므로 상세까지 무효화됨)
+  revalidateTag(BOARD_POSTS_CACHE_TAG, "max");
 }
 
 /** 테이블 정보가 없거나 매핑에 없는 테이블 → 기존 동작대로 전체 무효화 (하위호환 폴백) */
@@ -63,6 +71,8 @@ export async function POST(request: NextRequest) {
     revalidateRecords();
   } else if (CMM_CD_TABLES.has(table)) {
     revalidateTag(COMMON_CODES_CACHE_TAG, "max");
+  } else if (BOARD_TABLES.has(table)) {
+    revalidateBoard();
   } else {
     revalidateAll();
   }

--- a/components/board/post-detail.tsx
+++ b/components/board/post-detail.tsx
@@ -72,7 +72,7 @@ export function PostDetail({ post }: PostDetailProps) {
       <div className="flex flex-col gap-1">
         <Body className="text-[17px] font-semibold leading-snug">{post.post_nm}</Body>
         <Caption>
-          {post.writ_mem_nm ?? "관리자"} · {dayjs(post.crt_at).format("YYYY.MM.DD")}
+          {post.writ_mem_nm ?? "관리자"} · {dayjs(post.crt_at).format("YY.MM.DD")}
         </Caption>
       </div>
 

--- a/components/board/post-detail.tsx
+++ b/components/board/post-detail.tsx
@@ -6,9 +6,11 @@ import Link from "next/link";
 import ReactMarkdown from "react-markdown";
 import remarkGfm from "remark-gfm";
 import rehypeSlug from "rehype-slug";
-import dayjs from "dayjs";
 import { ChevronLeft, ChevronUp } from "lucide-react";
+import { dayjs } from "@/lib/dayjs";
 import type { BoardPost } from "@/lib/queries/board";
+import { checkBoardPermission } from "@/app/actions/check-board-permission";
+import { recordBoardReadAction } from "@/app/actions/record-board-read";
 import { deletePost } from "@/app/actions/delete-post";
 import { Body, Caption } from "@/components/common/typography";
 import { Button } from "@/components/ui/button";
@@ -17,14 +19,22 @@ import { Separator } from "@/components/ui/separator";
 
 type PostDetailProps = {
   post: BoardPost;
-  canEdit: boolean;
 };
 
-export function PostDetail({ post, canEdit }: PostDetailProps) {
+export function PostDetail({ post }: PostDetailProps) {
   const router = useRouter();
   const [deleteOpen, setDeleteOpen] = useState(false);
   const [deleting, setDeleting] = useState(false);
   const [showScrollTop, setShowScrollTop] = useState(false);
+
+  // SSG라 서버에서 못 하는 읽음 처리·권한 계산을 클라에서 수행한다.
+  const [canEdit, setCanEdit] = useState(false);
+  useEffect(() => {
+    recordBoardReadAction(post.post_id).catch(() => {});
+    checkBoardPermission(post.writ_mem_id)
+      .then((p) => setCanEdit(p.canEdit))
+      .catch(() => setCanEdit(false));
+  }, [post.post_id, post.writ_mem_id]);
 
   useEffect(() => {
     const onScroll = () => setShowScrollTop(window.scrollY > 200);

--- a/lib/queries/board.ts
+++ b/lib/queries/board.ts
@@ -1,4 +1,14 @@
+import { unstable_cache } from "next/cache";
+
 import { createUntypedAdminClient } from "@/lib/supabase/admin";
+
+/** 게시판 목록·상세 공개 데이터 캐시 태그 (brd_post_mst 변경 시 무효화) */
+export const BOARD_POSTS_CACHE_TAG = "board-posts";
+
+/** 특정 게시글 상세 캐시 태그 (`board-post:{postId}`) */
+export function boardPostCacheTag(postId: string): string {
+  return `board-post:${postId}`;
+}
 
 export type BoardPost = {
   post_id: string;
@@ -87,6 +97,38 @@ export async function getBoardPost(postId: string): Promise<BoardPost | null> {
     crt_at: post.crt_at,
     upd_at: post.upd_at,
   };
+}
+
+/**
+ * 게시판 목록 캐시 래퍼. 목록 페이지 SSG용.
+ * 무효화 주경로는 DB 트리거 웹훅(revalidateTag(board-posts))이고,
+ * revalidate 시간 만료는 웹훅 유실 시 영구 stale을 막는 안전망이다.
+ */
+export function getCachedBoardPosts(
+  teamId: string,
+  type: "notice" | "update",
+): Promise<BoardPostSummary[]> {
+  return unstable_cache(
+    () => getBoardPosts(teamId, type, { limit: 20 }),
+    [`board-posts-${teamId}-${type}`],
+    { tags: [BOARD_POSTS_CACHE_TAG], revalidate: 3600 },
+  )();
+}
+
+/**
+ * 게시글 상세 캐시 래퍼. 상세 페이지 온디맨드 캐시용.
+ * 태그 2개: 전체 목록 무효화(board-posts)와 특정 글 무효화(board-post:{id}) 둘 다에 반응하도록 유지.
+ * DB 직접 수정(트리거 → board-posts) / 앱 내 수정(revalidateTag(board-post:{id})) 어느 경로로든 갱신됨.
+ */
+export function getCachedBoardPost(postId: string): Promise<BoardPost | null> {
+  return unstable_cache(
+    () => getBoardPost(postId),
+    [`board-post-${postId}`],
+    {
+      tags: [BOARD_POSTS_CACHE_TAG, boardPostCacheTag(postId)],
+      revalidate: 3600,
+    },
+  )();
 }
 
 /** 로그인한 멤버가 해당 팀/타입에서 읽지 않은 게시글이 있는지 확인 */

--- a/lib/supabase/proxy.ts
+++ b/lib/supabase/proxy.ts
@@ -19,10 +19,15 @@ export async function updateSession(request: NextRequest) {
   // 비로그인 상태에서도 접근 가능한 공개 경로 목록
   const pathname = request.nextUrl.pathname;
   const publicPaths = ["/", "/rules", "/join", "/newbie", "/races", "/records", "/projects", "/terms", "/privacy", "/policy", "/settings"];
+  // /board(게시판)은 공개 SSG 페이지 — 목록(/board)·상세(/board/[id]) 모두 비로그인 접근 허용.
+  //   (쓰기/수정 전용 하위 경로 /board/write·/board/[id]/edit는 admin 폼이라 아래 prefix로 공개되지만,
+  //    실제 인가는 페이지의 getCurrentMember 게이트와 서버 액션(withAdminOrThrow)이 재검증하므로 안전하다.)
   // /api/* 는 각 라우트가 자체 인증(멤버 체크·웹훅 시크릿)을 수행하므로 리다이렉트 제외.
   // 쿠키 없는 서버-투-서버 요청(revalidate 웹훅, OG 봇, 크론)을 로그인 페이지로 보내면 안 됨.
   const isPublic =
     publicPaths.includes(pathname) ||
+    pathname === "/board" ||
+    pathname.startsWith("/board/") ||
     pathname.startsWith("/auth") ||
     pathname === "/api" ||
     pathname.startsWith("/api/");

--- a/supabase/migrations/20260721110000_board_revalidate_trigger.sql
+++ b/supabase/migrations/20260721110000_board_revalidate_trigger.sql
@@ -1,0 +1,11 @@
+-- 게시판(brd_post_mst) 변경 시 revalidation 트리거
+-- 기존 revalidate_records() 함수를 재활용 (같은 /api/revalidate 엔드포인트 호출).
+-- 함수 body가 TG_TABLE_NAME('brd_post_mst')을 실어 보내므로,
+-- /api/revalidate의 BOARD_TABLES 분기가 board-posts 태그만 무효화한다(홈·대회·랭킹 안 건드림).
+-- DB 직접 수정(SQL로 공지 편집 등)도 이 트리거를 타므로 앱을 거치지 않아도 캐시가 갱신된다.
+
+-- brd_post_mst (게시글 생성/수정/삭제 — soft delete(del_yn) 포함)
+DROP TRIGGER IF EXISTS trg_brd_post_mst_revalidate ON public.brd_post_mst;
+CREATE TRIGGER trg_brd_post_mst_revalidate
+  AFTER INSERT OR UPDATE OR DELETE ON public.brd_post_mst
+  FOR EACH ROW EXECUTE FUNCTION revalidate_records();


### PR DESCRIPTION
## 관련 이슈

- 관련 이슈 없음

## 요약

거의 안 바뀌는데 자주 읽히는 게시판(공지·업데이트)을 **매 요청 DB 조회하는 동적 페이지 → 정적 생성(SSG) + 태그 기반 on-demand revalidation**으로 전환한다. 첫 요청 후엔 정적 HTML을 내주고, 글이 실제로 바뀔 때만 캐시를 다시 굽는다.

## AS-IS (변경 전)

게시판 방문 시마다:

- `getCurrentMember()`로 로그인 확인 + `getRequestTeamContext()`로 팀 조회 (쿠키 접근 → 페이지가 **동적 렌더** 강제)
- 공지 20개 + 업데이트 20개를 **매 요청 DB에서 새로 조회**
- 상세도 요청마다 글 + 작성자 조회 + 읽음 처리 + 권한 계산
- 무효화는 `revalidatePath("/board")` (동적 페이지엔 사실상 무의미)
- 비로그인 시 서버에서 `/auth/login`으로 리다이렉트 (로그인 필수)

→ 안 바뀌는 데이터를 매번 다시 읽는 낭비 + 불필요한 DB 부하.

## TO-BE (변경 후)

- **목록 `/board`**: 정적 생성(**SSG**, 빌드 출력 `○`). `getCachedBoardPosts`(`unstable_cache`, 태그 `board-posts`). teamId는 단일팀 상수 고정.
- **상세 `/board/[id]`**: 온디맨드 캐시(`◐`). `getCachedBoardPost`(태그 `board-posts` + `board-post:{id}` 둘 다 — DB 직접수정/앱내수정 어느 경로로든 갱신).
- **인증·권한·읽음처리를 클라 서버액션으로 분리** (SSG라 서버에서 못 하므로):
  - `checkBoardPermission()` — 작성/수정 버튼 노출용 `canWrite`/`canEdit`
  - `recordBoardReadAction()` — 읽음 처리 (홈 미읽음 표시가 소비)
- **무효화 `revalidatePath` → `revalidateTag`** (`create`/`update`/`delete-post`). `/api/revalidate`에 **`BOARD_TABLES` 분기** 추가 → `brd_post_mst` 변경 시 `board-posts` 태그만 무효화(홈·대회·랭킹 안 건드림).
- **DB 트리거** `trg_brd_post_mst_revalidate`: 기존 `revalidate_records()` 재사용 (앱을 거치지 않는 DB 직접 수정도 캐시 갱신). **dev DB에만 적용됨** — prd는 이 PR 병합·배포 시 마이그레이션으로 반영.
- **게시판 공개 전환**: 미들웨어(`lib/supabase/proxy.ts`) `publicPaths`에 `/board` 추가 → 비로그인도 목록·상세 열람 가능. 쓰기/수정/삭제는 여전히 관리자만(페이지 게이트 + 서버액션 `withAdminOrThrow` 재검증).

### 검증

- `pnpm build`: `○ /board`(정적), `◐ /board/[id]`(온디맨드) 확인
- `pnpm test`: 233/233 통과
- 실제 굴려보기(비로그인): 목록 200(기존 307 리다이렉트→공개), 실제 글 상세 200, 없는 글 404 UI 정상

### 알려진 동작 변화

- 없는 글 접근 시 HTTP 상태가 404 → **200(soft 404)**. not-found 화면은 정상 표시되나 스트리밍/캐시 특성상 상태코드는 200.

## 변경 흐름 (Mermaid)

```mermaid
flowchart TD
    subgraph ASIS["AS-IS: 동적 렌더"]
        A1[요청] --> A2[getCurrentMember + team ctx]
        A2 --> A3[매번 DB 조회 공지·업데이트]
        A3 --> A4[동적 HTML]
    end

    subgraph TOBE["TO-BE: SSG + 태그 무효화"]
        B1[요청] --> B2{캐시 hit?}
        B2 -->|hit| B3[정적 HTML 즉시 반환]
        B2 -->|miss| B4[getCachedBoardPosts DB 1회] --> B5[캐시 굽고 반환]
        B6[글 생성·수정·삭제] -->|revalidateTag board-posts| B2
        B7[brd_post_mst DB 트리거] -->|/api/revalidate BOARD_TABLES| B2
    end
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새 기능**
  * 게시판을 로그인 없이 열람할 수 있도록 개선했습니다.
  * 게시글 작성·수정 버튼이 로그인 상태와 권한에 따라 표시됩니다.
  * 게시글 읽음 기록과 권한 확인을 지원합니다.

* **개선 사항**
  * 게시판 목록과 상세 게시글의 로딩 성능 및 최신 데이터 반영을 개선했습니다.
  * 게시글 생성·수정·삭제 후 변경 내용이 게시판에 빠르게 반영됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->