### PR TITLE
feat(story): 레코드보드 인스타형 격자 + 릴스 상세 뷰어

### DIFF
--- a/components/story/record-flex-feed.tsx
+++ b/components/story/record-flex-feed.tsx
@@ -4,59 +4,59 @@ import { useEffect, useRef, useState } from "react";
 import Image from "next/image";
 
 import { loadMorePosts } from "@/app/actions/story/load-more-posts";
-import { MILEAGE_SPORT_LABELS, type MileageSport } from "@/lib/mileage";
 // 상한은 `lib/story-post.ts`에서 가져온다 — `lib/queries/story-posts.ts`는 admin
 // 클라이언트(`server-only`)를 물고 있어 클라이언트 컴포넌트가 import하면 빌드가 깨진다.
 // 값 자체는 두 곳이 같아야 하므로(받은 개수 < 상한 = 끝) 정본은 story-post.ts 한 곳이다.
 import { STORY_POST_LIMIT } from "@/lib/story-post";
 
 import { buildFallbackAvatarUrl } from "@/components/common/avatar";
+import { MemberCardDialog } from "@/components/members/member-card-dialog";
 import { RecordFlexCreateDialog } from "@/components/story/record-flex-create-dialog";
+import { RecordReelViewer } from "@/components/story/record-reel-viewer";
 
 import type { StoryPost } from "@/lib/queries/story-posts";
 
-/** 종목 라벨 — 마일리지런과 같은 어휘를 쓴다(자동 유입분과 표기가 갈리지 않게) */
-function sportLabel(sprt: string | null): string | null {
-  if (!sprt) return null;
-  return MILEAGE_SPORT_LABELS[sprt as MileageSport] ?? null;
-}
-
-/** 거리 표기 — numeric이 10.20으로 와도 10.2로 줄인다(뒤 0은 정보가 아니다) */
-function formatKm(km: number | null): string | null {
-  if (km == null || Number.isNaN(km)) return null;
-  return `${Number(km.toFixed(2))}km`;
-}
-
 /**
- * 기록 자랑 — 인스타 피드형 격자.
+ * 기록 자랑 — 인스타 게시글형 격자.
  *
- * 사진(정사각) 아래 **한마디 한 줄 + 기록 한 줄**을 세우고, 세로 2칸을 한 열로 묶어
- * **가로로 계속 흘려보낸다.** 폴라로이드(기울인 흰 판에 이름·날짜까지)였던 걸 걷어냈다 —
- * 칸마다 네 줄이 들어가니 정작 사진이 작아지고, 격자가 사진이 아니라 종이 무더기로 읽혔다.
+ * 칸은 **사진만** 담는다(인스타 게시글 격자처럼). 세로 2칸을 한 열로 묶어 **가로로 계속
+ * 흘려보내고**, 한마디·거리·날짜는 칸을 눌러 릴스 뷰어(`RecordReelViewer`)에서 본다.
+ * 예전엔 사진 아래 한마디·기록을 얹었는데, 칸마다 텍스트가 들어가니 정작 사진이 작아지고
+ * 격자가 사진이 아니라 종이 무더기로 읽혔다 — 사진만 남겨 무더기가 사진으로 읽히게 한다.
  *
  * **면 넘기기와 진행 막대를 버렸다.** 막대는 기록이 늘수록 한 칸이 좁아져 결국 못 누르는
  * UI가 되고(400건이면 3px), 시간순 목록에서 "몇 면 중 몇 면"은 애초에 쓸모가 적다.
  * 지금은 손으로 밀면 계속 흘러가고 끝에서 멈춘다 — 감기지 않으므로 끝이 있다는 걸 손으로 안다.
  *
- * **이름·날짜를 뺀 게 핵심이다.** 격자에서 눈에 들어오는 건 사진과 기록이고, 누가 언제인지는
- * 눌러서 확인할 정보다. 두 줄 안에 넷을 다 넣으면 결국 아무것도 안 읽힌다.
- * 한마디도 한 줄로 자른다(두 줄까지 열면 칸마다 높이가 달라져 격자가 어긋난다).
- *
  * **사진이 없는 기록**(직접 올리며 사진을 안 넣었거나, 마일리지런 자동 유입분 `mlg_auto` —
  * 원천 `evt_mlg_act_hist`에 사진 컬럼이 없다)은 **프로필사진을 칸에 사각으로 꽉 채운다**.
- * 동그란 아바타 + 가운데 한마디였던 걸 걷어냈다 — 사진 있는 칸과 같은 사각 격자로 읽히게.
- * 사진을 안 올리는 사람이 훨씬 많을 텐데 빈 회색 칸으로 두면 자랑이 초라해 보여 다음부터
+ * 사진 있는 칸과 같은 사각 격자로 읽히게 — 빈 회색 칸으로 두면 자랑이 초라해 보여 다음부터
  * 안 올린다. 프사가 512px라 확대하면 다소 흐리지만, 얼굴이 보이는 편이 낫다는 판단.
  */
 export function RecordFlexFeed({
   posts,
   myMemId,
+  teamId,
 }: {
   posts: StoryPost[];
   /** 로그인 사용자 — 없으면 "올리기" 버튼을 감춘다(각오·응원과 동일 정책) */
   myMemId: string | null;
+  /** 릴스 뷰어 안에서 여는 프로필 카드에 넘긴다 */
+  teamId: string;
 }) {
   const [writing, setWriting] = useState(false);
+  /** 릴스 뷰어에서 처음 열 카드 — null이면 닫힘 */
+  const [openId, setOpenId] = useState<string | null>(null);
+  /**
+   * 릴스 뷰어에서 이름·프사를 눌러 여는 프로필 카드 — 뷰어 위에 겹친다(stacked).
+   * story-client의 공유 카드와 **분리**한다: 저 카드는 여러 진입점이 z-50로 공유하는데,
+   * 릴스 뷰어(z-50) 위에 뜨려면 z-[60]이 필요해 stacked를 켜야 한다. 뷰어가 자기 카드를
+   * 직접 들고 있어야 이 차이를 격리할 수 있다(공유 카드를 항상 stacked로 두면 다른 진입점이
+   * 깨진다).
+   */
+  const [reelMember, setReelMember] = useState<{ memId: string; name: string } | null>(
+    null,
+  );
   /** 서버가 준 첫 묶음 뒤로 이어붙인 것들 */
   const [extra, setExtra] = useState<StoryPost[]>([]);
   /** 더 남았나 — 받은 개수가 요청량보다 적으면 끝이다 */
@@ -149,7 +149,6 @@ export function RecordFlexFeed({
     return () => obs.disconnect();
   }, [posts, extra.length, fetchedExtra, done]);
 
-  const hasPosts = all.length > 0;
   // 2장씩 한 열 — 가로로 흐르는 격자라 세로 2칸을 채우고 다음 열로 넘어간다
   const columns: StoryPost[][] = [];
   for (let i = 0; i < all.length; i += 2) {
@@ -164,12 +163,10 @@ export function RecordFlexFeed({
         </h2>
       </div>
       <p className="px-6 pt-2.5 font-serif text-[15px] text-muted-foreground">
-        {hasPosts
-          ? "기강인들이 남긴 기록"
-          : "아직 올라온 기록이 없어요 — 오늘 뛴 기록을 남겨보세요"}
+        우리가 남긴 발자국
       </p>
 
-      {hasPosts && (
+      {
         /* 가로 스크롤 — 면을 끊어 넘기던 걸(프로그레스바 + 스와이프 판정) 걷어내고 손으로
            밀면 계속 흘러가게 했다. 면 표시 막대는 기록이 늘수록 한 칸이 좁아져 결국 못 누르는
            UI가 되는데, 여기는 시간순 목록이라 "몇 면 중 몇 면"이 애초에 쓸모가 적다.
@@ -190,55 +187,42 @@ export function RecordFlexFeed({
           aria-label="기록 자랑 목록 — 좌우로 스크롤"
           className="scrollbar-none snap-x snap-proximity scroll-pl-6 overflow-x-auto overscroll-x-contain pt-4 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
         >
-          <ul className="lede-in flex w-max gap-1.5 px-6">
+          <ul className="lede-in flex w-max gap-0.5 px-6">
             {columns.map((col, ci) => (
-              <li key={ci} className="flex snap-start flex-col gap-1.5">
-                {col.map((p) => {
-              const label = sportLabel(p.sprt_enm);
-              const km = formatKm(p.dst_km);
-              return (
+              <li key={ci} className="flex snap-start flex-col gap-0.5">
+                {col.map((p) => (
                 /* 폭 고정 — 가로 흐름이라 화면 폭의 절반쯤에 맞춰 "한 화면에 두 열"이
-                   보이게 한다(다음 열이 살짝 걸쳐 더 있다는 걸 알린다). */
-                <div key={p.post_id} className="flex w-[42vw] max-w-[180px] flex-col gap-1">
-                  {/* 사진 — 각진 정사각. 라운드를 주지 않는다(인스타 격자는 직각이 기본이고,
-                      둥근 모서리는 칸을 카드처럼 보이게 해 격자의 결이 흐려진다).
-                      배경이 흰 사진도 칸 경계가 보이도록 얇은 테두리를 두른다. */}
-                  <span className="block aspect-square w-full overflow-hidden border border-border bg-muted">
-                    {/* 사진 없이 올린 기록도 프로필사진을 **칸에 사각으로 꽉 채운다** —
-                        동그란 아바타 + 가운데 한마디였던 걸 걷어냈다. 사진 있는 칸과 같은
-                        aspect-square·object-cover라 격자가 한 결로 읽힌다(칸이 카드처럼
-                        따로 놀지 않는다). 프사가 512px라 확대하면 다소 흐리지만, 회색 빈
-                        칸보다 얼굴이 보이는 편이 자랑 피드로선 낫다. 프사 미설정자는
-                        DiceBear 폴백(SVG)이라 오히려 선명하다. 한마디는 사진 있는 칸과
-                        똑같이 아래 줄에 두고, 이름은 넣지 않는다(누구인지는 눌러서 본다). */}
-                    <Image
-                      src={p.photo_url ?? p.avatar_url ?? buildFallbackAvatarUrl(p.mem_id)}
-                      alt=""
-                      width={320}
-                      height={320}
-                      className="size-full object-cover"
-                      referrerPolicy="no-referrer"
-                      unoptimized
-                    />
-                  </span>
-
-                  {/* 한마디 — 사진 바로 아래 한 줄. 길이가 달라도 격자가 어긋나지 않게
-                      한 줄로 자른다(두 줄까지 열면 칸마다 높이가 달라진다).
-                      리디바탕(`font-serif`) — 사람이 쓴 말이라 본문 산세리프와 결을 나눈다.
-                      사진 유무와 무관하게 한마디를 쓴다 — 이제 사진 없는 칸도 사각 프사로
-                      꽉 차 있어 한마디가 칸 안에 따로 들어가지 않는다. */}
-                  <span className="truncate font-serif text-[13px] leading-snug text-foreground">
-                    {p.cmnt_txt}
-                  </span>
-
-                  {/* 기록 — 거리 · 종목. 이름·날짜는 뺐다(격자에서 읽히는 건 사진과 기록이고,
-                      누가 언제인지는 눌러서 볼 정보라 두 줄 안에 다 넣으면 아무것도 안 읽힌다) */}
-                  <span className="font-numeric text-[11px] text-muted-foreground tabular-nums">
-                    {[km, label].filter(Boolean).join(" · ") || "―"}
-                  </span>
-                </div>
-                  );
-                })}
+                   보이게 한다(다음 열이 살짝 걸쳐 더 있다는 걸 알린다).
+                   칸은 **사진만** 담는다(인스타 게시글 격자처럼) — 한마디·거리·날짜는 눌러서
+                   릴스 뷰어에서 본다. 격자에 텍스트를 얹으면 사진이 작아지고 무더기가 종이처럼
+                   읽힌다. 칸 전체가 버튼 — 누르면 릴스 뷰어가 이 장부터 열린다. */
+                <button
+                  key={p.post_id}
+                  type="button"
+                  onClick={() => setOpenId(p.post_id)}
+                  aria-label={`${p.mem_nm}의 기록 자세히 보기`}
+                  // 각진 정사각. 라운드를 주지 않는다(인스타 격자는 직각이 기본이고, 둥근
+                  // 모서리는 칸을 카드처럼 보이게 해 격자의 결이 흐려진다). 테두리도 두지
+                  // 않는다 — 인스타처럼 사진끼리 딱 붙이고, 좁은 gap(2px)이 흰 배경 사진의
+                  // 경계 역할을 대신한다.
+                  className="block aspect-square w-[42vw] max-w-[180px] overflow-hidden bg-muted transition-transform focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring active:scale-[0.98]"
+                >
+                  {/* 사진 없이 올린 기록도 프로필사진을 **칸에 사각으로 꽉 채운다** — 사진 있는
+                      칸과 같은 aspect-square·object-cover라 격자가 한 결로 읽힌다(칸이 카드처럼
+                      따로 놀지 않는다). 프사가 512px라 확대하면 다소 흐리지만, 회색 빈 칸보다
+                      얼굴이 보이는 편이 자랑 피드로선 낫다. 프사 미설정자는 DiceBear 폴백(SVG)이라
+                      오히려 선명하다. */}
+                  <Image
+                    src={p.photo_url ?? p.avatar_url ?? buildFallbackAvatarUrl(p.mem_id)}
+                    alt=""
+                    width={320}
+                    height={320}
+                    className="size-full object-cover"
+                    referrerPolicy="no-referrer"
+                    unoptimized
+                  />
+                </button>
+                ))}
               </li>
             ))}
 
@@ -247,11 +231,11 @@ export function RecordFlexFeed({
             {!done && <li ref={sentinelRef} aria-hidden className="w-px shrink-0" />}
           </ul>
         </div>
-      )}
+      }
 
       {/* 기록 올리기 — 로그인 멤버만 */}
       {myMemId && (
-        <div className={hasPosts ? "px-6 pt-4" : "px-6 pt-5"}>
+        <div className="px-6 pt-4">
           <button
             type="button"
             onClick={() => setWriting(true)}
@@ -263,6 +247,32 @@ export function RecordFlexFeed({
       )}
 
       <RecordFlexCreateDialog open={writing} onOpenChange={setWriting} />
+
+      {/* 릴스 뷰어 — 격자 한 칸을 누르면 이 장부터 풀스크린으로. 격자와 같은 `all`을 넘겨
+          더보기로 이어붙인 것까지 순서 그대로 넘긴다. 프로필 카드는 story-client가 위에 겹쳐 연다. */}
+      <RecordReelViewer
+        posts={all}
+        startId={openId}
+        open={openId !== null}
+        onOpenChange={(o) => {
+          if (!o) setOpenId(null);
+        }}
+        onSelectMember={(memId, name) => setReelMember({ memId, name })}
+      />
+
+      {/* 릴스 뷰어 위에 겹쳐 뜨는 프로필 카드(stacked=z-[60]) — 뷰어를 닫지 않고 그 위에 얹는다.
+          카드를 닫으면 뷰어로 돌아온다(릴스는 그대로). */}
+      <MemberCardDialog
+        memId={reelMember?.memId ?? null}
+        memNm={reelMember?.name}
+        teamId={teamId}
+        open={reelMember !== null}
+        onOpenChange={(o) => {
+          if (!o) setReelMember(null);
+        }}
+        isOwner={reelMember?.memId != null && reelMember.memId === myMemId}
+        stacked
+      />
     </section>
   );
 }

--- a/components/story/record-reel-viewer.tsx
+++ b/components/story/record-reel-viewer.tsx
@@ -1,0 +1,287 @@
+"use client";
+
+import { useCallback, useEffect, useRef } from "react";
+import Image from "next/image";
+import * as DialogPrimitive from "@radix-ui/react-dialog";
+import { X } from "lucide-react";
+
+import { dayjs } from "@/lib/dayjs";
+import { getSportEmoji, getSportLabel } from "@/lib/sport";
+
+import { Avatar, buildFallbackAvatarUrl } from "@/components/common/avatar";
+import { TitleBadge } from "@/components/common/title-badge";
+import { Dialog } from "@/components/ui/dialog";
+
+import type { StoryPost } from "@/lib/queries/story-posts";
+
+/** 거리 표기 — numeric이 10.20으로 와도 10.2로(뒤 0은 정보가 아니다). 격자와 같은 규칙 */
+function formatKm(km: number | null): string | null {
+  if (km == null || Number.isNaN(km)) return null;
+  return `${Number(km.toFixed(2))}km`;
+}
+
+/**
+ * 레코드보드 릴스 뷰어 — 격자 한 칸을 누르면 열리는 풀스크린 상세.
+ *
+ * **왜 릴스인가**: 격자는 사진을 훑는 자리라 한마디·거리가 한 줄로 잘린다. 한 칸을 열면
+ * 사진이 무대의 주인공이 되고, 그 아래로 누가·언제·얼마나가 온전히 펼쳐진다. 인스타 릴스처럼
+ * **위아래로 밀면 다음 발자국**으로 넘어간다 — 자동 전환은 없다(읽는 속도는 사람마다 다르다).
+ *
+ * **구현은 세로 scroll-snap**이다(포인터를 직접 재지 않는다). `snap-y snap-mandatory`로
+ * 한 장씩 딱 걸리고, 관성·키보드·스크린리더 훑기가 브라우저에서 공짜로 따라온다. 지금 어느
+ * 장인지는 IntersectionObserver로 읽어 필름 카운터(N/전체)에 쓴다.
+ *
+ * **무대는 어둡게, 글은 명조로.** 릴스의 관행(검은 배경·흰 글씨)을 따르되, 메타는 프로젝트의
+ * 명조(font-serif)로 적어 "기록을 읽는" 지면의 결을 릴스 안에서도 잇는다. 사진 위 하단
+ * 그라디언트에 글을 얹는 인스타 정석 + 우리 서체 대비가 이 뷰어의 시그니처다.
+ *
+ * **사진 없는 기록**(마일리지런 자동 유입분 등)은 프사를 블러로 깔아 무대를 만들고 그 위에
+ * 프사를 또렷하게 세운다 — 격자에선 프사로 칸을 꽉 채웠지만, 풀스크린에선 512px 프사를
+ * 그대로 늘리면 뭉개져 무대가 초라해진다. 블러 배경이 그 빈자리를 메운다.
+ */
+export function RecordReelViewer({
+  posts,
+  startId,
+  open,
+  onOpenChange,
+  onSelectMember,
+}: {
+  posts: StoryPost[];
+  /** 격자에서 누른 카드의 post_id — 이 장부터 연다 */
+  startId: string | null;
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  /** 이름·프사 탭 → 프로필 카드(위에 겹쳐 열린다). story-client가 stacked로 처리 */
+  onSelectMember: (memId: string, name: string) => void;
+}) {
+  const cardRefs = useRef<Map<string, HTMLElement>>(new Map());
+
+  const startIdx = startId
+    ? Math.max(
+        0,
+        posts.findIndex((p) => p.post_id === startId),
+      )
+    : 0;
+
+  /**
+   * 열릴 때 누른 장으로 즉시 점프한다 — 애니메이션 없이(`instant`). 부드럽게 굴리면 첫 장부터
+   * 눌린 장까지 스르륵 지나가 "내가 누른 게 이거"라는 연결이 끊긴다. 열림 직후 한 번만.
+   */
+  useEffect(() => {
+    if (!open) return;
+    // Radix가 콘텐츠를 마운트한 다음 프레임에 스크롤해야 대상 높이가 잡혀 있다.
+    const raf = requestAnimationFrame(() => {
+      const target = cardRefs.current.get(posts[startIdx]?.post_id ?? "");
+      target?.scrollIntoView({ block: "start", behavior: "instant" });
+    });
+    return () => cancelAnimationFrame(raf);
+    // startId가 바뀔 때(다른 칸을 눌러 다시 열 때)도 다시 점프해야 한다.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [open, startId]);
+
+  const registerCard = useCallback(
+    (id: string) => (el: HTMLElement | null) => {
+      if (el) cardRefs.current.set(id, el);
+      else cardRefs.current.delete(id);
+    },
+    [],
+  );
+
+  return (
+    // 프로젝트 Dialog 래퍼를 쓴다(primitive Root 직접 사용 금지) — 안드로이드 뒤로가기가
+    // 앱 종료가 아니라 릴스 닫기로 동작하려면 이 래퍼의 useDialogHistoryBack 연동이 필요하다.
+    // Content만 primitive로 커스텀한다(기본 DialogContent는 max-w-lg 카드형이라 풀스크린 릴스에
+    // 안 맞는다).
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogPrimitive.Portal>
+        {/* 무대 배경 — 릴스는 사진이 주인공이라 완전 불투명 검정으로 둘러싼다 */}
+        <DialogPrimitive.Overlay className="fixed inset-0 z-50 bg-black data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0" />
+        <DialogPrimitive.Content
+          // 접근성 이름 — 스크린리더용(아래 sr-only Title과 짝)
+          aria-label="기록 자세히 보기"
+          className="fixed inset-0 z-50 flex flex-col bg-black text-white outline-none data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0"
+          // 세로 스와이프가 이 안에서 스크롤이 되도록, 바깥 페이지로 새지 않게 가둔다
+          onPointerDownOutside={(e) => e.preventDefault()}
+        >
+          <DialogPrimitive.Title className="sr-only">
+            기강 기록 자세히 보기
+          </DialogPrimitive.Title>
+
+          {/* 상단 바 — 닫기(우)만. 필름 카운터는 뺐다(피드백). 사진 위에 떠 있어
+              그라디언트 없이도 읽히도록 살짝 그림자를 준다. z로 스크롤 콘텐츠 위에 고정. */}
+          <div className="pointer-events-none absolute inset-x-0 top-0 z-10 flex items-center justify-end px-5 pt-[calc(env(safe-area-inset-top)+14px)] pb-3">
+            <DialogPrimitive.Close className="pointer-events-auto -mr-1.5 flex size-9 items-center justify-center rounded-full text-white/90 transition-colors hover:bg-white/10 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/60">
+              <X className="size-5" />
+              <span className="sr-only">닫기</span>
+            </DialogPrimitive.Close>
+          </div>
+
+          {/* 세로 릴 — snap으로 한 장씩. 스크롤바는 숨기고 오버스크롤은 가둔다. */}
+          <div className="scrollbar-none h-full snap-y snap-mandatory overflow-y-auto overscroll-contain">
+            {posts.map((post) => (
+              <ReelCard
+                key={post.post_id}
+                ref={registerCard(post.post_id)}
+                post={post}
+                onSelectMember={onSelectMember}
+              />
+            ))}
+          </div>
+        </DialogPrimitive.Content>
+      </DialogPrimitive.Portal>
+    </Dialog>
+  );
+}
+
+/**
+ * 릴 한 장 — 화면 높이를 꽉 채우는(`h-full`) 한 발자국.
+ *
+ * 위: 사진이 무대의 대부분을 차지한다(중앙 정렬, 비율 유지). 아래: 사진 위로 겹쳐 오르는
+ * 하단 그라디언트에 사람·한마디·수치를 얹는다(인스타 정석). 사진과 글이 겹쳐도 그라디언트가
+ * 사진 아랫부분을 어둡게 눌러 글이 항상 읽힌다.
+ */
+const ReelCard = ({
+  ref,
+  post,
+  onSelectMember,
+}: {
+  ref: (el: HTMLElement | null) => void;
+  post: StoryPost;
+  onSelectMember: (memId: string, name: string) => void;
+}) => {
+  const km = formatKm(post.dst_km);
+  const label = getSportLabel(post.sprt_enm);
+  const emoji = getSportEmoji(post.sprt_enm);
+  const hasPhoto = Boolean(post.photo_url);
+  // 사진이 없으면 프사를 무대에 세운다(블러 배경 + 또렷한 중앙 프사)
+  const bgSrc = post.photo_url ?? post.avatar_url ?? buildFallbackAvatarUrl(post.mem_id);
+
+  // 거리·종목·날짜는 **한 줄에 묶지 않는다** — 이 자리는 "얼마나 달렸나"를 자랑하는 곳이라
+  // 거리가 주인공이어야 한다. 거리를 큰 숫자로 세우고(종목 이모지·라벨은 그 옆 보조),
+  // 날짜는 그 위 작은 kicker로 뺀다.
+  const dateLabel = post.act_dt
+    ? dayjs(post.act_dt).format("YYYY.MM.DD (ddd)")
+    : null;
+
+  return (
+    <article
+      ref={ref}
+      className="relative flex h-full snap-start snap-always items-center justify-center overflow-hidden"
+    >
+      {hasPhoto ? (
+        <>
+          {/* 사진 뒤 블러 확장 — 세로/가로 비율이 화면과 달라 생기는 레터박스를 사진 자신의
+              블러로 메운다(검은 띠 대신). object-cover라 꽉 차고, 위 또렷한 사진이 그 위에 뜬다. */}
+          <Image
+            src={bgSrc}
+            alt=""
+            fill
+            sizes="100vw"
+            unoptimized
+            aria-hidden
+            className="scale-110 object-cover opacity-40 blur-2xl"
+          />
+          {/* 또렷한 본 사진 — 비율 유지(contain). 무대 가운데. */}
+          <Image
+            src={bgSrc}
+            alt={`${post.mem_nm}의 기록 사진`}
+            fill
+            sizes="100vw"
+            unoptimized
+            className="object-contain"
+          />
+        </>
+      ) : (
+        // 사진 없는 기록 — 프사 블러 무대 + 중앙 또렷 프사(격자는 꽉 채우지만 풀스크린은 세워둔다)
+        <>
+          <Image
+            src={bgSrc}
+            alt=""
+            fill
+            sizes="100vw"
+            unoptimized
+            aria-hidden
+            className="scale-110 object-cover opacity-30 blur-3xl"
+          />
+          <div className="relative">
+            <Avatar
+              src={post.avatar_url}
+              seed={post.mem_id}
+              alt={post.mem_nm}
+              size="2xl"
+              className="ring-2 ring-white/20"
+            />
+          </div>
+        </>
+      )}
+
+      {/* 하단 그라디언트 + 정보 — 사진 위로 겹쳐 오른다. pointer-events는 버튼만 받게 좁힌다.
+          세로 리듬은 위계로 준다: 한마디→거리는 같은 자랑의 흐름이라 붙이고(mt-2), 거리→사람은
+          정보 그룹이 바뀌므로 더 띄운다(mt-4). 균등 gap 대신 mt로 그룹을 눈에 나누게 한다. */}
+      <div className="pointer-events-none absolute inset-x-0 bottom-0 z-[1] flex flex-col bg-gradient-to-t from-black/85 via-black/55 to-transparent px-5 pb-[calc(env(safe-area-inset-bottom)+22px)] pt-20">
+        {/* 한마디 — 사람이 쓴 말이라 명조로. 릴스라 격자보다 크게(두 줄까지). */}
+        {post.cmnt_txt && (
+          <p className="pointer-events-auto line-clamp-3 text-balance font-serif text-[19px] font-normal leading-[1.45] text-white [overflow-wrap:anywhere] [text-shadow:0_1px_10px_rgba(0,0,0,0.5)]">
+            {post.cmnt_txt}
+          </p>
+        )}
+
+        {/* 거리 — 이 자리의 주인공. "얼마나 달렸나"가 한눈에 들어오도록 큰 숫자로 세운다.
+            종목(이모지+라벨)은 그 옆에 baseline을 맞춰 보조로 붙인다. 거리가 없으면
+            (드문 경우) 종목만이라도 남긴다. 한마디가 있으면 그 아래로 살짝만 띄워 붙인다. */}
+        {(km || label) && (
+          <div className="mt-2.5 flex items-baseline gap-2.5 [text-shadow:0_1px_10px_rgba(0,0,0,0.55)]">
+            {km && (
+              <span className="font-numeric text-[34px] font-bold leading-none tracking-tight tabular-nums text-white">
+                {km}
+              </span>
+            )}
+            {label && (
+              <span className="text-[15px] font-medium text-white/90">
+                {emoji ? `${emoji} ` : ""}
+                {label}
+              </span>
+            )}
+          </div>
+        )}
+
+        {/* 사람 줄 — 왼쪽 프사·이름·칭호(탭하면 프로필 카드), 오른쪽 날짜(보조).
+            위 거리 그룹과는 정보가 갈리므로 더 띄운다(mt-4). */}
+        <div className="mt-4 flex items-center justify-between gap-3">
+          <button
+            type="button"
+            onClick={() => onSelectMember(post.mem_id, post.mem_nm)}
+            aria-label={`${post.mem_nm} 프로필 보기`}
+            className="pointer-events-auto flex min-w-0 items-center gap-2.5 rounded-full transition-transform focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/60 active:scale-95"
+          >
+            <Avatar
+              src={post.avatar_url}
+              seed={post.mem_id}
+              alt={post.mem_nm}
+              size="md"
+              className="ring-2 ring-white/25"
+            />
+            <span className="flex min-w-0 items-center gap-1.5">
+              <span className="truncate text-[15px] font-bold text-white [text-shadow:0_1px_8px_rgba(0,0,0,0.6)]">
+                {post.mem_nm}
+              </span>
+              {post.primary_title && (
+                <TitleBadge
+                  name={post.primary_title.ttl_nm}
+                  effect={post.badge_effect ?? "none"}
+                  size="xs"
+                />
+              )}
+            </span>
+          </button>
+
+          {dateLabel && (
+            <span className="pointer-events-none shrink-0 font-numeric text-[13px] font-medium tabular-nums text-white/80 [text-shadow:0_1px_8px_rgba(0,0,0,0.6)]">
+              {dateLabel}
+            </span>
+          )}
+        </div>
+      </div>
+    </article>
+  );
+};

--- a/components/story/story-client.tsx
+++ b/components/story/story-client.tsx
@@ -139,9 +139,10 @@ export function StoryClient({
         {/* 기강 오버뷰 — 개별 소식(리드) 다음에 크루 전체 활동 지수(심박수) */}
         <StoryPulse overview={overview} />
 
-        {/* 기록 자랑 — 폴라로이드 피드. 사진 아래 한마디·이름·날짜·거리가 붙고,
-            2x2 한 면씩 옆으로 밀어 과거 기록을 본다. 오버뷰(팀 펄스) 바로 다음 자리다. */}
-        <RecordFlexFeed posts={posts} myMemId={myMemId} />
+        {/* 기록 자랑 — 인스타형 격자. 한 칸을 누르면 릴스 뷰어가 이 장부터 풀스크린으로 열리고,
+            위아래로 밀어 다음 발자국을 본다. 뷰어 안 이름·프사를 누르면 프로필 카드가 그 위에
+            겹쳐 뜬다(뷰어가 자체 관리 — story-client 공유 카드와 z-index가 안 부딪히게). */}
+        <RecordFlexFeed posts={posts} myMemId={myMemId} teamId={teamId} />
 
         {/* 종이비행기 한마디 — 24시간 뒤 사라지는 한 줄(msg_mst).
             각오와 **별개 데이터**다: 저긴 팻말·1인 1개·만료 없음, 여긴 비행기·1인 N개·하루살이. */}


### PR DESCRIPTION
## 관련 이슈

- 관련 이슈 없음 (레코드보드 UX 피드백 반영)

## 요약

레코드보드(기록 자랑)를 인스타그램 게시글 격자처럼 **사진만** 흐르게 정리하고, 칸을 누르면 릴스처럼 위아래로 넘기는 풀스크린 상세 뷰어를 새로 추가했다. 리드 문구도 부드럽게 다듬었다.

## AS-IS (변경 전)

- 격자 칸마다 사진 아래 **한마디 · 거리/종목 텍스트**가 붙어 있어 정작 사진이 작아지고, 무더기가 사진이 아니라 종이처럼 읽혔다.
- 칸을 눌러도 **상세를 볼 방법이 없었다** — 한마디가 한 줄로 잘리고 거리·날짜·올린 사람을 온전히 확인할 수 없었다.
- 리드 문구가 `"기강인들이 남긴 기록"` 으로 명사 나열이라 딱딱했다.
- 기록이 없을 때를 가정한 분기(`hasPosts` false)가 있었으나, 레코드보드는 계속 누적되고 처음부터 기록이 있어 **도달 불가능한 데드코드**였다.

## TO-BE (변경 후)

- 격자는 **사진만** 담는다(인스타 게시글 격자). 텍스트·테두리 제거, 사진 간격을 2px로 좁혀 촘촘하게 흐른다. 사진 없는 기록은 프사로 칸을 꽉 채워 같은 결로 읽힌다.
- 칸을 누르면 **릴스 상세 뷰어**(`RecordReelViewer`)가 그 장부터 풀스크린으로 열린다.
  - 위아래 **세로 스와이프**로 순서대로 이동(`snap-y snap-mandatory`, 자동 전환 없음).
  - 검은 무대에 사진이 주인공, 하단 그라디언트에 **거리를 큰 숫자로** 세우고(러닝 자랑의 핵심) 종목·날짜·한마디·올린 사람을 얹는다.
  - 사진 없는 기록은 프사 블러 배경 + 중앙 또렷 프사로 무대를 만든다.
  - 이름·프사를 누르면 **프로필 카드가 뷰어 위에 겹쳐(stacked)** 열리고, 닫으면 릴스로 복귀한다.
  - 프로젝트 `Dialog` 래퍼를 써 **안드로이드 뒤로가기**가 앱 종료가 아니라 릴스 닫기로 동작한다.
- 리드 문구: `"기강인들이 남긴 기록"` → **`"우리가 남긴 발자국"`**.
- `hasPosts` 데드코드 및 관련 미사용 헬퍼(`sportLabel`·`formatKm`)·import 정리.

## 변경 흐름 (Mermaid)

```mermaid
flowchart TD
    A[레코드보드 격자<br/>사진만] -->|칸 클릭| B[릴스 뷰어<br/>RecordReelViewer]
    B -->|위아래 세로 스와이프| B
    B -->|이름·프사 탭| C[프로필 카드<br/>MemberCardDialog stacked]
    C -->|닫기| B
    B -->|X · 뒤로가기| A
```

## 주요 변경 사항

- `components/story/record-reel-viewer.tsx` (신규): 릴스형 풀스크린 상세 뷰어
- `components/story/record-flex-feed.tsx`: 격자 사진-only 전환, 리드 문구, 데드코드 정리, 뷰어 연동
- `components/story/story-client.tsx`: `RecordFlexFeed`에 `teamId` 전달(뷰어 내 프로필 카드용)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새로운 기능**
  * 기록 피드를 사진 중심의 격자 형태로 개선했습니다.
  * 게시물을 누르면 전체 화면 릴스 형식으로 기록을 이어서 볼 수 있습니다.
  * 릴스에서 멤버 프로필 카드를 확인할 수 있습니다.
  * 사진이 없는 기록도 아바타와 함께 자연스럽게 표시됩니다.
* **개선 사항**
  * 기록의 한마디, 거리, 종목, 날짜 정보를 릴스 화면에서 확인할 수 있습니다.
  * 기록 피드의 페이징 및 중복 표시를 안정적으로 처리합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->