### PR TITLE
chore: set-project-state.json도 gitignore 처리

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -92,3 +92,4 @@ CLAUDE.local.md
 .env.*
 .gstack/
 .claude/dev-profile.toml
+.claude/set-project-state.json


### PR DESCRIPTION
## AS-IS
`set-project` 스킬이 생성하는 머신별 셋업 스탬프 파일 `.claude/set-project-state.json`이 git 추적 대상이라, 머신마다 셋업할 때마다 커밋 후보로 잡힘.

## TO-BE
`.claude/dev-profile.toml`(커밋 6aa44eb에서 이미 gitignore)과 동일하게 `.claude/set-project-state.json`도 `.gitignore`에 추가. 각 머신에서 독립 생성되는 개인 설정이므로 레포에 커밋하지 않는다.

## 변경
- `.gitignore`에 `.claude/set-project-state.json` 한 줄 추가

머신별 스탬프 파일이라 로컬에만 남기는 것이 `.claude` 개인설정 분리 방향과 일관됨.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018fYh2XfDUiNTNRGiqTLw9p

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * 프로젝트 상태 파일이 버전 관리 대상에서 제외되도록 설정을 업데이트했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->