### PR TITLE
fix(dev): /dev 라우트 게이트가 정적으로 굳어 404 나는 문제 수정

### DIFF
--- a/app/(info)/dev/layout.tsx
+++ b/app/(info)/dev/layout.tsx
@@ -1,4 +1,5 @@
 import { notFound } from "next/navigation";
+import { connection } from "next/server";
 
 import { isDevModeEnabled } from "@/lib/dev-mode";
 
@@ -7,18 +8,19 @@ import { isDevModeEnabled } from "@/lib/dev-mode";
  * 라우트 그룹 레이아웃에서 한 번에 가둔다 — 페이지마다 게이트를 붙이지 않기 위해서.
  * 개발 모드가 꺼져 있으면 404로 떨군다.
  *
- * force-dynamic 필수: isDevModeEnabled()는 cookies()/headers() 등 동적 API를 쓰지 않아
+ * connection() 필수: isDevModeEnabled()는 cookies()/headers() 등 동적 API를 쓰지 않아
  * cacheComponents 아래에서는 빌드 타임에 정적으로 프리렌더된다. 그러면 그 시점의
  * true/false가 정적 HTML(또는 정적 404)로 굳어져, 배포 후 환경변수를 바꿔도 재배포
  * 전까지 절대 안 바뀐다 — 개발계에서 링크는 보이는데 실제 페이지는 영구 404인 버그로 나타남.
+ * `export const dynamic = "force-dynamic"`은 cacheComponents와 호환되지 않아(빌드 에러)
+ * 쓸 수 없고, 동적 렌더링을 요구하는 정본 API인 connection()으로 강제한다.
  */
-export const dynamic = "force-dynamic";
-
-export default function DevLayout({
+export default async function DevLayout({
   children,
 }: {
   children: React.ReactNode;
 }) {
+  await connection();
   if (!isDevModeEnabled()) notFound();
   return children;
 }

--- a/app/(info)/dev/layout.tsx
+++ b/app/(info)/dev/layout.tsx
@@ -6,7 +6,14 @@ import { isDevModeEnabled } from "@/lib/dev-mode";
  * `/dev/*`는 시안 비교·이펙트 목업 등 개발 전용 지면이다. 운영에서 도달하면 안 되므로
  * 라우트 그룹 레이아웃에서 한 번에 가둔다 — 페이지마다 게이트를 붙이지 않기 위해서.
  * 개발 모드가 꺼져 있으면 404로 떨군다.
+ *
+ * force-dynamic 필수: isDevModeEnabled()는 cookies()/headers() 등 동적 API를 쓰지 않아
+ * cacheComponents 아래에서는 빌드 타임에 정적으로 프리렌더된다. 그러면 그 시점의
+ * true/false가 정적 HTML(또는 정적 404)로 굳어져, 배포 후 환경변수를 바꿔도 재배포
+ * 전까지 절대 안 바뀐다 — 개발계에서 링크는 보이는데 실제 페이지는 영구 404인 버그로 나타남.
  */
+export const dynamic = "force-dynamic";
+
 export default function DevLayout({
   children,
 }: {


### PR DESCRIPTION
## 관련 이슈

관련 이슈 없음

## 요약

개발 전용 `/dev/*` 라우트 게이트가 `cacheComponents` 아래에서 빌드 타임에 정적으로 프리렌더되어, 배포 후 환경변수를 바꿔도 재배포 전까지 반영되지 않던 문제를 수정합니다.

## AS-IS (변경 전)

- `app/(info)/dev/layout.tsx`의 `isDevModeEnabled()` 게이트는 `cookies()`/`headers()` 같은 동적 API를 쓰지 않는다. `cacheComponents: true` 아래에서 Next.js는 이런 세그먼트를 빌드 타임에 완전히 정적으로 프리렌더한다.
- 그 결과 빌드 시점의 게이트 결과(통과 vs `notFound()`)가 정적 HTML로 영구히 굳어, 이후 Vercel 환경변수(`NEXT_PUBLIC_ENABLE_DEV_MODE`)를 바꿔도 재배포 전까지 반영되지 않는다.
- `/story` 제호의 "지면"·"접속자" 링크는 `getCurrentMember()` 등으로 인해 동적 렌더링이라 현재 값을 정확히 반영하는 반면, 실제 목적지인 `/dev/story-styles`·`/dev/presence-styles`는 빌드 시점 값에 고정돼 개발계(`dev.gigang.team`)에서 "링크는 보이는데 클릭하면 404"가 뜨는 비대칭이 발생했다. (빌드 로그로 `/dev/story-styles`가 `○ Static`으로 생성됨을 확인)

## TO-BE (변경 후)

- `app/(info)/dev/layout.tsx`에 `export const dynamic = "force-dynamic"`을 추가해 이 세그먼트를 정적 프리렌더 대상에서 제외.
- `isDevModeEnabled()`가 매 요청마다 재평가되어, `/story` 링크와 동일하게 항상 현재 환경변수 값을 반영한다.
- `/dev/*` 아래 앞으로 추가될 다른 개발 전용 시안 페이지에도 동일하게 적용되는 공용 수정이다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **버그 수정**
  * 배포 후 개발자 기능 설정 변경이 반영되지 않아 페이지가 영구적으로 404로 표시될 수 있는 문제를 수정했습니다.
  * 개발자 관련 페이지가 최신 설정에 따라 동적으로 표시됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->