### PR TITLE
feat(mcp): 모임 설명 필드(#449) + 토큰 화면 뒤로가기·관리자 진입점(#447)

### DIFF
--- a/app/(info)/admin/page.tsx
+++ b/app/(info)/admin/page.tsx
@@ -18,6 +18,7 @@ import {
   Wallet,
   MessageSquare,
   CalendarDays,
+  KeyRound,
 } from "lucide-react";
 
 import {
@@ -217,6 +218,12 @@ export default function AdminDashboardPage() {
           icon={RefreshCw}
           label="UTMB 인덱스 갱신"
           hint="등록된 회원 전체 재조회"
+        />
+        <ToolCard
+          href="/mcp-tokens"
+          icon={KeyRound}
+          label="MCP 토큰"
+          hint="운영진 AI 조회·알림용 개인 액세스 토큰 관리"
         />
         <CardItem
           className="flex cursor-pointer flex-col gap-2 transition-colors active:bg-secondary"

--- a/app/(info)/layout.tsx
+++ b/app/(info)/layout.tsx
@@ -1,4 +1,4 @@
-import { BackHeader } from "@/components/back-header";
+import { InfoBackHeader } from "@/components/info-back-header";
 
 export default function InfoLayout({
   children,
@@ -7,7 +7,7 @@ export default function InfoLayout({
 }) {
   return (
     <div className="min-h-svh bg-background">
-      <BackHeader />
+      <InfoBackHeader />
       <main>{children}</main>
     </div>
   );

--- a/app/api/mcp/[transport]/route.ts
+++ b/app/api/mcp/[transport]/route.ts
@@ -100,7 +100,7 @@ const handler = createMcpHandler(
       {
         title: "오늘의 모임",
         description:
-          "오늘(또는 지정한 날짜, KST 기준) 우리 팀 모임 목록과 각 모임의 참석자 수를 반환합니다. 날짜는 YYYY-MM-DD.",
+          "오늘(또는 지정한 날짜, KST 기준) 우리 팀 모임 목록과 각 모임의 설명(본문)·참석자 수를 반환합니다. 날짜는 YYYY-MM-DD.",
         inputSchema: {
           date: z
             .string()

--- a/app/api/mcp/__tests__/tool-correctness.test.ts
+++ b/app/api/mcp/__tests__/tool-correctness.test.ts
@@ -23,7 +23,8 @@ import {
  *
  * ── dev 대조 결과(2026-07-24, vers=0 정본 보정 baseline) ──
  *  AC-10 list_today_gatherings(2026-07-04): baseline == UTC-range 등가형 → 동일 1행
- *    { gthr_id: d2867b5b…534d, stt_at: 2026-07-03T23:00:00Z, attendee_cnt: 10 }.
+ *    { gthr_id: d2867b5b…534d, stt_at: 2026-07-03T23:00:00Z, attendee_cnt: 10,
+ *      desc_txt: non-null(모임 설명 본문) }. (2026-07-25 desc_txt 필드 추가 후 재대조)
  *  AC-11 list_recent_members(limit 10): 10행, join_dt desc·crt_at desc.
  *    head=[김또낑(07-09), 정정만(07-09), 온보딩 5f6ae133(07-09), 온보딩 0fe17429(07-09), 박초록(07-06)…].
  *  AC-12 list_members_attendance: 활성 144행, 참석>0 88명, 미참석 56명.

--- a/components/info-back-header.tsx
+++ b/components/info-back-header.tsx
@@ -1,0 +1,26 @@
+"use client";
+
+import { usePathname } from "next/navigation";
+
+import { BackHeader } from "@/components/back-header";
+
+/**
+ * `(info)` 레이아웃 전용 BackHeader 래퍼.
+ *
+ * `/mcp-tokens`는 설정 화면(`/settings`)에서만 진입 링크가 있지만, 사용자가 북마크나
+ * 알림 등으로 직접 진입하면 브라우저 히스토리가 비어 있어 `BackHeader`의 기본 동작인
+ * `router.back()` 폴백이 먹통이 된다(#447). 이 경로에서만 `href="/settings"`를 강제해
+ * 뒤로가기가 항상 동작하도록 한다. 다른 (info) 페이지는 기존 `router.back()` 동작 유지.
+ *
+ * ⚠️ BackHeader의 빈-히스토리 폴백을 전역적으로 고치는 근본수정은 별도 이슈(#450) 범위다.
+ * 여기서는 mcp-tokens 경로 하나만 스코프로 좁혀 처리한다.
+ */
+export function InfoBackHeader() {
+  const pathname = usePathname();
+
+  if (pathname === "/mcp-tokens") {
+    return <BackHeader href="/settings" />;
+  }
+
+  return <BackHeader />;
+}

--- a/docs/superpowers/specs/2026-07-24-gigang-ops-mcp-design.md
+++ b/docs/superpowers/specs/2026-07-24-gigang-ops-mcp-design.md
@@ -67,7 +67,7 @@
 
 | 도구 | 입력 | 출력(행) | 권한 |
 |---|---|---|---|
-| `list_today_gatherings` | `date?`(KST, 기본 오늘) | gthr_id, gthr_nm, gthr_type_enm, stt_at, end_at, loc_txt, max_prt_cnt, attendee_cnt | 멤버 |
+| `list_today_gatherings` | `date?`(KST, 기본 오늘) | gthr_id, gthr_nm, gthr_type_enm, stt_at, end_at, loc_txt, max_prt_cnt, desc_txt, attendee_cnt | 멤버 |
 | `list_recent_members` | `limit?`(기본 10) | mem_id, mem_nm, join_dt, team_role_cd, mem_st_cd | 멤버 |
 | `list_members_attendance` | `limit?` | mem_id, mem_nm, join_dt, attendance_cnt, last_attended_at | 멤버 |
 | `get_member_profile` | `member_id`(uuid) \| `name` | mem_nm, birth_dt, gdr_enm, join_dt, team_role_cd, mem_st_cd, intro_txt, avatar_url | 멤버 (연락처·계좌 절대 미포함) |
@@ -85,7 +85,7 @@
 
 ### 5.1 list_today_gatherings
 ```sql
-select g.gthr_id, g.gthr_nm, g.gthr_type_enm, g.stt_at, g.end_at, g.loc_txt, g.max_prt_cnt,
+select g.gthr_id, g.gthr_nm, g.gthr_type_enm, g.stt_at, g.end_at, g.loc_txt, g.max_prt_cnt, g.desc_txt,
        count(a.attd_id) as attendee_cnt
 from gthr_mst g
 left join gthr_attd_rel a on a.gthr_id = g.gthr_id

--- a/lib/mcp/queries.ts
+++ b/lib/mcp/queries.ts
@@ -85,6 +85,7 @@ export type TodayGatheringRow = {
   end_at: string | null;
   loc_txt: string | null;
   max_prt_cnt: number | null;
+  desc_txt: string | null;
   attendee_cnt: number;
 };
 
@@ -259,7 +260,7 @@ export async function listTodayGatherings(
   const { data, error } = await supabase
     .from("gthr_mst")
     .select(
-      "gthr_id, gthr_nm, gthr_type_enm, stt_at, end_at, loc_txt, max_prt_cnt, gthr_attd_rel(count)",
+      "gthr_id, gthr_nm, gthr_type_enm, stt_at, end_at, loc_txt, max_prt_cnt, desc_txt, gthr_attd_rel(count)",
     )
     .eq("team_id", teamId)
     .eq("del_yn", false)
@@ -277,6 +278,7 @@ export async function listTodayGatherings(
       end_at: (g.end_at as string | null) ?? null,
       loc_txt: (g.loc_txt as string | null) ?? null,
       max_prt_cnt: (g.max_prt_cnt as number | null) ?? null,
+      desc_txt: (g.desc_txt as string | null) ?? null,
       attendee_cnt: countRel?.[0]?.count ?? 0,
     };
   });


### PR DESCRIPTION
운영 MCP 실사용 피드백(#449, #447) 반영.

## #449 — `list_today_gatherings`에 모임 설명(본문) 추가
`gthr_mst.desc_txt`를 응답에 추가(비민감, 공개 설명). 소비자 도구(뉴비추천 등)가 모임 난이도/페이스/거리를 근거로 매칭할 수 있게.
- `lib/mcp/queries.ts` select·반환타입, 도구 description, 스펙 §4/§5.1 갱신.

## #447 (MCP 범위만) — 토큰 화면 뒤로가기 + 관리자 진입점
- **뒤로가기 버그(스코프 수정)**: `/mcp-tokens` 직접 진입 시 `BackHeader`의 `router.back()` 폴백이 빈 히스토리로 먹통. `components/info-back-header.tsx`(신규)로 **이 경로에서만** `href="/settings"` 강제. 다른 (info) 페이지 동작 불변.
- **관리자 진입점**: `/admin`에 "MCP 토큰" 카드 추가.
- ⚠️ **전역 근본수정**(모든 `(info)` 페이지 직접진입 뒤로가기)은 범위 분리 → **#450**으로 별도 트래킹.

## 검증
309 tests green, tsc/build 0. dev DB에 7/27~31 난이도별 테스트 모임 5개 삽입(MCP 수집 확인용).

Closes #449

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **새 기능**
  - 관리자 대시보드의 도구 섹션에서 MCP 토큰 관리 화면으로 바로 이동할 수 있습니다.
  - MCP 토큰 화면에서 이전 화면으로 안정적으로 돌아갈 수 있습니다.

- **개선 사항**
  - 오늘의 모임 조회 결과에 모임 설명이 함께 표시됩니다.
  - 모임 설명 데이터가 비어 있는 경우에도 안정적으로 처리됩니다.

- **문서**
  - 오늘의 모임 조회 결과에 설명 정보가 포함되도록 관련 기준 문서를 업데이트했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->