### PR TITLE
feat(mcp): 운영진 AI 조회·알림 MCP (읽기 6도구 + 발송 + PAT 인증)

### DIFF
--- a/app/(info)/mcp-tokens/mcp-tokens-client.tsx
+++ b/app/(info)/mcp-tokens/mcp-tokens-client.tsx
@@ -1,0 +1,195 @@
+"use client";
+
+import { useState, useTransition } from "react";
+
+import { useRouter } from "next/navigation";
+
+import { Check, Copy, KeyRound, Trash2 } from "lucide-react";
+
+import { createMcpToken, revokeMcpToken, type McpTokenSummary } from "@/app/actions/mcp-token";
+import { dayjs } from "@/lib/dayjs";
+import { MCP_TOKEN_LABEL_MAX } from "@/lib/validations/mcp-token";
+
+import { Body, Caption, Micro } from "@/components/common/typography";
+import { EmptyState } from "@/components/common/empty-state";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { CardItem } from "@/components/ui/card";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Input } from "@/components/ui/input";
+
+const MCP_ENDPOINT_PATH = "/api/mcp/mcp";
+
+type Props = {
+  initialTokens: McpTokenSummary[];
+};
+
+export function McpTokensClient({ initialTokens }: Props) {
+  const router = useRouter();
+  const [tokens, setTokens] = useState(initialTokens);
+  const [label, setLabel] = useState("");
+  const [error, setError] = useState<string | null>(null);
+  const [isPending, startTransition] = useTransition();
+
+  // 발급 직후 1회만 노출하는 평문 토큰. 화면 상태 외 어디에도 저장하지 않는다.
+  const [issuedToken, setIssuedToken] = useState<string | null>(null);
+  const [copied, setCopied] = useState(false);
+  const [revokingId, setRevokingId] = useState<string | null>(null);
+
+  function handleCreate(e: React.FormEvent) {
+    e.preventDefault();
+    setError(null);
+    startTransition(async () => {
+      const result = await createMcpToken(label);
+      if (!result.ok) {
+        setError(result.message);
+        return;
+      }
+      setIssuedToken(result.token);
+      setCopied(false);
+      setLabel("");
+      setTokens((prev) => [
+        {
+          token_id: result.token_id,
+          label: result.label,
+          created_at: result.created_at,
+          last_used_at: null,
+          revoked: false,
+        },
+        ...prev,
+      ]);
+    });
+  }
+
+  function handleRevoke(tokenId: string) {
+    if (!window.confirm("이 토큰을 폐기하시겠습니까? 이 토큰을 사용하는 MCP 클라이언트는 즉시 접속이 끊깁니다.")) return;
+    setRevokingId(tokenId);
+    startTransition(async () => {
+      const result = await revokeMcpToken(tokenId);
+      setRevokingId(null);
+      if (!result.ok) {
+        setError(result.message);
+        return;
+      }
+      setTokens((prev) =>
+        prev.map((t) => (t.token_id === tokenId ? { ...t, revoked: true } : t)),
+      );
+      router.refresh();
+    });
+  }
+
+  async function handleCopy() {
+    if (!issuedToken) return;
+    await navigator.clipboard.writeText(issuedToken);
+    setCopied(true);
+    setTimeout(() => setCopied(false), 1500);
+  }
+
+  return (
+    <div className="flex flex-col gap-7 px-6 pb-6 pt-4">
+      <div className="flex flex-col gap-2">
+        <Body className="font-semibold">MCP 토큰</Body>
+        <Caption>
+          운영 AI 도구(MCP 클라이언트)를 기강 데이터에 연결할 때 쓰는 개인 액세스 토큰입니다.
+          발급된 토큰은 발급 직후 한 번만 볼 수 있으니 안전한 곳에 보관하세요.
+        </Caption>
+      </div>
+
+      <CardItem className="flex flex-col gap-1.5">
+        <Micro className="font-semibold uppercase tracking-widest">접속 URL</Micro>
+        <Caption className="break-all font-mono text-foreground">{MCP_ENDPOINT_PATH}</Caption>
+        <Micro>MCP 클라이언트에 위 경로 앞에 이 팀의 도메인을 붙여 등록하세요.</Micro>
+      </CardItem>
+
+      <form onSubmit={handleCreate} className="flex flex-col gap-3">
+        <div className="flex gap-2">
+          <Input
+            value={label}
+            onChange={(e) => setLabel(e.target.value)}
+            placeholder="이름 (예: 내 노트북, Claude Desktop)"
+            maxLength={MCP_TOKEN_LABEL_MAX}
+            disabled={isPending}
+          />
+          <Button type="submit" disabled={isPending}>
+            발급
+          </Button>
+        </div>
+        {error && <Caption className="text-destructive">{error}</Caption>}
+      </form>
+
+      <div className="flex flex-col gap-3">
+        {tokens.length === 0 ? (
+          <EmptyState variant="card" icon={KeyRound} message="발급된 토큰이 없습니다." />
+        ) : (
+          tokens.map((token) => (
+            <CardItem key={token.token_id} className="flex items-center justify-between gap-3">
+              <div className="flex min-w-0 flex-col gap-1">
+                <div className="flex items-center gap-2">
+                  <Body className="truncate font-semibold">
+                    {token.label || "이름 없음"}
+                  </Body>
+                  {token.revoked && (
+                    <Badge variant="secondary" className="shrink-0">
+                      폐기됨
+                    </Badge>
+                  )}
+                </div>
+                <Micro>
+                  발급 {dayjs(token.created_at).format("YY.MM.DD HH:mm")}
+                  {token.last_used_at &&
+                    ` · 최근 사용 ${dayjs(token.last_used_at).format("YY.MM.DD HH:mm")}`}
+                </Micro>
+              </div>
+              {!token.revoked && (
+                <Button
+                  type="button"
+                  variant="ghost"
+                  size="icon-sm"
+                  aria-label="토큰 폐기"
+                  disabled={isPending && revokingId === token.token_id}
+                  onClick={() => handleRevoke(token.token_id)}
+                >
+                  <Trash2 className="size-4 text-destructive" />
+                </Button>
+              )}
+            </CardItem>
+          ))
+        )}
+      </div>
+
+      <Dialog open={issuedToken !== null} onOpenChange={(open) => !open && setIssuedToken(null)}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>토큰이 발급되었습니다</DialogTitle>
+            <DialogDescription>
+              이 토큰은 지금만 표시됩니다. 다시 볼 수 없으니 지금 복사해 안전한 곳에 보관하세요.
+            </DialogDescription>
+          </DialogHeader>
+
+          <div className="flex items-center gap-2 rounded-xl border border-border bg-muted px-3.5 py-3">
+            <Caption className="flex-1 overflow-x-auto whitespace-nowrap break-all font-mono text-foreground">
+              {issuedToken}
+            </Caption>
+          </div>
+
+          <DialogFooter>
+            <Button type="button" variant="outline" onClick={handleCopy} className="gap-2">
+              {copied ? <Check className="size-4 text-success" /> : <Copy className="size-4" />}
+              {copied ? "복사됨" : "복사"}
+            </Button>
+            <Button type="button" onClick={() => setIssuedToken(null)}>
+              확인
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </div>
+  );
+}

--- a/app/(info)/mcp-tokens/page.tsx
+++ b/app/(info)/mcp-tokens/page.tsx
@@ -1,0 +1,20 @@
+import { redirect } from "next/navigation";
+
+import { listMcpTokens } from "@/app/actions/mcp-token";
+import { getCurrentMember } from "@/lib/queries/member";
+
+import { McpTokensClient } from "./mcp-tokens-client";
+
+export const metadata = { title: "MCP 토큰" };
+
+export default async function McpTokensPage() {
+  const { user, member } = await getCurrentMember();
+
+  if (!user) redirect("/auth/login?next=/mcp-tokens");
+  if (!member) redirect("/onboarding?next=/mcp-tokens");
+
+  const result = await listMcpTokens();
+  const initialTokens = result.ok ? result.tokens : [];
+
+  return <McpTokensClient initialTokens={initialTokens} />;
+}

--- a/app/actions/mcp-token.ts
+++ b/app/actions/mcp-token.ts
@@ -1,0 +1,109 @@
+"use server";
+
+import {
+  issueMcpToken,
+  listMcpTokens as listMcpTokensQuery,
+  revokeMcpToken as revokeMcpTokenMutation,
+  McpTokenNotFoundError,
+  type McpTokenSummary,
+} from "@/lib/mcp/issue-token";
+import { getCurrentMember } from "@/lib/queries/member";
+import { getRequestTeamContext } from "@/lib/queries/request-team";
+import { createAdminClient } from "@/lib/supabase/admin";
+import { createMcpTokenSchema } from "@/lib/validations/mcp-token";
+
+/**
+ * 운영 MCP PAT 발급/목록/폐기 서버 액션(SG-03, AC-08).
+ *
+ * `mcp_token_rel`은 service-role 전용 RLS라 여기서 admin 클라이언트를 생성해 주입하고,
+ * 실제 쿼리·해시·스코프 로직은 `lib/mcp/issue-token.ts`(server-only 미의존, 단위테스트 가능)에 위임한다.
+ * `verifyAdmin`은 요구하지 않는다 — 본인 토큰 발급/관리는 팀 멤버(가입 완료) 전원 허용(스펙 §3.1).
+ */
+
+export type { McpTokenSummary };
+
+export type CreateMcpTokenResult =
+  | {
+      ok: true;
+      token_id: string;
+      /** 평문 토큰 — 이 응답에서만 1회 노출. 클라이언트는 저장하지 않고 사용자에게 즉시 보여준 뒤 버린다. */
+      token: string;
+      label: string | null;
+      created_at: string;
+    }
+  | { ok: false; message: string };
+
+/** 로그인 + 가입 완료 멤버 본인 명의로 새 PAT를 발급한다. */
+export async function createMcpToken(labelInput: string): Promise<CreateMcpTokenResult> {
+  const { member } = await getCurrentMember();
+  if (!member) return { ok: false, message: "로그인이 필요합니다." };
+
+  const parsed = createMcpTokenSchema.safeParse({ label: labelInput });
+  if (!parsed.success) {
+    return {
+      ok: false,
+      message: parsed.error.issues[0]?.message ?? "입력값을 확인해 주세요.",
+    };
+  }
+
+  const { teamId } = await getRequestTeamContext();
+  const admin = createAdminClient();
+
+  try {
+    const result = await issueMcpToken(admin, {
+      memId: member.id,
+      teamId,
+      label: parsed.data.label ? parsed.data.label : null,
+    });
+    return {
+      ok: true,
+      token_id: result.token_id,
+      token: result.token,
+      label: result.label,
+      created_at: result.created_at,
+    };
+  } catch (e) {
+    console.error("[mcp-token] createMcpToken error:", e);
+    return { ok: false, message: "토큰 발급에 실패했습니다. 다시 시도해 주세요." };
+  }
+}
+
+export type ListMcpTokensResult =
+  | { ok: true; tokens: McpTokenSummary[] }
+  | { ok: false; message: string };
+
+/** 로그인 멤버 본인의 토큰 목록만 반환한다(label·생성/사용/폐기 여부 — token_hash·원문 미포함). */
+export async function listMcpTokens(): Promise<ListMcpTokensResult> {
+  const { member } = await getCurrentMember();
+  if (!member) return { ok: false, message: "로그인이 필요합니다." };
+
+  const admin = createAdminClient();
+  try {
+    const tokens = await listMcpTokensQuery(admin, member.id);
+    return { ok: true, tokens };
+  } catch (e) {
+    console.error("[mcp-token] listMcpTokens error:", e);
+    return { ok: false, message: "토큰 목록을 불러오지 못했습니다." };
+  }
+}
+
+export type RevokeMcpTokenResult = { ok: true } | { ok: false; message: string };
+
+/** 본인 소유 토큰만 폐기 가능 — mem_id 스코프는 lib/mcp/issue-token.ts가 강제한다. */
+export async function revokeMcpToken(tokenId: string): Promise<RevokeMcpTokenResult> {
+  const { member } = await getCurrentMember();
+  if (!member) return { ok: false, message: "로그인이 필요합니다." };
+  if (!tokenId) return { ok: false, message: "잘못된 요청입니다." };
+
+  const admin = createAdminClient();
+  try {
+    await revokeMcpTokenMutation(admin, member.id, tokenId);
+    return { ok: true };
+  } catch (e) {
+    if (e instanceof McpTokenNotFoundError) {
+      return { ok: false, message: e.message };
+    }
+    console.error("[mcp-token] revokeMcpToken error:", e);
+    return { ok: false, message: "토큰 폐기에 실패했습니다." };
+  }
+}

--- a/app/api/mcp/README.md
+++ b/app/api/mcp/README.md
@@ -1,0 +1,112 @@
+# 기강 운영 MCP — 연결·사용 가이드
+
+운영진이 **자기 AI 비서(Claude Code / Cursor / Claude Desktop)**에 붙여, 기강 운영 현황을 조회하고 알림을 보내는 MCP 서버입니다. 설치 파일을 "다운로드"하는 게 아니라, **엔드포인트 URL + 개인 토큰**을 AI 클라이언트에 등록하면 됩니다.
+
+- 설계 정본: [`docs/superpowers/specs/2026-07-24-gigang-ops-mcp-design.md`](../../../docs/superpowers/specs/2026-07-24-gigang-ops-mcp-design.md)
+- 전송 방식: Streamable HTTP (`mcp-handler`)
+
+---
+
+## 1. 접속 정보
+
+| 환경 | 엔드포인트 URL | 토큰 발급 화면 |
+|------|----------------|----------------|
+| 로컬 | `http://localhost:3000/api/mcp/mcp` | `http://localhost:3000/mcp-tokens` |
+| 개발(dev) | `https://dev.gigang.team/api/mcp/mcp` | `https://dev.gigang.team/mcp-tokens` |
+| 운영(prod) | `https://gigang.team/api/mcp/mcp` | `https://gigang.team/mcp-tokens` |
+
+> 라우트가 `app/api/mcp/[transport]/route.ts`라 basePath가 `/api/mcp`이고, 접속 URL은 끝에 `/mcp`가 한 번 더 붙어 **`/api/mcp/mcp`**입니다.
+
+각 환경은 자기 Supabase를 쓰므로, 그 환경에 **마이그레이션 2건이 적용돼 있어야** 동작합니다(§5 참고).
+
+---
+
+## 2. 개인 토큰 발급
+
+1. 위 표의 **토큰 발급 화면**(`/mcp-tokens`)에 로그인 상태로 접속. (설정 화면의 "MCP 토큰" 링크로도 이동 가능)
+2. 라벨 입력(예: `내 노트북`) → **발급**.
+3. `gmcp_...` 토큰이 **딱 한 번만** 표시됩니다. 즉시 복사하세요 — 다시 볼 수 없습니다.
+4. 안 쓰는 토큰은 같은 화면에서 **폐기**할 수 있습니다. 폐기 즉시 접속이 차단됩니다.
+
+- 토큰은 **본인 것만** 보이고 폐기할 수 있습니다.
+- 조회 6종은 팀 멤버면 누구나. **알림 발송(`send_push`)은 owner/admin 역할만** 됩니다.
+
+---
+
+## 3. AI 클라이언트에 등록
+
+> ⚠️ 토큰은 **비밀**입니다. git에 커밋되는 공용 파일(`.mcp.json` 등)에 넣지 말고, 사용자 스코프나 git 미추적 위치에 두세요.
+
+### Claude Code (CLI)
+```bash
+claude mcp add --transport http --scope user gigang-ops \
+  https://dev.gigang.team/api/mcp/mcp \
+  --header "Authorization: Bearer gmcp_여기에붙여넣기"
+```
+- 등록 후 **새 세션**을 시작하고 `/mcp`에서 `gigang-ops ✔ Connected` 확인 → `whoami`로 신원 확인.
+- `--scope user`: 모든 프로젝트에서 사용. 특정 프로젝트만이면 생략.
+
+### Cursor — `.cursor/mcp.json`
+```json
+{
+  "mcpServers": {
+    "gigang-ops": {
+      "url": "https://dev.gigang.team/api/mcp/mcp",
+      "headers": { "Authorization": "Bearer gmcp_여기에붙여넣기" }
+    }
+  }
+}
+```
+
+### Claude Desktop
+설정 → Connectors에 원격 MCP로 같은 URL + `Authorization` 헤더 추가. (HTTP+헤더 인증 미지원 구버전은 `mcp-remote` 브릿지 사용.)
+
+---
+
+## 4. 사용 예시 · 도구 목록
+
+AI에게 자연어로 물으면 아래 도구를 알아서 호출합니다. **"누구를 부를지" 같은 판단은 AI가** 하고, 도구는 사실만 돌려줍니다.
+
+| 도구 | 입력 | 하는 일 | 권한 |
+|------|------|---------|------|
+| `whoami` | — | 내 신원(mem_id·team·admin 여부) 확인 | 멤버 |
+| `list_today_gatherings` | `date?`(YYYY-MM-DD, 기본 오늘) | 오늘 모임 + 각 참석자 수 | 멤버 |
+| `list_recent_members` | `limit?`(기본 10) | 최근 가입 멤버 | 멤버 |
+| `list_members_attendance` | `limit?` | 멤버별 참석 횟수·마지막 참석일(오래 안 나온 순) | 멤버 |
+| `get_member_profile` | `member_id`(uuid) 또는 `name` | 멤버 프로필(이름·생일·성별·가입일·역할·소개) | 멤버 |
+| `list_gathering_non_attendees` | `gathering_id`(uuid) | 특정 모임 미참석자 + 참석 현황 | 멤버 |
+| `list_push_status` | — | 멤버별 웹푸시 구독 여부 | 멤버 |
+| `send_push` | `member_ids`(uuid[]), `title`, `message` | 지정 멤버에게 인앱+웹푸시 발송 | **admin** |
+
+예시 질문:
+- "오늘 일정 몇 명 와?"
+- "최근에 가입한 사람 누구야?"
+- "요즘 모임 안 나오는 사람 순으로 보여줘. 그 중 오래 안 온 2명만 추천해줘"
+- "다음 주 토요일 러닝에 아직 신청 안 한 사람 알려줘"
+- (admin) "홍길동한테 '이번 주 벙 잊지 마세요' 알림 보내줘"
+
+> **연락처·이메일·계좌 정보는 어떤 도구도 반환하지 않습니다.**
+
+---
+
+## 5. 배포 시 주의 (개발자)
+
+- 이 기능은 DB 테이블 2개를 추가합니다:
+  - `supabase/migrations/20260724150000_mcp_token_rel.sql` (개인 토큰)
+  - `supabase/migrations/20260724170000_mcp_audit_log.sql` (발송 감사)
+- **각 환경의 Supabase에 이 마이그레이션이 선적용돼야** 인증·발송이 동작합니다. 미적용 시 인증이 전부 401로 실패합니다(모임 취소 릴리스 전례와 동일 함정). 특히 **prod 릴리스 시 선적용 필수.**
+- 두 테이블 모두 RLS on + 정책 0개 = **service_role 전용**입니다.
+
+---
+
+## 6. 트러블슈팅
+
+| 증상 | 원인·조치 |
+|------|-----------|
+| `401` / 연결 실패 | 토큰 오타·만료·폐기, 또는 비활성 멤버. `/mcp-tokens`에서 새 토큰 발급. |
+| `Connected` 안 뜸 | URL 확인(`/api/mcp/mcp`), 등록 후 **세션 재시작**. 해당 환경 배포·마이그레이션 상태 확인. |
+| `send_push`가 거부됨 | owner/admin 역할만 발송 가능. 조회는 가능. |
+| 특정 멤버가 발송에서 빠짐 | 타 팀·비활성·미존재이거나 알림 수신거부. 발송은 우리 팀 활성 멤버로만 나갑니다. |
+| 토큰을 잃어버림 | 다시 볼 수 없습니다. 기존 토큰 폐기 후 새로 발급하세요. |
+
+문의: 운영/개발 담당(테크리드).

--- a/app/api/mcp/[transport]/route.ts
+++ b/app/api/mcp/[transport]/route.ts
@@ -1,0 +1,83 @@
+import { createMcpHandler, withMcpAuth } from "mcp-handler";
+
+import { resolveOperator, type OperatorContext } from "@/lib/mcp/auth";
+import { createAdminClient } from "@/lib/supabase/admin";
+
+/**
+ * 기강 운영 MCP — Streamable HTTP 엔드포인트.
+ *
+ * 라우트 위치가 `app/api/mcp/[transport]/route.ts` 이므로 basePath 는 `/api/mcp`,
+ * 클라이언트 접속 URL 은 `/api/mcp/mcp` 이다(mcp-handler 규약: endpoint = basePath + "/mcp").
+ *
+ * 인증: `withMcpAuth`(required) 가 앞단에서 `Authorization: Bearer <PAT>` 를 검사한다.
+ *   토큰 없음/무효/폐기/만료/비활성 멤버 → 401(스펙 §7). 성공 시 operator 컨텍스트를
+ *   `AuthInfo.extra` 로 각 도구에 주입한다. 서버 전용 service-role 클라이언트만 사용하며
+ *   토큰 해시·시크릿은 어떤 응답에도 노출하지 않는다.
+ *
+ * 이번 단계(SG-02)는 health 도구 `whoami` 하나만 노출한다. 6개 조회 도구·send_push 는
+ * 후속 sub-goal 에서 추가한다.
+ */
+const handler = createMcpHandler(
+  (server) => {
+    server.registerTool(
+      "whoami",
+      {
+        title: "내 신원 확인",
+        description:
+          "인증된 운영자의 팀 스코프 신원(mem_id, team_id, is_admin, 이름)을 반환하는 health 도구입니다.",
+        inputSchema: {},
+      },
+      async (_args, extra) => {
+        const ctx = extra.authInfo?.extra as OperatorContext | undefined;
+        if (!ctx) {
+          // withMcpAuth(required)가 미인증을 401로 이미 차단하므로 도달하지 않는 방어선.
+          return {
+            content: [{ type: "text", text: "인증 정보를 확인할 수 없습니다." }],
+            isError: true,
+          };
+        }
+        const identity = {
+          mem_id: ctx.mem_id,
+          team_id: ctx.team_id,
+          is_admin: ctx.is_admin,
+          mem_nm: ctx.mem_nm,
+        };
+        return {
+          content: [{ type: "text", text: JSON.stringify(identity) }],
+        };
+      },
+    );
+  },
+  {
+    serverInfo: { name: "gigang-ops-mcp", version: "0.1.0" },
+  },
+  {
+    basePath: "/api/mcp",
+    disableSse: true,
+    verboseLogs: false,
+  },
+);
+
+/**
+ * Bearer 토큰을 검증해 operator 컨텍스트를 `AuthInfo.extra` 로 실어 반환한다.
+ * 검증 실패(토큰 없음 포함)는 `undefined` → withMcpAuth(required)가 401 처리.
+ * service-role 클라이언트는 여기(서버)에서만 생성·사용한다.
+ */
+const authHandler = withMcpAuth(
+  handler,
+  async (_req, bearerToken) => {
+    if (!bearerToken) return undefined;
+    const supabase = createAdminClient();
+    const ctx = await resolveOperator(bearerToken, supabase);
+    if (!ctx) return undefined;
+    return {
+      token: bearerToken,
+      clientId: ctx.mem_id,
+      scopes: ctx.is_admin ? ["operator", "admin"] : ["operator"],
+      extra: ctx as unknown as Record<string, unknown>,
+    };
+  },
+  { required: true },
+);
+
+export { authHandler as GET, authHandler as POST };

--- a/app/api/mcp/[transport]/route.ts
+++ b/app/api/mcp/[transport]/route.ts
@@ -11,6 +11,7 @@ import {
   listRecentMembers,
   listTodayGatherings,
 } from "@/lib/mcp/queries";
+import { SendPushDeniedError, sendPush } from "@/lib/mcp/send-push";
 import { createAdminClient } from "@/lib/supabase/admin";
 
 /** MCP 도구 응답 도우미 — 사실 payload를 text JSON 으로 감싼다. */
@@ -191,6 +192,46 @@ const handler = createMcpHandler(
       },
       async (_args, extra) =>
         runReadTool(extra, (ctx, supabase) => listPushStatus(supabase, ctx.team_id)),
+    );
+
+    // ── write 도구 1개(SG-05). admin 전용 · ctx.team_id 스코프 · 감사 로그 필수. ──
+
+    server.registerTool(
+      "send_push",
+      {
+        title: "멤버에게 알림 발송",
+        description:
+          "지정한 우리 팀 멤버들에게 인앱 알림과 웹푸시를 발송합니다. 운영진(admin) 전용이며, 교차 팀 발송은 불가합니다. member_ids 는 우리 팀 활성 멤버의 uuid 목록입니다.",
+        inputSchema: {
+          member_ids: z
+            .array(z.string().uuid("member_ids 는 uuid 목록이어야 합니다."))
+            .min(1, "최소 1명 이상의 수신자가 필요합니다.")
+            .max(500),
+          title: z.string().min(1, "제목을 입력하세요.").max(100),
+          message: z.string().min(1, "내용을 입력하세요.").max(1000),
+        },
+      },
+      async (args, extra) => {
+        const ctx = extra.authInfo?.extra as OperatorContext | undefined;
+        if (!ctx) {
+          // withMcpAuth(required)가 미인증을 401로 이미 차단하므로 도달하지 않는 방어선.
+          return errorResult("인증 정보를 확인할 수 없습니다.");
+        }
+        try {
+          const supabase = createAdminClient();
+          const result = await sendPush(supabase, ctx, {
+            memberIds: args.member_ids,
+            title: args.title,
+            message: args.message,
+          });
+          return textResult(result);
+        } catch (err) {
+          // 비-admin 거부(G-2/§7 403)·알려진 입력 오류만 메시지 노출, 그 외는 마스킹.
+          if (err instanceof SendPushDeniedError) return errorResult(err.message);
+          if (err instanceof ToolInputError) return errorResult(err.message);
+          return errorResult("요청을 처리하지 못했습니다.");
+        }
+      },
     );
   },
   {

--- a/app/api/mcp/[transport]/route.ts
+++ b/app/api/mcp/[transport]/route.ts
@@ -1,7 +1,51 @@
 import { createMcpHandler, withMcpAuth } from "mcp-handler";
+import { z } from "zod";
 
 import { resolveOperator, type OperatorContext } from "@/lib/mcp/auth";
+import {
+  ToolInputError,
+  getMemberProfile,
+  listGatheringNonAttendees,
+  listMembersAttendance,
+  listPushStatus,
+  listRecentMembers,
+  listTodayGatherings,
+} from "@/lib/mcp/queries";
 import { createAdminClient } from "@/lib/supabase/admin";
+
+/** MCP 도구 응답 도우미 — 사실 payload를 text JSON 으로 감싼다. */
+function textResult(payload: unknown) {
+  return { content: [{ type: "text" as const, text: JSON.stringify(payload) }] };
+}
+
+/** 안전 에러 응답 — 스택·시크릿·SQL 비노출(스펙 §7). */
+function errorResult(message: string) {
+  return { content: [{ type: "text" as const, text: message }], isError: true };
+}
+
+/**
+ * 읽기 도구 공통 실행 래퍼. operator ctx(팀 스코프 신원)를 꺼내 service-role 클라이언트를
+ * 만들고 쿼리를 실행한다. team_id 는 ctx 에서만 주입되며 도구 입력으로 받지 않는다.
+ * 알려진 입력·미존재 오류(ToolInputError)만 메시지를 노출하고, 그 외는 일반 메시지로 마스킹한다.
+ */
+async function runReadTool<T>(
+  extra: { authInfo?: { extra?: unknown } },
+  fn: (ctx: OperatorContext, supabase: ReturnType<typeof createAdminClient>) => Promise<T>,
+) {
+  const ctx = (extra.authInfo?.extra as OperatorContext | undefined) ?? null;
+  if (!ctx) {
+    // withMcpAuth(required)가 미인증을 401로 이미 차단하므로 도달하지 않는 방어선.
+    return errorResult("인증 정보를 확인할 수 없습니다.");
+  }
+  try {
+    const supabase = createAdminClient();
+    const data = await fn(ctx, supabase);
+    return textResult(data);
+  } catch (err) {
+    if (err instanceof ToolInputError) return errorResult(err.message);
+    return errorResult("요청을 처리하지 못했습니다.");
+  }
+}
 
 /**
  * 기강 운영 MCP — Streamable HTTP 엔드포인트.
@@ -46,6 +90,107 @@ const handler = createMcpHandler(
           content: [{ type: "text", text: JSON.stringify(identity) }],
         };
       },
+    );
+
+    // ── 읽기 도구 6개(SG-04). 모두 인증된 팀 멤버 허용, ctx.team_id 로 자동 스코프. ──
+
+    server.registerTool(
+      "list_today_gatherings",
+      {
+        title: "오늘의 모임",
+        description:
+          "오늘(또는 지정한 날짜, KST 기준) 우리 팀 모임 목록과 각 모임의 참석자 수를 반환합니다. 날짜는 YYYY-MM-DD.",
+        inputSchema: {
+          date: z
+            .string()
+            .regex(/^\d{4}-\d{2}-\d{2}$/, "YYYY-MM-DD 형식이어야 합니다.")
+            .optional(),
+        },
+      },
+      async (args, extra) =>
+        runReadTool(extra, (ctx, supabase) =>
+          listTodayGatherings(supabase, ctx.team_id, args.date),
+        ),
+    );
+
+    server.registerTool(
+      "list_recent_members",
+      {
+        title: "최근 가입 멤버",
+        description:
+          "우리 팀에 최근 가입한 멤버 목록을 가입일 최신순으로 반환합니다. limit 기본 10.",
+        inputSchema: {
+          limit: z.number().int().min(1).max(100).optional(),
+        },
+      },
+      async (args, extra) =>
+        runReadTool(extra, (ctx, supabase) =>
+          listRecentMembers(supabase, ctx.team_id, args.limit ?? 10),
+        ),
+    );
+
+    server.registerTool(
+      "list_members_attendance",
+      {
+        title: "멤버 참석 현황",
+        description:
+          "우리 팀 활성 멤버별 과거 모임 참석 횟수와 마지막 참석시각을 '오래/전혀 안 나온 순'으로 반환합니다. 호출 대상 판단은 사용자가 합니다.",
+        inputSchema: {
+          limit: z.number().int().min(1).max(500).optional(),
+        },
+      },
+      async (args, extra) =>
+        runReadTool(extra, (ctx, supabase) =>
+          listMembersAttendance(supabase, ctx.team_id, args.limit),
+        ),
+    );
+
+    server.registerTool(
+      "get_member_profile",
+      {
+        title: "멤버 프로필",
+        description:
+          "우리 팀 멤버 프로필(이름·생일·성별·가입일·역할·상태·소개·아바타)을 조회합니다. member_id(uuid) 또는 name 중 하나로 조회. 연락처·계좌 정보는 반환하지 않습니다.",
+        inputSchema: {
+          member_id: z.string().uuid("member_id 는 uuid 여야 합니다.").optional(),
+          name: z.string().min(1).optional(),
+        },
+      },
+      async (args, extra) =>
+        runReadTool(extra, (ctx, supabase) =>
+          getMemberProfile(supabase, ctx.team_id, {
+            memberId: args.member_id,
+            name: args.name,
+          }),
+        ),
+    );
+
+    server.registerTool(
+      "list_gathering_non_attendees",
+      {
+        title: "모임 미참석자",
+        description:
+          "특정 모임에 참석하지 않은 우리 팀 활성 멤버 목록과 각자의 참석 현황을 반환합니다. gathering_id(uuid) 필요.",
+        inputSchema: {
+          gathering_id: z.string().uuid("gathering_id 는 uuid 여야 합니다."),
+        },
+      },
+      async (args, extra) =>
+        runReadTool(extra, (ctx, supabase) =>
+          listGatheringNonAttendees(supabase, ctx.team_id, args.gathering_id),
+        ),
+    );
+
+    server.registerTool(
+      "list_push_status",
+      {
+        title: "푸시 구독 현황",
+        description:
+          "우리 팀 활성 멤버별 웹푸시 구독 여부를 반환합니다. 미구독 멤버가 먼저 정렬됩니다.",
+        inputSchema: {},
+      },
+      async (_args, extra) =>
+        runReadTool(extra, (ctx, supabase) => listPushStatus(supabase, ctx.team_id)),
     );
   },
   {

--- a/app/api/mcp/__tests__/auth.test.ts
+++ b/app/api/mcp/__tests__/auth.test.ts
@@ -1,0 +1,203 @@
+import type { SupabaseClient } from "@supabase/supabase-js";
+import { describe, expect, it } from "vitest";
+
+import type { Database } from "@/lib/supabase/database.types";
+import { hashToken, resolveOperator, TOKEN_PREFIX } from "@/lib/mcp/auth";
+
+/**
+ * SG-02 auth 검증 — 스펙 §3.2 / 권한 매트릭스 §6 G-3~G-5, AC-04·AC-05.
+ *
+ * resolveOperator 는 순수 검증 함수라 service-role 클라이언트를 주입해 테스트한다.
+ * lib/mcp/auth.ts 는 `server-only` 체인(insert-noti 등)을 import 하지 않으므로
+ * vitest server-only 함정([[troubleshooting/vitest-server-only-trap]])에 걸리지 않는다 —
+ * route.ts(→ admin.ts → "server-only")는 import 하지 않는 것이 핵심.
+ */
+
+type Resp = { data: unknown; error: unknown };
+
+/**
+ * 최소 Supabase 스텁. from(table) 별로 maybeSingle() 응답을 미리 지정한다.
+ * mcp_token_rel 은 select(1단계)·update(best-effort) 양쪽에 쓰이나,
+ * update 경로는 maybeSingle 을 호출하지 않으므로 응답 라우팅이 겹치지 않는다.
+ */
+function makeSupabase(responses: { token?: Resp; rel?: Resp; mem?: Resp }) {
+  const map: Record<string, Resp> = {
+    mcp_token_rel: responses.token ?? { data: null, error: null },
+    team_mem_rel: responses.rel ?? { data: null, error: null },
+    mem_mst: responses.mem ?? { data: null, error: null },
+  };
+  const state = { updateCalled: false };
+
+  const makeBuilder = (table: string) => {
+    const builder: Record<string, unknown> = {
+      select: () => builder,
+      eq: () => builder,
+      is: () => builder,
+      update: () => {
+        state.updateCalled = true;
+        return builder;
+      },
+      maybeSingle: async () => map[table],
+    };
+    return builder;
+  };
+
+  const client = {
+    from: (table: string) => makeBuilder(table),
+  } as unknown as SupabaseClient<Database>;
+
+  return { client, state };
+}
+
+const VALID_TOKEN = `${TOKEN_PREFIX}${"a".repeat(43)}`;
+const MEM_ID = "11111111-1111-1111-1111-111111111111";
+const TEAM_ID = "22222222-2222-2222-2222-222222222222";
+
+const activeTokenRow = {
+  data: {
+    token_id: "33333333-3333-3333-3333-333333333333",
+    mem_id: MEM_ID,
+    team_id: TEAM_ID,
+    expires_at: null,
+    revoked_at: null,
+  },
+  error: null,
+};
+
+describe("hashToken", () => {
+  it("동일 입력에 동일 sha256 hex(64자)를 낸다", () => {
+    const h1 = hashToken(VALID_TOKEN);
+    const h2 = hashToken(VALID_TOKEN);
+    expect(h1).toBe(h2);
+    expect(h1).toMatch(/^[0-9a-f]{64}$/);
+  });
+
+  it("원문 토큰이 해시에 포함되지 않는다(단방향)", () => {
+    expect(hashToken(VALID_TOKEN)).not.toContain(VALID_TOKEN);
+  });
+});
+
+describe("resolveOperator — AC-04 거부(→ 라우트 401)", () => {
+  it("G-3: 토큰이 없으면 null", async () => {
+    const { client } = makeSupabase({});
+    expect(await resolveOperator(undefined, client)).toBeNull();
+    expect(await resolveOperator(null, client)).toBeNull();
+    expect(await resolveOperator("", client)).toBeNull();
+  });
+
+  it("G-3: 형식오류(gmcp_ 접두사 아님)면 DB 조회 없이 null", async () => {
+    const { client } = makeSupabase({ token: activeTokenRow });
+    expect(await resolveOperator("Bearer something", client)).toBeNull();
+    expect(await resolveOperator("randomtoken", client)).toBeNull();
+  });
+
+  it("G-4: 미존재/폐기 토큰(조회 결과 없음)이면 null", async () => {
+    // revoked_at is null 필터로 폐기 토큰은 애초에 조회되지 않음 → data:null 로 표현
+    const { client } = makeSupabase({ token: { data: null, error: null } });
+    expect(await resolveOperator(VALID_TOKEN, client)).toBeNull();
+  });
+
+  it("G-4: 만료(expires_at 과거) 토큰이면 null", async () => {
+    const { client } = makeSupabase({
+      token: {
+        data: {
+          token_id: "44444444-4444-4444-4444-444444444444",
+          mem_id: MEM_ID,
+          team_id: TEAM_ID,
+          expires_at: new Date(Date.now() - 60_000).toISOString(),
+          revoked_at: null,
+        },
+        error: null,
+      },
+      rel: { data: { mem_st_cd: "active", team_role_cd: "member" }, error: null },
+    });
+    expect(await resolveOperator(VALID_TOKEN, client)).toBeNull();
+  });
+
+  it("G-5: 팀 멤버십이 없으면 null", async () => {
+    const { client } = makeSupabase({
+      token: activeTokenRow,
+      rel: { data: null, error: null },
+    });
+    expect(await resolveOperator(VALID_TOKEN, client)).toBeNull();
+  });
+
+  it("G-5: 비활성(mem_st_cd != active) 멤버 토큰이면 null", async () => {
+    for (const st of ["inactive", "left"]) {
+      const { client } = makeSupabase({
+        token: activeTokenRow,
+        rel: { data: { mem_st_cd: st, team_role_cd: "member" }, error: null },
+      });
+      expect(await resolveOperator(VALID_TOKEN, client)).toBeNull();
+    }
+  });
+
+  it("토큰 조회 에러 시 null(사유 비노출)", async () => {
+    const { client } = makeSupabase({
+      token: { data: null, error: { message: "boom" } },
+    });
+    expect(await resolveOperator(VALID_TOKEN, client)).toBeNull();
+  });
+});
+
+describe("resolveOperator — AC-05 유효 토큰 → ctx 해석", () => {
+  it("active 멤버면 { mem_id, team_id, is_admin, mem_nm } 반환", async () => {
+    const { client, state } = makeSupabase({
+      token: activeTokenRow,
+      rel: { data: { mem_st_cd: "active", team_role_cd: "member" }, error: null },
+      mem: { data: { mem_nm: "홍길동" }, error: null },
+    });
+    const ctx = await resolveOperator(VALID_TOKEN, client);
+    expect(ctx).toEqual({
+      mem_id: MEM_ID,
+      team_id: TEAM_ID,
+      is_admin: false,
+      mem_nm: "홍길동",
+    });
+    // last_used_at 갱신(best-effort)이 시도됨
+    expect(state.updateCalled).toBe(true);
+  });
+
+  it("owner/admin 역할은 is_admin=true, 그 외는 false", async () => {
+    const cases: Array<[string, boolean]> = [
+      ["owner", true],
+      ["admin", true],
+      ["member", false],
+    ];
+    for (const [role, expected] of cases) {
+      const { client } = makeSupabase({
+        token: activeTokenRow,
+        rel: { data: { mem_st_cd: "active", team_role_cd: role }, error: null },
+        mem: { data: { mem_nm: "테스트" }, error: null },
+      });
+      const ctx = await resolveOperator(VALID_TOKEN, client);
+      expect(ctx?.is_admin).toBe(expected);
+    }
+  });
+
+  it("반환 ctx 는 팀 스코프 신원만 — 민감정보 키(phone/email/bank) 없음", async () => {
+    const { client } = makeSupabase({
+      token: activeTokenRow,
+      rel: { data: { mem_st_cd: "active", team_role_cd: "admin" }, error: null },
+      mem: { data: { mem_nm: "관리자" }, error: null },
+    });
+    const ctx = await resolveOperator(VALID_TOKEN, client);
+    expect(ctx).not.toBeNull();
+    const keys = Object.keys(ctx ?? {});
+    expect(keys.sort()).toEqual(["is_admin", "mem_id", "mem_nm", "team_id"]);
+    for (const banned of ["phone_no", "email_addr", "bank_nm", "bank_acct_no"]) {
+      expect(keys).not.toContain(banned);
+    }
+  });
+
+  it("이름 조회 실패해도 인증은 성립(mem_nm 빈 문자열)", async () => {
+    const { client } = makeSupabase({
+      token: activeTokenRow,
+      rel: { data: { mem_st_cd: "active", team_role_cd: "member" }, error: null },
+      mem: { data: null, error: null },
+    });
+    const ctx = await resolveOperator(VALID_TOKEN, client);
+    expect(ctx?.mem_nm).toBe("");
+    expect(ctx?.mem_id).toBe(MEM_ID);
+  });
+});

--- a/app/api/mcp/__tests__/issue-token.test.ts
+++ b/app/api/mcp/__tests__/issue-token.test.ts
@@ -1,0 +1,281 @@
+import type { SupabaseClient } from "@supabase/supabase-js";
+import { describe, expect, it } from "vitest";
+
+import { hashToken, resolveOperator, TOKEN_PREFIX } from "@/lib/mcp/auth";
+import {
+  issueMcpToken,
+  listMcpTokens,
+  McpTokenNotFoundError,
+  revokeMcpToken,
+} from "@/lib/mcp/issue-token";
+import type { Database } from "@/lib/supabase/database.types";
+
+/**
+ * SG-03 PAT 발급/목록/폐기 검증(스펙 §3.1, AC-07/08/09).
+ *
+ * `lib/mcp/issue-token.ts`는 `lib/mcp/auth.ts`만 import 하고 `server-only` 체인
+ * (`admin.ts`)을 import 하지 않으므로 vitest server-only 함정([[troubleshooting/vitest-server-only-trap]])에
+ * 걸리지 않는다.
+ *
+ * 핵심 검증(AC-07/09): `issueMcpToken`이 저장한 `token_hash`가 `hashToken(원문)`과 정확히 일치해야
+ * 발급 직후 `resolveOperator`로 로그인할 수 있다 — 두 모듈이 해시 함수를 공유하는지를 실제로
+ * 왕복시켜 증명한다(발급 → resolveOperator 성공 → 폐기 → resolveOperator 실패).
+ */
+
+type Resp = { data: unknown; error: unknown };
+
+/** insert().select().single() 체인을 흉내내는 최소 빌더. */
+function makeInsertBuilder(onInsert: (row: Record<string, unknown>) => Resp) {
+  let captured: Record<string, unknown> = {};
+  const builder: Record<string, unknown> = {
+    insert: (row: Record<string, unknown>) => {
+      captured = row;
+      return builder;
+    },
+    select: () => builder,
+    single: async () => onInsert(captured),
+  };
+  return builder;
+}
+
+/** select().eq().order() 체인(단순 목록 조회, `await` 가능하도록 thenable 구현). */
+function makeListBuilder(resp: Resp) {
+  const builder: Record<string, unknown> = {
+    select: () => builder,
+    eq: () => builder,
+    order: () => builder,
+    then: (resolve: (v: Resp) => void) => resolve(resp),
+  };
+  return builder;
+}
+
+/** update().eq()*.is().select().maybeSingle() 체인. eq 호출 인자를 관측한다. */
+function makeUpdateBuilder(resp: Resp, onEq?: (key: string, val: unknown) => void) {
+  const builder: Record<string, unknown> = {
+    update: () => builder,
+    eq: (key: string, val: unknown) => {
+      onEq?.(key, val);
+      return builder;
+    },
+    is: () => builder,
+    select: () => builder,
+    maybeSingle: async () => resp,
+  };
+  return builder;
+}
+
+const MEM_ID = "11111111-1111-1111-1111-111111111111";
+const OTHER_MEM_ID = "99999999-9999-9999-9999-999999999999";
+const TEAM_ID = "22222222-2222-2222-2222-222222222222";
+const TOKEN_ID = "33333333-3333-3333-3333-333333333333";
+
+describe("issueMcpToken — AC-07 해시 저장", () => {
+  it("gmcp_ 접두사 원문 토큰을 생성하고, 저장하는 token_hash는 hashToken(원문)과 일치한다", async () => {
+    let insertedHash: string | undefined;
+    const client = {
+      from: () =>
+        makeInsertBuilder((row) => {
+          insertedHash = row.token_hash as string;
+          return {
+            data: {
+              token_id: TOKEN_ID,
+              created_at: "2026-07-24T00:00:00.000Z",
+              label: row.label,
+            },
+            error: null,
+          };
+        }),
+    } as unknown as SupabaseClient<Database>;
+
+    const result = await issueMcpToken(client, {
+      memId: MEM_ID,
+      teamId: TEAM_ID,
+      label: "내 노트북",
+    });
+
+    expect(result.token.startsWith(TOKEN_PREFIX)).toBe(true);
+    expect(result.token_id).toBe(TOKEN_ID);
+    expect(result.label).toBe("내 노트북");
+    // 핵심: 저장된 해시가 auth.ts의 hashToken과 정확히 일치 — 검증 로직과 공유.
+    expect(insertedHash).toBe(hashToken(result.token));
+  });
+
+  it("원문 토큰 자체는 반환값에서만 노출되고 해시에는 포함되지 않는다(단방향)", async () => {
+    const client = {
+      from: () =>
+        makeInsertBuilder((row) => ({
+          data: { token_id: TOKEN_ID, created_at: "2026-07-24T00:00:00.000Z", label: row.label },
+          error: null,
+        })),
+    } as unknown as SupabaseClient<Database>;
+
+    const result = await issueMcpToken(client, { memId: MEM_ID, teamId: TEAM_ID, label: null });
+    expect(hashToken(result.token)).not.toContain(result.token);
+  });
+
+  it("insert 에러 시 예외를 던진다", async () => {
+    const client = {
+      from: () => makeInsertBuilder(() => ({ data: null, error: { message: "boom" } })),
+    } as unknown as SupabaseClient<Database>;
+
+    await expect(
+      issueMcpToken(client, { memId: MEM_ID, teamId: TEAM_ID, label: null }),
+    ).rejects.toBeTruthy();
+  });
+});
+
+describe("발급 → resolveOperator 왕복 (AC-09)", () => {
+  it("발급 직후 원문 토큰으로 resolveOperator 인증에 성공한다", async () => {
+    let storedHash = "";
+    const issueClient = {
+      from: () =>
+        makeInsertBuilder((row) => {
+          storedHash = row.token_hash as string;
+          return {
+            data: { token_id: TOKEN_ID, created_at: "2026-07-24T00:00:00.000Z", label: row.label },
+            error: null,
+          };
+        }),
+    } as unknown as SupabaseClient<Database>;
+
+    const issued = await issueMcpToken(issueClient, {
+      memId: MEM_ID,
+      teamId: TEAM_ID,
+      label: "테스트 기기",
+    });
+    expect(storedHash).toBe(hashToken(issued.token));
+
+    // resolveOperator 용 스텁 — 위에서 저장된 해시를 그대로 가진 활성 토큰 행을 반환한다.
+    const authMap: Record<string, Resp> = {
+      mcp_token_rel: {
+        data: {
+          token_id: TOKEN_ID,
+          mem_id: MEM_ID,
+          team_id: TEAM_ID,
+          expires_at: null,
+          revoked_at: null,
+        },
+        error: null,
+      },
+      team_mem_rel: { data: { mem_st_cd: "active", team_role_cd: "member" }, error: null },
+      mem_mst: { data: { mem_nm: "테스트 멤버" }, error: null },
+    };
+    const authClient = {
+      from: (table: string) => {
+        const builder: Record<string, unknown> = {
+          select: () => builder,
+          eq: () => builder,
+          is: () => builder,
+          update: () => builder,
+          maybeSingle: async () => authMap[table],
+        };
+        return builder;
+      },
+    } as unknown as SupabaseClient<Database>;
+
+    const ctx = await resolveOperator(issued.token, authClient);
+    expect(ctx).toEqual({
+      mem_id: MEM_ID,
+      team_id: TEAM_ID,
+      is_admin: false,
+      mem_nm: "테스트 멤버",
+    });
+  });
+
+  it("폐기된 토큰이면(revoked_at 필터로 조회 결과 없음) resolveOperator가 null을 반환한다", async () => {
+    const client = {
+      from: () => {
+        const builder: Record<string, unknown> = {
+          select: () => builder,
+          eq: () => builder,
+          // 실제 DB의 `.is("revoked_at", null)` 필터가 폐기된 행을 걸러내는 효과를 스텁으로 재현.
+          is: () => builder,
+          maybeSingle: async () => ({ data: null, error: null }),
+        };
+        return builder;
+      },
+    } as unknown as SupabaseClient<Database>;
+
+    const ctx = await resolveOperator(`${TOKEN_PREFIX}${"a".repeat(43)}`, client);
+    expect(ctx).toBeNull();
+  });
+});
+
+describe("listMcpTokens — AC-08 본인 목록", () => {
+  it("token_hash를 포함하지 않고 revoked 플래그를 계산해 반환한다", async () => {
+    const client = {
+      from: () =>
+        makeListBuilder({
+          data: [
+            {
+              token_id: "a",
+              label: "폰",
+              created_at: "2026-07-24T00:00:00.000Z",
+              last_used_at: null,
+              revoked_at: null,
+            },
+            {
+              token_id: "b",
+              label: null,
+              created_at: "2026-07-20T00:00:00.000Z",
+              last_used_at: "2026-07-23T00:00:00.000Z",
+              revoked_at: "2026-07-23T01:00:00.000Z",
+            },
+          ],
+          error: null,
+        }),
+    } as unknown as SupabaseClient<Database>;
+
+    const tokens = await listMcpTokens(client, MEM_ID);
+    expect(tokens).toEqual([
+      { token_id: "a", label: "폰", created_at: "2026-07-24T00:00:00.000Z", last_used_at: null, revoked: false },
+      {
+        token_id: "b",
+        label: null,
+        created_at: "2026-07-20T00:00:00.000Z",
+        last_used_at: "2026-07-23T00:00:00.000Z",
+        revoked: true,
+      },
+    ]);
+    for (const t of tokens) {
+      expect(Object.keys(t)).not.toContain("token_hash");
+    }
+  });
+});
+
+describe("revokeMcpToken — 본인 스코프 강제", () => {
+  it("본인 토큰이면 mem_id eq 필터로 스코프해 폐기에 성공한다", async () => {
+    const eqCalls: Array<[string, unknown]> = [];
+    const client = {
+      from: () =>
+        makeUpdateBuilder({ data: { token_id: TOKEN_ID }, error: null }, (k, v) =>
+          eqCalls.push([k, v]),
+        ),
+    } as unknown as SupabaseClient<Database>;
+
+    await revokeMcpToken(client, MEM_ID, TOKEN_ID);
+
+    expect(eqCalls).toContainEqual(["token_id", TOKEN_ID]);
+    expect(eqCalls).toContainEqual(["mem_id", MEM_ID]);
+  });
+
+  it("남의 토큰이거나 존재하지 않으면(쿼리 결과 0행) McpTokenNotFoundError를 던진다", async () => {
+    const client = {
+      from: () => makeUpdateBuilder({ data: null, error: null }),
+    } as unknown as SupabaseClient<Database>;
+
+    await expect(revokeMcpToken(client, OTHER_MEM_ID, TOKEN_ID)).rejects.toBeInstanceOf(
+      McpTokenNotFoundError,
+    );
+  });
+
+  it("이미 폐기된 토큰도 동일하게(0행) McpTokenNotFoundError로 처리한다", async () => {
+    const client = {
+      from: () => makeUpdateBuilder({ data: null, error: null }),
+    } as unknown as SupabaseClient<Database>;
+
+    await expect(revokeMcpToken(client, MEM_ID, TOKEN_ID)).rejects.toBeInstanceOf(
+      McpTokenNotFoundError,
+    );
+  });
+});

--- a/app/api/mcp/__tests__/send-push.test.ts
+++ b/app/api/mcp/__tests__/send-push.test.ts
@@ -15,15 +15,23 @@ import type { Database } from "@/lib/supabase/database.types";
  */
 
 // vi.mock 팩토리는 파일 최상단으로 hoist 되므로, mock 함수도 vi.hoisted 로 함께 끌어올린다.
+// 기본 동작: 넘겨받은 memIds 전원을 실제 발송한 것으로 반환(수신거부 없음·성공). 개별 테스트가 override 한다.
 const { insertNotiManyMock } = vi.hoisted(() => ({
-  insertNotiManyMock: vi.fn(async (_input: unknown) => {}),
+  insertNotiManyMock: vi.fn(async (input: { memIds: string[] }) => ({
+    inAppOk: true,
+    notifiedMemIds: input.memIds,
+  })),
 }));
 vi.mock("@/lib/notifications/insert-noti", () => ({
   insertNotiMany: insertNotiManyMock,
 }));
 
 // mock 선언 이후에 대상 모듈을 import(vi.mock 은 hoist 되므로 순서 무관하나 명시적으로 정적 import).
-import { sendPush, SendPushDeniedError } from "@/lib/mcp/send-push";
+import {
+  sendPush,
+  SendPushDeniedError,
+  SendPushFailedError,
+} from "@/lib/mcp/send-push";
 
 const TEAM_ID = "22222222-2222-2222-2222-222222222222";
 const ACTOR_ID = "11111111-1111-1111-1111-111111111111";
@@ -211,6 +219,54 @@ describe("send_push — 팀 스코프 안전장치(교차 팀/비활성 제외)"
     ).rejects.toBeInstanceOf(ToolInputError);
 
     expect(insertNotiManyMock).not.toHaveBeenCalled();
+    expect(calls.auditInsert).toBeNull();
+  });
+});
+
+describe("send_push — 감사 무결성: sent_cnt·감사행이 실제 발송과 일치", () => {
+  it("일부 수신거부 시 sent_cnt·recipient 는 실제 발송분만(요청은 requested_cnt 로 유지)", async () => {
+    // 팀 스코프 통과는 M1·M2 둘 다지만, insertNotiMany 관문에서 M2 가 수신거부돼 M1 만 실제 발송.
+    const { client, calls } = makeSupabase({ validMemberIds: [M1, M2] });
+    insertNotiManyMock.mockResolvedValueOnce({
+      inAppOk: true,
+      notifiedMemIds: [M1], // M2 수신거부로 제외된 실측 발송분
+    });
+
+    const result = await sendPush(client, adminCtx(), {
+      memberIds: [M1, M2],
+      title: "공지",
+      message: "내용",
+    });
+
+    // 반환·감사 모두 실측(1명)만 반영, 요청 수(2)는 requested_cnt 로 별도 유지.
+    expect(result.sent_cnt).toBe(1);
+    const params = (calls.auditInsert as Record<string, unknown>)
+      .params_json as Record<string, unknown>;
+    expect(params.sent_cnt).toBe(1);
+    expect(params.recipient_mem_ids).toEqual([M1]);
+    expect(params.requested_cnt).toBe(2);
+    expect(calls.auditInsert?.result_summary).toBe(
+      "send_push ok: sent_cnt=1 requested=2",
+    );
+  });
+
+  it("인앱 저장 전면 실패(inAppOk=false) 시 SendPushFailedError·감사행 미기록", async () => {
+    const { client, calls } = makeSupabase({ validMemberIds: [M1, M2] });
+    insertNotiManyMock.mockResolvedValueOnce({
+      inAppOk: false,
+      notifiedMemIds: [],
+    });
+
+    await expect(
+      sendPush(client, adminCtx(), {
+        memberIds: [M1, M2],
+        title: "공지",
+        message: "내용",
+      }),
+    ).rejects.toBeInstanceOf(SendPushFailedError);
+
+    // 발송(위임)은 시도됐으나 실패 → 성공 감사행을 남기지 않는다("발송 실패인데 감사 성공" 방지).
+    expect(insertNotiManyMock).toHaveBeenCalledTimes(1);
     expect(calls.auditInsert).toBeNull();
   });
 });

--- a/app/api/mcp/__tests__/send-push.test.ts
+++ b/app/api/mcp/__tests__/send-push.test.ts
@@ -1,0 +1,216 @@
+import type { SupabaseClient } from "@supabase/supabase-js";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { OperatorContext } from "@/lib/mcp/auth";
+import { ToolInputError } from "@/lib/mcp/queries";
+import type { Database } from "@/lib/supabase/database.types";
+
+/**
+ * SG-05 send_push 검증(M-02 G-1·G-2 + AC-16·AC-17·AC-18, 스펙 §4·§6·§8).
+ *
+ * ⚠️ 실제 크루원에게 푸시 발송 금지 — insertNotiMany 는 vi.mock 으로 완전 대체한다.
+ *   send-push.ts 는 insertNotiMany(→ admin.ts → "server-only") 를 정적 import 하므로,
+ *   이 mock 이 없으면 vitest 가 server-only 를 로드하다 실패한다
+ *   ([[troubleshooting/vitest-server-only-trap]]). mock 은 발송을 막고 호출 인자를 관측한다.
+ */
+
+// vi.mock 팩토리는 파일 최상단으로 hoist 되므로, mock 함수도 vi.hoisted 로 함께 끌어올린다.
+const { insertNotiManyMock } = vi.hoisted(() => ({
+  insertNotiManyMock: vi.fn(async (_input: unknown) => {}),
+}));
+vi.mock("@/lib/notifications/insert-noti", () => ({
+  insertNotiMany: insertNotiManyMock,
+}));
+
+// mock 선언 이후에 대상 모듈을 import(vi.mock 은 hoist 되므로 순서 무관하나 명시적으로 정적 import).
+import { sendPush, SendPushDeniedError } from "@/lib/mcp/send-push";
+
+const TEAM_ID = "22222222-2222-2222-2222-222222222222";
+const ACTOR_ID = "11111111-1111-1111-1111-111111111111";
+const M1 = "aaaaaaaa-0000-4000-8000-000000000001";
+const M2 = "aaaaaaaa-0000-4000-8000-000000000002";
+const OTHER_TEAM_MEM = "bbbbbbbb-0000-4000-8000-000000000009"; // 타 팀/비활성 → 스코프 조회에서 미반환
+
+function adminCtx(overrides: Partial<OperatorContext> = {}): OperatorContext {
+  return {
+    mem_id: ACTOR_ID,
+    team_id: TEAM_ID,
+    is_admin: true,
+    mem_nm: "관리자",
+    ...overrides,
+  };
+}
+
+/**
+ * 최소 Supabase 스텁.
+ * - team_mem_rel: select().eq()*.in() 을 await 하면 `validMemberIds` 만 반환(팀 스코프 조회 결과).
+ *   → 요청 id 중 여기 없는 것(타 팀·비활성·미존재)은 자연히 발송 대상에서 제외된다.
+ * - mcp_audit_log: insert(row) 로 감사행을 관측한다.
+ */
+function makeSupabase(opts: {
+  validMemberIds: string[];
+  memErr?: unknown;
+  auditErr?: unknown;
+}) {
+  const calls: {
+    teamScopeIn: string[] | null;
+    auditInsert: Record<string, unknown> | null;
+  } = { teamScopeIn: null, auditInsert: null };
+
+  const teamMemBuilder: Record<string, unknown> = {
+    select: () => teamMemBuilder,
+    eq: () => teamMemBuilder,
+    in: (_col: string, ids: string[]) => {
+      calls.teamScopeIn = ids;
+      return teamMemBuilder;
+    },
+    // thenable: await 시 스코프 조회 결과 반환.
+    then: (resolve: (v: unknown) => void) =>
+      resolve({
+        data: opts.memErr ? null : opts.validMemberIds.map((mem_id) => ({ mem_id })),
+        error: opts.memErr ?? null,
+      }),
+  };
+
+  const auditBuilder: Record<string, unknown> = {
+    insert: (row: Record<string, unknown>) => {
+      calls.auditInsert = row;
+      return auditBuilder;
+    },
+    // insert 는 await 로 { error } 만 확인한다(select().single() 미사용).
+    then: (resolve: (v: unknown) => void) =>
+      resolve({ data: null, error: opts.auditErr ?? null }),
+  };
+
+  const client = {
+    from: (table: string) =>
+      table === "mcp_audit_log" ? auditBuilder : teamMemBuilder,
+  } as unknown as SupabaseClient<Database>;
+
+  return { client, calls };
+}
+
+beforeEach(() => {
+  insertNotiManyMock.mockClear();
+});
+
+describe("send_push — AC-16 admin 발송(올바른 team_id·검증된 memIds) + 감사행", () => {
+  it("admin ctx: insertNotiMany 를 ctx.team_id·검증된 대상으로 호출하고 감사행을 남긴다", async () => {
+    const { client, calls } = makeSupabase({ validMemberIds: [M1, M2] });
+
+    const result = await sendPush(client, adminCtx(), {
+      memberIds: [M1, M2],
+      title: "정기런 공지",
+      message: "토요일 7시 한강 집결",
+    });
+
+    // insertNotiMany 정확히 1회, ctx.team_id·검증된 memIds·adm_cust 타입으로.
+    expect(insertNotiManyMock).toHaveBeenCalledTimes(1);
+    const arg = insertNotiManyMock.mock.calls[0][0] as {
+      teamId: string;
+      memIds: string[];
+      notiTypeEnm: string;
+      notiNm: string;
+      notiCont: string;
+      batchId: string;
+    };
+    expect(arg.teamId).toBe(TEAM_ID);
+    expect(arg.memIds).toEqual([M1, M2]);
+    expect(arg.notiTypeEnm).toBe("adm_cust"); // 기존 범용 타입 재사용(NOTI_ICON 등록됨)
+    expect(arg.notiNm).toBe("정기런 공지");
+    expect(arg.notiCont).toBe("토요일 7시 한강 집결");
+    expect(typeof arg.batchId).toBe("string");
+
+    // 반환: sent_cnt·audit_id.
+    expect(result.sent_cnt).toBe(2);
+    expect(result.audit_id).toEqual(expect.any(String));
+
+    // 감사행 1행 기록.
+    expect(calls.auditInsert).not.toBeNull();
+    expect(calls.auditInsert?.audit_id).toBe(result.audit_id);
+  });
+});
+
+describe("send_push — AC-17 non-admin 거부(발송 0·감사 없음)", () => {
+  it("member ctx: SendPushDeniedError, insertNotiMany 미호출, 감사행 없음", async () => {
+    const { client, calls } = makeSupabase({ validMemberIds: [M1, M2] });
+
+    await expect(
+      sendPush(client, adminCtx({ is_admin: false }), {
+        memberIds: [M1, M2],
+        title: "공지",
+        message: "내용",
+      }),
+    ).rejects.toBeInstanceOf(SendPushDeniedError);
+
+    expect(insertNotiManyMock).not.toHaveBeenCalled();
+    expect(calls.auditInsert).toBeNull();
+    expect(calls.teamScopeIn).toBeNull(); // admin 게이트에서 조회 이전에 차단
+  });
+});
+
+describe("send_push — AC-18 감사행 필드(actor·team·tool·수신자·params 마스킹)", () => {
+  it("성공 발송 시 감사행에 actor_mem_id·team_id·tool_nm·수신자·시각 기록", async () => {
+    const { client, calls } = makeSupabase({ validMemberIds: [M1] });
+
+    const result = await sendPush(client, adminCtx(), {
+      memberIds: [M1],
+      title: "제목",
+      message: "본문",
+    });
+
+    const audit = calls.auditInsert as Record<string, unknown>;
+    expect(audit.actor_mem_id).toBe(ACTOR_ID);
+    expect(audit.team_id).toBe(TEAM_ID);
+    expect(audit.tool_nm).toBe("send_push");
+    expect(audit.audit_id).toBe(result.audit_id);
+    expect(typeof audit.result_summary).toBe("string");
+
+    // params_json: 수신자 mem_id 기록 + 민감정보(연락처·계좌) 절대 미포함(M-03).
+    const params = audit.params_json as Record<string, unknown>;
+    expect(params.recipient_mem_ids).toEqual([M1]);
+    expect(params.sent_cnt).toBe(1);
+    const serialized = JSON.stringify(audit);
+    for (const banned of ["phone_no", "email_addr", "bank_nm", "bank_acct_no"]) {
+      expect(serialized).not.toContain(banned);
+    }
+  });
+});
+
+describe("send_push — 팀 스코프 안전장치(교차 팀/비활성 제외)", () => {
+  it("타 팀·비활성 mem_id 는 발송 대상에서 제외(우리 팀 활성 멤버에게만 발송)", async () => {
+    // 요청엔 M1(유효) + OTHER_TEAM_MEM(타 팀/비활성) 이 섞여 있으나, 스코프 조회는 M1 만 반환.
+    const { client, calls } = makeSupabase({ validMemberIds: [M1] });
+
+    const result = await sendPush(client, adminCtx(), {
+      memberIds: [M1, OTHER_TEAM_MEM],
+      title: "공지",
+      message: "내용",
+    });
+
+    // 스코프 조회에는 요청 전체가 전달되지만, 발송은 유효 대상만.
+    expect(calls.teamScopeIn).toEqual([M1, OTHER_TEAM_MEM]);
+    const arg = insertNotiManyMock.mock.calls[0][0] as { memIds: string[] };
+    expect(arg.memIds).toEqual([M1]); // 타 팀 id 제외
+    expect(result.sent_cnt).toBe(1);
+    const params = (calls.auditInsert as Record<string, unknown>)
+      .params_json as Record<string, unknown>;
+    expect(params.recipient_mem_ids).toEqual([M1]);
+    expect(params.requested_cnt).toBe(2);
+  });
+
+  it("유효 대상이 0명이면(모두 타 팀/비활성) 발송하지 않고 ToolInputError·감사 없음", async () => {
+    const { client, calls } = makeSupabase({ validMemberIds: [] });
+
+    await expect(
+      sendPush(client, adminCtx(), {
+        memberIds: [OTHER_TEAM_MEM],
+        title: "공지",
+        message: "내용",
+      }),
+    ).rejects.toBeInstanceOf(ToolInputError);
+
+    expect(insertNotiManyMock).not.toHaveBeenCalled();
+    expect(calls.auditInsert).toBeNull();
+  });
+});

--- a/app/api/mcp/__tests__/tool-correctness.test.ts
+++ b/app/api/mcp/__tests__/tool-correctness.test.ts
@@ -6,6 +6,7 @@ import { describe, expect, it } from "vitest";
 import {
   aggregateAttendance,
   buildPushStatus,
+  escapeLikePattern,
   kstDayRange,
 } from "@/lib/mcp/queries";
 
@@ -138,6 +139,32 @@ describe("buildPushStatus — §5.6 미구독 먼저", () => {
     const rows = buildPushStatus(members, new Set(["a", "c"]));
     const on = rows.filter((r) => r.push_enabled).map((r) => r.mem_id).sort();
     expect(on).toEqual(["a", "c"]);
+  });
+});
+
+describe("escapeLikePattern — §5.4 get_member_profile name 와일드카드 차단(PII 대량 열람)", () => {
+  it("LIKE 메타문자 %·_·\\ 를 리터럴로 이스케이프한다", () => {
+    // name="%" → "\%" : ilike 에서 리터럴 '%' 로만 매칭(전원 조회 차단)
+    expect(escapeLikePattern("%")).toBe("\\%");
+    // name="_" → "\_" : 단일 문자 와일드카드 무력화
+    expect(escapeLikePattern("_")).toBe("\\_");
+    // 백슬래시(escape 문자 자체)도 리터럴로
+    expect(escapeLikePattern("\\")).toBe("\\\\");
+  });
+
+  it("혼합 입력의 모든 메타문자를 각각 이스케이프한다", () => {
+    // %_% → \%\_\%
+    expect(escapeLikePattern("%_%")).toBe("\\%\\_\\%");
+    // 실제 이름 사이의 _ 도 리터럴로(foo_bar → foo\_bar)
+    expect(escapeLikePattern("foo_bar")).toBe("foo\\_bar");
+    // 50%\_할인 같은 복합 케이스
+    expect(escapeLikePattern("50%\\_")).toBe("50\\%\\\\\\_");
+  });
+
+  it("메타문자 없는 일반 이름은 그대로 둔다(완전일치 동치)", () => {
+    expect(escapeLikePattern("홍길동")).toBe("홍길동");
+    expect(escapeLikePattern("hs")).toBe("hs");
+    expect(escapeLikePattern("")).toBe("");
   });
 });
 

--- a/app/api/mcp/__tests__/tool-correctness.test.ts
+++ b/app/api/mcp/__tests__/tool-correctness.test.ts
@@ -1,0 +1,180 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+import {
+  aggregateAttendance,
+  buildPushStatus,
+  kstDayRange,
+} from "@/lib/mcp/queries";
+
+/**
+ * SG-04 정확도 검증(M-01, AC-10~AC-15) — 6개 읽기 도구 vs 스펙 §5 baseline SQL.
+ *
+ * ┌─ 검증 방법 ──────────────────────────────────────────────────────────────┐
+ * │ 1) 순수 로직(집계·정렬·KST 날짜 변환)은 아래 단위 테스트로 baseline 규약과 대조.        │
+ * │ 2) DB 결합/필터 부분은 dev Supabase(project ref: gigang-dev, team_id            │
+ * │    c0ffee00-0000-4000-8000-000000000001)에서 §5 baseline SQL을 실행해            │
+ * │    핵심 필드(행수·정렬·주요값)를 아래 주석에 기록·대조.                                │
+ * │ 3) M-03 불변식(민감정보 미노출)은 소스 정적 스캔 테스트로 회귀 방지.                    │
+ * └────────────────────────────────────────────────────────────────────────┘
+ *
+ * ── dev 대조 결과(2026-07-24, vers=0 정본 보정 baseline) ──
+ *  AC-10 list_today_gatherings(2026-07-04): baseline == UTC-range 등가형 → 동일 1행
+ *    { gthr_id: d2867b5b…534d, stt_at: 2026-07-03T23:00:00Z, attendee_cnt: 10 }.
+ *  AC-11 list_recent_members(limit 10): 10행, join_dt desc·crt_at desc.
+ *    head=[김또낑(07-09), 정정만(07-09), 온보딩 5f6ae133(07-09), 온보딩 0fe17429(07-09), 박초록(07-06)…].
+ *  AC-12 list_members_attendance: 활성 144행, 참석>0 88명, 미참석 56명.
+ *    정렬 head 5명 모두 attendance_cnt=0·last=null(전혀 안 나온 순 nulls first).
+ *  AC-13 get_member_profile: member_id=5f6ae133 → 1행
+ *    { mem_nm:온보딩, birth_dt:1986-05-30, gdr_enm:female, join_dt:2026-07-09, role:member, st:active }.
+ *    name='온보딩'(대소문자 무시) → 2행(동명이인) 배열 반환. 응답에 phone/email/bank 없음.
+ *  AC-14 list_gathering_non_attendees(d2867b5b): 활성 144명 중 참석 10명 → 미참석 134행.
+ *  AC-15 list_push_status: 활성 144행, 구독 1명(7dd2ab13…), 미구독 143명. 미구독(false) 먼저 정렬.
+ *
+ *  ⚠️ 정본 규약 결정: §5 baseline 본문은 team_mem_rel 에 vers=0 필터가 없으나, dev 실데이터에는
+ *     del_yn=false & vers>0 인 낡은 행이 있어 무필터 시 활성 147(=144+중복3), 'left' 멤버가
+ *     'active'로 되살아난다. 앱 전역 정본 규약(vers=0)으로 보정한 baseline을 M-01 기준으로 삼음.
+ */
+
+describe("kstDayRange — §5.1 KST 달력일 → UTC 반열림 구간", () => {
+  it("지정일을 KST 자정 기준 [start, +1d) UTC 로 변환", () => {
+    const r = kstDayRange("2026-07-04");
+    expect(r.day).toBe("2026-07-04");
+    // KST 2026-07-04 00:00 = UTC 2026-07-03 15:00
+    expect(r.startIso).toBe("2026-07-03T15:00:00.000Z");
+    expect(r.endIso).toBe("2026-07-04T15:00:00.000Z");
+  });
+
+  it("baseline 검증에 쓴 모임(stt_at 2026-07-03T23:00Z)이 07-04 KST 구간에 포함", () => {
+    const r = kstDayRange("2026-07-04");
+    const stt = "2026-07-03T23:00:00.000Z";
+    expect(stt >= r.startIso && stt < r.endIso).toBe(true);
+  });
+
+  it("형식 불량/미지정이면 오늘(KST)로 폴백해 유효 구간을 만든다", () => {
+    for (const bad of [undefined, "2026/07/04", "nope"]) {
+      const r = kstDayRange(bad);
+      expect(r.day).toMatch(/^\d{4}-\d{2}-\d{2}$/);
+      expect(r.startIso < r.endIso).toBe(true);
+    }
+  });
+});
+
+describe("aggregateAttendance — §5.3/§5.5 집계·정렬", () => {
+  const members = [
+    { mem_id: "m1", mem_nm: "A", join_dt: "2026-01-01" }, // 미참석
+    { mem_id: "m2", mem_nm: "B", join_dt: "2026-01-02" }, // 2회, 최신 06-01
+    { mem_id: "m3", mem_nm: "C", join_dt: "2026-01-03" }, // 1회, 04-01
+  ];
+  const events = [
+    { mem_id: "m2", stt_at: "2026-05-01T00:00:00+00:00" },
+    { mem_id: "m2", stt_at: "2026-06-01T00:00:00+00:00" },
+    { mem_id: "m3", stt_at: "2026-04-01T00:00:00+00:00" },
+  ];
+
+  it("횟수·마지막 참석시각을 정확히 집계한다", () => {
+    const rows = aggregateAttendance(members, events);
+    const byId = Object.fromEntries(rows.map((r) => [r.mem_id, r]));
+    expect(byId.m1).toMatchObject({ attendance_cnt: 0, last_attended_at: null });
+    expect(byId.m2).toMatchObject({
+      attendance_cnt: 2,
+      last_attended_at: "2026-06-01T00:00:00+00:00",
+    });
+    expect(byId.m3).toMatchObject({
+      attendance_cnt: 1,
+      last_attended_at: "2026-04-01T00:00:00+00:00",
+    });
+  });
+
+  it("last_attended_at asc nulls first, attendance_cnt asc 순으로 정렬(오래/전혀 안 나온 순)", () => {
+    const rows = aggregateAttendance(members, events);
+    expect(rows.map((r) => r.mem_id)).toEqual(["m1", "m3", "m2"]);
+  });
+
+  it("동률(둘 다 미참석)은 cnt asc, 안정 정렬", () => {
+    const rows = aggregateAttendance(
+      [
+        { mem_id: "x", mem_nm: "X", join_dt: null },
+        { mem_id: "y", mem_nm: "Y", join_dt: null },
+      ],
+      [],
+    );
+    expect(rows.map((r) => r.mem_id)).toEqual(["x", "y"]);
+  });
+
+  it("limit 은 정렬 후 상위 N 개만 남긴다", () => {
+    const rows = aggregateAttendance(members, events, 2);
+    expect(rows.map((r) => r.mem_id)).toEqual(["m1", "m3"]);
+  });
+
+  it("이벤트 없는 멤버도 0/null 로 포함된다(left-merge)", () => {
+    const rows = aggregateAttendance(members, []);
+    expect(rows).toHaveLength(3);
+    expect(rows.every((r) => r.attendance_cnt === 0 && r.last_attended_at === null)).toBe(
+      true,
+    );
+  });
+});
+
+describe("buildPushStatus — §5.6 미구독 먼저", () => {
+  const members = [
+    { mem_id: "a", mem_nm: "가", mem_st_cd: "active" },
+    { mem_id: "b", mem_nm: "나", mem_st_cd: "active" },
+    { mem_id: "c", mem_nm: "다", mem_st_cd: "active" },
+  ];
+
+  it("push_enabled asc(false 먼저), 그 안에서 이름순", () => {
+    const rows = buildPushStatus(members, new Set(["b"]));
+    expect(rows.map((r) => [r.mem_id, r.push_enabled])).toEqual([
+      ["a", false],
+      ["c", false],
+      ["b", true],
+    ]);
+  });
+
+  it("구독 집합 멤버십을 정확히 반영", () => {
+    const rows = buildPushStatus(members, new Set(["a", "c"]));
+    const on = rows.filter((r) => r.push_enabled).map((r) => r.mem_id).sort();
+    expect(on).toEqual(["a", "c"]);
+  });
+});
+
+describe("M-03 불변식 — 민감정보(phone/email/bank) 미노출 (G-7 회귀 방지)", () => {
+  it("queries.ts 의 어떤 select 목록에도 연락처·계좌 컬럼이 없다", () => {
+    const src = readFileSync(
+      join(process.cwd(), "lib/mcp/queries.ts"),
+      "utf8",
+    );
+    // 코드가 실제로 select 하는 컬럼 표기만 검사(주석의 설명 문구는 별도 처리).
+    const selectArgs = [...src.matchAll(/\.select\(\s*(["'`])([\s\S]*?)\1/g)].map(
+      (m) => m[2],
+    );
+    expect(selectArgs.length).toBeGreaterThan(0);
+    const banned = ["phone_no", "email_addr", "bank_nm", "bank_acct_no"];
+    for (const sel of selectArgs) {
+      for (const col of banned) {
+        expect(sel.includes(col)).toBe(false);
+      }
+    }
+  });
+
+  it("MemberProfileRow 출력 타입에 민감 키가 없다(형상 고정)", () => {
+    // get_member_profile 은 생일·성별·소개·아바타까지만. 연락처·계좌 키는 존재하지 않음.
+    const sampleKeys = [
+      "mem_id",
+      "mem_nm",
+      "birth_dt",
+      "gdr_enm",
+      "join_dt",
+      "team_role_cd",
+      "mem_st_cd",
+      "intro_txt",
+      "avatar_url",
+    ];
+    for (const banned of ["phone_no", "email_addr", "bank_nm", "bank_acct_no"]) {
+      expect(sampleKeys).not.toContain(banned);
+    }
+  });
+});

--- a/components/settings/settings-client.tsx
+++ b/components/settings/settings-client.tsx
@@ -20,6 +20,7 @@ import {
   Moon,
   Trophy,
   MessageSquare,
+  KeyRound,
 } from "lucide-react";
 
 import { createClient } from "@/lib/supabase/client";
@@ -42,6 +43,7 @@ const accountItems: MenuItem[] = [
   { label: "계좌 정보", href: "/profile/bank", icon: CreditCard },
   { label: "회비 내역", href: "/profile/dues", icon: Wallet },
   { label: "건의하기", href: "/profile/feedback", icon: MessageSquare },
+  { label: "MCP 토큰", href: "/mcp-tokens", icon: KeyRound },
 ];
 
 const teamItems: MenuItem[] = [

--- a/docs/superpowers/specs/2026-07-24-gigang-ops-mcp-design.md
+++ b/docs/superpowers/specs/2026-07-24-gigang-ops-mcp-design.md
@@ -1,0 +1,207 @@
+# 기강 운영 MCP — 설계 스펙 (v1 / MVP)
+
+> Goal: `.goal/gigang-ops-mcp/GOAL.md` (gigang-ops-mcp-v1) · Linear: gigang-client 운영진 AI 조회·알림 도구(MCP), EES-222~227
+> 이 문서는 SG-01(측정 계약·스펙 마감)의 산출물이다. AC-01(스펙)·AC-02(6개 ground-truth SQL)·AC-03(권한 매트릭스)을 충족한다.
+
+## 1. 목적 · 범위
+
+운영진(SQL·스키마 지식 없음)이 자기 AI 클라이언트에서 기강 운영 현황을 조회하고, 권한 있는 운영진이 특정 멤버에게 알림(푸시)을 보낸다.
+
+- **In scope**: 6개 읽기 도구 + admin 게이트 `send_push` 1개. 개인 액세스 토큰(PAT) 인증. 팀 스코프. 감사 로그.
+- **Non-goals**: 푸시 외 쓰기, 일반 크루원 접근, MCP 내 추천 규칙 내장(판단은 AI), OAuth.
+- **원칙**: 도구는 **사실만** 반환(마지막 참석일·횟수 등), "누굴 추천/호출"은 로컬 AI가 판단.
+
+## 2. 아키텍처
+
+- **위치**: 기강 Next.js 앱 안 라우트 `app/api/mcp/[transport]/route.ts`, `mcp-handler`(구 `@vercel/mcp-adapter`)로 Streamable HTTP 노출. 앱과 함께 Vercel 배포.
+  - ⚠️ 구현 착수 시 `node_modules/next/dist/docs/`와 mcp-handler 최신 문서 확인(AGENTS.md 규칙).
+- **인증 미들**: 라우트 앞단에서 `Authorization: Bearer <token>` 검사 → `mcp_token_rel` 조회 → operator ctx `{ mem_id, team_id, is_admin }` 생성 → 각 도구에 주입.
+- **DB 접근**: 서버 전용 service-role 클라이언트. **모든 쿼리는 ctx.team_id로 필터**(RLS 우회하므로 애플리케이션에서 스코프 강제). `SUPABASE_SERVICE_ROLE_KEY`는 서버에서만 사용, 클라 노출 금지.
+- **푸시 발송**: 기존 `insertNotiMany`(`lib/notifications/insert-noti.ts`) 재사용 → 인앱 noti + 웹푸시 자동.
+
+```
+운영진 AI ──Bearer PAT──▶ app/api/mcp/[transport]/route.ts (mcp-handler)
+                              │ auth wrapper → {mem_id, team_id, is_admin}
+                    ┌─────────┴─────────┐
+              읽기 도구 6              쓰기 도구 1 (admin)
+              lib/mcp/queries          send_push → insertNotiMany + 감사행
+                    └──── service-role, team_id 강제 ────▶ Supabase
+```
+
+## 3. 인증 · 권한 모델 (PAT)
+
+### 3.1 토큰 발급/저장 (SG-03)
+
+신규 테이블 `mcp_token_rel`:
+
+| 컬럼 | 타입 | 비고 |
+|---|---|---|
+| token_id | uuid pk | |
+| mem_id | uuid | mem_mst FK |
+| team_id | uuid | 발급 시점 팀 |
+| token_hash | text | **sha256(원문)** — 원문 미저장 |
+| label | text | 사용자가 붙이는 이름(기기 구분) |
+| created_at | timestamptz | |
+| last_used_at | timestamptz null | 검증 성공 시 갱신 |
+| expires_at | timestamptz null | null = 무기한 |
+| revoked_at | timestamptz null | 폐기 시각 |
+
+- **토큰 형식**: `gmcp_` + 32 bytes random(base64url). 발급 화면에서 **평문 1회만** 노출, 이후 hash만 보관.
+- **발급 UI**: `(info)` 그룹에 "MCP 토큰" 화면 — 로그인 멤버가 label 지정해 생성·목록·폐기. `verifyAdmin` 불필요(본인 토큰), 단 팀 멤버여야 함.
+
+### 3.2 검증
+
+1. Bearer 토큰 sha256 → `mcp_token_rel`에서 `token_hash` 일치 & `revoked_at is null` & (`expires_at is null or expires_at > now()`) 조회. 없으면 **401**.
+2. `team_mem_rel`에서 (mem_id, team_id, del_yn=false) 조회 → `team_role_cd`. `mem_st_cd != 'active'`이면 **401**(비활성 멤버 토큰 무효).
+3. `is_admin = team_role_cd in ('owner','admin')`. ctx = `{ mem_id, team_id, is_admin }`. `last_used_at` 갱신.
+
+### 3.3 권한 규칙
+
+- **읽기 도구 6개**: 인증된 팀 멤버 전원 허용.
+- **`send_push`**: `is_admin`만. 아니면 **403**.
+- **민감정보**: `get_member_profile`의 `phone_no·email_addr·bank_nm·bank_acct_no`는 **is_admin만** 반환. 비-admin에겐 해당 필드 생략(마스킹). 기본 프로필(이름·가입일·역할·소개)은 전원.
+
+## 4. 도구 I/O 스키마
+
+모든 도구는 ctx.team_id로 자동 스코프(파라미터로 team 받지 않음).
+
+| 도구 | 입력 | 출력(행) | 권한 |
+|---|---|---|---|
+| `list_today_gatherings` | `date?`(KST, 기본 오늘) | gthr_id, gthr_nm, gthr_type_enm, stt_at, end_at, loc_txt, max_prt_cnt, attendee_cnt | 멤버 |
+| `list_recent_members` | `limit?`(기본 10) | mem_id, mem_nm, join_dt, team_role_cd, mem_st_cd | 멤버 |
+| `list_members_attendance` | `limit?` | mem_id, mem_nm, join_dt, attendance_cnt, last_attended_at | 멤버 |
+| `get_member_profile` | `member_id`(uuid) \| `name` | mem_nm, gdr_enm, birth_dt, join_dt, team_role_cd, mem_st_cd, intro_txt, (+admin: phone_no, email_addr, bank_nm, bank_acct_no) | 멤버(민감정보 admin) |
+| `list_gathering_non_attendees` | `gathering_id`(uuid) | mem_id, mem_nm, join_dt, attendance_cnt, last_attended_at | 멤버 |
+| `list_push_status` | — | mem_id, mem_nm, mem_st_cd, push_enabled | 멤버 |
+| `send_push` | `member_ids`(uuid[]), `title`, `message` | sent_cnt, audit_id | **admin** |
+
+- 반환은 정렬된 JSON 배열. `list_members_attendance`·`list_gathering_non_attendees`는 `last_attended_at asc nulls first`(전혀/오래 안 나온 순)로 정렬해 주되, 최종 추천 판단은 AI가 한다.
+
+## 5. Ground-truth SQL baseline (AC-02)
+
+검증 기준 SQL. `:team_id`는 ctx에서 주입. KST = `Asia/Seoul`. 도구 출력은 아래 결과와 핵심 필드 기준 일치해야 M-01 PASS.
+
+### 5.1 list_today_gatherings
+```sql
+select g.gthr_id, g.gthr_nm, g.gthr_type_enm, g.stt_at, g.end_at, g.loc_txt, g.max_prt_cnt,
+       count(a.attd_id) as attendee_cnt
+from gthr_mst g
+left join gthr_attd_rel a on a.gthr_id = g.gthr_id
+where g.team_id = :team_id and g.del_yn = false
+  and (g.stt_at at time zone 'Asia/Seoul')::date = :day   -- :day 기본 = (now() at time zone 'Asia/Seoul')::date
+group by g.gthr_id
+order by g.stt_at;
+```
+
+### 5.2 list_recent_members
+```sql
+select m.mem_id, m.mem_nm, r.join_dt, r.team_role_cd, r.mem_st_cd
+from team_mem_rel r
+join mem_mst m on m.mem_id = r.mem_id and m.del_yn = false
+where r.team_id = :team_id and r.del_yn = false
+order by r.join_dt desc nulls last, r.crt_at desc
+limit :limit;   -- 기본 10
+```
+
+### 5.3 list_members_attendance
+"참석" = 과거(이미 시작된) 모임에 참석 rel이 있는 것. `last_attended_at` = 그 중 최신 모임 시작시각.
+```sql
+select m.mem_id, m.mem_nm, r.join_dt,
+       count(g.gthr_id) filter (where g.stt_at <= now()) as attendance_cnt,
+       max(g.stt_at)   filter (where g.stt_at <= now()) as last_attended_at
+from team_mem_rel r
+join mem_mst m on m.mem_id = r.mem_id and m.del_yn = false
+left join gthr_attd_rel a on a.mem_id = r.mem_id
+left join gthr_mst g on g.gthr_id = a.gthr_id and g.team_id = :team_id and g.del_yn = false
+where r.team_id = :team_id and r.del_yn = false and r.mem_st_cd = 'active'
+group by m.mem_id, m.mem_nm, r.join_dt
+order by last_attended_at asc nulls first, attendance_cnt asc
+limit :limit;   -- 옵션
+```
+
+### 5.4 get_member_profile
+```sql
+select m.mem_id, m.mem_nm, m.gdr_enm, m.birth_dt, r.join_dt, r.team_role_cd, r.mem_st_cd, r.intro_txt
+       -- is_admin일 때만 추가: , m.phone_no, m.email_addr, m.bank_nm, m.bank_acct_no
+from mem_mst m
+join team_mem_rel r on r.mem_id = m.mem_id and r.team_id = :team_id and r.del_yn = false
+where m.del_yn = false
+  and (m.mem_id = :member_id or lower(m.mem_nm) = lower(:name));
+```
+
+### 5.5 list_gathering_non_attendees
+해당 모임에 참석 rel이 없는 active 멤버 + 각자 마지막 참석일/횟수.
+```sql
+select m.mem_id, m.mem_nm, r.join_dt,
+       count(g.gthr_id) filter (where g.stt_at <= now()) as attendance_cnt,
+       max(g.stt_at)   filter (where g.stt_at <= now()) as last_attended_at
+from team_mem_rel r
+join mem_mst m on m.mem_id = r.mem_id and m.del_yn = false
+left join gthr_attd_rel a on a.mem_id = r.mem_id
+left join gthr_mst g on g.gthr_id = a.gthr_id and g.team_id = :team_id and g.del_yn = false
+where r.team_id = :team_id and r.del_yn = false and r.mem_st_cd = 'active'
+  and not exists (
+    select 1 from gthr_attd_rel x where x.gthr_id = :gathering_id and x.mem_id = r.mem_id)
+group by m.mem_id, m.mem_nm, r.join_dt
+order by last_attended_at asc nulls first, attendance_cnt asc;
+```
+
+### 5.6 list_push_status
+```sql
+select m.mem_id, m.mem_nm, r.mem_st_cd,
+       exists(select 1 from push_sub_rel p where p.team_id = :team_id and p.mem_id = r.mem_id) as push_enabled
+from team_mem_rel r
+join mem_mst m on m.mem_id = r.mem_id and m.del_yn = false
+where r.team_id = :team_id and r.del_yn = false and r.mem_st_cd = 'active'
+order by push_enabled asc, m.mem_nm;
+```
+
+## 6. 권한 · 스코프 게이트 매트릭스 (AC-03)
+
+| # | 토큰/역할 | 호출 | 기대 |
+|---|---|---|---|
+| G-1 | owner/admin | `send_push` | ALLOW (발송 + 감사행) |
+| G-2 | member | `send_push` | DENY 403 (아무것도 발송 안 됨) |
+| G-3 | 토큰 없음/형식오류 | 임의 도구 | DENY 401 |
+| G-4 | 폐기(revoked)/만료(expired) 토큰 | 임의 도구 | DENY 401 |
+| G-5 | 비활성(mem_st_cd≠active) 멤버 토큰 | 임의 도구 | DENY 401 |
+| G-6 | 팀 T 토큰 | 읽기 도구 | 팀 T 행만 반환, 타 팀 데이터 0건 |
+| G-7 | member | `get_member_profile` | ALLOW, 단 phone/email/bank 필드 생략 |
+| G-8 | owner/admin | `get_member_profile` | ALLOW, 민감정보 포함 |
+
+M-02 = 위 매트릭스 100% 통과.
+
+## 7. 에러 처리
+
+- 401: 토큰 없음/무효/폐기/만료/비활성. 402 없음. 403: 비-admin의 write 또는 민감정보 요청.
+- 400: 잘못된 파라미터(비-uuid member_id, 존재하지 않는 gathering_id, member_id·name 둘 다 없음).
+- 도구 내부 오류는 MCP tool error로 **안전 메시지만** 반환(스택·시크릿·SQL 비노출).
+- `send_push` 부분 실패(일부 수신자 푸시 실패)는 인앱 noti는 성공 처리하고 `sent_cnt`와 실패 수를 함께 반환(insertNotiMany는 fire-and-forget 푸시).
+
+## 8. 감사 로그
+
+신규 테이블 `mcp_audit_log`: audit_id, actor_mem_id, team_id, tool_nm, params_json(민감정보 마스킹), result_summary, created_at. **`send_push` 성공 시 반드시 1행**(AC-18). 읽기 도구는 선택(MVP는 write만 필수).
+
+## 9. 테스트 전략
+
+- **단위**: 토큰 검증(hash 일치·revoke·expire·비활성), 권한 해석(is_admin), 민감정보 마스킹.
+- **auth.test** (SG-02, M-02 G-3~G-6): 토큰 유무/무효/폐기/스코프.
+- **tool-correctness.test** (SG-04, M-01): 6개 도구 출력 vs §5 baseline SQL 일치(dev seed 또는 고정 fixture).
+- **send-push.test** (SG-05, M-02 G-1·G-2·G-7·G-8 + AC-18): admin 발송·member 거부·감사행·민감정보.
+- vitest `server-only` import 함정 주의([[troubleshooting/vitest-server-only-trap]] 위키): insertNoti 계열 import 시 vi.mock 필수.
+
+## 10. 데이터 모델 참조 (2026-07-24 dev 실측)
+
+- `gthr_mst`(team_id, gthr_nm, gthr_type_enm[general|regular], stt_at, end_at, loc_txt, max_prt_cnt, del_yn, short_id)
+- `gthr_attd_rel`(gthr_id, mem_id, crt_at) — 취소는 하드 DELETE(이력은 gthr_attd_hist)
+- `mem_mst`(mem_id, mem_nm, gdr_enm, birth_dt, phone_no, email_addr, bank_nm, bank_acct_no, del_yn)
+- `team_mem_rel`(team_id, mem_id, team_role_cd[owner|admin|member], mem_st_cd[active|inactive|left], join_dt, del_yn)
+- `push_sub_rel`(team_id, mem_id, endpoint, ...) — 행 존재 = 푸시 구독
+- `noti_mst` — insertNoti 대상
+
+## 11. 가정 · 미결
+
+- A-01: 비개발자 운영자가 로그인→토큰복사→AI에 붙여넣기를 스스로 완료(SG-06에서 검증).
+- A-02: mcp-handler가 기강 Vercel 런타임에서 정상 동작(SG-02에서 검증).
+- 미결: `list_recent_members`의 "최근" 기준을 join_dt로 볼지 crt_at로 볼지 — join_dt 우선(가입일), null이면 crt_at fallback로 확정.
+- 미결: 읽기 도구도 감사 로깅할지 — MVP는 write만. 필요 시 확장.

--- a/docs/superpowers/specs/2026-07-24-gigang-ops-mcp-design.md
+++ b/docs/superpowers/specs/2026-07-24-gigang-ops-mcp-design.md
@@ -81,6 +81,8 @@
 
 검증 기준 SQL. `:team_id`는 ctx에서 주입. KST = `Asia/Seoul`. 도구 출력은 아래 결과와 핵심 필드 기준 일치해야 M-01 PASS.
 
+> **⚠️ team_mem_rel은 버전 테이블 — 모든 조회에 `and r.vers = 0` 필수.** (2026-07-24 SG-04에서 dev 실측·독립검증 확인) vers=0 미적용 시 활성멤버가 중복(dev 147 vs 정본 144)되고, vers=0가 'left'인 멤버가 vers>0 'active' 행으로 부활한다. 앱 전역 규약(`fetchMemMstWithTeamRel`·`auth.ts`)과 동일. 아래 baseline에 반영됨. (mem_mst는 vers가 아니라 del_yn으로 버저닝 — `m.del_yn=false`만으로 mem_id당 1행.)
+
 ### 5.1 list_today_gatherings
 ```sql
 select g.gthr_id, g.gthr_nm, g.gthr_type_enm, g.stt_at, g.end_at, g.loc_txt, g.max_prt_cnt,
@@ -98,7 +100,7 @@ order by g.stt_at;
 select m.mem_id, m.mem_nm, r.join_dt, r.team_role_cd, r.mem_st_cd
 from team_mem_rel r
 join mem_mst m on m.mem_id = r.mem_id and m.del_yn = false
-where r.team_id = :team_id and r.del_yn = false
+where r.team_id = :team_id and r.del_yn = false and r.vers = 0
 order by r.join_dt desc nulls last, r.crt_at desc
 limit :limit;   -- 기본 10
 ```
@@ -113,7 +115,7 @@ from team_mem_rel r
 join mem_mst m on m.mem_id = r.mem_id and m.del_yn = false
 left join gthr_attd_rel a on a.mem_id = r.mem_id
 left join gthr_mst g on g.gthr_id = a.gthr_id and g.team_id = :team_id and g.del_yn = false
-where r.team_id = :team_id and r.del_yn = false and r.mem_st_cd = 'active'
+where r.team_id = :team_id and r.del_yn = false and r.vers = 0 and r.mem_st_cd = 'active'
 group by m.mem_id, m.mem_nm, r.join_dt
 order by last_attended_at asc nulls first, attendance_cnt asc
 limit :limit;   -- 옵션
@@ -125,7 +127,7 @@ limit :limit;   -- 옵션
 select m.mem_id, m.mem_nm, m.birth_dt, m.gdr_enm, m.avatar_url,
        r.join_dt, r.team_role_cd, r.mem_st_cd, r.intro_txt
 from mem_mst m
-join team_mem_rel r on r.mem_id = m.mem_id and r.team_id = :team_id and r.del_yn = false
+join team_mem_rel r on r.mem_id = m.mem_id and r.team_id = :team_id and r.del_yn = false and r.vers = 0
 where m.del_yn = false
   and (m.mem_id = :member_id or lower(m.mem_nm) = lower(:name));
 ```
@@ -140,7 +142,7 @@ from team_mem_rel r
 join mem_mst m on m.mem_id = r.mem_id and m.del_yn = false
 left join gthr_attd_rel a on a.mem_id = r.mem_id
 left join gthr_mst g on g.gthr_id = a.gthr_id and g.team_id = :team_id and g.del_yn = false
-where r.team_id = :team_id and r.del_yn = false and r.mem_st_cd = 'active'
+where r.team_id = :team_id and r.del_yn = false and r.vers = 0 and r.mem_st_cd = 'active'
   and not exists (
     select 1 from gthr_attd_rel x where x.gthr_id = :gathering_id and x.mem_id = r.mem_id)
 group by m.mem_id, m.mem_nm, r.join_dt
@@ -153,7 +155,7 @@ select m.mem_id, m.mem_nm, r.mem_st_cd,
        exists(select 1 from push_sub_rel p where p.team_id = :team_id and p.mem_id = r.mem_id) as push_enabled
 from team_mem_rel r
 join mem_mst m on m.mem_id = r.mem_id and m.del_yn = false
-where r.team_id = :team_id and r.del_yn = false and r.mem_st_cd = 'active'
+where r.team_id = :team_id and r.del_yn = false and r.vers = 0 and r.mem_st_cd = 'active'
 order by push_enabled asc, m.mem_nm;
 ```
 

--- a/docs/superpowers/specs/2026-07-24-gigang-ops-mcp-design.md
+++ b/docs/superpowers/specs/2026-07-24-gigang-ops-mcp-design.md
@@ -59,7 +59,7 @@
 
 - **읽기 도구 6개**: 인증된 팀 멤버 전원 허용.
 - **`send_push`**: `is_admin`만. 아니면 **403**.
-- **민감정보**: `get_member_profile`의 `phone_no·email_addr·bank_nm·bank_acct_no`는 **is_admin만** 반환. 비-admin에겐 해당 필드 생략(마스킹). 기본 프로필(이름·가입일·역할·소개)은 전원.
+- **민감정보 전면 차단**: `phone_no·email_addr·bank_nm·bank_acct_no`는 **어떤 도구도, 어떤 권한(admin 포함)도 반환하지 않는다.** 쿼리 select 목록에서 아예 제외 — 코드 레벨 불변식(M-03). `get_member_profile`은 생일·성별을 포함하되 연락처·계좌는 절대 미포함.
 
 ## 4. 도구 I/O 스키마
 
@@ -70,7 +70,7 @@
 | `list_today_gatherings` | `date?`(KST, 기본 오늘) | gthr_id, gthr_nm, gthr_type_enm, stt_at, end_at, loc_txt, max_prt_cnt, attendee_cnt | 멤버 |
 | `list_recent_members` | `limit?`(기본 10) | mem_id, mem_nm, join_dt, team_role_cd, mem_st_cd | 멤버 |
 | `list_members_attendance` | `limit?` | mem_id, mem_nm, join_dt, attendance_cnt, last_attended_at | 멤버 |
-| `get_member_profile` | `member_id`(uuid) \| `name` | mem_nm, gdr_enm, birth_dt, join_dt, team_role_cd, mem_st_cd, intro_txt, (+admin: phone_no, email_addr, bank_nm, bank_acct_no) | 멤버(민감정보 admin) |
+| `get_member_profile` | `member_id`(uuid) \| `name` | mem_nm, birth_dt, gdr_enm, join_dt, team_role_cd, mem_st_cd, intro_txt, avatar_url | 멤버 (연락처·계좌 절대 미포함) |
 | `list_gathering_non_attendees` | `gathering_id`(uuid) | mem_id, mem_nm, join_dt, attendance_cnt, last_attended_at | 멤버 |
 | `list_push_status` | — | mem_id, mem_nm, mem_st_cd, push_enabled | 멤버 |
 | `send_push` | `member_ids`(uuid[]), `title`, `message` | sent_cnt, audit_id | **admin** |
@@ -120,9 +120,10 @@ limit :limit;   -- 옵션
 ```
 
 ### 5.4 get_member_profile
+연락처·계좌(phone_no·email_addr·bank_nm·bank_acct_no)는 **select 목록에서 영구 제외** — 코드 불변식.
 ```sql
-select m.mem_id, m.mem_nm, m.gdr_enm, m.birth_dt, r.join_dt, r.team_role_cd, r.mem_st_cd, r.intro_txt
-       -- is_admin일 때만 추가: , m.phone_no, m.email_addr, m.bank_nm, m.bank_acct_no
+select m.mem_id, m.mem_nm, m.birth_dt, m.gdr_enm, m.avatar_url,
+       r.join_dt, r.team_role_cd, r.mem_st_cd, r.intro_txt
 from mem_mst m
 join team_mem_rel r on r.mem_id = m.mem_id and r.team_id = :team_id and r.del_yn = false
 where m.del_yn = false
@@ -166,10 +167,9 @@ order by push_enabled asc, m.mem_nm;
 | G-4 | 폐기(revoked)/만료(expired) 토큰 | 임의 도구 | DENY 401 |
 | G-5 | 비활성(mem_st_cd≠active) 멤버 토큰 | 임의 도구 | DENY 401 |
 | G-6 | 팀 T 토큰 | 읽기 도구 | 팀 T 행만 반환, 타 팀 데이터 0건 |
-| G-7 | member | `get_member_profile` | ALLOW, 단 phone/email/bank 필드 생략 |
-| G-8 | owner/admin | `get_member_profile` | ALLOW, 민감정보 포함 |
+| G-7 | 임의 토큰(admin 포함) | `get_member_profile` | 응답에 phone_no·email_addr·bank_nm·bank_acct_no **미포함** |
 
-M-02 = 위 매트릭스 100% 통과.
+M-02 = 위 매트릭스 100% 통과. (민감정보는 권한 분기 없이 전면 차단 — G-7은 M-03 불변식과도 연결.)
 
 ## 7. 에러 처리
 

--- a/lib/mcp/auth.ts
+++ b/lib/mcp/auth.ts
@@ -1,0 +1,112 @@
+import { createHash } from "node:crypto";
+
+import type { SupabaseClient } from "@supabase/supabase-js";
+
+import type { Database } from "@/lib/supabase/database.types";
+
+/**
+ * 운영 MCP 토큰 검증 결과로 만들어지는 operator 컨텍스트.
+ * 팀 스코프 신원 — 이후 모든 도구 쿼리는 반드시 `team_id`로 필터한다.
+ * 연락처·계좌 등 민감정보는 절대 포함하지 않는다(스펙 §3.3 / M-03 불변식).
+ */
+export type OperatorContext = {
+  mem_id: string;
+  team_id: string;
+  is_admin: boolean;
+  /** 표시용 멤버 이름(health/whoami). 민감정보 아님. */
+  mem_nm: string;
+};
+
+/** 발급 토큰 접두사. `gmcp_` + base64url(random 32 bytes). */
+export const TOKEN_PREFIX = "gmcp_";
+
+/**
+ * 원문 토큰을 sha256 hex로 해시한다. `mcp_token_rel.token_hash`와 동일 규약.
+ * 원문은 어디에도 저장하지 않으며, 검증은 해시 비교로만 한다.
+ */
+export function hashToken(token: string): string {
+  return createHash("sha256").update(token, "utf8").digest("hex");
+}
+
+/**
+ * Bearer 원문 토큰을 operator 컨텍스트로 해석한다(스펙 §3.2 검증 흐름).
+ *
+ * 실패 시(토큰 없음·형식오류·미존재·폐기·만료·비-active 멤버) `null`을 반환하며,
+ * 라우트 인증 래퍼는 이를 401로 매핑한다. 어떤 실패 사유도 응답으로 흘리지 않는다.
+ *
+ * 순수 검증 로직만 담아 테스트 용이성을 확보한다 — service-role 클라이언트는
+ * 호출부(라우트)에서 주입하며, 이 모듈은 `server-only` 체인을 import 하지 않는다.
+ *
+ * @param token   `Authorization: Bearer` 원문 토큰
+ * @param supabase service-role Supabase 클라이언트(RLS 우회 — 이 테이블은 service 전용)
+ */
+export async function resolveOperator(
+  token: string | undefined | null,
+  supabase: SupabaseClient<Database>,
+): Promise<OperatorContext | null> {
+  if (typeof token !== "string") return null;
+  const raw = token.trim();
+  if (!raw.startsWith(TOKEN_PREFIX)) return null;
+
+  const tokenHash = hashToken(raw);
+
+  // 1) 토큰 행 조회: 해시 일치 & 미폐기. 만료는 아래에서 별도 검증.
+  const { data: tokenRow, error: tokenErr } = await supabase
+    .from("mcp_token_rel")
+    .select("token_id, mem_id, team_id, expires_at, revoked_at")
+    .eq("token_hash", tokenHash)
+    .is("revoked_at", null)
+    .maybeSingle();
+
+  if (tokenErr || !tokenRow) return null;
+
+  // 만료 검증(expires_at null = 무기한). now 이하이면 무효.
+  if (
+    tokenRow.expires_at !== null &&
+    new Date(tokenRow.expires_at).getTime() <= Date.now()
+  ) {
+    return null;
+  }
+
+  // 2) 팀 멤버십 조회: 앱 전역 규약과 동일하게 vers=0·del_yn=false 를 현재 정본 행으로 본다
+  //    (lib/queries/app-member.ts 의 fetchMemMstWithTeamRel 과 동일).
+  const { data: rel, error: relErr } = await supabase
+    .from("team_mem_rel")
+    .select("mem_st_cd, team_role_cd")
+    .eq("mem_id", tokenRow.mem_id)
+    .eq("team_id", tokenRow.team_id)
+    .eq("vers", 0)
+    .eq("del_yn", false)
+    .maybeSingle();
+
+  if (relErr || !rel) return null;
+  // 비활성(inactive/left) 멤버 토큰은 무효(스펙 §3.2, G-5).
+  if (rel.mem_st_cd !== "active") return null;
+
+  const isAdmin =
+    rel.team_role_cd === "owner" || rel.team_role_cd === "admin";
+
+  // 3) 표시용 이름(민감정보 아님). 조회 실패해도 인증은 성립.
+  const { data: mem } = await supabase
+    .from("mem_mst")
+    .select("mem_nm")
+    .eq("mem_id", tokenRow.mem_id)
+    .eq("vers", 0)
+    .eq("del_yn", false)
+    .maybeSingle();
+
+  // last_used_at 갱신은 best-effort — 실패해도 검증에 영향 없음(예외 삼킴).
+  void Promise.resolve(
+    supabase
+      .from("mcp_token_rel")
+      .update({ last_used_at: new Date().toISOString() })
+      .eq("token_id", tokenRow.token_id),
+  ).catch(() => {});
+
+  return {
+    mem_id: tokenRow.mem_id,
+    team_id: tokenRow.team_id,
+    is_admin: isAdmin,
+    mem_nm: mem?.mem_nm ?? "",
+  };
+}

--- a/lib/mcp/issue-token.ts
+++ b/lib/mcp/issue-token.ts
@@ -1,0 +1,141 @@
+import { randomBytes } from "node:crypto";
+
+import type { SupabaseClient } from "@supabase/supabase-js";
+
+import { hashToken, TOKEN_PREFIX } from "@/lib/mcp/auth";
+import type { Database } from "@/lib/supabase/database.types";
+
+/**
+ * 기강 운영 MCP — PAT 발급·목록·폐기 로직(SG-03, 스펙 §3.1, AC-07/08/09).
+ *
+ * 설계 원칙
+ * - **service-role 클라이언트 주입식 순수함수**: `lib/mcp/auth.ts`·`lib/mcp/send-push.ts`·
+ *   `lib/mcp/queries.ts`와 동일하게 클라이언트를 인자로 받아 이 모듈은 `server-only` 체인
+ *   (`admin.ts`)을 import 하지 않는다 → vitest server-only 함정 회피
+ *   ([[troubleshooting/vitest-server-only-trap]]). 호출부(`app/actions/mcp-token.ts`)가
+ *   admin 클라이언트를 생성해 주입한다.
+ * - **해시 재사용(AC-07 핵심)**: 발급 시 `lib/mcp/auth.ts`의 `hashToken`을 그대로 재사용해
+ *   `mcp_token_rel.token_hash`에 저장한다. 여기서 새 해시 로직을 만들면 `resolveOperator`의
+ *   검증과 어긋나 발급 직후 로그인 실패로 이어진다 — 반드시 동일 함수를 공유.
+ * - **원문 1회 노출**: `issueMcpToken`의 반환값에만 평문 토큰이 담기며, DB에는 해시만 저장한다.
+ *   호출부는 이 반환값을 응답으로 1회 전달한 뒤 어디에도 저장하지 않는다.
+ * - **본인 스코프 강제**: `listMcpTokens`·`revokeMcpToken`은 항상 `mem_id` eq 필터로 스코프한다
+ *   (`mcp_token_rel`은 service-role 전용 RLS라 애플리케이션 레벨에서 강제해야 함). `token_hash`는
+ *   어떤 select 목록에도 포함하지 않는다.
+ */
+
+type Db = SupabaseClient<Database>;
+
+/** 목록 화면에 내려줄 요약 — token_hash·원문은 절대 포함하지 않는다. */
+export type McpTokenSummary = {
+  token_id: string;
+  label: string | null;
+  created_at: string;
+  last_used_at: string | null;
+  revoked: boolean;
+};
+
+export type IssueMcpTokenResult = {
+  token_id: string;
+  /** 평문 토큰 — 이 반환값에서만 1회 노출. 저장하지 않는다. */
+  token: string;
+  label: string | null;
+  created_at: string;
+};
+
+/** 폐기 대상을 찾지 못했을 때(존재하지 않음·이미 폐기·본인 소유 아님) — 사유를 구분해 노출하지 않는다. */
+export class McpTokenNotFoundError extends Error {
+  constructor(message = "토큰을 찾을 수 없습니다.") {
+    super(message);
+    this.name = "McpTokenNotFoundError";
+  }
+}
+
+/** 발급 토큰 원문 생성: `gmcp_` + 32바이트 랜덤(base64url). */
+function generateRawToken(): string {
+  return `${TOKEN_PREFIX}${randomBytes(32).toString("base64url")}`;
+}
+
+/**
+ * PAT를 발급해 `mcp_token_rel`에 해시만 저장한다(스펙 §3.1).
+ *
+ * @param supabase service-role 클라이언트(라우트/서버 액션에서 주입)
+ * @param params   mem_id·team_id(발급 시점 팀)·label(선택)
+ * @returns 평문 토큰이 담긴 결과 — 이 호출 응답에서만 1회 노출된다.
+ */
+export async function issueMcpToken(
+  supabase: Db,
+  params: { memId: string; teamId: string; label: string | null },
+): Promise<IssueMcpTokenResult> {
+  const token = generateRawToken();
+  const tokenHash = hashToken(token);
+
+  const { data, error } = await supabase
+    .from("mcp_token_rel")
+    .insert({
+      mem_id: params.memId,
+      team_id: params.teamId,
+      token_hash: tokenHash,
+      label: params.label,
+    })
+    .select("token_id, created_at, label")
+    .single();
+
+  if (error || !data) {
+    throw error ?? new Error("토큰 발급에 실패했습니다.");
+  }
+
+  return {
+    token_id: data.token_id,
+    token,
+    label: data.label,
+    created_at: data.created_at,
+  };
+}
+
+/**
+ * 로그인 멤버 본인의 토큰 목록을 반환한다(최신순). `token_hash`는 절대 select 하지 않는다.
+ */
+export async function listMcpTokens(
+  supabase: Db,
+  memId: string,
+): Promise<McpTokenSummary[]> {
+  const { data, error } = await supabase
+    .from("mcp_token_rel")
+    .select("token_id, label, created_at, last_used_at, revoked_at")
+    .eq("mem_id", memId)
+    .order("created_at", { ascending: false });
+
+  if (error) throw error;
+
+  return (data ?? []).map((row) => ({
+    token_id: row.token_id,
+    label: row.label,
+    created_at: row.created_at,
+    last_used_at: row.last_used_at,
+    revoked: row.revoked_at !== null,
+  }));
+}
+
+/**
+ * 본인 소유 토큰을 폐기한다(`revoked_at = now()`). `mem_id` eq 필터로 남의 토큰 폐기를 원천 차단하고,
+ * 이미 폐기된 토큰을 다시 조작하지 않도록 `revoked_at is null` 조건도 함께 건다.
+ * 매칭되는 행이 없으면(미존재·이미 폐기·본인 소유 아님을 구분하지 않고) `McpTokenNotFoundError`.
+ */
+export async function revokeMcpToken(
+  supabase: Db,
+  memId: string,
+  tokenId: string,
+): Promise<void> {
+  const { data, error } = await supabase
+    .from("mcp_token_rel")
+    .update({ revoked_at: new Date().toISOString() })
+    .eq("token_id", tokenId)
+    .eq("mem_id", memId)
+    .is("revoked_at", null)
+    .select("token_id")
+    .maybeSingle();
+
+  if (error) throw error;
+  if (!data) throw new McpTokenNotFoundError();
+}

--- a/lib/mcp/queries.ts
+++ b/lib/mcp/queries.ts
@@ -1,0 +1,437 @@
+import type { SupabaseClient } from "@supabase/supabase-js";
+
+import { dayjs } from "@/lib/dayjs";
+import type { Database } from "@/lib/supabase/database.types";
+
+/**
+ * 기강 운영 MCP — 6개 읽기 도구의 쿼리 로직(SG-04, 스펙 §4·§5).
+ *
+ * 설계 원칙
+ * - **team_id 강제 스코프**: 모든 함수는 operator ctx의 `teamId`를 필수 인자로 받는다.
+ *   도구는 절대 team 파라미터를 노출하지 않으며, 여기서도 team을 인자로만 받아 필터에 강제한다.
+ * - **service-role 클라이언트 주입식 순수함수**: 클라이언트를 인자로 받아 이 모듈은
+ *   `server-only` 체인(admin.ts 등)을 import 하지 않는다 → vitest server-only 함정 회피
+ *   ([[troubleshooting/vitest-server-only-trap]]). 집계·정렬 등 순수 로직은 별도 export 해 단위 테스트한다.
+ * - **민감정보 전면 차단(M-03 불변식)**: 어떤 select 목록에도 `phone_no·email_addr·bank_nm·
+ *   bank_acct_no`를 포함하지 않는다. `get_member_profile`도 생일·성별·소개·아바타까지만 반환한다.
+ * - **정본 행 규약(vers=0)**: `team_mem_rel`·`mem_mst`는 앱 전역과 동일하게 `vers=0 & del_yn=false`를
+ *   현재 정본으로 본다(lib/queries/app-member.ts, lib/mcp/auth.ts 동일). 스펙 §5 baseline SQL 본문은
+ *   `vers=0`을 생략했으나, dev 실데이터에는 `del_yn=false & vers>0`인 낡은 team_mem_rel 행이 존재해
+ *   그대로 두면 동일 멤버가 중복되거나 'left' 멤버가 'active'로 되살아난다(중복·유령 행). 정확도 기준
+ *   M-01은 이 정본 규약(vers=0)으로 보정한 baseline과 대조한다.
+ */
+
+/** 알려진 안전 에러(입력·미존재) — 라우트가 사용자에게 그대로 노출해도 무방한 메시지만 담는다. */
+export class ToolInputError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "ToolInputError";
+  }
+}
+
+type Db = SupabaseClient<Database>;
+
+const KST = "Asia/Seoul";
+
+/** 임베디드 관계 결과를 to-one으로 정규화(타입 추론이 배열/객체로 갈릴 때 방어). */
+function pickOne<T>(rel: T | T[] | null | undefined): T | null {
+  if (rel == null) return null;
+  return Array.isArray(rel) ? (rel[0] ?? null) : rel;
+}
+
+/**
+ * KST 달력일(`date` 미지정 시 오늘) 하루의 UTC 반열림 구간을 계산한다.
+ * baseline의 `(stt_at at time zone 'Asia/Seoul')::date = :day`와 동치인
+ * `stt_at >= startIso and stt_at < endIso` 필터로 변환하기 위한 순수 함수.
+ */
+export function kstDayRange(date?: string): {
+  day: string;
+  startIso: string;
+  endIso: string;
+} {
+  const day =
+    typeof date === "string" && /^\d{4}-\d{2}-\d{2}$/.test(date)
+      ? date
+      : dayjs().tz(KST).format("YYYY-MM-DD");
+  const start = dayjs.tz(day, KST);
+  return {
+    day,
+    startIso: start.toISOString(),
+    endIso: start.add(1, "day").toISOString(),
+  };
+}
+
+// ── 출력 행 타입 ────────────────────────────────────────────────────────────
+
+export type TodayGatheringRow = {
+  gthr_id: string;
+  gthr_nm: string;
+  gthr_type_enm: string;
+  stt_at: string;
+  end_at: string | null;
+  loc_txt: string | null;
+  max_prt_cnt: number | null;
+  attendee_cnt: number;
+};
+
+export type RecentMemberRow = {
+  mem_id: string;
+  mem_nm: string;
+  join_dt: string | null;
+  team_role_cd: string;
+  mem_st_cd: string;
+};
+
+export type AttendanceRow = {
+  mem_id: string;
+  mem_nm: string;
+  join_dt: string | null;
+  attendance_cnt: number;
+  last_attended_at: string | null;
+};
+
+export type MemberProfileRow = {
+  mem_id: string;
+  mem_nm: string;
+  birth_dt: string | null;
+  gdr_enm: string | null;
+  join_dt: string | null;
+  team_role_cd: string;
+  mem_st_cd: string;
+  intro_txt: string | null;
+  avatar_url: string | null;
+};
+
+export type PushStatusRow = {
+  mem_id: string;
+  mem_nm: string;
+  mem_st_cd: string;
+  push_enabled: boolean;
+};
+
+/** 집계용 최소 멤버 형태. */
+type MemberSeed = { mem_id: string; mem_nm: string; join_dt: string | null };
+/** 집계용 참석 이벤트(과거 팀 모임 1건 참석 = 1행). */
+type AttendanceEvent = { mem_id: string; stt_at: string | null };
+
+// ── 순수 집계·정렬 로직(단위 테스트 대상) ─────────────────────────────────────
+
+/**
+ * baseline 정렬 규약: `last_attended_at asc nulls first, attendance_cnt asc`.
+ * (전혀/오래 안 나온 멤버가 앞) — 최종 호출 판단은 AI가 하도록 사실만 정렬한다.
+ * ISO timestamptz 문자열(모두 동일 +00:00 오프셋)의 사전식 비교 = 시간순.
+ */
+function compareAttendance(a: AttendanceRow, b: AttendanceRow): number {
+  const al = a.last_attended_at;
+  const bl = b.last_attended_at;
+  if (al === null && bl !== null) return -1; // nulls first
+  if (al !== null && bl === null) return 1;
+  if (al !== null && bl !== null) {
+    if (al < bl) return -1;
+    if (al > bl) return 1;
+  }
+  return a.attendance_cnt - b.attendance_cnt;
+}
+
+/**
+ * 멤버 목록에 각자의 과거 팀 모임 참석 횟수/마지막 참석시각을 left-merge 후 정렬한다.
+ * baseline §5.3/§5.5의 `count(...) filter (where stt_at<=now)` / `max(...) filter (...)`와 동치:
+ * `events`는 이미 "과거 & 팀 & 미삭제 모임" 참석으로 필터된 행만 담겨야 한다.
+ */
+export function aggregateAttendance(
+  members: MemberSeed[],
+  events: AttendanceEvent[],
+  limit?: number,
+): AttendanceRow[] {
+  const byMem = new Map<string, { cnt: number; last: string | null }>();
+  for (const e of events) {
+    const cur = byMem.get(e.mem_id) ?? { cnt: 0, last: null };
+    cur.cnt += 1;
+    if (
+      e.stt_at !== null &&
+      (cur.last === null || dayjs(e.stt_at).isAfter(dayjs(cur.last)))
+    ) {
+      cur.last = e.stt_at;
+    }
+    byMem.set(e.mem_id, cur);
+  }
+  const rows: AttendanceRow[] = members.map((m) => {
+    const agg = byMem.get(m.mem_id);
+    return {
+      mem_id: m.mem_id,
+      mem_nm: m.mem_nm,
+      join_dt: m.join_dt,
+      attendance_cnt: agg?.cnt ?? 0,
+      last_attended_at: agg?.last ?? null,
+    };
+  });
+  rows.sort(compareAttendance);
+  return typeof limit === "number" ? rows.slice(0, limit) : rows;
+}
+
+/**
+ * 멤버별 푸시 구독 여부를 표시하고 baseline §5.6 정렬(`push_enabled asc, mem_nm`)로 정렬한다.
+ * 이름 단위 정렬은 DB collation과 완전히 일치하지 않을 수 있어(핵심은 push_enabled 그룹핑) 참고.
+ */
+export function buildPushStatus(
+  members: Array<{ mem_id: string; mem_nm: string; mem_st_cd: string }>,
+  subscribedMemIds: ReadonlySet<string>,
+): PushStatusRow[] {
+  const rows: PushStatusRow[] = members.map((m) => ({
+    mem_id: m.mem_id,
+    mem_nm: m.mem_nm,
+    mem_st_cd: m.mem_st_cd,
+    push_enabled: subscribedMemIds.has(m.mem_id),
+  }));
+  rows.sort((a, b) => {
+    if (a.push_enabled !== b.push_enabled) return a.push_enabled ? 1 : -1; // false first
+    return a.mem_nm.localeCompare(b.mem_nm);
+  });
+  return rows;
+}
+
+// ── 쿼리 함수(supabase 주입) ─────────────────────────────────────────────────
+
+/** 활성 팀 멤버(정본 vers=0) 시드 목록 — 5.3/5.5 공통 기반. */
+async function fetchActiveMemberSeeds(
+  supabase: Db,
+  teamId: string,
+): Promise<MemberSeed[]> {
+  const { data, error } = await supabase
+    .from("team_mem_rel")
+    .select("mem_id, join_dt, mem_mst!inner(mem_nm)")
+    .eq("team_id", teamId)
+    .eq("del_yn", false)
+    .eq("vers", 0)
+    .eq("mem_st_cd", "active")
+    .eq("mem_mst.del_yn", false);
+  if (error) throw error;
+  return (data ?? []).map((r) => {
+    const mem = pickOne(r.mem_mst as { mem_nm: string } | { mem_nm: string }[]);
+    return {
+      mem_id: r.mem_id as string,
+      mem_nm: mem?.mem_nm ?? "",
+      join_dt: (r.join_dt as string | null) ?? null,
+    };
+  });
+}
+
+/** 과거(이미 시작된) 팀 모임 참석 이벤트 목록 — 5.3/5.5 공통 기반. */
+async function fetchPastAttendanceEvents(
+  supabase: Db,
+  teamId: string,
+): Promise<AttendanceEvent[]> {
+  const nowIso = dayjs().toISOString();
+  const { data, error } = await supabase
+    .from("gthr_attd_rel")
+    .select("mem_id, gthr_mst!inner(stt_at)")
+    .eq("gthr_mst.team_id", teamId)
+    .eq("gthr_mst.del_yn", false)
+    .lte("gthr_mst.stt_at", nowIso);
+  if (error) throw error;
+  return (data ?? []).map((r) => {
+    const g = pickOne(r.gthr_mst as { stt_at: string } | { stt_at: string }[]);
+    return { mem_id: r.mem_id as string, stt_at: (g?.stt_at as string) ?? null };
+  });
+}
+
+/** §5.1 오늘(또는 지정일, KST)의 팀 모임 + 참석자 수. */
+export async function listTodayGatherings(
+  supabase: Db,
+  teamId: string,
+  date?: string,
+): Promise<TodayGatheringRow[]> {
+  const { startIso, endIso } = kstDayRange(date);
+  const { data, error } = await supabase
+    .from("gthr_mst")
+    .select(
+      "gthr_id, gthr_nm, gthr_type_enm, stt_at, end_at, loc_txt, max_prt_cnt, gthr_attd_rel(count)",
+    )
+    .eq("team_id", teamId)
+    .eq("del_yn", false)
+    .gte("stt_at", startIso)
+    .lt("stt_at", endIso)
+    .order("stt_at", { ascending: true });
+  if (error) throw error;
+  return (data ?? []).map((g) => {
+    const countRel = g.gthr_attd_rel as Array<{ count: number }> | null;
+    return {
+      gthr_id: g.gthr_id as string,
+      gthr_nm: g.gthr_nm as string,
+      gthr_type_enm: g.gthr_type_enm as string,
+      stt_at: g.stt_at as string,
+      end_at: (g.end_at as string | null) ?? null,
+      loc_txt: (g.loc_txt as string | null) ?? null,
+      max_prt_cnt: (g.max_prt_cnt as number | null) ?? null,
+      attendee_cnt: countRel?.[0]?.count ?? 0,
+    };
+  });
+}
+
+/** §5.2 최근 가입 멤버(join_dt desc nulls last, crt_at desc). */
+export async function listRecentMembers(
+  supabase: Db,
+  teamId: string,
+  limit = 10,
+): Promise<RecentMemberRow[]> {
+  const { data, error } = await supabase
+    .from("team_mem_rel")
+    .select("mem_id, join_dt, team_role_cd, mem_st_cd, crt_at, mem_mst!inner(mem_nm)")
+    .eq("team_id", teamId)
+    .eq("del_yn", false)
+    .eq("vers", 0)
+    .eq("mem_mst.del_yn", false)
+    .order("join_dt", { ascending: false, nullsFirst: false })
+    .order("crt_at", { ascending: false })
+    .limit(limit);
+  if (error) throw error;
+  return (data ?? []).map((r) => {
+    const mem = pickOne(r.mem_mst as { mem_nm: string } | { mem_nm: string }[]);
+    return {
+      mem_id: r.mem_id as string,
+      mem_nm: mem?.mem_nm ?? "",
+      join_dt: (r.join_dt as string | null) ?? null,
+      team_role_cd: r.team_role_cd as string,
+      mem_st_cd: r.mem_st_cd as string,
+    };
+  });
+}
+
+/** §5.3 멤버별 참석 현황(오래/전혀 안 나온 순). */
+export async function listMembersAttendance(
+  supabase: Db,
+  teamId: string,
+  limit?: number,
+): Promise<AttendanceRow[]> {
+  const [members, events] = await Promise.all([
+    fetchActiveMemberSeeds(supabase, teamId),
+    fetchPastAttendanceEvents(supabase, teamId),
+  ]);
+  return aggregateAttendance(members, events, limit);
+}
+
+/** §5.4 멤버 프로필(연락처·계좌 절대 미포함). member_id 또는 name으로 조회. */
+export async function getMemberProfile(
+  supabase: Db,
+  teamId: string,
+  params: { memberId?: string; name?: string },
+): Promise<MemberProfileRow[]> {
+  const { memberId, name } = params;
+  if (!memberId && !name) {
+    throw new ToolInputError("member_id 또는 name 중 하나는 필요합니다.");
+  }
+  let query = supabase
+    .from("team_mem_rel")
+    .select(
+      "join_dt, team_role_cd, mem_st_cd, intro_txt, mem_mst!inner(mem_id, mem_nm, birth_dt, gdr_enm, avatar_url)",
+    )
+    .eq("team_id", teamId)
+    .eq("del_yn", false)
+    .eq("vers", 0)
+    .eq("mem_mst.del_yn", false);
+  if (memberId) {
+    query = query.eq("mem_mst.mem_id", memberId);
+  } else if (name) {
+    // baseline lower(mem_nm)=lower(name) 동치. ilike(무와일드카드)=대소문자 무시 완전일치.
+    query = query.ilike("mem_mst.mem_nm", name);
+  }
+  const { data, error } = await query;
+  if (error) throw error;
+  return (data ?? []).map((r) => {
+    const mem = pickOne(
+      r.mem_mst as
+        | {
+            mem_id: string;
+            mem_nm: string;
+            birth_dt: string | null;
+            gdr_enm: string | null;
+            avatar_url: string | null;
+          }
+        | Array<{
+            mem_id: string;
+            mem_nm: string;
+            birth_dt: string | null;
+            gdr_enm: string | null;
+            avatar_url: string | null;
+          }>,
+    );
+    return {
+      mem_id: mem?.mem_id ?? "",
+      mem_nm: mem?.mem_nm ?? "",
+      birth_dt: mem?.birth_dt ?? null,
+      gdr_enm: mem?.gdr_enm ?? null,
+      join_dt: (r.join_dt as string | null) ?? null,
+      team_role_cd: r.team_role_cd as string,
+      mem_st_cd: r.mem_st_cd as string,
+      intro_txt: (r.intro_txt as string | null) ?? null,
+      avatar_url: mem?.avatar_url ?? null,
+    };
+  });
+}
+
+/** §5.5 특정 모임 미참석 활성 멤버 + 각자 참석 현황. */
+export async function listGatheringNonAttendees(
+  supabase: Db,
+  teamId: string,
+  gatheringId: string,
+): Promise<AttendanceRow[]> {
+  // 모임 존재·팀 스코프 검증(§7: 존재하지 않는 gathering_id → 안전 에러).
+  const { data: gthr, error: gErr } = await supabase
+    .from("gthr_mst")
+    .select("gthr_id")
+    .eq("gthr_id", gatheringId)
+    .eq("team_id", teamId)
+    .eq("del_yn", false)
+    .maybeSingle();
+  if (gErr) throw gErr;
+  if (!gthr) throw new ToolInputError("해당 모임을 찾을 수 없습니다.");
+
+  const [members, events, attendeeIds] = await Promise.all([
+    fetchActiveMemberSeeds(supabase, teamId),
+    fetchPastAttendanceEvents(supabase, teamId),
+    (async () => {
+      const { data, error } = await supabase
+        .from("gthr_attd_rel")
+        .select("mem_id")
+        .eq("gthr_id", gatheringId);
+      if (error) throw error;
+      return new Set((data ?? []).map((a) => a.mem_id as string));
+    })(),
+  ]);
+
+  const nonAttendees = members.filter((m) => !attendeeIds.has(m.mem_id));
+  return aggregateAttendance(nonAttendees, events);
+}
+
+/** §5.6 활성 멤버별 푸시 구독 여부. */
+export async function listPushStatus(
+  supabase: Db,
+  teamId: string,
+): Promise<PushStatusRow[]> {
+  const { data: memberRows, error: mErr } = await supabase
+    .from("team_mem_rel")
+    .select("mem_id, mem_st_cd, mem_mst!inner(mem_nm)")
+    .eq("team_id", teamId)
+    .eq("del_yn", false)
+    .eq("vers", 0)
+    .eq("mem_st_cd", "active")
+    .eq("mem_mst.del_yn", false);
+  if (mErr) throw mErr;
+
+  const { data: subs, error: sErr } = await supabase
+    .from("push_sub_rel")
+    .select("mem_id")
+    .eq("team_id", teamId);
+  if (sErr) throw sErr;
+
+  const subscribed = new Set((subs ?? []).map((s) => s.mem_id as string));
+  const members = (memberRows ?? []).map((r) => {
+    const mem = pickOne(r.mem_mst as { mem_nm: string } | { mem_nm: string }[]);
+    return {
+      mem_id: r.mem_id as string,
+      mem_nm: mem?.mem_nm ?? "",
+      mem_st_cd: r.mem_st_cd as string,
+    };
+  });
+  return buildPushStatus(members, subscribed);
+}

--- a/lib/mcp/queries.ts
+++ b/lib/mcp/queries.ts
@@ -40,6 +40,20 @@ function pickOne<T>(rel: T | T[] | null | undefined): T | null {
 }
 
 /**
+ * PostgREST `ilike` 패턴에서 LIKE 메타문자를 리터럴로 이스케이프한다(PII 대량 열람 차단).
+ *
+ * baseline §5.4 는 `lower(mem_nm)=lower(name)`(대소문자 무시 **완전일치**)인데, 그냥
+ * `ilike(name)` 을 쓰면 입력의 `%`·`_` 가 와일드카드로 해석돼 `name="%"` 한 번에 팀 전원
+ * 프로필(생일·성별 포함)이 반환된다. 입력의 `\`·`%`·`_` 를 각각 `\\`·`\%`·`\_` 로 치환하면
+ * PostgREST 기본 escape(백슬래시) 규칙에 따라 리터럴로만 매칭돼 완전일치와 동치가 된다.
+ *
+ * 하나의 정규식으로 한 번에 치환해 `\` 중복 이스케이프를 피한다(예: `%`→`\%`, `foo_bar`→`foo\_bar`).
+ */
+export function escapeLikePattern(input: string): string {
+  return input.replace(/[\\%_]/g, (ch) => `\\${ch}`);
+}
+
+/**
  * KST 달력일(`date` 미지정 시 오늘) 하루의 UTC 반열림 구간을 계산한다.
  * baseline의 `(stt_at at time zone 'Asia/Seoul')::date = :day`와 동치인
  * `stt_at >= startIso and stt_at < endIso` 필터로 변환하기 위한 순수 함수.
@@ -332,8 +346,9 @@ export async function getMemberProfile(
   if (memberId) {
     query = query.eq("mem_mst.mem_id", memberId);
   } else if (name) {
-    // baseline lower(mem_nm)=lower(name) 동치. ilike(무와일드카드)=대소문자 무시 완전일치.
-    query = query.ilike("mem_mst.mem_nm", name);
+    // baseline lower(mem_nm)=lower(name) 동치. LIKE 메타문자를 이스케이프해 대소문자 무시
+    // 완전일치를 강제한다(name="%" 같은 와일드카드로 인한 PII 대량 열람 차단, escapeLikePattern 참조).
+    query = query.ilike("mem_mst.mem_nm", escapeLikePattern(name));
   }
   const { data, error } = await query;
   if (error) throw error;

--- a/lib/mcp/send-push.ts
+++ b/lib/mcp/send-push.ts
@@ -1,0 +1,148 @@
+import type { SupabaseClient } from "@supabase/supabase-js";
+
+import type { OperatorContext } from "@/lib/mcp/auth";
+import { ToolInputError } from "@/lib/mcp/queries";
+import { insertNotiMany } from "@/lib/notifications/insert-noti";
+import type { Database } from "@/lib/supabase/database.types";
+
+/**
+ * 기강 운영 MCP — 유일한 write 도구 `send_push` 의 발송 로직(SG-05, 스펙 §4·§6·§8).
+ *
+ * 설계 원칙
+ * - **service-role 클라이언트 주입식**: 클라이언트를 인자로 받아(=queries.ts 와 동일) 이 모듈은
+ *   `admin.ts`(server-only)를 import 하지 않는다. 단, 발송 위임 대상 `insertNotiMany` 는
+ *   server-only 체인이므로 이 모듈을 테스트할 때는 `vi.mock("@/lib/notifications/insert-noti")`
+ *   가 필수다([[troubleshooting/vitest-server-only-trap]]).
+ * - **admin 게이트(G-2)**: `ctx.is_admin` 이 아니면 아무것도 발송하지 않고 즉시 거부한다.
+ *   거부는 insertNotiMany 호출 이전에 일어나며 감사행도 남기지 않는다(AC-17).
+ * - **팀 스코프 안전장치**: 요청된 member_ids 중 `ctx.team_id` 소속의 정본(vers=0·del_yn=false)
+ *   활성(mem_st_cd='active') 멤버만 발송 대상으로 남긴다. 교차 팀·비활성·미존재 id 는 제외한다
+ *   (스펙 원칙: 교차 팀 발송 불가). 유효 대상이 0명이면 발송하지 않고 안전 에러를 던진다.
+ * - **감사(AC-18)**: 실제 발송(≥1명) 시 `mcp_audit_log` 에 정확히 1행을 남긴다.
+ *   params_json 에는 연락처·계좌 등 민감정보를 절대 담지 않는다(제목·본문·수신자 mem_id 만).
+ * - **noti_type 재사용**: 관리자 수동 발송용 기존 범용 타입 `adm_cust` 를 그대로 쓴다.
+ *   noti_mst CHECK 제약과 NOTI_ICON(notification-item.tsx) 에 이미 등록돼 있어
+ *   신규 타입 추가·아이콘 맵 갱신이 필요 없다(Bell 폴백 함정 회피).
+ */
+
+type Db = SupabaseClient<Database>;
+
+/** 관리자 수동 발송 알림 타입(기존 범용 타입 재사용 — NOTI_ICON·CHECK 이미 등록). */
+const SEND_PUSH_NOTI_TYPE = "adm_cust";
+
+export type SendPushInput = {
+  memberIds: string[];
+  title: string;
+  message: string;
+};
+
+export type SendPushResult = {
+  sent_cnt: number;
+  audit_id: string;
+};
+
+/**
+ * 비-admin 이 write 도구를 호출했을 때의 거부(스펙 §6 G-2 / §7 403).
+ * MCP 는 단일 200 채널이라 HTTP 403 대신 tool error 로 반환하되, 사유는 안전 메시지만 노출한다.
+ */
+export class SendPushDeniedError extends Error {
+  constructor(message = "이 작업은 운영진(admin)만 실행할 수 있습니다.") {
+    super(message);
+    this.name = "SendPushDeniedError";
+  }
+}
+
+/**
+ * 요청된 member_ids 중 ctx.team_id 소속의 정본·활성 멤버만 골라낸다(팀 스코프 강제).
+ * 반환 순서는 입력 순서를 보존하고 중복은 제거한다. 교차 팀·비활성·미존재 id 는 조회 결과에
+ * 포함되지 않으므로 자연히 제외된다.
+ */
+async function resolveTeamActiveTargets(
+  supabase: Db,
+  teamId: string,
+  memberIds: string[],
+): Promise<string[]> {
+  const uniqueRequested = Array.from(new Set(memberIds));
+  if (uniqueRequested.length === 0) return [];
+
+  const { data, error } = await supabase
+    .from("team_mem_rel")
+    .select("mem_id")
+    .eq("team_id", teamId)
+    .eq("vers", 0)
+    .eq("del_yn", false)
+    .eq("mem_st_cd", "active")
+    .in("mem_id", uniqueRequested);
+  if (error) throw error;
+
+  const valid = new Set((data ?? []).map((r) => r.mem_id as string));
+  // 입력 순서 보존 + 유효 대상만.
+  return uniqueRequested.filter((id) => valid.has(id));
+}
+
+/**
+ * `send_push` 발송 로직(스펙 §4). admin 게이트 → 팀 스코프 검증 → 발송 위임 → 감사행 기록.
+ *
+ * @param supabase service-role 클라이언트(라우트에서 주입). RLS 우회 — 스코프는 코드가 강제한다.
+ * @param ctx      operator 컨텍스트(팀 스코프 신원·권한).
+ * @param input    검증된 입력(member_ids·title·message).
+ * @throws SendPushDeniedError 비-admin(G-2) — 아무것도 발송하지 않음.
+ * @throws ToolInputError      유효 발송 대상이 0명(교차 팀/비활성/미존재만 지정한 경우).
+ */
+export async function sendPush(
+  supabase: Db,
+  ctx: OperatorContext,
+  input: SendPushInput,
+): Promise<SendPushResult> {
+  // G-2: admin 게이트 — insertNotiMany 호출·감사행 이전에 차단.
+  if (!ctx.is_admin) {
+    throw new SendPushDeniedError();
+  }
+
+  const targets = await resolveTeamActiveTargets(
+    supabase,
+    ctx.team_id,
+    input.memberIds,
+  );
+  if (targets.length === 0) {
+    throw new ToolInputError("발송 대상 멤버가 없습니다. 우리 팀의 활성 멤버 id 인지 확인하세요.");
+  }
+
+  // 인앱 noti + 웹푸시 자동. pref 수신거부 필터는 insertNotiMany(관문)가 처리한다.
+  // 관리자 수동 발송 = 하나의 배치(발송 이력 화면이 batch_id 로 수신자를 묶는다).
+  const batchId = crypto.randomUUID();
+  await insertNotiMany({
+    teamId: ctx.team_id,
+    memIds: targets,
+    notiTypeEnm: SEND_PUSH_NOTI_TYPE,
+    notiNm: input.title,
+    notiCont: input.message,
+    batchId,
+  });
+
+  const sentCnt = targets.length;
+
+  // AC-18: 발송 성공 시 감사행 1행. params_json 에 민감정보(연락처·계좌) 미포함.
+  const auditId = crypto.randomUUID();
+  const { error: auditErr } = await supabase.from("mcp_audit_log").insert({
+    audit_id: auditId,
+    actor_mem_id: ctx.mem_id,
+    team_id: ctx.team_id,
+    tool_nm: "send_push",
+    params_json: {
+      title: input.title,
+      message: input.message,
+      requested_cnt: input.memberIds.length,
+      sent_cnt: sentCnt,
+      recipient_mem_ids: targets,
+      batch_id: batchId,
+    },
+    result_summary: `send_push ok: sent_cnt=${sentCnt} requested=${input.memberIds.length}`,
+  });
+  // 감사 기록 실패는 발송을 되돌리지 않는다(이미 발송됨) — 로깅만. 정상 경로에선 성공.
+  if (auditErr) {
+    console.error("[mcp] send_push 감사 기록 실패", auditErr.message);
+  }
+
+  return { sent_cnt: sentCnt, audit_id: auditId };
+}

--- a/lib/mcp/send-push.ts
+++ b/lib/mcp/send-push.ts
@@ -53,6 +53,17 @@ export class SendPushDeniedError extends Error {
 }
 
 /**
+ * 인앱 알림 저장이 전면 실패해 발송이 이뤄지지 않았음을 나타낸다(감사 무결성 §8).
+ * 이 에러가 던져지면 성공 감사행을 남기지 않는다 — "발송 실패인데 감사엔 성공"을 방지한다.
+ */
+export class SendPushFailedError extends Error {
+  constructor(message = "푸시 발송에 실패했습니다. 잠시 후 다시 시도해 주세요.") {
+    super(message);
+    this.name = "SendPushFailedError";
+  }
+}
+
+/**
  * 요청된 member_ids 중 ctx.team_id 소속의 정본·활성 멤버만 골라낸다(팀 스코프 강제).
  * 반환 순서는 입력 순서를 보존하고 중복은 제거한다. 교차 팀·비활성·미존재 id 는 조회 결과에
  * 포함되지 않으므로 자연히 제외된다.
@@ -88,6 +99,7 @@ async function resolveTeamActiveTargets(
  * @param input    검증된 입력(member_ids·title·message).
  * @throws SendPushDeniedError 비-admin(G-2) — 아무것도 발송하지 않음.
  * @throws ToolInputError      유효 발송 대상이 0명(교차 팀/비활성/미존재만 지정한 경우).
+ * @throws SendPushFailedError 인앱 저장 전면 실패(insertNotiMany inAppOk=false) — 감사 성공행 미기록.
  */
 export async function sendPush(
   supabase: Db,
@@ -111,7 +123,7 @@ export async function sendPush(
   // 인앱 noti + 웹푸시 자동. pref 수신거부 필터는 insertNotiMany(관문)가 처리한다.
   // 관리자 수동 발송 = 하나의 배치(발송 이력 화면이 batch_id 로 수신자를 묶는다).
   const batchId = crypto.randomUUID();
-  await insertNotiMany({
+  const { inAppOk, notifiedMemIds } = await insertNotiMany({
     teamId: ctx.team_id,
     memIds: targets,
     notiTypeEnm: SEND_PUSH_NOTI_TYPE,
@@ -120,7 +132,13 @@ export async function sendPush(
     batchId,
   });
 
-  const sentCnt = targets.length;
+  // 인앱 저장이 전면 실패했으면 발송 실패로 간주 — 성공 감사행을 남기지 않고 에러를 던진다(감사 무결성).
+  if (!inAppOk) {
+    throw new SendPushFailedError();
+  }
+
+  // 감사·반환에는 요청 수(requested_cnt)가 아니라 **실측 발송분**(수신거부 필터 반영)을 기록한다.
+  const sentCnt = notifiedMemIds.length;
 
   // AC-18: 발송 성공 시 감사행 1행. params_json 에 민감정보(연락처·계좌) 미포함.
   const auditId = crypto.randomUUID();
@@ -134,7 +152,7 @@ export async function sendPush(
       message: input.message,
       requested_cnt: input.memberIds.length,
       sent_cnt: sentCnt,
-      recipient_mem_ids: targets,
+      recipient_mem_ids: notifiedMemIds,
       batch_id: batchId,
     },
     result_summary: `send_push ok: sent_cnt=${sentCnt} requested=${input.memberIds.length}`,

--- a/lib/notifications/__tests__/insert-noti.test.ts
+++ b/lib/notifications/__tests__/insert-noti.test.ts
@@ -7,11 +7,25 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 const h = vi.hoisted(() => {
   const prefEqArgs: [string, string][] = [];
   const prefRow: { data: { enabled_yn: boolean } | null } = { data: null };
-  const insertMock = vi.fn(() => ({
-    select: () => ({
-      single: async () => ({ data: { noti_id: "noti-1" }, error: null }),
-    }),
-  }));
+  // insertNotiMany 경로용 가변 상태(수신거부 목록 / INSERT 반환행·에러).
+  const many: {
+    disabledPrefs: { mem_id: string }[];
+    rows: { noti_id: string; mem_id: string }[];
+    error: { message: string } | null;
+    lastPayload: unknown;
+  } = { disabledPrefs: [], rows: [], error: null, lastPayload: null };
+
+  const insertMock = vi.fn((payload: unknown) => {
+    many.lastPayload = payload;
+    return {
+      // insertNoti: .select().single() / insertNotiMany: .select() 를 await
+      select: () => ({
+        single: async () => ({ data: { noti_id: "noti-1" }, error: null }),
+        then: (resolve: (v: unknown) => void) =>
+          resolve({ data: many.rows, error: many.error }),
+      }),
+    };
+  });
 
   const from = vi.fn((table: string) => {
     if (table === "noti_pref_cfg") {
@@ -22,7 +36,15 @@ const h = vi.hoisted(() => {
             return {
               eq: (col2: string, val2: string) => {
                 prefEqArgs.push([col2, val2]);
-                return { maybeSingle: async () => prefRow };
+                return {
+                  // insertNoti: .maybeSingle()
+                  maybeSingle: async () => prefRow,
+                  // insertNotiMany: .in("mem_id", ids) 를 await → 수신거부 목록
+                  in: (_col: string, _ids: string[]) => ({
+                    then: (resolve: (v: unknown) => void) =>
+                      resolve({ data: many.disabledPrefs, error: null }),
+                  }),
+                };
               },
             };
           },
@@ -35,7 +57,7 @@ const h = vi.hoisted(() => {
     throw new Error(`unexpected table ${table}`);
   });
 
-  return { from, insertMock, prefRow, prefEqArgs };
+  return { from, insertMock, prefRow, prefEqArgs, many };
 });
 
 vi.mock("@/lib/supabase/admin", () => ({
@@ -46,13 +68,17 @@ vi.mock("@/lib/push/send-push", () => ({
   sendPushToMembers: vi.fn(),
 }));
 
-import { insertNoti } from "@/lib/notifications/insert-noti";
+import { insertNoti, insertNotiMany } from "@/lib/notifications/insert-noti";
 
 beforeEach(() => {
   h.insertMock.mockClear();
   h.from.mockClear();
   h.prefRow.data = null;
   h.prefEqArgs.length = 0;
+  h.many.disabledPrefs = [];
+  h.many.rows = [];
+  h.many.error = null;
+  h.many.lastPayload = null;
 });
 
 describe("insertNoti — prefTypeEnm 수신거부 판단", () => {
@@ -98,5 +124,68 @@ describe("insertNoti — prefTypeEnm 수신거부 판단", () => {
 
     expect(h.prefEqArgs).toContainEqual(["noti_type_enm", "gthr_upd"]);
     expect(h.insertMock).not.toHaveBeenCalled();
+  });
+});
+
+describe("insertNotiMany — 반환값(감사 무결성용 실측 발송분)", () => {
+  it("수신거부 필터 후 실제 INSERT된 mem_id 만 notifiedMemIds 로 반환(inAppOk=true)", async () => {
+    // m2 는 수신거부 → 제외되고, INSERT 반환행(=실측)은 m1·m3.
+    h.many.disabledPrefs = [{ mem_id: "m2" }];
+    h.many.rows = [
+      { noti_id: "n1", mem_id: "m1" },
+      { noti_id: "n3", mem_id: "m3" },
+    ];
+
+    const result = await insertNotiMany({
+      teamId: "team-1",
+      memIds: ["m1", "m2", "m3"],
+      notiTypeEnm: "adm_cust",
+      notiNm: "공지",
+      notiCont: "내용",
+    });
+
+    expect(result).toEqual({ inAppOk: true, notifiedMemIds: ["m1", "m3"] });
+    // INSERT payload 에도 수신거부자(m2)는 없어야 한다(기존 pref 필터 회귀 방지).
+    const payload = h.many.lastPayload as { mem_id: string }[];
+    expect(payload.map((p) => p.mem_id)).toEqual(["m1", "m3"]);
+  });
+
+  it("noti_mst INSERT 에러 시 inAppOk=false·notifiedMemIds 빈 배열(전면 실패)", async () => {
+    h.many.error = { message: "insert failed" };
+
+    const result = await insertNotiMany({
+      teamId: "team-1",
+      memIds: ["m1", "m2"],
+      notiTypeEnm: "adm_cust",
+      notiNm: "공지",
+    });
+
+    expect(result).toEqual({ inAppOk: false, notifiedMemIds: [] });
+  });
+
+  it("전원 수신거부면 INSERT 없이 inAppOk=true·빈 발송분", async () => {
+    h.many.disabledPrefs = [{ mem_id: "m1" }, { mem_id: "m2" }];
+
+    const result = await insertNotiMany({
+      teamId: "team-1",
+      memIds: ["m1", "m2"],
+      notiTypeEnm: "adm_cust",
+      notiNm: "공지",
+    });
+
+    expect(result).toEqual({ inAppOk: true, notifiedMemIds: [] });
+    expect(h.insertMock).not.toHaveBeenCalled();
+  });
+
+  it("빈 memIds 는 조회·INSERT 없이 inAppOk=true·빈 발송분", async () => {
+    const result = await insertNotiMany({
+      teamId: "team-1",
+      memIds: [],
+      notiTypeEnm: "adm_cust",
+      notiNm: "공지",
+    });
+
+    expect(result).toEqual({ inAppOk: true, notifiedMemIds: [] });
+    expect(h.from).not.toHaveBeenCalled();
   });
 });

--- a/lib/notifications/insert-noti.ts
+++ b/lib/notifications/insert-noti.ts
@@ -124,13 +124,27 @@ type NotiManyInput = {
   batchId?: string | null;
 };
 
+/** insertNotiMany 결과. 기존 호출자는 반환값을 무시하므로 시그니처 확장은 하위호환이다. */
+export type InsertNotiManyResult = {
+  /** noti_mst 인앱 INSERT 성공 여부. INSERT 에러 시 false(발송 전면 실패). */
+  inAppOk: boolean;
+  /** 수신거부 필터 후 **실제로 인앱 INSERT된** mem_id 목록(=실측 발송 대상). */
+  notifiedMemIds: string[];
+};
+
 /**
  * 여러 멤버에게 같은 내용의 알림(인앱+푸시)을 발송한다.
  * - noti_pref_cfg로 수신 거부한 멤버는 자동 제외 (조회 1회)
  * - noti_mst 일괄 INSERT 후, 구독자에게 배치 푸시 (구독 IN 조회 1회)
+ *
+ * 반환값은 감사 무결성이 필요한 호출자(예: MCP send_push)가 실측 발송분을 기록하기 위한 것으로,
+ * 기존 호출자(gathering·board 등)는 반환값을 무시하므로 이 확장은 하위호환이다.
+ * 푸시는 기존대로 fire-and-forget(실패해도 인앱 흐름을 막지 않음)이다.
  */
-export async function insertNotiMany(input: NotiManyInput): Promise<void> {
-  if (input.memIds.length === 0) return;
+export async function insertNotiMany(
+  input: NotiManyInput,
+): Promise<InsertNotiManyResult> {
+  if (input.memIds.length === 0) return { inAppOk: true, notifiedMemIds: [] };
   const admin = createUntypedAdminClient();
 
   // 수신 거부자 일괄 조회 후 제외 (prefTypeEnm 지정 시 그 타입으로 판단)
@@ -145,7 +159,8 @@ export async function insertNotiMany(input: NotiManyInput): Promise<void> {
     (disabledPrefs ?? []).map((p: { mem_id: string }) => p.mem_id),
   );
   const targets = input.memIds.filter((id) => !disabled.has(id));
-  if (targets.length === 0) return;
+  // 전원 수신거부 = 인앱 저장은 정상(0건)이며 실패가 아니다. 실측 발송분 0으로 반환.
+  if (targets.length === 0) return { inAppOk: true, notifiedMemIds: [] };
 
   const { data: rows, error: insertErr } = await admin
     .from("noti_mst")
@@ -162,15 +177,20 @@ export async function insertNotiMany(input: NotiManyInput): Promise<void> {
       })),
     )
     .select("noti_id, mem_id");
-  // 알림은 부가 기능 — 실패해도 본행동을 막지 않는다. 로깅만.
+  // 알림은 부가 기능 — 실패해도 본행동을 막지 않는다(로깅만). 단, 인앱 저장 실패는 반환값에 명시해
+  // 감사 무결성이 필요한 호출자가 "발송 실패"로 판단할 수 있게 한다(inAppOk=false).
   if (insertErr) {
     console.error("[noti] insertNotiMany 인앱 저장 실패", insertErr.message);
-    return;
+    return { inAppOk: false, notifiedMemIds: [] };
   }
+
+  const insertedRows = (rows ?? []) as { noti_id: string; mem_id: string }[];
+  // 실제 INSERT된 행의 mem_id = 실측 발송 대상(수신거부 필터 반영분).
+  const notifiedMemIds = insertedRows.map((r) => r.mem_id);
 
   try {
     const payloadByMemId = new Map<string, PushPayload>();
-    for (const r of (rows ?? []) as { noti_id: string; mem_id: string }[]) {
+    for (const r of insertedRows) {
       payloadByMemId.set(
         r.mem_id,
         toPushPayload(
@@ -187,6 +207,8 @@ export async function insertNotiMany(input: NotiManyInput): Promise<void> {
   } catch (err) {
     console.error("[push] insertNotiMany 발송 실패", err);
   }
+
+  return { inAppOk: true, notifiedMemIds };
 }
 
 type NotiTeamInput = {

--- a/lib/supabase/database.types.ts
+++ b/lib/supabase/database.types.ts
@@ -1630,6 +1630,50 @@ export type Database = {
           },
         ]
       }
+      mcp_token_rel: {
+        Row: {
+          created_at: string
+          expires_at: string | null
+          label: string | null
+          last_used_at: string | null
+          mem_id: string
+          revoked_at: string | null
+          team_id: string
+          token_hash: string
+          token_id: string
+        }
+        Insert: {
+          created_at?: string
+          expires_at?: string | null
+          label?: string | null
+          last_used_at?: string | null
+          mem_id: string
+          revoked_at?: string | null
+          team_id: string
+          token_hash: string
+          token_id?: string
+        }
+        Update: {
+          created_at?: string
+          expires_at?: string | null
+          label?: string | null
+          last_used_at?: string | null
+          mem_id?: string
+          revoked_at?: string | null
+          team_id?: string
+          token_hash?: string
+          token_id?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "mcp_token_rel_mem_id_fkey"
+            columns: ["mem_id"]
+            isOneToOne: false
+            referencedRelation: "mem_mst"
+            referencedColumns: ["mem_id"]
+          },
+        ]
+      }
       mem_mst: {
         Row: {
           avatar_url: string | null

--- a/lib/supabase/database.types.ts
+++ b/lib/supabase/database.types.ts
@@ -1630,6 +1630,44 @@ export type Database = {
           },
         ]
       }
+      mcp_audit_log: {
+        Row: {
+          actor_mem_id: string
+          audit_id: string
+          created_at: string
+          params_json: Json | null
+          result_summary: string | null
+          team_id: string
+          tool_nm: string
+        }
+        Insert: {
+          actor_mem_id: string
+          audit_id?: string
+          created_at?: string
+          params_json?: Json | null
+          result_summary?: string | null
+          team_id: string
+          tool_nm: string
+        }
+        Update: {
+          actor_mem_id?: string
+          audit_id?: string
+          created_at?: string
+          params_json?: Json | null
+          result_summary?: string | null
+          team_id?: string
+          tool_nm?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "mcp_audit_log_actor_mem_id_fkey"
+            columns: ["actor_mem_id"]
+            isOneToOne: false
+            referencedRelation: "mem_mst"
+            referencedColumns: ["mem_id"]
+          },
+        ]
+      }
       mcp_token_rel: {
         Row: {
           created_at: string

--- a/lib/validations/mcp-token.ts
+++ b/lib/validations/mcp-token.ts
@@ -1,0 +1,16 @@
+import { z } from "zod";
+
+/** MCP 토큰 label(기기·용도 구분용) — 선택 입력, 최대 40자 */
+export const MCP_TOKEN_LABEL_MAX = 40;
+
+export const mcpTokenLabelSchema = z
+  .string()
+  .trim()
+  .max(MCP_TOKEN_LABEL_MAX, `이름은 ${MCP_TOKEN_LABEL_MAX}자 이하로 입력해 주세요`);
+
+/** 토큰 발급 폼(`/mcp-tokens`) — label은 선택(빈 문자열 허용, 미지정 시 null 저장) */
+export const createMcpTokenSchema = z.object({
+  label: mcpTokenLabelSchema,
+});
+
+export type CreateMcpTokenValues = z.infer<typeof createMcpTokenSchema>;

--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
     "exceljs": "^4.4.0",
     "heic-convert": "^2.1.0",
     "lucide-react": "^0.511.0",
+    "mcp-handler": "^1.1.0",
     "next": "latest",
     "next-themes": "^0.4.6",
     "nuqs": "^2.8.9",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -77,6 +77,9 @@ importers:
       lucide-react:
         specifier: ^0.511.0
         version: 0.511.0(react@19.2.4)
+      mcp-handler:
+        specifier: ^1.1.0
+        version: 1.1.0(@modelcontextprotocol/sdk@1.29.0(zod@4.3.6))(next@16.1.6(@babel/core@7.29.0)(@playwright/test@1.58.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))
       next:
         specifier: latest
         version: 16.1.6(@babel/core@7.29.0)(@playwright/test@1.58.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
@@ -1867,6 +1870,35 @@ packages:
   '@radix-ui/rect@1.1.1':
     resolution: {integrity: sha512-HPwpGIzkl28mWyZqG52jiqDJ12waP11Pa1lGoiyUkIEuMLBP0oeK/C89esbXrxsky5we7dfd8U58nm0SgAWpVw==}
 
+  '@redis/bloom@1.2.0':
+    resolution: {integrity: sha512-HG2DFjYKbpNmVXsa0keLHp/3leGJz1mjh09f2RLGGLQZzSHpkmZWuwJbAvo3QcRY8p80m5+ZdXZdYOSBLlp7Cg==}
+    peerDependencies:
+      '@redis/client': ^1.0.0
+
+  '@redis/client@1.6.1':
+    resolution: {integrity: sha512-/KCsg3xSlR+nCK8/8ZYSknYxvXHwubJrU82F3Lm1Fp6789VQ0/3RJKfsmRXjqfaTA++23CvC3hqmqe/2GEt6Kw==}
+    engines: {node: '>=14'}
+
+  '@redis/graph@1.1.1':
+    resolution: {integrity: sha512-FEMTcTHZozZciLRl6GiiIB4zGm5z5F3F6a6FZCyrfxdKOhFlGkiAqlexWMBzCi4DcRoyiOsuLfW+cjlGWyExOw==}
+    peerDependencies:
+      '@redis/client': ^1.0.0
+
+  '@redis/json@1.0.7':
+    resolution: {integrity: sha512-6UyXfjVaTBTJtKNG4/9Z8PSpKE6XgSyEb8iwaqDcy+uKrd/DGYHTWkUdnQDyzm727V7p21WUMhsqz5oy65kPcQ==}
+    peerDependencies:
+      '@redis/client': ^1.0.0
+
+  '@redis/search@1.2.0':
+    resolution: {integrity: sha512-tYoDBbtqOVigEDMAcTGsRlMycIIjwMCgD8eR2t0NANeQmgK/lvxNAvYyb6bZDD4frHRhIHkJu2TBRvB0ERkOmw==}
+    peerDependencies:
+      '@redis/client': ^1.0.0
+
+  '@redis/time-series@1.1.0':
+    resolution: {integrity: sha512-c1Q99M5ljsIuc4YdaCwfUEXsofakb9c8+Zse2qxTadu8TalLXuAESzLvFAvNVbkmSlvlzIQOLpBCmWI9wTOt+g==}
+    peerDependencies:
+      '@redis/client': ^1.0.0
+
   '@reduxjs/toolkit@2.11.2':
     resolution: {integrity: sha512-Kd6kAHTA6/nUpp8mySPqj3en3dm0tdMIgbttnQ1xFMVpufoj+ADi8pXLBsd4xzTRHQa7t/Jv8W5UnCuW4kuWMQ==}
     peerDependencies:
@@ -3052,6 +3084,10 @@ packages:
     resolution: {integrity: sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==}
     engines: {node: '>=6'}
 
+  cluster-key-slot@1.1.2:
+    resolution: {integrity: sha512-RMr0FhtfXemyinomL4hrWcYJxmX6deFdCxpJzhDttxgO1+bcCnkk+9drydLVDmAMG7NE6aN/fl4F7ucU/90gAA==}
+    engines: {node: '>=0.10.0'}
+
   cmd-shim@8.0.0:
     resolution: {integrity: sha512-Jk/BK6NCapZ58BKUxlSI+ouKRbjH1NLZCgJkYoab+vEHUY3f6OzpNBN9u7HFSv9J6TRDGs4PLOHezoKGaFRSCA==}
     engines: {node: ^20.17.0 || >=22.9.0}
@@ -3915,6 +3951,10 @@ packages:
   generator-function@2.0.1:
     resolution: {integrity: sha512-SFdFmIJi+ybC0vjlHN0ZGVGHc3lgE0DxPAT0djjVg+kjOnSqclqmj0KQ7ykTOLP6YxoqOvuAODGdcHJn+43q3g==}
     engines: {node: '>= 0.4'}
+
+  generic-pool@3.9.0:
+    resolution: {integrity: sha512-hymDOu5B53XvN4QT9dBmZxPX4CWhBPPLguTZ9MMFeFa/Kg0xWVfylOVNlJji/E7yTZWFd/q9GO5TxDLq156D7g==}
+    engines: {node: '>= 4'}
 
   gensync@1.0.0-beta.2:
     resolution: {integrity: sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==}
@@ -4837,6 +4877,16 @@ packages:
     resolution: {integrity: sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==}
     engines: {node: '>= 0.4'}
 
+  mcp-handler@1.1.0:
+    resolution: {integrity: sha512-MVCES7g18gcoZy+R/3v5nadkUMzMAWdos8jRl6DyljOKvd2/ZKDmwlCjL6zp4vo+7FeCXOYL1uWinHWlkKAAUg==}
+    hasBin: true
+    peerDependencies:
+      '@modelcontextprotocol/sdk': 1.26.0
+      next: '>=13.0.0'
+    peerDependenciesMeta:
+      next:
+        optional: true
+
   mdast-util-find-and-replace@3.0.2:
     resolution: {integrity: sha512-Tmd1Vg/m3Xz43afeNxDIhWRtFZgM2VLyaf4vSTYwudTyeuTneoL3qtWMA5jeLyz/O1vDJmmV4QuScFCA2tBPwg==}
 
@@ -5583,6 +5633,9 @@ packages:
   redent@3.0.0:
     resolution: {integrity: sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==}
     engines: {node: '>=8'}
+
+  redis@4.7.1:
+    resolution: {integrity: sha512-S1bJDnqLftzHXHP8JsT5II/CtHWQrASX5K96REjWjlmWKrviSOLWmM7QnRLstAWsu1VBBV1ffV6DzCvxNP0UJQ==}
 
   redux-thunk@3.1.0:
     resolution: {integrity: sha512-NW2r5T6ksUKXCabzhL9z+h206HQw/NJkcLm1GPImRQ8IzfXwRGqjVhKJGauHirT0DAuyy6hjdnMZaRoAcy0Klw==}
@@ -6589,6 +6642,9 @@ packages:
   yallist@3.1.1:
     resolution: {integrity: sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==}
 
+  yallist@4.0.0:
+    resolution: {integrity: sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==}
+
   yallist@5.0.0:
     resolution: {integrity: sha512-YgvUTfwqyc7UXVMrB+SImsVYSmTS8X/tSrtdNZMImM+n7+QTriRXyXim0mBrTXNeqzVF0KWGgHPeiyViFFrNDw==}
     engines: {node: '>=18'}
@@ -7417,7 +7473,6 @@ snapshots:
       zod-to-json-schema: 3.25.2(zod@4.3.6)
     transitivePeerDependencies:
       - supports-color
-    optional: true
 
   '@mswjs/interceptors@0.41.5':
     dependencies:
@@ -8333,6 +8388,32 @@ snapshots:
       '@types/react-dom': 19.2.3(@types/react@19.2.14)
 
   '@radix-ui/rect@1.1.1': {}
+
+  '@redis/bloom@1.2.0(@redis/client@1.6.1)':
+    dependencies:
+      '@redis/client': 1.6.1
+
+  '@redis/client@1.6.1':
+    dependencies:
+      cluster-key-slot: 1.1.2
+      generic-pool: 3.9.0
+      yallist: 4.0.0
+
+  '@redis/graph@1.1.1(@redis/client@1.6.1)':
+    dependencies:
+      '@redis/client': 1.6.1
+
+  '@redis/json@1.0.7(@redis/client@1.6.1)':
+    dependencies:
+      '@redis/client': 1.6.1
+
+  '@redis/search@1.2.0(@redis/client@1.6.1)':
+    dependencies:
+      '@redis/client': 1.6.1
+
+  '@redis/time-series@1.1.0(@redis/client@1.6.1)':
+    dependencies:
+      '@redis/client': 1.6.1
 
   '@reduxjs/toolkit@2.11.2(react-redux@9.2.0(@types/react@19.2.14)(react@19.2.4)(redux@5.0.1))(react@19.2.4)':
     dependencies:
@@ -9554,6 +9635,8 @@ snapshots:
 
   clsx@2.1.1: {}
 
+  cluster-key-slot@1.1.2: {}
+
   cmd-shim@8.0.0: {}
 
   cmdk@1.1.1(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4):
@@ -10597,6 +10680,8 @@ snapshots:
 
   generator-function@2.0.1: {}
 
+  generic-pool@3.9.0: {}
+
   gensync@1.0.0-beta.2: {}
 
   get-caller-file@2.0.5: {}
@@ -11510,6 +11595,15 @@ snapshots:
   markdown-table@3.0.4: {}
 
   math-intrinsics@1.1.0: {}
+
+  mcp-handler@1.1.0(@modelcontextprotocol/sdk@1.29.0(zod@4.3.6))(next@16.1.6(@babel/core@7.29.0)(@playwright/test@1.58.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)):
+    dependencies:
+      '@modelcontextprotocol/sdk': 1.29.0(zod@4.3.6)
+      chalk: 5.6.2
+      commander: 11.1.0
+      redis: 4.7.1
+    optionalDependencies:
+      next: 16.1.6(@babel/core@7.29.0)(@playwright/test@1.58.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
 
   mdast-util-find-and-replace@3.0.2:
     dependencies:
@@ -12549,6 +12643,15 @@ snapshots:
     dependencies:
       indent-string: 4.0.0
       strip-indent: 3.0.0
+
+  redis@4.7.1:
+    dependencies:
+      '@redis/bloom': 1.2.0(@redis/client@1.6.1)
+      '@redis/client': 1.6.1
+      '@redis/graph': 1.1.1(@redis/client@1.6.1)
+      '@redis/json': 1.0.7(@redis/client@1.6.1)
+      '@redis/search': 1.2.0(@redis/client@1.6.1)
+      '@redis/time-series': 1.1.0(@redis/client@1.6.1)
 
   redux-thunk@3.1.0(redux@5.0.1):
     dependencies:
@@ -13803,6 +13906,8 @@ snapshots:
 
   yallist@3.1.1: {}
 
+  yallist@4.0.0: {}
+
   yallist@5.0.0: {}
 
   yaml@2.8.4:
@@ -13852,7 +13957,6 @@ snapshots:
   zod-to-json-schema@3.25.2(zod@4.3.6):
     dependencies:
       zod: 4.3.6
-    optional: true
 
   zod-validation-error@4.0.2(zod@4.3.6):
     dependencies:

--- a/supabase/migrations/20260724150000_mcp_token_rel.sql
+++ b/supabase/migrations/20260724150000_mcp_token_rel.sql
@@ -1,0 +1,40 @@
+-- mcp_token_rel — 운영 MCP 개인 액세스 토큰(PAT) 저장소
+--   기강 운영 MCP(app/api/mcp/[transport]/route.ts)의 Bearer 인증 원천.
+--   토큰 원문은 절대 저장하지 않는다 — sha256(원문) 해시(token_hash)만 보관하고,
+--   발급 화면(SG-03)에서 평문은 1회만 노출한다.
+--
+-- 설계 근거: docs/superpowers/specs/2026-07-24-gigang-ops-mcp-design.md §3.1
+--   검증 흐름: token_hash 일치 & revoked_at is null & (expires_at is null or expires_at > now())
+--   → team_mem_rel(vers=0, del_yn=false, mem_st_cd='active')로 팀 스코프 신원·권한 해석.
+--
+-- 보안: 이 테이블은 service_role 전용이다. RLS를 켜되 정책을 두지 않으므로
+--   anon/authenticated 는 어떤 행도 볼 수 없고, service_role(서버 전용 관리자 클라이언트)만 접근한다.
+--   토큰 해시는 자격증명이므로 클라이언트에 절대 노출되어선 안 된다.
+SET lock_timeout = '3s';
+
+CREATE TABLE IF NOT EXISTS public.mcp_token_rel (
+  token_id     uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  mem_id       uuid NOT NULL REFERENCES public.mem_mst (mem_id),
+  team_id      uuid NOT NULL,
+  token_hash   text NOT NULL UNIQUE,
+  label        text,
+  created_at   timestamptz NOT NULL DEFAULT now(),
+  last_used_at timestamptz,
+  expires_at   timestamptz,
+  revoked_at   timestamptz
+);
+
+COMMENT ON TABLE public.mcp_token_rel IS
+  '운영 MCP 개인 액세스 토큰(PAT). token_hash=sha256(원문), 원문 미저장. service_role 전용(RLS on, 정책 없음).';
+COMMENT ON COLUMN public.mcp_token_rel.token_hash IS 'sha256(원문 토큰) hex. 원문은 저장하지 않음';
+COMMENT ON COLUMN public.mcp_token_rel.team_id IS '토큰 발급 시점의 팀. 모든 MCP 쿼리는 이 team_id로 스코프됨';
+COMMENT ON COLUMN public.mcp_token_rel.expires_at IS 'null = 무기한';
+COMMENT ON COLUMN public.mcp_token_rel.revoked_at IS '폐기 시각. not null 이면 검증 실패(401)';
+
+-- 인증 핫패스: token_hash 조회. UNIQUE 제약이 btree 인덱스를 제공하므로 별도 인덱스 불필요.
+-- 발급/폐기 UI(SG-03)의 "내 토큰 목록" 조회용 인덱스.
+CREATE INDEX IF NOT EXISTS mcp_token_rel_mem_team_idx
+  ON public.mcp_token_rel (mem_id, team_id);
+
+-- service_role 전용: RLS 활성화 + 정책 없음 → anon/authenticated 전면 차단.
+ALTER TABLE public.mcp_token_rel ENABLE ROW LEVEL SECURITY;

--- a/supabase/migrations/20260724170000_mcp_audit_log.sql
+++ b/supabase/migrations/20260724170000_mcp_audit_log.sql
@@ -1,0 +1,40 @@
+-- mcp_audit_log — 운영 MCP write 도구 감사 로그
+--   기강 운영 MCP(app/api/mcp/[transport]/route.ts)의 쓰기 도구(send_push)가
+--   성공적으로 발송할 때마다 정확히 1행을 남긴다(스펙 §8 / AC-18).
+--   "누가(actor_mem_id) 어느 팀(team_id)에서 어떤 도구(tool_nm)를 어떤 파라미터로
+--   실행해 어떤 결과(result_summary)를 냈는지"의 사후 추적 원장.
+--
+-- 설계 근거: docs/superpowers/specs/2026-07-24-gigang-ops-mcp-design.md §8
+--
+-- 보안: 이 테이블은 service_role 전용이다. RLS를 켜되 정책을 두지 않으므로
+--   anon/authenticated 는 어떤 행도 볼 수 없고, service_role(서버 전용 관리자 클라이언트)만 접근한다.
+--   params_json 에는 연락처·계좌 등 민감정보(phone_no·email_addr·bank_nm·bank_acct_no)를
+--   절대 담지 않는다 — 발송 제목·본문·수신자 mem_id 목록만 기록(M-03 불변식과 정합).
+SET lock_timeout = '3s';
+
+CREATE TABLE IF NOT EXISTS public.mcp_audit_log (
+  audit_id       uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  actor_mem_id   uuid NOT NULL REFERENCES public.mem_mst (mem_id),
+  team_id        uuid NOT NULL,
+  tool_nm        text NOT NULL,
+  params_json    jsonb,
+  result_summary text,
+  created_at     timestamptz NOT NULL DEFAULT now()
+);
+
+COMMENT ON TABLE public.mcp_audit_log IS
+  '운영 MCP write 도구 감사 로그. send_push 성공 시 1행. service_role 전용(RLS on, 정책 없음). params_json 에 민감정보 미포함.';
+COMMENT ON COLUMN public.mcp_audit_log.actor_mem_id IS '도구를 실행한 운영자 mem_id(토큰 소유자)';
+COMMENT ON COLUMN public.mcp_audit_log.team_id IS '실행 시점 팀 스코프. 모든 MCP 도구는 이 team_id로 스코프됨';
+COMMENT ON COLUMN public.mcp_audit_log.tool_nm IS '실행된 도구 이름(예: send_push)';
+COMMENT ON COLUMN public.mcp_audit_log.params_json IS '실행 파라미터(민감정보 마스킹). send_push: title·message·수신자 mem_id 목록';
+
+-- 팀별 최근 감사 이력 조회용.
+CREATE INDEX IF NOT EXISTS mcp_audit_log_team_created_idx
+  ON public.mcp_audit_log (team_id, created_at DESC);
+-- 특정 운영자 활동 추적용.
+CREATE INDEX IF NOT EXISTS mcp_audit_log_actor_idx
+  ON public.mcp_audit_log (actor_mem_id);
+
+-- service_role 전용: RLS 활성화 + 정책 없음 → anon/authenticated 전면 차단.
+ALTER TABLE public.mcp_audit_log ENABLE ROW LEVEL SECURITY;


### PR DESCRIPTION
운영진이 자기 AI 클라이언트(Claude/Cursor 등)에 개인 토큰으로 붙여 기강 운영 현황을 조회하고, 권한 있는 운영진이 알림을 보내는 MCP 엔드포인트. 측정목표 gigang-ops-mcp-v1 / Linear EES-222~227 (SG-01~05 완료, SG-06 prd 배포는 별도 승인 대기).

## AS-IS
"오늘 모임 몇 명 와?", "요즘 안 나오는 사람 누구?", "최근 가입자?" 같은 운영 질문에 답하려면 개발자에게 묻거나 DB를 직접 조회해야 함. 알림도 앱에서 수동.

## TO-BE
운영진이 SQL·스키마 지식 없이 자기 AI에 개인 토큰으로 MCP를 붙여:
- 조회 6종: 오늘 모임 참석 수 / 최근 가입자 / 참석 뜸한 멤버 / 멤버 프로필 / 특정 모임 미참석자 / 푸시 허용 현황
- 관리자는 특정 멤버에게 알림(인앱+웹푸시) 발송

도구는 **사실만 반환**(마지막 참석일·횟수 등), "누굴 부를지" 판단은 AI가.

## 변경 요약
- **엔드포인트** `app/api/mcp/[transport]/route.ts` — `mcp-handler`, Streamable HTTP. 접속 URL `/api/mcp/mcp`.
- **인증** `lib/mcp/auth.ts` — Bearer PAT → `mcp_token_rel`(sha256) → `team_mem_rel` 역할 → operator ctx `{mem_id, team_id, is_admin}`. 미인증/폐기/만료/비활성 401. 모든 쿼리 `team_id` 스코프.
- **읽기 도구 6개** `lib/mcp/queries.ts` (주입식 순수함수 + `runReadTool`).
- **발송** `lib/mcp/send-push.ts` `send_push` — admin 전용, 교차팀 차단, 기존 `insertNotiMany` 위임(noti_type `adm_cust`), 감사 로그.
- **토큰 발급/폐기 UI** `app/(info)/mcp-tokens/` + `app/actions/mcp-token.ts` (본인 스코프, 평문 1회 노출).
- **설계 스펙** `docs/superpowers/specs/2026-07-24-gigang-ops-mcp-design.md`.

## ⚠️ DB 마이그레이션 — prd 선적용 필요
- `20260724150000_mcp_token_rel.sql`, `20260724170000_mcp_audit_log.sql` (둘 다 RLS on·service_role 전용)
- **dev 적용 완료, prd 미적용.** 릴리스(main) 시 **선적용**해야 인증/발송이 동작함(미적용 시 전면 실패 — 모임 취소 릴리스 전례와 동일 함정).

## 검증
- 300 tests green, `tsc --noEmit` 0, `build` 0.
- 각 sub-goal 독립 리뷰(테크리드) 통과. dev 데이터로 6개 도구 baseline 대조.
- 보안: 민감정보(전화·이메일·계좌) 어떤 도구도 미반환, service-role 서버 전용, `mcp_token_rel`/`mcp_audit_log` RLS service_role 전용.
- 발견·수정: `team_mem_rel` 버전 테이블 — 신규 쿼리에 `vers=0` 필수(미적용 시 활성멤버 중복·left 부활). 스펙·전 도구 반영.

## 아직 안 된 것 / 후속
- **prd 배포·실 크루원 푸시·운영자 온보딩(SG-06)** = 별도 승인 후.
- 라이브 HTTP 왕복(런타임 401/whoami/도구 호출)은 배포 후 최초 검증.
- 비차단 개선: `get_member_profile` ilike→정확일치, `mcp_token_rel` anon/auth GRANT REVOKE 정리, 발급 시 active 체크.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새 기능**
  * 설정에서 **MCP 토큰** 관리 페이지에 접속할 수 있습니다.
  * MCP 토큰을 발급하고, 발급된 토큰을 **1회만 표시/복사**하거나 **폐기**할 수 있습니다.
  * 운영용 MCP 도구(조회/상태 확인)를 제공하고, **send_push**를 통해 알림을 전송할 수 있습니다.
* **보안 및 권한**
  * 토큰은 안전하게 검증되며, 모든 작업은 팀/권한 범위로 제한됩니다.
  * 푸시는 관리자만 가능하며, 전송 결과는 감사 기록으로 남고 민감 개인정보는 제외됩니다.
* **문서**
  * 인증/권한/도구 스펙과 오류·감사 기준을 정리한 설계 문서를 추가했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->