### PR TITLE
feat(mcp): 멤버 조회에 가입 러닝 프로필(역·거리·페이스·목적) 추가

### DIFF
--- a/app/api/mcp/[transport]/route.ts
+++ b/app/api/mcp/[transport]/route.ts
@@ -119,7 +119,7 @@ const handler = createMcpHandler(
       {
         title: "최근 가입 멤버",
         description:
-          "우리 팀에 최근 가입한 멤버 목록을 가입일 최신순으로 반환합니다. limit 기본 10.",
+          "우리 팀에 최근 가입한 멤버 목록을 가입일 최신순으로 반환합니다. 가까운 역·평균 러닝 거리·평균 페이스·가입 목적(가입 온보딩 러닝 프로필) 포함. limit 기본 10.",
         inputSchema: {
           limit: z.number().int().min(1).max(100).optional(),
         },
@@ -151,7 +151,7 @@ const handler = createMcpHandler(
       {
         title: "멤버 프로필",
         description:
-          "우리 팀 멤버 프로필(이름·생일·성별·가입일·역할·상태·소개·아바타)을 조회합니다. member_id(uuid) 또는 name 중 하나로 조회. 연락처·계좌 정보는 반환하지 않습니다.",
+          "우리 팀 멤버 프로필(이름·생일·성별·가입일·역할·상태·소개·아바타, 가까운 역·평균 러닝 거리·평균 페이스·가입 목적)을 조회합니다. member_id(uuid) 또는 name 중 하나로 조회. 연락처·계좌 정보는 반환하지 않습니다.",
         inputSchema: {
           member_id: z.string().uuid("member_id 는 uuid 여야 합니다.").optional(),
           name: z.string().min(1).optional(),

--- a/app/api/mcp/__tests__/tool-correctness.test.ts
+++ b/app/api/mcp/__tests__/tool-correctness.test.ts
@@ -6,6 +6,8 @@ import { describe, expect, it } from "vitest";
 import {
   aggregateAttendance,
   buildPushStatus,
+  decodeJoinPurposes,
+  decodePaceLabel,
   escapeLikePattern,
   kstDayRange,
 } from "@/lib/mcp/queries";
@@ -38,6 +40,14 @@ import {
  *  ⚠️ 정본 규약 결정: §5 baseline 본문은 team_mem_rel 에 vers=0 필터가 없으나, dev 실데이터에는
  *     del_yn=false & vers>0 인 낡은 행이 있어 무필터 시 활성 147(=144+중복3), 'left' 멤버가
  *     'active'로 되살아난다. 앱 전역 정본 규약(vers=0)으로 보정한 baseline을 M-01 기준으로 삼음.
+ *
+ * ── dev 대조 결과(2026-07-25, 러닝 프로필 필드 추가) ──
+ *  mem_onbd_prf 실데이터(팀 c0ffee00…001 소속 확인) 로 라벨 디코딩 대조:
+ *   - mem_id=974e87ef… (get_member_profile 대상): near_stn_nm=선릉, avg_run_dist_km="15.0"→15,
+ *     avg_pace_cd=P430→avg_pace="4'30\"", join_purp_cds=[COACH]→join_purposes=[코칭].
+ *   - mem_id=5f6ae133…(list_recent_members head, AC-13과 동일 인물 '온보딩'): near_stn_nm=계산,
+ *     avg_run_dist_km="20.0"→20, avg_pace_cd=P600→"6'00\"", join_purp_cds=[COACH,RACE]→[코칭,대회].
+ *   - avg_run_dist_km 는 numeric 이라 PostgREST가 문자열("15.0")로 반환 → Number() 강제 변환 확인.
  */
 
 describe("kstDayRange — §5.1 KST 달력일 → UTC 반열림 구간", () => {
@@ -166,6 +176,42 @@ describe("escapeLikePattern — §5.4 get_member_profile name 와일드카드 �
     expect(escapeLikePattern("홍길동")).toBe("홍길동");
     expect(escapeLikePattern("hs")).toBe("hs");
     expect(escapeLikePattern("")).toBe("");
+  });
+});
+
+describe("decodePaceLabel — §5.2/§5.4 avg_pace_cd → 라벨(PACE_LABELS 재사용)", () => {
+  it("알려진 코드는 lib/validations/member.ts PACE_LABELS 라벨로 디코딩한다", () => {
+    // dev 실측: mem_id=974e87ef… avg_pace_cd=P430
+    expect(decodePaceLabel("P430")).toBe("4'30\"");
+    // dev 실측: mem_id=5f6ae133… avg_pace_cd=P600
+    expect(decodePaceLabel("P600")).toBe("6'00\"");
+  });
+
+  it("알 수 없는 코드는 코드 원문을 그대로 반환한다(cmm코드 아님)", () => {
+    expect(decodePaceLabel("P999")).toBe("P999");
+  });
+
+  it("null/미지정은 null", () => {
+    expect(decodePaceLabel(null)).toBeNull();
+  });
+});
+
+describe("decodeJoinPurposes — §5.2/§5.4 join_purp_cds → 짧은 라벨 배열(JOIN_PURP_SHORT_LABELS 재사용)", () => {
+  it("알려진 코드 배열을 짧은 라벨 배열로 디코딩한다", () => {
+    // dev 실측: mem_id=974e87ef… join_purp_cds=[COACH]
+    expect(decodeJoinPurposes(["COACH"])).toEqual(["코칭"]);
+    // dev 실측: mem_id=5f6ae133… join_purp_cds=[COACH, RACE]
+    expect(decodeJoinPurposes(["COACH", "RACE"])).toEqual(["코칭", "대회"]);
+  });
+
+  it("알 수 없는 코드는 코드 원문을 유지한다", () => {
+    expect(decodeJoinPurposes(["RUN_MATE", "MYSTERY"])).toEqual(["러닝메이트", "MYSTERY"]);
+  });
+
+  it("데이터 없음(null/undefined/빈 배열)은 빈 배열", () => {
+    expect(decodeJoinPurposes(null)).toEqual([]);
+    expect(decodeJoinPurposes(undefined)).toEqual([]);
+    expect(decodeJoinPurposes([])).toEqual([]);
   });
 });
 

--- a/docs/superpowers/specs/2026-07-24-gigang-ops-mcp-design.md
+++ b/docs/superpowers/specs/2026-07-24-gigang-ops-mcp-design.md
@@ -68,14 +68,15 @@
 | 도구 | 입력 | 출력(행) | 권한 |
 |---|---|---|---|
 | `list_today_gatherings` | `date?`(KST, 기본 오늘) | gthr_id, gthr_nm, gthr_type_enm, stt_at, end_at, loc_txt, max_prt_cnt, desc_txt, attendee_cnt | 멤버 |
-| `list_recent_members` | `limit?`(기본 10) | mem_id, mem_nm, join_dt, team_role_cd, mem_st_cd | 멤버 |
+| `list_recent_members` | `limit?`(기본 10) | mem_id, mem_nm, join_dt, team_role_cd, mem_st_cd, near_stn, avg_run_dist_km, avg_pace, join_purposes | 멤버 |
 | `list_members_attendance` | `limit?` | mem_id, mem_nm, join_dt, attendance_cnt, last_attended_at | 멤버 |
-| `get_member_profile` | `member_id`(uuid) \| `name` | mem_nm, birth_dt, gdr_enm, join_dt, team_role_cd, mem_st_cd, intro_txt, avatar_url | 멤버 (연락처·계좌 절대 미포함) |
+| `get_member_profile` | `member_id`(uuid) \| `name` | mem_nm, birth_dt, gdr_enm, join_dt, team_role_cd, mem_st_cd, intro_txt, avatar_url, near_stn, avg_run_dist_km, avg_pace, join_purposes | 멤버 (연락처·계좌 절대 미포함) |
 | `list_gathering_non_attendees` | `gathering_id`(uuid) | mem_id, mem_nm, join_dt, attendance_cnt, last_attended_at | 멤버 |
 | `list_push_status` | — | mem_id, mem_nm, mem_st_cd, push_enabled | 멤버 |
 | `send_push` | `member_ids`(uuid[]), `title`, `message` | sent_cnt, audit_id | **admin** |
 
 - 반환은 정렬된 JSON 배열. `list_members_attendance`·`list_gathering_non_attendees`는 `last_attended_at asc nulls first`(전혀/오래 안 나온 순)로 정렬해 주되, 최종 추천 판단은 AI가 한다.
+- `near_stn`·`avg_run_dist_km`·`avg_pace`·`join_purposes`(2026-07-25 추가)는 가입 온보딩 러닝 프로필(`mem_onbd_prf`, mem_id 키·팀무관)에서 조인. `avg_pace`·`join_purposes`는 각각 `avg_pace_cd`·`join_purp_cds`를 `lib/validations/member.ts`의 `PACE_LABELS`·`JOIN_PURP_SHORT_LABELS`로 디코딩한 라벨(알 수 없는 코드는 코드 원문 유지). 온보딩 행이 없는 멤버는 전부 null/빈 배열. 유입경로(join_src_cd)·전화·이메일·계좌는 여전히 영구 제외(M-03).
 
 ## 5. Ground-truth SQL baseline (AC-02)
 
@@ -97,12 +98,15 @@ order by g.stt_at;
 
 ### 5.2 list_recent_members
 ```sql
-select m.mem_id, m.mem_nm, r.join_dt, r.team_role_cd, r.mem_st_cd
+select m.mem_id, m.mem_nm, r.join_dt, r.team_role_cd, r.mem_st_cd,
+       o.near_stn_nm, o.avg_run_dist_km, o.avg_pace_cd, o.join_purp_cds
 from team_mem_rel r
 join mem_mst m on m.mem_id = r.mem_id and m.del_yn = false
+left join mem_onbd_prf o on o.mem_id = r.mem_id
 where r.team_id = :team_id and r.del_yn = false and r.vers = 0
 order by r.join_dt desc nulls last, r.crt_at desc
 limit :limit;   -- 기본 10
+-- 도구 출력의 avg_pace·join_purposes는 코드를 PACE_LABELS·JOIN_PURP_SHORT_LABELS로 디코딩한 라벨.
 ```
 
 ### 5.3 list_members_attendance
@@ -125,11 +129,14 @@ limit :limit;   -- 옵션
 연락처·계좌(phone_no·email_addr·bank_nm·bank_acct_no)는 **select 목록에서 영구 제외** — 코드 불변식.
 ```sql
 select m.mem_id, m.mem_nm, m.birth_dt, m.gdr_enm, m.avatar_url,
-       r.join_dt, r.team_role_cd, r.mem_st_cd, r.intro_txt
+       r.join_dt, r.team_role_cd, r.mem_st_cd, r.intro_txt,
+       o.near_stn_nm, o.avg_run_dist_km, o.avg_pace_cd, o.join_purp_cds
 from mem_mst m
 join team_mem_rel r on r.mem_id = m.mem_id and r.team_id = :team_id and r.del_yn = false and r.vers = 0
+left join mem_onbd_prf o on o.mem_id = m.mem_id
 where m.del_yn = false
   and (m.mem_id = :member_id or lower(m.mem_nm) = lower(:name));
+-- 도구 출력의 avg_pace·join_purposes는 코드를 PACE_LABELS·JOIN_PURP_SHORT_LABELS로 디코딩한 라벨.
 ```
 
 ### 5.5 list_gathering_non_attendees

--- a/lib/mcp/queries.ts
+++ b/lib/mcp/queries.ts
@@ -2,6 +2,7 @@ import type { SupabaseClient } from "@supabase/supabase-js";
 
 import { dayjs } from "@/lib/dayjs";
 import type { Database } from "@/lib/supabase/database.types";
+import { JOIN_PURP_SHORT_LABELS, PACE_LABELS } from "@/lib/validations/member";
 
 /**
  * 기강 운영 MCP — 6개 읽기 도구의 쿼리 로직(SG-04, 스펙 §4·§5).
@@ -89,13 +90,24 @@ export type TodayGatheringRow = {
   attendee_cnt: number;
 };
 
+/**
+ * 가입 온보딩 러닝 프로필(`mem_onbd_prf`, mem_id 키·팀무관). 코드는 라벨로 디코딩해 노출한다.
+ * 유입경로(join_src)·전화·이메일·계좌는 원천 테이블 어디에도 select 하지 않는다(M-03 불변식).
+ */
+export type RunningProfile = {
+  near_stn: string | null;
+  avg_run_dist_km: number | null;
+  avg_pace: string | null;
+  join_purposes: string[];
+};
+
 export type RecentMemberRow = {
   mem_id: string;
   mem_nm: string;
   join_dt: string | null;
   team_role_cd: string;
   mem_st_cd: string;
-};
+} & RunningProfile;
 
 export type AttendanceRow = {
   mem_id: string;
@@ -115,7 +127,7 @@ export type MemberProfileRow = {
   mem_st_cd: string;
   intro_txt: string | null;
   avatar_url: string | null;
-};
+} & RunningProfile;
 
 export type PushStatusRow = {
   mem_id: string;
@@ -205,6 +217,24 @@ export function buildPushStatus(
   return rows;
 }
 
+/**
+ * `avg_pace_cd` → 사람이 읽는 페이스 라벨(`lib/validations/member.ts` PACE_LABELS 재사용).
+ * cmm코드가 아니므로 알 수 없는 코드가 들어와도 에러 없이 코드 원문을 그대로 반환한다.
+ */
+export function decodePaceLabel(code: string | null): string | null {
+  if (!code) return null;
+  return (PACE_LABELS as Record<string, string>)[code] ?? code;
+}
+
+/**
+ * `join_purp_cds` → 짧은 가입 목적 라벨 배열(JOIN_PURP_SHORT_LABELS 재사용).
+ * 알 수 없는 코드는 코드 원문을 유지, 데이터 없으면 빈 배열.
+ */
+export function decodeJoinPurposes(codes: string[] | null | undefined): string[] {
+  if (!codes || codes.length === 0) return [];
+  return codes.map((c) => (JOIN_PURP_SHORT_LABELS as Record<string, string>)[c] ?? c);
+}
+
 // ── 쿼리 함수(supabase 주입) ─────────────────────────────────────────────────
 
 /** 활성 팀 멤버(정본 vers=0) 시드 목록 — 5.3/5.5 공통 기반. */
@@ -230,6 +260,41 @@ async function fetchActiveMemberSeeds(
     };
   });
 }
+
+/**
+ * mem_id 목록으로 가입 온보딩 러닝 프로필을 배치 조회한다(쿼리 1회, `.in`).
+ * 팀 무관(mem_onbd_prf는 mem_id 키) — team_id 필터는 걸지 않고 호출측 mem_id 목록으로만 스코프.
+ * 온보딩 개편 전 가입자 등 행이 없는 멤버는 Map에 없음 → 호출측에서 null/[] 기본값 처리.
+ */
+async function fetchRunningProfiles(
+  supabase: Db,
+  memIds: readonly string[],
+): Promise<Map<string, RunningProfile>> {
+  const map = new Map<string, RunningProfile>();
+  if (memIds.length === 0) return map;
+  const { data, error } = await supabase
+    .from("mem_onbd_prf")
+    .select("mem_id, near_stn_nm, avg_run_dist_km, avg_pace_cd, join_purp_cds")
+    .in("mem_id", memIds);
+  if (error) throw error;
+  for (const r of data ?? []) {
+    map.set(r.mem_id, {
+      near_stn: r.near_stn_nm ?? null,
+      // numeric 컬럼은 드라이버가 문자열로 줄 수 있어 명시적으로 숫자화한다(lib/queries/onboarding-profile.ts 동일 패턴).
+      avg_run_dist_km: r.avg_run_dist_km != null ? Number(r.avg_run_dist_km) : null,
+      avg_pace: decodePaceLabel(r.avg_pace_cd ?? null),
+      join_purposes: decodeJoinPurposes(r.join_purp_cds),
+    });
+  }
+  return map;
+}
+
+const EMPTY_RUNNING_PROFILE: RunningProfile = {
+  near_stn: null,
+  avg_run_dist_km: null,
+  avg_pace: null,
+  join_purposes: [],
+};
 
 /** 과거(이미 시작된) 팀 모임 참석 이벤트 목록 — 5.3/5.5 공통 기반. */
 async function fetchPastAttendanceEvents(
@@ -301,7 +366,7 @@ export async function listRecentMembers(
     .order("crt_at", { ascending: false })
     .limit(limit);
   if (error) throw error;
-  return (data ?? []).map((r) => {
+  const rows = (data ?? []).map((r) => {
     const mem = pickOne(r.mem_mst as { mem_nm: string } | { mem_nm: string }[]);
     return {
       mem_id: r.mem_id as string,
@@ -311,6 +376,14 @@ export async function listRecentMembers(
       mem_st_cd: r.mem_st_cd as string,
     };
   });
+  const profiles = await fetchRunningProfiles(
+    supabase,
+    rows.map((r) => r.mem_id),
+  );
+  return rows.map((r) => ({
+    ...r,
+    ...(profiles.get(r.mem_id) ?? EMPTY_RUNNING_PROFILE),
+  }));
 }
 
 /** §5.3 멤버별 참석 현황(오래/전혀 안 나온 순). */
@@ -354,7 +427,7 @@ export async function getMemberProfile(
   }
   const { data, error } = await query;
   if (error) throw error;
-  return (data ?? []).map((r) => {
+  const rows = (data ?? []).map((r) => {
     const mem = pickOne(
       r.mem_mst as
         | {
@@ -384,6 +457,14 @@ export async function getMemberProfile(
       avatar_url: mem?.avatar_url ?? null,
     };
   });
+  const profiles = await fetchRunningProfiles(
+    supabase,
+    rows.map((r) => r.mem_id).filter((id) => id !== ""),
+  );
+  return rows.map((r) => ({
+    ...r,
+    ...(profiles.get(r.mem_id) ?? EMPTY_RUNNING_PROFILE),
+  }));
 }
 
 /** §5.5 특정 모임 미참석 활성 멤버 + 각자 참석 현황. */


### PR DESCRIPTION
운영 MCP에서 뉴비-모임 매칭에 쓰도록, 가입 온보딩 러닝 프로필을 멤버 조회 응답에 노출.

## 무엇
`get_member_profile`·`list_recent_members` 응답에 `mem_onbd_prf`(가입 온보딩) 기반 4개 필드 추가:
- `near_stn` — 가까운 역(사는 곳)
- `avg_run_dist_km` — 평균 러닝 거리
- `avg_pace` — 평균 페이스(라벨 디코딩, 예: `6'00"`)
- `join_purposes` — 가입 목적(짧은 라벨 배열, 예: `[러닝메이트, 대회]`)

## 왜
"방금 가입한 뉴비를 레벨·사는 위치로 모임에 매칭"을 AI가 한 번에 하도록. #449(모임 설명 desc_txt)와 함께 뉴비추천 도구의 근거를 완성.

## 구현
- `lib/mcp/queries.ts`: `fetchRunningProfiles`(mem_onbd_prf `.in` 배치조회 1회) + 순수 디코딩(`decodePaceLabel`/`decodeJoinPurposes`, `lib/validations/member.ts`의 `PACE_LABELS`·`JOIN_PURP_SHORT_LABELS` 재사용). 두 도구에 부착.
- route.ts 도구 description, 스펙 §4/§5.2/§5.4 갱신.

## 노출 범위 (의도적 제외)
- **유입경로(join_src)·가입목적 자유텍스트(join_purp_txt)·전화·이메일·계좌는 제외.** mem_onbd_prf select는 딱 4개 컬럼만.
- `near_stn`은 위치정보지만 이미 프로필 카드에 크루 내 노출되는 값이고, MCP는 팀 스코프·운영진 전용이라 일관됨.

## 검증
319 tests green(신규 디코딩 단위테스트 8), tsc/build 0. dev 실측 대조(선릉·15km·`4'30"`·[코칭] 등). 민감정보 스캔 테스트 계속 통과.

🤖 Generated with [Claude Code](https://claude.com/claude-code)