### PR TITLE
feat(profile): 프로필탭 얼굴에 사진 변경 배지 추가

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -274,6 +274,7 @@ import { H1, H2, Body, Caption, Micro, SectionLabel } from "@/components/common/
 | MemberCardDetail | `member-card-detail.tsx` | `memId`, `data`, `locked?`, `edit?` | 소개판 본체 — **한 컴포넌트가 두 판을 그린다**(§아래). `edit`이 있으면 편집판(프로필탭), 없으면 공개판(팝업). 편집 핸들러는 전부 `edit` 안에 모여 있다(한마디 포함) |
 | MemberCardDialog | `member-card-dialog.tsx` | `memId`, `memNm?`, `teamId`, `open`, `onOpenChange`, `stacked?` | **공개판 전용.** 오픈 시 RPC 1회 + 스켈레톤·재시도·탈퇴 폴백. `stacked`로 다른 시트 위에 겹침. `isOwner`는 없다 — 내 카드를 열어도 편집 어포던스가 없다 |
 | IntroEditDialog | `intro-edit-dialog.tsx` | `open`, `onOpenChange`, `initialValue`, `onSaved?`, `stacked?` | 한마디 한 줄 인라인 편집(페이지 이동 없음) |
+| AvatarEditDialog | `profile/avatar-edit-dialog.tsx` | `open`, `onOpenChange`, `memId`, `memNm`, `currentUrl`, `onSaved?` | 프로필 사진 인라인 변경 — 미리보기 + 기본 이미지로 되돌리기 |
 | ProfileTabCard | `profile/profile-tab-card.tsx` | `memId`, `teamMemId`, `teamId`, `card`, `utmb`, … | 프로필탭 본문 — `MemberCardDetail`에 `edit`을 물리고 편집 다이얼로그들을 연결 |
 
 - **간단 vs 상세**: 간단 카드는 "이 사람이 누구인지"(한마디·러닝 프로필), 상세 카드는 "이 사람의 실적".
@@ -366,9 +367,20 @@ import { H1, H2, Body, Caption, Micro, SectionLabel } from "@/components/common/
 - **활동 포인트**(`stats.activity_score`) — 최근활동 헤더 우측 primary pill + `HelpTip`
   ("모임 참석·대회 출전·기록 등록으로 쌓여요"). 적립 규칙 전문은 여전히 비공개.
   **남의 카드에는 절대 노출하지 않는다** — 공개되면 사실상 공개 랭킹 지표가 된다(렌더 테스트가 지킨다).
-- **편집 진입점**: 한마디·칭호·기록 관리/추가·UTMB는 그 자리에서 다이얼로그로 열고,
+- **편집 진입점**: 사진·한마디·칭호·기록 관리/추가·UTMB는 그 자리에서 다이얼로그로 열고,
   **러닝 프로필 + 가입 목적만 `/profile/edit#running-profile`로 보낸다.** 역 콤보박스·페이스 셀렉트·
-  목적 칩을 다이얼로그로 다시 만들면 폼이 두 벌이 되어 한쪽만 고쳐 어긋난다.
+  목적 칩을 다이얼로그로 다시 만들면 폼이 두 벌이 되어 한쪽만 고쳐 어긋난다. 사진은 파일 하나를
+  고르는 일이라 폼이 두 벌이 되지 않으므로 다이얼로그 쪽이다.
+- **프로필 사진은 얼굴 우하단 카메라 배지**(`AvatarEditDialog`). 얼굴 탭은 이미 공개판 팝업을
+  여는 자리라 진입점을 겹칠 수 없어 배지로 뗐고, 배지는 아바타 버튼의 **형제**로 둔다(안에 넣으면
+  버튼 속 버튼이라 마크업이 깨지고 사진 변경 탭이 팝업까지 연다). 판 색 테(`ring-board`)로 얼굴에서
+  떼어 놓고 앰버는 쓰지 않는다 — 스크린 존 계기 표시 전용이라서.
+  **공개판엔 당연히 안 붙는다**(렌더 테스트가 지킨다).
+  `/profile/edit` 맨 위 사진 영역은 **그대로 둔다** — 편집 페이지에서 사진만 못 바꾸는 게 더
+  이상하다. 대신 서버 처리(HEIC 변환·EXIF 회전·512 정사각 webp·업로드·옛 파일 제거)는
+  `lib/storage/avatar.ts` 한 곳을 `updateProfile`·`updateAvatar` 두 액션이 공유한다
+  (각자 만들면 한쪽만 `.rotate()`를 빠뜨려 사진이 눕는 걸 눈으로만 알게 된다 —
+  `lib/storage/post-photo.ts`와 같은 이유). 사진을 바꿔도 **전당 캐시는 안 턴다**(§기강의 전당).
 - 프로필탭은 **서버에서** `getPublicMemberCard()`를 부른다. 클라이언트 조회로 옮기면 편집 액션들의
   `revalidatePath("/profile")`이 통째로 무력화된다.
 - RPC는 `mem_st_cd = 'active'`만 돌려주므로 **비활성·탈퇴면 카드가 null**이다 — 빈 화면 대신

--- a/app/actions/profile/update-avatar.ts
+++ b/app/actions/profile/update-avatar.ts
@@ -45,10 +45,13 @@ export async function updateAvatar(formData: FormData): Promise<Result> {
     const oldPath = avatarPathInBucket(supabase, member.avatar_url);
 
     let avatarUrl: string | null = null;
+    // 방금 올린 파일 — DB가 안 받으면 되돌려 지운다(아래 error 분기)
+    let newPath: string | null = null;
     if (hasFile) {
       const uploaded = await uploadAvatar(supabase, member.id, file);
       if (!uploaded.ok) return { ok: false, message: uploaded.message };
       avatarUrl = uploaded.url;
+      newPath = uploaded.path;
     }
 
     const { error } = await supabase
@@ -60,6 +63,8 @@ export async function updateAvatar(formData: FormData): Promise<Result> {
 
     if (error) {
       console.error("[update-avatar] mem_mst error:", error);
+      // DB가 안 받았으면 방금 올린 파일은 아무도 참조하지 않는다 — 고아로 남기지 않는다
+      await removeAvatarFile(supabase, newPath);
       return { ok: false, message: "저장에 실패했습니다." };
     }
 

--- a/app/actions/profile/update-avatar.ts
+++ b/app/actions/profile/update-avatar.ts
@@ -1,0 +1,72 @@
+"use server";
+
+import { revalidatePath } from "next/cache";
+
+import { withActive } from "@/lib/actions/auth";
+import {
+  avatarPathInBucket,
+  removeAvatarFile,
+  uploadAvatar,
+  validateAvatarFile,
+} from "@/lib/storage/avatar";
+
+type Result =
+  | { ok: true; avatarUrl: string | null }
+  | { ok: false; message: string };
+
+/**
+ * 프로필 사진만 바꾸기 — 프로필탭 아바타의 카메라 배지가 부른다.
+ *
+ * `updateProfile`과 갈라 둔 이유: 저쪽은 이름·성별·생년월일·이메일을 **함께** 받아
+ * `profileEditSchema`로 검증한다. 사진만 고치자고 그 값들을 프로필탭이 들고 다니며
+ * 되돌려 보내면, 폼 스키마가 바뀔 때 이 경로가 조용히 어긋난다.
+ *
+ * 이미지 처리·업로드·옛 파일 제거는 `lib/storage/avatar.ts`를 두 액션이 공유한다.
+ *
+ * **전당 캐시(`records-team-v6`)는 일부러 안 턴다.** 프사가 거기 보이는 건 종목별 1위뿐인데
+ * 무효화는 대상을 못 가려서, 아무나 사진 한 장 바꿀 때마다 전당 전체가 캐시 미스가 된다
+ * (한마디·대표 칭호와 같은 규칙 — §DESIGN.md 기강의 전당).
+ */
+export async function updateAvatar(formData: FormData): Promise<Result> {
+  const file = formData.get("file") as File | null;
+  const hasFile = !!file && file.size > 0;
+  const remove = formData.get("removeAvatar") === "true";
+
+  if (!hasFile && !remove) {
+    return { ok: false, message: "변경할 사진이 없습니다." };
+  }
+
+  if (hasFile) {
+    const invalid = validateAvatarFile(file);
+    if (invalid) return { ok: false, message: invalid };
+  }
+
+  return withActive(async ({ member, supabase }) => {
+    const oldPath = avatarPathInBucket(supabase, member.avatar_url);
+
+    let avatarUrl: string | null = null;
+    if (hasFile) {
+      const uploaded = await uploadAvatar(supabase, member.id, file);
+      if (!uploaded.ok) return { ok: false, message: uploaded.message };
+      avatarUrl = uploaded.url;
+    }
+
+    const { error } = await supabase
+      .from("mem_mst")
+      .update({ avatar_url: avatarUrl })
+      .eq("mem_id", member.id)
+      .eq("vers", 0)
+      .eq("del_yn", false);
+
+    if (error) {
+      console.error("[update-avatar] mem_mst error:", error);
+      return { ok: false, message: "저장에 실패했습니다." };
+    }
+
+    // DB 커밋 성공 후에만 기존 파일 제거 (실패는 무시)
+    await removeAvatarFile(supabase, oldPath);
+
+    revalidatePath("/profile");
+    return { ok: true, avatarUrl };
+  });
+}

--- a/app/actions/update-profile.ts
+++ b/app/actions/update-profile.ts
@@ -1,18 +1,13 @@
 "use server";
 
 import { withActive } from "@/lib/actions/auth";
+import {
+  avatarPathInBucket,
+  removeAvatarFile,
+  uploadAvatar,
+  validateAvatarFile,
+} from "@/lib/storage/avatar";
 import { profileEditSchema } from "@/lib/validations/member";
-
-const MAX_SIZE = 512;
-const QUALITY = 80;
-const MAX_FILE_SIZE = 10 * 1024 * 1024; // 10MB
-const ALLOWED_TYPES = [
-  "image/jpeg",
-  "image/png",
-  "image/webp",
-  "image/heic",
-  "image/heif",
-];
 
 type Result =
   | { ok: true; avatarUrl?: string | null }
@@ -39,78 +34,23 @@ export async function updateProfile(formData: FormData): Promise<Result> {
   const hasFile = !!file && file.size > 0;
   const removeAvatar = formData.get("removeAvatar") === "true";
 
+  // 사진 검증은 DB 왕복 전에 — 이름만 고쳤는데 사진이 틀려 저장이 반쯤 되는 걸 막는다
   if (hasFile) {
-    if (file.size > MAX_FILE_SIZE)
-      return { ok: false, message: "이미지는 10MB 이하만 가능합니다." };
-    if (!ALLOWED_TYPES.includes(file.type))
-      return { ok: false, message: "JPG, PNG, WebP, HEIC 형식만 가능합니다." };
+    const invalid = validateAvatarFile(file);
+    if (invalid) return { ok: false, message: invalid };
   }
 
   return withActive(async ({ member, supabase }) => {
-    const bucketUrl = supabase.storage.from("avatars").getPublicUrl("").data
-      .publicUrl;
-    const currentInBucket =
-      member.avatar_url && member.avatar_url.startsWith(bucketUrl)
-        ? member.avatar_url.replace(bucketUrl, "")
-        : null;
+    const currentInBucket = avatarPathInBucket(supabase, member.avatar_url);
 
     // undefined = avatar_url 미변경
     let newAvatarUrl: string | null | undefined = undefined;
     let oldPathToRemove: string | null = null;
 
     if (hasFile) {
-      let buffer = Buffer.from(await file.arrayBuffer());
-
-      const isHeic = file.type === "image/heic" || file.type === "image/heif";
-      if (isHeic) {
-        try {
-          // @ts-expect-error -- heic-convert에 타입 선언 없음
-          const { default: convert } = await import("heic-convert");
-          const converted = await convert({
-            buffer,
-            format: "JPEG",
-            quality: 0.9,
-          });
-          buffer = Buffer.from(converted);
-        } catch (e) {
-          console.error("[update-profile] heic-convert error:", e);
-          return {
-            ok: false,
-            message: "HEIC 변환에 실패했습니다. JPG로 변환 후 다시 시도해 주세요.",
-          };
-        }
-      }
-
-      let resized: Buffer;
-      try {
-        const { default: sharp } = await import("sharp");
-        resized = await sharp(buffer)
-          .rotate()
-          .resize(MAX_SIZE, MAX_SIZE, { fit: "cover" })
-          .webp({ quality: QUALITY })
-          .toBuffer();
-      } catch (e) {
-        console.error("[update-profile] sharp error:", e);
-        return {
-          ok: false,
-          message: "이미지 처리에 실패했습니다. JPG 또는 PNG로 변환 후 다시 시도해 주세요.",
-        };
-      }
-
-      const filePath = `${member.id}/${Date.now()}.webp`;
-      const { error: uploadError } = await supabase.storage
-        .from("avatars")
-        .upload(filePath, resized, {
-          upsert: true,
-          contentType: "image/webp",
-        });
-      if (uploadError) {
-        console.error("[update-profile] storage error:", uploadError);
-        return { ok: false, message: `업로드 실패: ${uploadError.message}` };
-      }
-
-      newAvatarUrl = supabase.storage.from("avatars").getPublicUrl(filePath)
-        .data.publicUrl;
+      const uploaded = await uploadAvatar(supabase, member.id, file);
+      if (!uploaded.ok) return { ok: false, message: uploaded.message };
+      newAvatarUrl = uploaded.url;
       oldPathToRemove = currentInBucket;
     } else if (removeAvatar) {
       newAvatarUrl = null;
@@ -139,9 +79,7 @@ export async function updateProfile(formData: FormData): Promise<Result> {
     }
 
     // DB 커밋 성공 후에만 기존 파일 제거 (실패는 무시)
-    if (oldPathToRemove) {
-      await supabase.storage.from("avatars").remove([oldPathToRemove]);
-    }
+    await removeAvatarFile(supabase, oldPathToRemove);
 
     return { ok: true, avatarUrl: newAvatarUrl };
   });

--- a/app/actions/update-profile.ts
+++ b/app/actions/update-profile.ts
@@ -46,11 +46,14 @@ export async function updateProfile(formData: FormData): Promise<Result> {
     // undefined = avatar_url 미변경
     let newAvatarUrl: string | null | undefined = undefined;
     let oldPathToRemove: string | null = null;
+    // 방금 올린 파일 — DB가 안 받으면 되돌려 지운다(아래 eMst 분기)
+    let newPathToRollback: string | null = null;
 
     if (hasFile) {
       const uploaded = await uploadAvatar(supabase, member.id, file);
       if (!uploaded.ok) return { ok: false, message: uploaded.message };
       newAvatarUrl = uploaded.url;
+      newPathToRollback = uploaded.path;
       oldPathToRemove = currentInBucket;
     } else if (removeAvatar) {
       newAvatarUrl = null;
@@ -75,6 +78,8 @@ export async function updateProfile(formData: FormData): Promise<Result> {
 
     if (eMst) {
       console.error("[update-profile] mem_mst error:", eMst);
+      // DB가 안 받았으면 방금 올린 파일은 아무도 참조하지 않는다 — 고아로 남기지 않는다
+      await removeAvatarFile(supabase, newPathToRollback);
       return { ok: false, message: "저장에 실패했습니다." };
     }
 

--- a/components/members/__tests__/member-card-detail-render.test.ts
+++ b/components/members/__tests__/member-card-detail-render.test.ts
@@ -45,6 +45,7 @@ const BASE: MemberCardData = {
 
 const EDIT = {
   onOpenPublicCard: () => {},
+  onEditAvatar: () => {},
   onEditIntro: () => {},
   onEditTitles: () => {},
   onEditProfile: () => {},
@@ -108,6 +109,14 @@ describe("편집판(내 프로필탭)", () => {
     expect(render({ rctn_recv_cnt: 1484 }, true)).toContain("1,484");
   });
 
+  // 얼굴 탭은 공개판 팝업을 여는 자리라, 사진 변경 진입점은 별도 배지여야 한다.
+  // 하나로 합치면 사진을 바꾸려던 탭이 팝업을 연다.
+  it("얼굴에 사진 변경 배지가 붙고, 카드 보기 버튼과 따로 선다", () => {
+    const html = render({}, true);
+    expect(html).toContain("프로필 사진 변경");
+    expect(html).toContain("남들에게 보이는 내 카드 보기");
+  });
+
   it("대표 칭호가 없으면 점선 껍데기가 자리를 지킨다", () => {
     expect(render({ primary_title: null }, true)).toContain("대표 칭호 고르기");
   });
@@ -166,6 +175,7 @@ describe("공개판(남이 보는 카드)", () => {
     // 고치는 자리는 프로필탭 한 곳이다. 팝업은 결과를 확인하는 자리라 한마디도 못 고친다.
     expect(html).not.toContain("한마디 수정");
     expect(html).not.toContain("한마디 남기기");
+    expect(html).not.toContain("프로필 사진 변경");
     expect(html).toContain("올해는 서브4 간다"); // 읽히기는 한다
   });
 

--- a/components/members/__tests__/member-card-detail-render.test.ts
+++ b/components/members/__tests__/member-card-detail-render.test.ts
@@ -110,11 +110,19 @@ describe("편집판(내 프로필탭)", () => {
   });
 
   // 얼굴 탭은 공개판 팝업을 여는 자리라, 사진 변경 진입점은 별도 배지여야 한다.
-  // 하나로 합치면 사진을 바꾸려던 탭이 팝업을 연다.
-  it("얼굴에 사진 변경 배지가 붙고, 카드 보기 버튼과 따로 선다", () => {
+  // 배지를 아바타 버튼 **안에** 넣으면 버튼 속 버튼이라 마크업이 깨지고, 사진을 바꾸려던
+  // 탭이 팝업까지 연다 — 라벨 존재만 보면 그 회귀를 못 잡으므로 중첩 여부를 직접 못박는다.
+  it("얼굴에 사진 변경 배지가 붙고, 카드 보기 버튼 안에 중첩되지 않는다", () => {
     const html = render({}, true);
     expect(html).toContain("프로필 사진 변경");
-    expect(html).toContain("남들에게 보이는 내 카드 보기");
+
+    const cardBtnAt = html.indexOf("남들에게 보이는 내 카드 보기");
+    const cardBtnEnd = html.indexOf("</button>", cardBtnAt);
+    const badgeAt = html.indexOf("프로필 사진 변경");
+
+    expect(cardBtnAt).toBeGreaterThan(-1);
+    // 배지가 카드 보기 버튼이 닫힌 뒤에 나온다 = 그 안에 들어 있지 않다
+    expect(badgeAt).toBeGreaterThan(cardBtnEnd);
   });
 
   it("대표 칭호가 없으면 점선 껍데기가 자리를 지킨다", () => {

--- a/components/members/member-card-detail.tsx
+++ b/components/members/member-card-detail.tsx
@@ -6,6 +6,7 @@ import Link from "next/link";
 
 import {
   CalendarDays,
+  Camera,
   ChevronDown,
   ChevronRight,
   History,
@@ -76,6 +77,8 @@ const PURPOSE_TIP_MS = 3000;
 export type MemberCardEdit = {
   /** 얼굴·이름 탭 → 남들에게 보이는 내 카드(팝업) */
   onOpenPublicCard: () => void;
+  /** 얼굴 우하단 카메라 배지 → 프로필 사진 변경 */
+  onEditAvatar: () => void;
   /** 한마디 줄 탭 → 한 줄 인라인 편집 */
   onEditIntro: () => void;
   /** 대표 칭호 옆 연필 → 내 컬렉션 */
@@ -349,20 +352,36 @@ export function MemberCardDetail({
 
         <div className="relative flex flex-col items-center gap-1.5">
           {edit ? (
-            <button
-              type="button"
-              onClick={edit.onOpenPublicCard}
-              aria-label="남들에게 보이는 내 카드 보기"
-              className="rounded-full transition-opacity active:opacity-80 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-board-amber"
-            >
-              <Avatar
-                src={data.avatar_url}
-                seed={memId}
-                alt={data.mem_nm}
-                size="2xl"
-                className="ring-2 ring-board-foreground/15"
-              />
-            </button>
+            // 얼굴 탭은 이미 공개판 팝업을 여는 자리라, 사진 변경은 우하단 배지로 뗀다.
+            // 배지는 아바타 버튼의 **형제**여야 한다 — 안에 넣으면 버튼 속 버튼이라 마크업이
+            // 깨지고, 사진 변경 탭이 팝업까지 같이 연다.
+            <div className="relative">
+              <button
+                type="button"
+                onClick={edit.onOpenPublicCard}
+                aria-label="남들에게 보이는 내 카드 보기"
+                className="rounded-full transition-opacity active:opacity-80 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-board-amber"
+              >
+                <Avatar
+                  src={data.avatar_url}
+                  seed={memId}
+                  alt={data.mem_nm}
+                  size="2xl"
+                  className="ring-2 ring-board-foreground/15"
+                />
+              </button>
+
+              {/* 판 색으로 테를 둘러(ring-board) 아바타에서 떼어 놓는다. 앰버는 계기 표시
+                  전용이라 여기 안 쓰고, 히트 영역은 28px로 손가락이 겨냥할 수 있게 잡는다. */}
+              <button
+                type="button"
+                onClick={edit.onEditAvatar}
+                aria-label="프로필 사진 변경"
+                className="absolute bottom-0 right-0 inline-flex size-7 items-center justify-center rounded-full bg-primary text-primary-foreground ring-2 ring-board transition-opacity active:opacity-80 focus-visible:outline-none focus-visible:ring-board-amber"
+              >
+                <Camera aria-hidden className="size-3.5" />
+              </button>
+            </div>
           ) : (
             <Avatar
               src={data.avatar_url}

--- a/components/profile/avatar-edit-dialog.tsx
+++ b/components/profile/avatar-edit-dialog.tsx
@@ -95,7 +95,9 @@ function AvatarEditForm({
   const [saving, setSaving] = useState(false);
   const fileInputRef = useRef<HTMLInputElement>(null);
 
-  // 언마운트/상태 교체 시 미리보기 objectURL 정리
+  // 미리보기 objectURL 정리는 **여기 한 곳**이 맡는다. `state`가 deps라 사진을 바꿔 끼울
+  // 때도 cleanup이 직전 URL을 들고 돌고, 언마운트도 같은 경로다 — 고르기·되돌리기 쪽에서
+  // 따로 해제하면 같은 책임이 세 군데로 흩어진다.
   useEffect(() => {
     return () => {
       if (state.kind === "new") URL.revokeObjectURL(state.previewUrl);
@@ -115,10 +117,10 @@ function AvatarEditForm({
     setCompressing(true);
     try {
       const processed = await compressAvatarFile(file);
-      const previewUrl = URL.createObjectURL(processed);
-      setState((prev) => {
-        if (prev.kind === "new") URL.revokeObjectURL(prev.previewUrl);
-        return { kind: "new", file: processed, previewUrl };
+      setState({
+        kind: "new",
+        file: processed,
+        previewUrl: URL.createObjectURL(processed),
       });
     } catch {
       toast.error("이미지를 불러오지 못했습니다. 다른 사진으로 시도해 주세요.");
@@ -128,10 +130,7 @@ function AvatarEditForm({
   }
 
   function handleRemovePhoto() {
-    setState((prev) => {
-      if (prev.kind === "new") URL.revokeObjectURL(prev.previewUrl);
-      return { kind: "removed" };
-    });
+    setState({ kind: "removed" });
   }
 
   const previewSrc =

--- a/components/profile/avatar-edit-dialog.tsx
+++ b/components/profile/avatar-edit-dialog.tsx
@@ -1,0 +1,246 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+import { useRouter } from "next/navigation";
+
+import { toast } from "sonner";
+import { Camera } from "lucide-react";
+
+import { updateAvatar } from "@/app/actions/profile/update-avatar";
+import { compressAvatarFile } from "@/lib/image/avatar-compress";
+
+import { Avatar } from "@/components/common/avatar";
+import {
+  ResponsiveDrawer,
+  ResponsiveDrawerContent,
+  ResponsiveDrawerHeader,
+  ResponsiveDrawerTitle,
+} from "@/components/common/responsive-drawer";
+import { Caption } from "@/components/common/typography";
+import { Button } from "@/components/ui/button";
+
+/** 클라이언트 선검증 — 서버(`validateAvatarFile`)와 같은 값. 넘치면 올리기 전에 잡는다 */
+const MAX_BYTES = 10 * 1024 * 1024;
+
+const ACCEPT = "image/jpeg,image/png,image/webp,image/heic,image/heif";
+
+type AvatarState =
+  | { kind: "current" }
+  | { kind: "new"; file: File; previewUrl: string }
+  | { kind: "removed" };
+
+/**
+ * 프로필 사진 인라인 편집 — 프로필 수정 화면으로 이동하지 않고 사진만 바꾼다.
+ *
+ * 한마디(`IntroEditDialog`)와 같은 그릇·같은 어법이다: 프로필탭의 편집 진입점은 그 자리에서
+ * 다이얼로그로 여는 게 기본이고, 폼이 두 벌이 될 위험이 있는 것(러닝 프로필)만 `/profile/edit`로
+ * 보낸다. 사진은 파일 하나 고르는 일이라 폼이 두 벌이 되지 않는다.
+ *
+ * `/profile/edit` 맨 위 사진 영역은 그대로 둔다 — 편집 페이지에서 사진만 못 바꾸는 게 더 이상하고,
+ * 저장은 양쪽 다 `lib/storage/avatar.ts` 한 곳을 지난다.
+ */
+export function AvatarEditDialog({
+  open,
+  onOpenChange,
+  memId,
+  memNm,
+  currentUrl,
+  onSaved,
+}: {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  /** 프사 미설정 시 폴백 아바타 seed */
+  memId: string;
+  memNm: string;
+  currentUrl: string | null;
+  /** 저장 성공 후 호출 — 열려 있는 카드의 사진을 갱신하는 용도 */
+  onSaved?: (avatarUrl: string | null) => void;
+}) {
+  // 닫혀 있을 땐 폼을 언마운트한다 — 재진입 시 이전에 고른 사진이 남지 않게(IntroEditDialog와 동일).
+  if (!open) {
+    return (
+      <ResponsiveDrawer open={false} onOpenChange={onOpenChange}>
+        <></>
+      </ResponsiveDrawer>
+    );
+  }
+
+  return (
+    <AvatarEditForm
+      onOpenChange={onOpenChange}
+      memId={memId}
+      memNm={memNm}
+      currentUrl={currentUrl}
+      onSaved={onSaved}
+    />
+  );
+}
+
+function AvatarEditForm({
+  onOpenChange,
+  memId,
+  memNm,
+  currentUrl,
+  onSaved,
+}: {
+  onOpenChange: (open: boolean) => void;
+  memId: string;
+  memNm: string;
+  currentUrl: string | null;
+  onSaved?: (avatarUrl: string | null) => void;
+}) {
+  const router = useRouter();
+  const [state, setState] = useState<AvatarState>({ kind: "current" });
+  const [compressing, setCompressing] = useState(false);
+  const [saving, setSaving] = useState(false);
+  const fileInputRef = useRef<HTMLInputElement>(null);
+
+  // 언마운트/상태 교체 시 미리보기 objectURL 정리
+  useEffect(() => {
+    return () => {
+      if (state.kind === "new") URL.revokeObjectURL(state.previewUrl);
+    };
+  }, [state]);
+
+  async function handlePickFile(e: React.ChangeEvent<HTMLInputElement>) {
+    const file = e.target.files?.[0];
+    e.target.value = ""; // 같은 파일 재선택 허용
+    if (!file) return;
+
+    if (file.size > MAX_BYTES) {
+      toast.error("이미지는 10MB 이하만 가능합니다.");
+      return;
+    }
+
+    setCompressing(true);
+    try {
+      const processed = await compressAvatarFile(file);
+      const previewUrl = URL.createObjectURL(processed);
+      setState((prev) => {
+        if (prev.kind === "new") URL.revokeObjectURL(prev.previewUrl);
+        return { kind: "new", file: processed, previewUrl };
+      });
+    } catch {
+      toast.error("이미지를 불러오지 못했습니다. 다른 사진으로 시도해 주세요.");
+    } finally {
+      setCompressing(false);
+    }
+  }
+
+  function handleRemovePhoto() {
+    setState((prev) => {
+      if (prev.kind === "new") URL.revokeObjectURL(prev.previewUrl);
+      return { kind: "removed" };
+    });
+  }
+
+  const previewSrc =
+    state.kind === "new"
+      ? state.previewUrl
+      : state.kind === "removed"
+        ? null
+        : currentUrl;
+
+  // 지울 사진이 있는지: 새 사진을 골랐거나, 기존 사진이 그대로 있을 때
+  const hasRemovablePhoto =
+    state.kind === "new" || (state.kind === "current" && !!currentUrl);
+
+  const busy = saving || compressing;
+
+  async function handleSave() {
+    if (busy || state.kind === "current") return;
+
+    setSaving(true);
+    try {
+      const formData = new FormData();
+      if (state.kind === "new") formData.append("file", state.file);
+      else formData.append("removeAvatar", "true");
+
+      const result = await updateAvatar(formData);
+      if (!result.ok) {
+        toast.error(result.message ?? "저장에 실패했습니다");
+        return;
+      }
+      onSaved?.(result.avatarUrl);
+      onOpenChange(false);
+      router.refresh();
+      toast.success("프로필 사진을 바꿨어요");
+    } catch {
+      toast.error("저장 중 문제가 발생했습니다. 잠시 후 다시 시도해 주세요.");
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  return (
+    <ResponsiveDrawer open onOpenChange={onOpenChange}>
+      <ResponsiveDrawerContent
+        className="flex flex-col gap-0"
+        dialogClassName="max-w-sm"
+      >
+        <ResponsiveDrawerHeader className="px-4 py-4 text-left">
+          <ResponsiveDrawerTitle>프로필 사진</ResponsiveDrawerTitle>
+        </ResponsiveDrawerHeader>
+
+        <div className="flex flex-col gap-3 px-4 pb-6">
+          {/* 미리보기 자체가 고르기 버튼이다 — 수정 화면(`/profile/edit`)과 같은 조작감 */}
+          <div className="flex flex-col items-center gap-2">
+            <button
+              type="button"
+              onClick={() => fileInputRef.current?.click()}
+              disabled={busy}
+              aria-label="사진 고르기"
+              className="relative size-24 overflow-hidden rounded-full focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+            >
+              <Avatar src={previewSrc} seed={memId} size="2xl" alt={memNm} />
+              <span className="absolute inset-0 flex items-center justify-center rounded-full bg-black/10 transition-colors hover:bg-black/30">
+                <Camera aria-hidden className="size-6 text-white" />
+              </span>
+            </button>
+            <input
+              ref={fileInputRef}
+              type="file"
+              accept={ACCEPT}
+              onChange={handlePickFile}
+              className="hidden"
+            />
+            <div className="flex items-center gap-3">
+              <Caption>
+                {compressing ? "사진 준비 중..." : "사진을 탭하여 변경"}
+              </Caption>
+              {hasRemovablePhoto && !busy && (
+                <button
+                  type="button"
+                  onClick={handleRemovePhoto}
+                  className="text-xs text-destructive underline-offset-2 hover:underline"
+                >
+                  기본 이미지로
+                </button>
+              )}
+            </div>
+          </div>
+
+          <div className="flex gap-2">
+            <Button
+              type="button"
+              variant="outline"
+              className="flex-1"
+              onClick={() => onOpenChange(false)}
+              disabled={saving}
+            >
+              취소
+            </Button>
+            <Button
+              type="button"
+              className="flex-1"
+              onClick={() => void handleSave()}
+              disabled={busy || state.kind === "current"}
+            >
+              {saving ? "저장 중..." : "저장"}
+            </Button>
+          </div>
+        </div>
+      </ResponsiveDrawerContent>
+    </ResponsiveDrawer>
+  );
+}

--- a/components/profile/profile-tab-card.tsx
+++ b/components/profile/profile-tab-card.tsx
@@ -6,6 +6,7 @@ import { useRouter } from "next/navigation";
 import { IntroEditDialog } from "@/components/members/intro-edit-dialog";
 import { MemberCardDetail } from "@/components/members/member-card-detail";
 import { MemberCardDialogDynamic as MemberCardDialog } from "@/components/members/member-card-dialog-dynamic";
+import { AvatarEditDialog } from "@/components/profile/avatar-edit-dialog";
 import { CollectionSheet } from "@/components/profile/collection-sheet";
 import { RaceHistoryDialog } from "@/components/profile/race-history-dialog";
 import { RaceRecordDialog } from "@/components/profile/race-record-dialog";
@@ -58,6 +59,7 @@ export function ProfileTabCard({
   const [collectionOpen, setCollectionOpen] = useState(false);
   const [publicCardOpen, setPublicCardOpen] = useState(false);
   const [introOpen, setIntroOpen] = useState(false);
+  const [avatarOpen, setAvatarOpen] = useState(false);
   const [recordOpen, setRecordOpen] = useState(false);
   const [historyOpen, setHistoryOpen] = useState(false);
   const [utmbOpen, setUtmbOpen] = useState(false);
@@ -65,11 +67,16 @@ export function ProfileTabCard({
   // 저장 직후 router.refresh()가 돌기 전에도 바뀐 값이 보이도록 낙관적으로 덮어쓴다.
   const [intro, setIntro] = useState(card.intro_txt ?? "");
   const [utmbState, setUtmbState] = useState(utmb);
+  // undefined = 아직 안 고침(서버 값 그대로). null은 "기본 이미지로 되돌림"이라 구분이 필요하다.
+  const [avatarUrl, setAvatarUrl] = useState<string | null | undefined>(
+    undefined,
+  );
 
   const view: MemberCardData = {
     ...card,
     intro_txt: intro || null,
     utmb_index: utmbState?.utmb_index ?? null,
+    ...(avatarUrl !== undefined && { avatar_url: avatarUrl }),
   };
 
   return (
@@ -79,6 +86,7 @@ export function ProfileTabCard({
         data={view}
         edit={{
           onOpenPublicCard: () => setPublicCardOpen(true),
+          onEditAvatar: () => setAvatarOpen(true),
           onEditIntro: () => setIntroOpen(true),
           onEditTitles: () => setCollectionOpen(true),
           onEditProfile: () => router.push(RUNNING_PROFILE_HREF),
@@ -87,6 +95,15 @@ export function ProfileTabCard({
           onLinkUtmb: () => setUtmbOpen(true),
           point: card.stats.activity_score,
         }}
+      />
+
+      <AvatarEditDialog
+        open={avatarOpen}
+        onOpenChange={setAvatarOpen}
+        memId={memId}
+        memNm={card.mem_nm}
+        currentUrl={view.avatar_url}
+        onSaved={setAvatarUrl}
       />
 
       <IntroEditDialog

--- a/lib/storage/avatar.ts
+++ b/lib/storage/avatar.ts
@@ -1,0 +1,139 @@
+import "server-only";
+
+import type { SupabaseClient } from "@supabase/supabase-js";
+
+import { AVATAR_TARGET_PX } from "@/lib/image/avatar-compress";
+
+/**
+ * 아바타 사진 처리 — 검증 → HEIC 변환 → 정사각 리사이즈 → Storage 업로드 → 옛 파일 제거.
+ *
+ * **두 경로가 공유한다**: 프로필 수정 화면 전체 저장(`updateProfile`)과 프로필탭의 사진만
+ * 바꾸기(`updateAvatar`). 액션마다 복붙해 두면 한쪽만 EXIF 회전(`.rotate()`)이나 HEIC 변환을
+ * 빠뜨려도 아무도 모른다 — 사진이 눕거나 아이폰 기본 포맷 업로드가 실패하는 건 눈으로 봐야만
+ * 드러난다(`lib/storage/post-photo.ts`와 같은 이유·같은 어법).
+ *
+ * 규격 상수(512px)는 `lib/image/avatar-compress.ts`에 있다 — 클라이언트가 업로드 전에
+ * **같은 크기로** 미리 줄이기 때문이다(이 파일은 `server-only`라 클라이언트가 import할 수
+ * 없어 상수를 그쪽에 뒀다). 두 값이 갈리면 브라우저가 줄여 보낸 사진을 서버가 한 번 더
+ * 줄여 손실이 겹친다.
+ */
+
+/** 아바타가 사는 버킷. 멤버별 폴더(`{mem_id}/{timestamp}.webp`) */
+export const AVATAR_BUCKET = "avatars";
+
+/** webp 품질 — 클라이언트 선압축(0.85)보다 낮게 잡아도 이미 줄어든 사진이라 차이가 작다 */
+const AVATAR_QUALITY = 80;
+
+export const AVATAR_MAX_BYTES = 10 * 1024 * 1024;
+
+export const AVATAR_TYPES = [
+  "image/jpeg",
+  "image/png",
+  "image/webp",
+  "image/heic",
+  "image/heif",
+] as const;
+
+/** 업로드 전 검증 — 통과하면 null, 아니면 사용자에게 보여줄 문구 */
+export function validateAvatarFile(file: File): string | null {
+  if (file.size > AVATAR_MAX_BYTES) return "이미지는 10MB 이하만 가능합니다.";
+  if (!(AVATAR_TYPES as readonly string[]).includes(file.type))
+    return "JPG, PNG, WebP, HEIC 형식만 가능합니다.";
+  return null;
+}
+
+/**
+ * 현재 아바타 URL이 우리 버킷 안 파일이면 그 경로를, 아니면 null.
+ *
+ * 카카오·구글 OAuth가 넣어 준 외부 URL은 우리가 지울 수 없으므로 여기서 걸러진다.
+ */
+export function avatarPathInBucket(
+  supabase: SupabaseClient,
+  avatarUrl: string | null,
+): string | null {
+  if (!avatarUrl) return null;
+  const bucketUrl = supabase.storage.from(AVATAR_BUCKET).getPublicUrl("").data
+    .publicUrl;
+  return avatarUrl.startsWith(bucketUrl)
+    ? avatarUrl.replace(bucketUrl, "")
+    : null;
+}
+
+export type UploadAvatarResult =
+  | { ok: false; message: string }
+  | { ok: true; url: string };
+
+/**
+ * 아바타 업로드 — HEIC 변환 → 512 정사각 webp → Storage.
+ *
+ * 옛 파일 제거는 **여기서 하지 않는다.** DB 커밋이 실패했는데 파일을 먼저 지우면 프로필
+ * 사진이 통째로 사라지므로, 호출자가 `mem_mst` update 성공 후에 `removeAvatarFile()`을 부른다.
+ */
+export async function uploadAvatar(
+  supabase: SupabaseClient,
+  memberId: string,
+  file: File,
+): Promise<UploadAvatarResult> {
+  const invalid = validateAvatarFile(file);
+  if (invalid) return { ok: false, message: invalid };
+
+  let buffer = Buffer.from(await file.arrayBuffer());
+
+  const isHeic = file.type === "image/heic" || file.type === "image/heif";
+  if (isHeic) {
+    try {
+      // @ts-expect-error -- heic-convert에 타입 선언 없음
+      const { default: convert } = await import("heic-convert");
+      const converted = await convert({ buffer, format: "JPEG", quality: 0.9 });
+      buffer = Buffer.from(converted);
+    } catch (e) {
+      console.error("[avatar] heic-convert error:", e);
+      return {
+        ok: false,
+        message: "HEIC 변환에 실패했습니다. JPG로 변환 후 다시 시도해 주세요.",
+      };
+    }
+  }
+
+  let resized: Buffer;
+  try {
+    const { default: sharp } = await import("sharp");
+    resized = await sharp(buffer)
+      // EXIF 회전을 먼저 먹인다 — 빼면 아이폰 세로 사진이 눕는다
+      .rotate()
+      .resize(AVATAR_TARGET_PX, AVATAR_TARGET_PX, { fit: "cover" })
+      .webp({ quality: AVATAR_QUALITY })
+      .toBuffer();
+  } catch (e) {
+    console.error("[avatar] sharp error:", e);
+    return {
+      ok: false,
+      message:
+        "이미지 처리에 실패했습니다. JPG 또는 PNG로 변환 후 다시 시도해 주세요.",
+    };
+  }
+
+  const filePath = `${memberId}/${Date.now()}.webp`;
+  const { error } = await supabase.storage
+    .from(AVATAR_BUCKET)
+    .upload(filePath, resized, { upsert: true, contentType: "image/webp" });
+  if (error) {
+    console.error("[avatar] storage error:", error);
+    return { ok: false, message: `업로드 실패: ${error.message}` };
+  }
+
+  return {
+    ok: true,
+    url: supabase.storage.from(AVATAR_BUCKET).getPublicUrl(filePath).data
+      .publicUrl,
+  };
+}
+
+/** 옛 파일 제거 — DB 커밋 성공 후에만 부른다. 실패는 무시(고아 파일은 사용자에게 안 보인다) */
+export async function removeAvatarFile(
+  supabase: SupabaseClient,
+  path: string | null,
+): Promise<void> {
+  if (!path) return;
+  await supabase.storage.from(AVATAR_BUCKET).remove([path]);
+}

--- a/lib/storage/avatar.ts
+++ b/lib/storage/avatar.ts
@@ -61,13 +61,19 @@ export function avatarPathInBucket(
 
 export type UploadAvatarResult =
   | { ok: false; message: string }
-  | { ok: true; url: string };
+  | { ok: true; url: string; path: string };
 
 /**
  * 아바타 업로드 — HEIC 변환 → 512 정사각 webp → Storage.
  *
- * 옛 파일 제거는 **여기서 하지 않는다.** DB 커밋이 실패했는데 파일을 먼저 지우면 프로필
- * 사진이 통째로 사라지므로, 호출자가 `mem_mst` update 성공 후에 `removeAvatarFile()`을 부른다.
+ * 파일 제거는 **여기서 하지 않는다.** 사진을 먼저 올리고 DB를 나중에 쓰는 순서라 양쪽으로
+ * 보상이 필요한데, 어느 쪽인지는 호출자만 안다:
+ * - DB 커밋 **성공** → 옛 파일을 지운다(`removeAvatarFile(oldPath)`). 여기서 미리 지우면
+ *   커밋이 실패했을 때 프로필 사진이 통째로 사라진다.
+ * - DB 커밋 **실패** → 방금 올린 파일을 지운다(`removeAvatarFile(path)`). 아무도 참조하지
+ *   않는 채 스토리지에 쌓이기만 한다.
+ *
+ * 반환하는 `path`가 그 되돌리기용이다(`uploadPostPhoto`와 같은 계약).
  */
 export async function uploadAvatar(
   supabase: SupabaseClient,
@@ -118,14 +124,20 @@ export async function uploadAvatar(
     .from(AVATAR_BUCKET)
     .upload(filePath, resized, { upsert: true, contentType: "image/webp" });
   if (error) {
+    // 원문은 로그에만 — Storage 내부 문구는 사용자가 이해할 수 없고 버킷 정책 같은
+    // 내부 사정이 그대로 화면에 실린다.
     console.error("[avatar] storage error:", error);
-    return { ok: false, message: `업로드 실패: ${error.message}` };
+    return {
+      ok: false,
+      message: "사진 업로드에 실패했습니다. 잠시 후 다시 시도해 주세요.",
+    };
   }
 
   return {
     ok: true,
     url: supabase.storage.from(AVATAR_BUCKET).getPublicUrl(filePath).data
       .publicUrl,
+    path: filePath,
   };
 }
 


### PR DESCRIPTION
## 관련 이슈

관련 이슈 없음

## 요약

프로필탭 아바타 우하단에 카메라 배지를 붙여, 프로필 사진을 그 자리에서 바로 바꿀 수 있게 한다.
한마디·칭호·기록과 같은 인라인 편집 어법을 사진에도 적용했다.

## AS-IS (변경 전)

- 프로필 사진을 바꾸려면 `/profile/edit` 맨 위 사진 영역까지 들어가야 했다.
- 그런데 프로필탭에서 거기로 가는 링크는 **러닝 프로필 연필**(`#running-profile` 앵커) 하나뿐이라, 사진 변경 입구가 사실상 숨어 있었다.
- 프로필탭 아바타는 이미 버튼이지만 누르면 "남들에게 보이는 내 카드" 팝업이 열려서, 사진 변경을 얹을 자리가 없었다.
- 서버는 `updateProfile(formData)` 하나가 이름·성별·생년월일·이메일·사진을 통째로 받아 `profileEditSchema`로 검증한다 — 사진만 바꿀 방법이 없었다.

## TO-BE (변경 후)

**① 카메라 배지** (`components/members/member-card-detail.tsx`)

- 아바타 우하단 28px 원형 배지. `edit`이 있을 때(편집판)만 그린다 — **공개판엔 편집 어포던스가 하나도 없어야 한다**는 기존 규칙 유지.
- 배지는 아바타 버튼의 **형제**다. 안에 넣으면 버튼 속 버튼이라 마크업이 깨지고, 사진 변경 탭이 공개판 팝업까지 같이 연다.
- `bg-primary` + `ring-board`(판 색 테로 얼굴에서 분리). `--board-amber`는 스크린 존 계기 표시 전용이라 쓰지 않았다.

**② `AvatarEditDialog`** (신규 `components/profile/avatar-edit-dialog.tsx`)

- `IntroEditDialog`와 같은 그릇(`ResponsiveDrawer`)·같은 구조. 미리보기 탭 → 사진 고르기 → 저장, "기본 이미지로" 되돌리기도 여기 포함.
- `open`일 때만 폼을 마운트해 재진입 시 이전 선택이 남지 않는다.
- `/profile/edit`의 사진 영역은 **그대로 뒀다** — 편집 페이지에서 사진만 못 바꾸는 게 더 이상하다.

**③ `updateAvatar` 액션 분리** (신규 `app/actions/profile/update-avatar.ts`)

- 사진만 받는 액션. `updateProfile`을 재사용하면 프로필탭이 이름·성별·생년월일을 들고 다니며 되돌려 보내야 하고, 폼 스키마가 바뀔 때 이 경로가 조용히 어긋난다.
- 성공 시 `revalidatePath("/profile")`. **전당 캐시(`records-team-v6`)는 일부러 안 턴다** — 프사가 거기 보이는 건 종목별 1위뿐인데 무효화가 대상을 못 가려서, 아무나 사진 한 장 바꿀 때마다 전당 전체가 캐시 미스가 된다(한마디·대표 칭호와 같은 규칙).

**④ 이미지 처리 공유** (신규 `lib/storage/avatar.ts`)

- HEIC 변환 · EXIF 회전(`.rotate()`) · 512 정사각 webp · Storage 업로드 · 옛 파일 제거를 `update-profile.ts`에서 뽑아 **두 액션이 공유**한다.
- 각자 만들면 한쪽만 EXIF 회전을 빠뜨려 사진이 눕는 걸 눈으로만 알게 된다 (`lib/storage/post-photo.ts`와 같은 이유·같은 어법).
- `updateProfile`의 동작은 그대로다(옛 파일 제거는 여전히 DB 커밋 성공 후).

**⑤ 낙관적 반영** (`components/profile/profile-tab-card.tsx`)

- 저장이 돌려준 URL을 `intro`·`utmb`와 같은 방식으로 state에 얹어 `router.refresh()` 전에도 즉시 보인다.
- `undefined`(아직 안 고침)와 `null`(기본 이미지로 되돌림)을 구분한다.

## 변경 흐름 (Mermaid)

```mermaid
flowchart TD
    subgraph ASIS["AS-IS"]
        A1[프로필탭] -->|러닝 프로필 연필| A2["/profile/edit"]
        A2 --> A3[사진 고르기]
        A3 --> A4[저장 - 이름·이메일·사진 통째로]
        A4 --> A5[updateProfile]
        A5 --> A6[[이미지 처리 · 업로드]]
    end

    subgraph TOBE["TO-BE"]
        B1[프로필탭] -->|얼굴 우하단 카메라 배지| B2[AvatarEditDialog]
        B2 --> B3[사진 고르기 / 기본 이미지로]
        B3 --> B4[저장]
        B4 --> B5[updateAvatar]
        C1["/profile/edit"] --> C2[updateProfile]
        B5 --> D["lib/storage/avatar.ts<br/>HEIC 변환 · EXIF 회전 · 512 webp<br/>업로드 · 옛 파일 제거"]
        C2 --> D
        B5 --> E["revalidatePath('/profile')<br/>전당 캐시는 안 텀"]
    end
```

## 검증

- `tsc --noEmit` 통과
- `eslint` 통과
- `vitest run` — 37 파일 442 테스트 통과
- 렌더 테스트에 두 줄 추가: 편집판엔 배지가 뜨고 카드 보기 버튼과 따로 서는지, **공개판엔 "프로필 사진 변경"이 없는지**

> 참고: `pnpm build`는 이 PR과 무관한 기존 문제로 실패한다 — `app/actions/mcp-token.ts:23`이 `"use server"` 파일에서 타입을 re-export해 Next 16 Turbopack이 거부한다(#444에서 유입). 별건으로 처리 필요.

## 문서

- `DESIGN.md` — 편집 진입점 규칙에 사진 추가, 배지 배치 이유·`lib/storage/avatar.ts` 공유 원칙 기록, 컴포넌트 카탈로그에 `AvatarEditDialog` 행 추가

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새로운 기능**
  * 프로필 편집 화면에서 프로필 사진을 변경하거나 기본 이미지로 삭제할 수 있습니다.
  * 카메라 배지를 통해 사진 변경 창을 바로 열 수 있습니다.
  * 사진 선택 시 미리보기와 자동 최적화가 제공됩니다.
  * 파일 형식 및 크기 검증과 저장 결과 안내가 추가되었습니다.

* **버그 수정**
  * 프로필 사진 저장 및 삭제 처리의 안정성이 향상되었습니다.
  * 변경된 프로필 사진이 저장 직후 화면에 즉시 반영됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->