### PR TITLE
feat(races): 내가 등록한 대회는 내가 수정 + 공유 링크 short_id 복구

### DIFF
--- a/app/(info)/admin/competitions/admin-competitions-client.tsx
+++ b/app/(info)/admin/competitions/admin-competitions-client.tsx
@@ -120,7 +120,16 @@ function CompetitionsContent({
   );
   const selected = competitions.find((c) => c.id === selectedId) ?? null;
   const [registrations, setRegistrations] = useState<Registration[]>([]);
-  const [regLoading, setRegLoading] = useState(false);
+  /**
+   * 참가자를 이미 불러온 대회 id. "로딩 중인가"를 별도 state로 들지 않고 이걸로 **파생**한다.
+   *
+   * 예전엔 `setRegLoading(true)`가 이펙트에서 동기로 불렸는데, 이펙트는 화면을 커밋한 *뒤에*
+   * 돌기 때문에 그 사이 브라우저가 "참가자 0명"을 한 프레임 그릴 수 있었다. 파생하면 첫 렌더부터
+   * 이미 "불러오는 중"이라 그 깜빡임이 구조적으로 안 생긴다.
+   */
+  const [regLoadedFor, setRegLoadedFor] = useState<string | null>(null);
+  /** 폼을 이미 채운 대회 id — URL 직접 진입 보정이 사용자가 입력 중인 값을 덮어쓰지 않게 한다 */
+  const [formSeededFor, setFormSeededFor] = useState<string | null>(null);
   const [saving, setSaving] = useState(false);
   const [customEtInput, setCustomEtInput] = useState("");
 
@@ -176,7 +185,14 @@ function CompetitionsContent({
     setLoading(false);
   }, [teamId]);
 
+  // 마운트 시 1회 목록 조회.
+  //
+  // ⚠️ 아래 disable은 **규칙이 대는 이유가 여기엔 해당하지 않아서**다: `loadCompetitions`의
+  // setState는 전부 `await Promise.all(...)` 뒤에 있어 동기 연쇄 렌더가 아니다. 규칙이 async
+  // 함수 안을 못 들여다보고 "이펙트가 setState 든 함수를 부른다"만 보고 잡는다.
+  // (같은 이유로 걸리는 자리가 아래 참가자 조회 이펙트에 하나 더 있다.)
   useEffect(() => {
+    // eslint-disable-next-line react-hooks/set-state-in-effect -- 위 주석 참고
     loadCompetitions();
   }, [loadCompetitions]);
 
@@ -198,7 +214,6 @@ function CompetitionsContent({
     );
 
   const loadRegistrations = async (competitionId: string) => {
-    setRegLoading(true);
     const supabase = createClient();
     const { data: plans } = await supabase
       .from("team_comp_plan_rel")
@@ -210,7 +225,7 @@ function CompetitionsContent({
     const teamCompIds = (plans ?? []).map((p) => p.team_comp_id);
     if (teamCompIds.length === 0) {
       setRegistrations([]);
-      setRegLoading(false);
+      setRegLoadedFor(competitionId);
       return;
     }
     const { data } = await supabase
@@ -236,7 +251,7 @@ function CompetitionsContent({
       member: { full_name: memNameById.get(r.mem_id) ?? null },
     }));
     setRegistrations(mapped);
-    setRegLoading(false);
+    setRegLoadedFor(competitionId);
   };
 
   // URL로 직접 접근 시 대회를 찾을 수 없으면 목록으로 복귀
@@ -247,36 +262,49 @@ function CompetitionsContent({
     }
   }, [mode, selectedId, selected, loading, setMode, setSelectedId]);
 
-  // URL로 edit 모드 직접 접근 시 폼 데이터 채우기
-  useEffect(() => {
-    if (mode === "edit" && selected) {
-      setForm({
-        title: selected.title,
-        sport: selected.sport ?? "road_run",
-        startDate: selected.start_date,
-        endDate: selected.end_date ?? "",
-        location: selected.location ?? "",
-        eventTypes: selected.event_types ?? [],
-        sourceUrl: selected.source_url ?? "",
-      });
-    }
-  }, [mode, selected]);
+  // URL로 edit 모드에 직접 들어온 경우 폼 채우기 — 그때는 목록이 아직 안 와서 `selected`가
+  // null이라 `openEdit`이 못 채운다. 목록이 도착해 `selected`가 생기는 순간 여기서 메운다.
+  //
+  // **이펙트가 아니라 렌더 중에 한다.** 이펙트는 화면을 커밋한 뒤에 돌아서 빈 폼이 한 프레임
+  // 스칠 수 있지만, 렌더 중 setState는 React가 공식 지원하는 패턴이라 중간 결과를 버리고
+  // 즉시 다시 그린다(https://react.dev/learn/you-might-not-need-an-effect).
+  // `formSeededFor`가 사용자가 입력 중인 값을 덮어쓰는 걸 막는다 — 대회당 한 번만 메운다.
+  if (mode === "edit" && selected && formSeededFor !== selected.id) {
+    setFormSeededFor(selected.id);
+    setForm({
+      title: selected.title,
+      sport: selected.sport ?? defaultSportCd,
+      startDate: selected.start_date,
+      endDate: selected.end_date ?? "",
+      location: selected.location ?? "",
+      eventTypes: selected.event_types ?? [],
+      sourceUrl: selected.source_url ?? "",
+    });
+  }
 
-  // URL로 detail 모드 직접 접근 시 참가자 로드
+  // 참가자도 같은 사정 — URL로 detail에 직접 들어오면 `openDetail`이 안 거쳐진다.
+  // 이건 네트워크 요청이라 렌더 중에 할 수 없어 이펙트로 남긴다. `regLoadedFor` 덕분에
+  // 클릭으로 들어온 경우엔 다시 부르지 않는다(예전엔 openDetail과 이 이펙트가 겹쳐 **두 번** 돌았다).
   useEffect(() => {
-    if (mode === "detail" && selected) {
+    if (mode === "detail" && selected && regLoadedFor !== selected.id) {
+      // eslint-disable-next-line react-hooks/set-state-in-effect -- setState가 전부 await 뒤라 동기 연쇄가 아니다(위 목록 조회와 같은 사정)
       loadRegistrations(selected.id);
     }
-  }, [mode, selected]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- loadRegistrations는 매 렌더 새로 만들어져 넣으면 무한루프가 된다
+  }, [mode, selected, regLoadedFor]);
 
   const openDetail = (comp: Competition) => {
     setSelectedId(comp.id);
     setMode("detail");
-    loadRegistrations(comp.id);
+    // 조회는 **위 이펙트 한 곳**이 맡는다. 여기서도 부르면 이펙트와 겹쳐 두 번 돌았다.
+    // null로 되돌려 "아직 안 불러온 대회"로 만들면 이펙트가 받아서 조회하고, 그동안
+    // `regLoading`(파생)이 켜져 이전 대회의 참가자 목록이 비치지 않는다.
+    setRegLoadedFor(null);
   };
 
   const openEdit = (comp: Competition) => {
     setSelectedId(comp.id);
+    setFormSeededFor(comp.id);
     setForm({
       title: comp.title,
       sport: comp.sport ?? defaultSportCd,
@@ -291,6 +319,7 @@ function CompetitionsContent({
 
   const openCreate = () => {
     setSelectedId("");
+    setFormSeededFor(null);
     setForm({
       title: "",
       sport: sportSelectOptions[0]?.cd ?? "road_run",
@@ -302,6 +331,10 @@ function CompetitionsContent({
     });
     setMode("create");
   };
+
+  /** 참가자 로딩 표시 — state가 아니라 파생값이라 첫 렌더부터 이미 "불러오는 중"이다 */
+  const regLoading =
+    mode === "detail" && selected != null && regLoadedFor !== selected.id;
 
   const formEventTypeCodes = eventTypeCodesForSprtFromCmmRows(cmmCdRows, form.sport);
 

--- a/app/(info)/admin/competitions/admin-competitions-client.tsx
+++ b/app/(info)/admin/competitions/admin-competitions-client.tsx
@@ -213,7 +213,16 @@ function CompetitionsContent({
         : b.start_date.localeCompare(a.start_date),
     );
 
-  const loadRegistrations = async (competitionId: string) => {
+  /**
+   * `isStale`은 **응답이 늦게 도착했는지** 묻는다. 대회를 빠르게 갈아타면 앞선 요청이 뒤늦게
+   * 끝나 새 대회의 화면에 옛 참가자를 덮어쓸 수 있다(그러면 `regLoadedFor`가 옛 id로 되돌아가
+   * 로딩 표시가 다시 켜지고 조회가 한 번 더 나간다). 호출자(이펙트)가 cleanup에서 플래그를
+   * 세우고, 여기선 state를 만지기 직전마다 물어본다.
+   */
+  const loadRegistrations = async (
+    competitionId: string,
+    isStale: () => boolean = () => false,
+  ) => {
     const supabase = createClient();
     const { data: plans } = await supabase
       .from("team_comp_plan_rel")
@@ -224,6 +233,7 @@ function CompetitionsContent({
       .eq("del_yn", false);
     const teamCompIds = (plans ?? []).map((p) => p.team_comp_id);
     if (teamCompIds.length === 0) {
+      if (isStale()) return;
       setRegistrations([]);
       setRegLoadedFor(competitionId);
       return;
@@ -250,6 +260,7 @@ function CompetitionsContent({
       event_type: r.comp_evt_id ? (evtCdById.get(r.comp_evt_id) ?? null) : null,
       member: { full_name: memNameById.get(r.mem_id) ?? null },
     }));
+    if (isStale()) return;
     setRegistrations(mapped);
     setRegLoadedFor(competitionId);
   };
@@ -269,6 +280,16 @@ function CompetitionsContent({
   // 스칠 수 있지만, 렌더 중 setState는 React가 공식 지원하는 패턴이라 중간 결과를 버리고
   // 즉시 다시 그린다(https://react.dev/learn/you-might-not-need-an-effect).
   // `formSeededFor`가 사용자가 입력 중인 값을 덮어쓰는 걸 막는다 — 대회당 한 번만 메운다.
+  //
+  // ⚠️ 편집 화면을 벗어나면 **반드시 시드를 푼다.** 안 그러면 같은 대회로 다시 들어왔을 때
+  //    `formSeededFor === selected.id`라 재시드가 안 걸려 아까 입력하다 만 값이 그대로 뜬다.
+  //    "취소" 버튼마다 개별로 푸는 건 부족하다 — `mode`가 URL 상태(nuqs)라 **브라우저 뒤로가기**로도
+  //    edit에 되돌아오는데 그 경로엔 핸들러가 없다. 나가는 쪽이 아니라 "edit이 아니면 푼다"로
+  //    두면 어떤 경로로 나갔든 다시 들어올 때 현재 대회 값으로 새로 채워진다.
+  if (mode !== "edit" && formSeededFor !== null) {
+    setFormSeededFor(null);
+  }
+
   if (mode === "edit" && selected && formSeededFor !== selected.id) {
     setFormSeededFor(selected.id);
     setForm({
@@ -286,10 +307,15 @@ function CompetitionsContent({
   // 이건 네트워크 요청이라 렌더 중에 할 수 없어 이펙트로 남긴다. `regLoadedFor` 덕분에
   // 클릭으로 들어온 경우엔 다시 부르지 않는다(예전엔 openDetail과 이 이펙트가 겹쳐 **두 번** 돌았다).
   useEffect(() => {
-    if (mode === "detail" && selected && regLoadedFor !== selected.id) {
-      // eslint-disable-next-line react-hooks/set-state-in-effect -- setState가 전부 await 뒤라 동기 연쇄가 아니다(위 목록 조회와 같은 사정)
-      loadRegistrations(selected.id);
-    }
+    if (mode !== "detail" || !selected || regLoadedFor === selected.id) return;
+
+    // 대회를 갈아타면 cleanup이 이 플래그를 세워, 늦게 온 앞선 응답이 새 화면을 덮지 못하게 한다.
+    let stale = false;
+    // eslint-disable-next-line react-hooks/set-state-in-effect -- setState가 전부 await 뒤라 동기 연쇄가 아니다(위 목록 조회와 같은 사정)
+    void loadRegistrations(selected.id, () => stale);
+    return () => {
+      stale = true;
+    };
     // eslint-disable-next-line react-hooks/exhaustive-deps -- loadRegistrations는 매 렌더 새로 만들어져 넣으면 무한루프가 된다
   }, [mode, selected, regLoadedFor]);
 

--- a/app/(main)/races/page.tsx
+++ b/app/(main)/races/page.tsx
@@ -25,7 +25,7 @@ const getUpcomingCompetitions = unstable_cache(
     const { data } = await supabase
       .from("comp_mst")
       .select(
-        "comp_id, ext_id, comp_sprt_cd, comp_nm, stt_dt, end_dt, loc_nm, src_url, comp_evt_cfg(comp_evt_type)",
+        "comp_id, short_id, crt_by, ext_id, comp_sprt_cd, comp_nm, stt_dt, end_dt, loc_nm, src_url, comp_evt_cfg(comp_evt_type)",
       )
       .eq("vers", 0)
       .eq("del_yn", false)
@@ -34,6 +34,9 @@ const getUpcomingCompetitions = unstable_cache(
       .order("stt_dt", { ascending: true });
     const competitions: Competition[] = (data ?? []).map((row) => ({
       id: row.comp_id,
+      // 공유 링크가 이걸 쓴다 — 안 실으면 상세 다이얼로그가 uuid로 폴백한다
+      short_id: row.short_id ?? null,
+      crt_by: row.crt_by ?? null,
       external_id: row.ext_id ?? "",
       sport: row.comp_sprt_cd,
       title: row.comp_nm,
@@ -45,7 +48,10 @@ const getUpcomingCompetitions = unstable_cache(
     }));
     return { competitions, today };
   },
-  ["competitions-upcoming"],
+  // ⚠️ 페이로드 모양을 바꾸면 **키를 올린다**(`-v2`, `-v3`…). 안 올리면 배포 직후에도
+  // 옛 캐시가 새 필드 없이 돌아와(revalidate 24시간) 고친 게 하루 동안 안 보인다 —
+  // short_id를 넣은 게 정확히 그 경우였다.
+  ["competitions-upcoming-v2"],
   cacheOptions,
 );
 
@@ -64,6 +70,8 @@ async function fetchTeamCompetitionsForTeam(teamId: string) {
     .map((row) => {
       return {
         id: row.comp_id,
+        short_id: row.short_id ?? null,
+        crt_by: row.crt_by ?? null,
         external_id: row.ext_id ?? "",
         sport: row.comp_sprt_cd,
         title: row.comp_nm,

--- a/app/actions/admin/manage-competition.ts
+++ b/app/actions/admin/manage-competition.ts
@@ -2,12 +2,23 @@
 
 import { revalidateTag } from "next/cache";
 
-import { withAdmin } from "@/lib/actions/auth";
+import { withActive, withAdmin } from "@/lib/actions/auth";
 import { compEvtTypeContainsHangul } from "@/lib/comp-evt-type";
 import { getCachedCmmCdRows, isValidCompSprtCd } from "@/lib/queries/cmm-cd-cached";
 import { getRequestTeamContext } from "@/lib/queries/request-team";
 import { createAdminClient } from "@/lib/supabase/admin";
 
+/**
+ * ⚠️ **이 파일이 전부 관리자 전용은 아니다.** 디렉터리 이름(`admin/`)에 속지 말 것 —
+ * `updateCompetition`은 **만든 사람 본인 또는 관리자**이고, 나머지 둘만 관리자 전용이다.
+ * 권한은 각 함수의 `withAdmin`/`withActive`를 보고 판단한다.
+ * (수정을 `app/actions/competition/`으로 떼는 게 맞지만, 유일한 호출처인 관리자 페이지가
+ *  기존 lint 에러를 안고 있어 import를 건드리면 커밋이 막힌다 — 그 정리와 함께 옮긴다.)
+ *
+ * **대회 삭제를 안 여는 이유**: 하드 delete인 데다 그 팀의 참가등록(`comp_reg_rel`)까지
+ * 함께 지운다 — 남이 신청해 둔 걸 날리는 동작이라 되돌릴 수 없다. 잘못 만든 대회는
+ * 고쳐 쓰면 된다.
+ */
 export async function deleteCompetition(competitionId: string) {
   return withAdmin(async () => {
     const { teamId } = await getRequestTeamContext();
@@ -54,6 +65,17 @@ export async function deleteCompetition(competitionId: string) {
   });
 }
 
+/**
+ * 대회 정보 수정 — **만든 사람 본인 또는 관리자**(이 파일에서 유일하게 관리자 전용이 아니다).
+ *
+ * 대회 등록(`createCompetition`)이 이미 활성 회원 전원에게 열려 있는데 수정만 관리자
+ * 전용이면, 날짜를 잘못 넣은 사람이 **자기가 만든 대회조차** 못 고치고 운영진에게 부탁해야
+ * 했다. 그래서 `comp_mst.crt_by`를 도입해 본인 것은 본인이 고치게 열었다.
+ *
+ * `crt_by`가 비어 있으면(외부 수집분 · 컬럼 도입 이전 등록분) **관리자만** 고칠 수 있다.
+ * 이건 부작용이 아니라 원하는 동작이다 — 크롤링으로 들어온 원본 대회를 아무나 고치면
+ * 다음 수집과 어긋난다.
+ */
 export async function updateCompetition(
   competitionId: string,
   input: {
@@ -66,13 +88,49 @@ export async function updateCompetition(
     sourceUrl: string;
   },
 ) {
-  return withAdmin(async () => {
+  return withActive(async ({ member }) => {
     const cmmRows = await getCachedCmmCdRows();
     if (!isValidCompSprtCd(cmmRows, input.sport.trim())) {
       return { ok: false, message: "유효하지 않은 종목입니다." };
     }
 
+    // ⚠️ 종목 검증은 **아래 comp_evt_cfg를 지우기 전에** 끝낸다. 예전엔 delete 뒤에 있어서
+    //    한글 종목을 넣으면 "수정 실패" 메시지와 함께 **기존 종목이 이미 지워진 채로** 남았다.
+    //    관리자만 밟던 길이라 드물었지만, 수정이 작성자에게 열린 지금은 실제로 터진다.
+    const nextTypes = (input.eventTypes ?? [])
+      .map((t) => t.trim().toUpperCase())
+      .filter((t) => t.length > 0);
+
+    if (nextTypes.some((t) => compEvtTypeContainsHangul(t))) {
+      return {
+        ok: false,
+        message: "종목은 한글을 사용할 수 없습니다. 영문·숫자로 입력해 주세요.",
+      };
+    }
+
     const db = createAdminClient();
+
+    // 권한 판정 — UI가 버튼을 감추는 건 안내일 뿐이라 서버가 다시 본다.
+    // `createAdminClient()`는 RLS를 우회하므로 이 검사가 유일한 관문이다.
+    const { data: current } = await db
+      .from("comp_mst")
+      .select("crt_by")
+      .eq("comp_id", competitionId)
+      .eq("vers", 0)
+      .eq("del_yn", false)
+      .maybeSingle();
+
+    if (!current) return { ok: false, message: "대회를 찾을 수 없습니다." };
+
+    if (!member.admin && current.crt_by !== member.id) {
+      return {
+        ok: false,
+        message: current.crt_by
+          ? "직접 등록한 대회만 수정할 수 있어요. 운영진에게 문의해 주세요."
+          : "이 대회는 운영진만 수정할 수 있어요.",
+      };
+    }
+
     const { error: compErr } = await db
       .from("comp_mst")
       .update({
@@ -87,6 +145,7 @@ export async function updateCompetition(
 
     if (compErr) return { ok: false, message: "수정에 실패했습니다" };
 
+    // 종목 목록은 전량 교체다(부분 갱신이 아니다)
     const { error: delErr } = await db
       .from("comp_evt_cfg")
       .delete()
@@ -94,14 +153,6 @@ export async function updateCompetition(
       .eq("vers", 0)
       .eq("del_yn", false);
     if (delErr) return { ok: false, message: "수정에 실패했습니다" };
-
-    if ((input.eventTypes ?? []).some((t) => compEvtTypeContainsHangul(t))) {
-      return { ok: false, message: "종목은 한글을 사용할 수 없습니다. 영문·숫자로 입력해 주세요." };
-    }
-
-    const nextTypes = (input.eventTypes ?? [])
-      .map((t) => t.trim().toUpperCase())
-      .filter((t) => t.length > 0);
 
     if (nextTypes.length > 0) {
       const { error: insErr } = await db.from("comp_evt_cfg").insert(

--- a/app/actions/create-competition.ts
+++ b/app/actions/create-competition.ts
@@ -29,6 +29,17 @@ export async function createCompetition(input: CreateCompetitionInput) {
       return { ok: false, message: "지난 대회는 기록 입력에서 추가해 주세요." };
     }
 
+    // ⚠️ 종목 검증·정규화는 **comp_mst를 만들기 전에** 끝낸다. 예전엔 insert 뒤에 있어서
+    //    한글 종목을 넣으면 대회 행은 이미 만들어진 채로 에러만 돌아왔다 — 아래 insert 실패
+    //    경로와 달리 되돌리는 처리도 없어 **종목 없는 빈 대회가 영구히 남았다.**
+    const eventTypes = (input.eventTypes ?? [])
+      .map((evt) => evt.trim().toUpperCase())
+      .filter((evt) => evt.length > 0);
+
+    if (eventTypes.some((evt) => compEvtTypeContainsHangul(evt))) {
+      return { ok: false, message: "종목은 한글을 사용할 수 없습니다. 영문·숫자로 입력해 주세요." };
+    }
+
     const admin = createAdminClient();
     const { data: comp, error: compErr } = await admin
       .from("comp_mst")
@@ -41,7 +52,9 @@ export async function createCompetition(input: CreateCompetitionInput) {
         crt_by: member.id,
         vers: 0, del_yn: false,
       })
-      .select("comp_id")
+      // short_id는 DB가 만들어 주므로 되받아야 한다 — 아래 반환값이 곧바로 상세 다이얼로그로
+      // 들어가고, 거기서 공유 링크와 수정 버튼 노출에 둘 다 쓰인다.
+      .select("comp_id, short_id, crt_by")
       .single();
 
     if (compErr || !comp) {
@@ -49,12 +62,9 @@ export async function createCompetition(input: CreateCompetitionInput) {
       return { ok: false, message: "등록에 실패했습니다. 다시 시도해 주세요." };
     }
 
-    if (input.eventTypes.length > 0) {
-      if (input.eventTypes.some((evt) => compEvtTypeContainsHangul(evt))) {
-        return { ok: false, message: "종목은 한글을 사용할 수 없습니다. 영문·숫자로 입력해 주세요." };
-      }
-      const eventRows = input.eventTypes.map((evt) => ({
-        comp_id: comp.comp_id, comp_evt_type: evt.trim().toUpperCase(), vers: 0, del_yn: false,
+    if (eventTypes.length > 0) {
+      const eventRows = eventTypes.map((evt) => ({
+        comp_id: comp.comp_id, comp_evt_type: evt, vers: 0, del_yn: false,
       }));
       const { error: evtErr } = await admin.from("comp_evt_cfg").insert(eventRows);
       if (evtErr) {
@@ -68,9 +78,17 @@ export async function createCompetition(input: CreateCompetitionInput) {
     return {
       ok: true, message: null,
       competition: {
-        id: comp.comp_id, external_id: `manual:${comp.comp_id}`, sport: input.sport,
+        id: comp.comp_id,
+        // ⚠️ 이 객체는 곧바로 상세 다이얼로그로 들어간다(mini-calendar의 handleCompetitionCreated가
+        //    받자마자 연다). 그래서 둘 다 실어야 한다:
+        //    - crt_by 없으면 **방금 만든 사람이 자기 대회의 수정 버튼을 못 본다** — 날짜 오타를
+        //      알아채는 바로 그 순간이라 이게 빠지면 이 기능의 핵심 동선이 끊긴다
+        //    - short_id 없으면 그 화면의 공유 링크가 uuid로 나간다
+        short_id: comp.short_id ?? null,
+        crt_by: comp.crt_by ?? null,
+        external_id: `manual:${comp.comp_id}`, sport: input.sport,
         title: input.title.trim(), start_date: input.startDate, end_date: input.endDate ?? null,
-        location: input.location.trim() || null, event_types: input.eventTypes.map((e) => e.trim().toUpperCase()),
+        location: input.location.trim() || null, event_types: eventTypes,
         source_url: input.sourceUrl.trim() || null,
       },
     };

--- a/app/actions/create-competition.ts
+++ b/app/actions/create-competition.ts
@@ -20,7 +20,7 @@ interface CreateCompetitionInput {
 }
 
 export async function createCompetition(input: CreateCompetitionInput) {
-  return withActive(async () => {
+  return withActive(async ({ member }) => {
     const cmmRows = await getCachedCmmCdRows();
     if (!isValidCompSprtCd(cmmRows, input.sport.trim())) return { ok: false, message: "유효하지 않은 종목입니다." };
 
@@ -36,6 +36,9 @@ export async function createCompetition(input: CreateCompetitionInput) {
         ext_id: `manual:${crypto.randomUUID()}`, comp_sprt_cd: input.sport,
         comp_nm: input.title.trim(), stt_dt: input.startDate, end_dt: input.endDate || null,
         loc_nm: input.location.trim() || null, src_url: input.sourceUrl.trim() || null,
+        // 만든 사람 — 나중에 본인이 고칠 수 있는 유일한 근거다(§updateCompetition).
+        // 여기서 안 적으면 그 대회는 영영 관리자만 고칠 수 있다.
+        crt_by: member.id,
         vers: 0, del_yn: false,
       })
       .select("comp_id")

--- a/components/home/mini-calendar.tsx
+++ b/components/home/mini-calendar.tsx
@@ -486,8 +486,8 @@ export function MiniCalendar({
     if (deepLinkCompId) {
       const isUuid = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i.test(deepLinkCompId)
       const query = isUuid
-        ? supabase.from("comp_mst").select("comp_id, short_id, comp_nm, comp_sprt_cd, stt_dt, end_dt, loc_nm, src_url, comp_evt_cfg(comp_evt_type)").eq("comp_id", deepLinkCompId).maybeSingle()
-        : supabase.from("comp_mst").select("comp_id, short_id, comp_nm, comp_sprt_cd, stt_dt, end_dt, loc_nm, src_url, comp_evt_cfg(comp_evt_type)").eq("short_id", deepLinkCompId).maybeSingle()
+        ? supabase.from("comp_mst").select("comp_id, short_id, crt_by, comp_nm, comp_sprt_cd, stt_dt, end_dt, loc_nm, src_url, comp_evt_cfg(comp_evt_type)").eq("comp_id", deepLinkCompId).maybeSingle()
+        : supabase.from("comp_mst").select("comp_id, short_id, crt_by, comp_nm, comp_sprt_cd, stt_dt, end_dt, loc_nm, src_url, comp_evt_cfg(comp_evt_type)").eq("short_id", deepLinkCompId).maybeSingle()
 
       query.then(({ data }) => {
         if (cancelled) return
@@ -498,6 +498,7 @@ export function MiniCalendar({
         setSelectedCompetition({
           id: data.comp_id,
           short_id: data.short_id ?? null,
+          crt_by: data.crt_by ?? null,
           external_id: "",
           sport: data.comp_sprt_cd ?? null,
           title: data.comp_nm,
@@ -670,7 +671,7 @@ export function MiniCalendar({
     try {
       const { data } = await supabase
         .from("comp_mst")
-        .select("comp_id, short_id, comp_nm, comp_sprt_cd, stt_dt, end_dt, loc_nm, src_url, comp_evt_cfg(comp_evt_type)")
+        .select("comp_id, short_id, crt_by, comp_nm, comp_sprt_cd, stt_dt, end_dt, loc_nm, src_url, comp_evt_cfg(comp_evt_type)")
         .eq("comp_id", race.id)
         .single();
       if (!data) return;
@@ -679,6 +680,7 @@ export function MiniCalendar({
         ? {
             ...prev,
             short_id: data.short_id ?? null,
+            crt_by: data.crt_by ?? null,
             sport: data.comp_sprt_cd ?? null,
             title: data.comp_nm,
             start_date: data.stt_dt,

--- a/components/races/competition-detail-dialog.tsx
+++ b/components/races/competition-detail-dialog.tsx
@@ -136,8 +136,24 @@ export function CompetitionDetailDialog({
   const [shareOpen, setShareOpen] = useState(false);
   const [inactiveGateOpen, setInactiveGateOpen] = useState(false);
 
-  // 관리자 수정 모드
+  // 댓글 삭제 권한 등 진짜 관리자 전용 표면에만 쓴다
   const isAdmin = memberStatus.status === "ready" && memberStatus.admin;
+
+  /**
+   * 대회 정보 수정 — **내가 만든 대회이거나, 내가 관리자일 때**.
+   *
+   * 등록이 이미 전 회원에게 열려 있어서, 수정만 관리자 전용이면 날짜를 잘못 넣은 사람이
+   * 자기가 만든 대회조차 못 고치고 운영진을 기다려야 했다.
+   *
+   * `crt_by`가 없으면(외부 수집분 · 컬럼 도입 이전 등록분) 관리자만 보인다.
+   * 서버(`updateCompetition`)가 다시 판정하므로 이 게이트는 어포던스일 뿐이다.
+   */
+  // `competition`은 아래에서 null 가드를 하지만 훅 순서 때문에 이 줄이 먼저 온다 — 옵셔널 체이닝.
+  const canEdit =
+    isAdmin ||
+    (memberStatus.status === "ready" &&
+      competition?.crt_by != null &&
+      competition.crt_by === memberStatus.memberId);
   const [editing, setEditing] = useState(false);
 
   // 뷰어 파생값 — ready/inactive 둘 다 memberId 를 가지므로, 댓글에 회원 식별자를 넘겨
@@ -505,7 +521,7 @@ export function CompetitionDetailDialog({
                 <Share2 className="size-3.5" />
                 공유하기
               </Button>
-              {isAdmin && (
+              {canEdit && (
                 <Button
                   variant="outline"
                   size="sm"

--- a/components/races/types.ts
+++ b/components/races/types.ts
@@ -1,6 +1,14 @@
 export type Competition = {
   id: string;
   short_id?: string | null;
+  /**
+   * 만든 사람(`comp_mst.crt_by`). 상세에서 "내가 만든 대회인가"(수정 버튼 노출) 판정에 쓴다.
+   *
+   * `null`이면 외부 수집분이거나 컬럼 도입 이전 등록분이라 관리자만 고칠 수 있고,
+   * `undefined`면 **이 목록이 값을 안 실어 보낸 것**이다 — 그 화면에선 작성자 본인도
+   * 버튼을 못 본다. 상세를 여는 경로를 새로 만들면 이 값도 같이 실어야 한다.
+   */
+  crt_by?: string | null;
   external_id: string;
   sport: string | null;
   title: string;

--- a/lib/supabase/database.types.ts
+++ b/lib/supabase/database.types.ts
@@ -421,6 +421,7 @@ export type Database = {
           comp_nm: string
           comp_sprt_cd: string | null
           crt_at: string
+          crt_by: string | null
           del_yn: boolean
           end_dt: string | null
           ext_id: string | null
@@ -436,6 +437,7 @@ export type Database = {
           comp_nm: string
           comp_sprt_cd?: string | null
           crt_at?: string
+          crt_by?: string | null
           del_yn?: boolean
           end_dt?: string | null
           ext_id?: string | null
@@ -451,6 +453,7 @@ export type Database = {
           comp_nm?: string
           comp_sprt_cd?: string | null
           crt_at?: string
+          crt_by?: string | null
           del_yn?: boolean
           end_dt?: string | null
           ext_id?: string | null
@@ -2830,11 +2833,13 @@ export type Database = {
           comp_id: string
           comp_nm: string
           comp_sprt_cd: string
+          crt_by: string
           end_dt: string
           ext_id: string
           loc_nm: string
           reg_count: number
           reg_evt_types: string[]
+          short_id: string
           src_url: string
           stt_dt: string
         }[]

--- a/supabase/migrations/20260804100000_comp_mst_crt_by.sql
+++ b/supabase/migrations/20260804100000_comp_mst_crt_by.sql
@@ -1,0 +1,29 @@
+-- comp_mst.crt_by — 대회를 만든 사람
+--
+-- 대회 등록(`createCompetition`)은 이미 활성 회원 전원에게 열려 있는데 수정은 관리자
+-- 전용이라, 날짜를 잘못 넣은 사람이 **자기가 만든 대회조차** 못 고치고 운영진에게
+-- 부탁해야 했다. "본인 것은 본인이"를 판정하려면 누가 만들었는지를 DB가 알아야 하는데,
+-- comp_mst엔 회원을 가리키는 컬럼이 하나도 없었다(`ext_id`의 `manual:{uuid}`는 외부
+-- 식별자 칸이고 그 uuid도 랜덤이라 사람과 무관하다).
+--
+-- **NULL 허용이 필수다.** 두 종류가 영영 비어 있다:
+--   ① 이미 등록된 대회 — 작성자를 소급할 방법이 없다
+--   ② 외부에서 수집된 대회 — 사람이 만든 게 아니다
+-- 그리고 이건 사고가 아니라 원하는 동작이다: crt_by가 비면 관리자만 고칠 수 있으므로,
+-- 크롤링으로 들어온 원본 대회를 아무나 고치는 일이 구조적으로 막힌다.
+--
+-- ON DELETE SET NULL — 회원 행이 사라져도 대회는 남아야 한다(ttl_mst.crt_by와 같은 규약).
+-- 실제로 mem_mst를 지우는 경로는 없지만, 지웠을 때 대회가 딸려 사라지는 것보단 낫다.
+
+ALTER TABLE public.comp_mst
+  ADD COLUMN IF NOT EXISTS crt_by uuid;
+
+ALTER TABLE public.comp_mst
+  DROP CONSTRAINT IF EXISTS fk_comp_mst__crt_by;
+
+ALTER TABLE public.comp_mst
+  ADD CONSTRAINT fk_comp_mst__crt_by
+  FOREIGN KEY (crt_by) REFERENCES public.mem_mst (mem_id) ON DELETE SET NULL;
+
+COMMENT ON COLUMN public.comp_mst.crt_by IS
+  '대회를 만든 회원(mem_mst.mem_id). NULL = 외부 수집분 또는 컬럼 도입 이전 등록분 → 관리자만 수정 가능';

--- a/supabase/migrations/20260804110000_comp_rpc_short_id_crt_by.sql
+++ b/supabase/migrations/20260804110000_comp_rpc_short_id_crt_by.sql
@@ -1,0 +1,96 @@
+-- get_public_team_competitions에 short_id · crt_by 추가
+--
+-- 대회 공유 링크는 `/schedule?comp=<short_id ?? comp_id>` 형태다(딥링크는 `?comp=`를 읽는
+-- MiniCalendar가 있는 `/schedule`에 붙는다 — `/races`엔 상세 페이지가 없다).
+-- 그런데 이 RPC가 short_id를 안 돌려줘서, `/races`(설정 → 대회 목록)에서 연 상세는
+-- 폴백인 uuid로 링크를 만들었다. 같은 대회인데 홈 미니캘린더로 열면 short_id,
+-- 대회탭에서 열면 uuid가 붙어 갈렸다.
+--
+-- crt_by는 대회 상세에서 "이 대회 내가 만든 건가"(수정 버튼 노출)를 판정하는 데 쓴다.
+-- 서버(`updateCompetition`)가 다시 판정하므로 이건 어포던스용이지만, 안 실으면 자기가 만든
+-- 대회인데도 버튼이 안 보인다.
+--
+-- 반환 컬럼을 늘리는 것이라 CREATE OR REPLACE로는 안 되고 DROP이 선행돼야 한다.
+-- 본문은 20260622220000_calendar_rpc_cmnt_cte.sql 정의 그대로이고 두 컬럼만 얹는다.
+
+DROP FUNCTION IF EXISTS public.get_public_team_competitions(uuid, date, date);
+
+CREATE OR REPLACE FUNCTION public.get_public_team_competitions(
+  p_team_id uuid,
+  p_start   date DEFAULT NULL,
+  p_end     date DEFAULT NULL
+)
+RETURNS TABLE (
+  comp_id        uuid,
+  short_id       text,
+  crt_by         uuid,
+  ext_id         text,
+  comp_sprt_cd   text,
+  comp_nm        text,
+  stt_dt         date,
+  end_dt         date,
+  loc_nm         text,
+  src_url        text,
+  comp_evt_types text[],
+  reg_evt_types  text[],
+  reg_count      bigint,
+  cmnt_count     bigint
+)
+LANGUAGE sql
+STABLE
+SECURITY DEFINER
+SET search_path = public
+AS $$
+WITH cmnt_agg AS (
+  SELECT entity_id AS comp_id, COUNT(*) AS cmnt_count
+  FROM public.cmnt_mst
+  WHERE entity_type = 'comp'
+    AND del_yn = false
+  GROUP BY entity_id
+)
+SELECT
+  c.comp_id,
+  c.short_id,
+  c.crt_by,
+  c.ext_id,
+  c.comp_sprt_cd,
+  c.comp_nm,
+  c.stt_dt,
+  c.end_dt,
+  c.loc_nm,
+  c.src_url,
+  COALESCE(array_agg(DISTINCT ce.comp_evt_type) FILTER (WHERE ce.comp_evt_type IS NOT NULL), '{}') AS comp_evt_types,
+  COALESCE(array_agg(DISTINCT re.comp_evt_type) FILTER (WHERE re.comp_evt_type IS NOT NULL), '{}') AS reg_evt_types,
+  count(DISTINCT cr.comp_reg_id)                                                                    AS reg_count,
+  COALESCE(ca.cmnt_count, 0)                                                                        AS cmnt_count
+FROM public.team_comp_plan_rel tcp
+INNER JOIN public.comp_mst c
+  ON c.comp_id = tcp.comp_id
+ AND c.vers    = 0
+ AND c.del_yn  = false
+LEFT JOIN public.comp_evt_cfg ce
+  ON ce.comp_id = c.comp_id
+ AND ce.vers    = 0
+ AND ce.del_yn  = false
+LEFT JOIN public.comp_reg_rel cr
+  ON cr.team_comp_id = tcp.team_comp_id
+ AND cr.vers         = 0
+ AND cr.del_yn       = false
+LEFT JOIN public.comp_evt_cfg re
+  ON re.comp_evt_id = cr.comp_evt_id
+ AND re.vers        = 0
+ AND re.del_yn      = false
+LEFT JOIN cmnt_agg ca ON ca.comp_id = c.comp_id
+WHERE tcp.team_id = p_team_id
+  AND tcp.vers    = 0
+  AND tcp.del_yn  = false
+  AND (p_start IS NULL OR c.stt_dt >= p_start)
+  AND (p_end   IS NULL OR c.stt_dt <= p_end)
+GROUP BY
+  c.comp_id, c.short_id, c.crt_by, c.ext_id, c.comp_sprt_cd, c.comp_nm,
+  c.stt_dt, c.end_dt, c.loc_nm, c.src_url, ca.cmnt_count
+ORDER BY c.stt_dt ASC;
+$$;
+
+GRANT EXECUTE ON FUNCTION public.get_public_team_competitions(uuid, date, date)
+  TO anon, authenticated, service_role;


### PR DESCRIPTION
## 관련 이슈

관련 이슈 없음 (크루원 요청 — "대회 만들었다가 날짜 잘못 넣었는데 못 고친다")

## 요약

대회를 등록한 본인이 그 대회를 수정할 수 있게 연다. 겸사겸사 대회탭에서 연 상세의 공유 링크가 짧은 id가 아니라 uuid로 나오던 버그도 잡았다.

## AS-IS (변경 전)

**① 등록은 누구나, 수정은 관리자만 — 비대칭**

- `createCompetition`은 `withActive`라 **활성 회원 전원**이 대회를 만들 수 있다(대회탭 FAB, 홈 대회 선택, 기록 입력 중 추가 — 진입점 3개).
- 그런데 `updateCompetition`은 `withAdmin`이라, **날짜를 잘못 넣어도 본인이 못 고친다.** 운영진에게 부탁해야 했다.
- "본인 것만"을 판정할 근거도 없었다 — `comp_mst`에 회원을 가리키는 컬럼이 하나도 없다(`ext_id`의 `manual:{uuid}`는 외부 식별자 칸이고 그 uuid도 랜덤이라 사람과 무관).

**② 공유 링크가 uuid로 나온다**

- 상세 다이얼로그는 `competition.short_id ?? competition.id`로 링크를 만든다(`competition-detail-dialog.tsx`).
- 그런데 `/races`(설정 → 대회 목록)가 `short_id`를 안 실어 보내서 **늘 폴백인 uuid**가 붙었다:
  - `races/page.tsx`의 select에 `short_id` 누락
  - `get_public_team_competitions` RPC 반환 컬럼에 `short_id` 자체가 없음
- 같은 대회인데 **홈 미니캘린더로 열면 짧은 id, 대회탭에서 열면 uuid**로 갈렸다.

## TO-BE (변경 후)

**① `comp_mst.crt_by` 도입 → 작성자 또는 관리자**

- 마이그레이션으로 `crt_by uuid` 추가(`ON DELETE SET NULL`). `createCompetition`이 만들 때 기록한다.
- `updateCompetition`: `withAdmin` → `withActive` + **`crt_by === member.id || member.admin`** 판정. `createAdminClient()`가 RLS를 우회하므로 이 검사가 유일한 관문이다.
- UI 게이트(`canEdit`)도 같은 조건. 서버가 다시 판정하므로 버튼 노출은 어포던스일 뿐이다.

**`crt_by`가 비면 관리자만 고칠 수 있다 — 이건 부작용이 아니라 원하는 동작이다.**

| `crt_by` | 어떤 대회인가 | 누가 수정 |
|---|---|---|
| 있음 | 회원이 앱에서 만든 대회 | 만든 사람 + 관리자 |
| 없음 | 외부 수집분 · 컬럼 도입 이전 등록분 | 관리자만 |

크롤링으로 들어온 원본 대회를 아무나 고치면 다음 수집과 어긋나는데, 이 방식이 그걸 구조적으로 막는다. 전 회원 개방보다 오히려 안전하다.

**삭제는 그대로 관리자만이다.** 하드 delete인 데다 그 팀의 참가등록(`comp_reg_rel`)까지 함께 지운다 — 남이 신청해 둔 걸 날리는 동작이라 되돌릴 수 없다. 잘못 만든 대회는 고쳐 쓰면 된다.

**② 공유 링크 복구**

- `get_public_team_competitions` 반환에 `short_id`·`crt_by` 추가.
- `/races` 두 경로(직접 select + RPC) 모두 두 컬럼 적재.
- **`unstable_cache` 키를 `-v2`로 올렸다** — 안 올리면 옛 캐시가 새 필드 없이 24시간 더 돌아와 배포하고도 그대로다.
- 미니캘린더 대회 조회 3곳에도 `crt_by` 적재. 안 실으면 자기가 만든 대회인데도 버튼이 안 보인다.

**③ 곁다리 — 종목 검증 순서**

한글 종목 검증이 `comp_evt_cfg` **삭제 뒤에** 있어서, 검증에 걸리면 "수정 실패" 메시지와 함께 **기존 종목이 이미 지워진 채로** 남았다. 관리자만 밟던 길이라 드물었지만 작성자에게 열면 실제로 터진다 — 검증을 앞으로 옮겼다.

## 변경 흐름 (Mermaid)

```mermaid
flowchart TD
    A[대회 상세에서 수정 시도] --> B{관리자인가}
    B -->|예| P[수정 허용]
    B -->|아니오| C{crt_by 있나}
    C -->|없음<br/>외부 수집분·기존 대회| D[거부<br/>운영진만 수정 가능]
    C -->|있음| E{crt_by == 나인가}
    E -->|예| P
    E -->|아니오| F[거부<br/>직접 등록한 대회만]
    P --> G[종목 한글 검증]
    G -->|실패| H[거부 — 이때 comp_evt_cfg는<br/>아직 안 지워진 상태]
    G -->|통과| I[comp_mst UPDATE<br/>→ comp_evt_cfg 전량 교체]
```

## ⚠️ 배포 순서

**마이그레이션을 코드보다 먼저 적용해야 한다.** `crt_by` 컬럼 없이 새 코드가 뜨면 `updateCompetition`의 select와 `/races` 조회가 **전부 실패**한다.

마이그레이션끼리도 순서가 있다 (컬럼이 먼저 생겨야 RPC가 참조 가능):

1. `20260804100000_comp_mst_crt_by.sql` — 컬럼 + FK
2. `20260804110000_comp_rpc_short_id_crt_by.sql` — RPC (`DROP` 후 재생성, 반환 컬럼이 늘어 `CREATE OR REPLACE` 불가)

## 검증

- `tsc --noEmit` 통과
- `eslint` 통과 (경고만, 전부 기존 것)
- `vitest run` — 37 파일 442 테스트 통과

## 남겨둔 것

- **수정 이력**: 누가 무엇을 바꿨는지는 아직 안 남는다(`upd_at`만 갱신). `comp_mst`는 `short_id`·`ext_id`가 둘 다 UNIQUE라 `team_mem_rel`식 인테이블 `vers` 스냅샷이 그대로 안 들어맞아(UNIQUE 위반 + 딥링크 `maybeSingle()` 파손) 별도 설계가 필요하다 — 다음 PR.
- **`updateCompetition` 파일 위치**: `app/actions/admin/`에 남겼다. 서버 액션은 페이지 게이트와 무관하게 액션 id로 직접 호출되므로 디렉터리 이름이 권한 주장인데, 유일한 호출처인 `admin-competitions-client.tsx`가 기존 lint 에러 3건(`react-hooks/set-state-in-effect`)을 안고 있어 import를 건드리면 pre-commit이 막힌다. 파일 상단에 "여기 전부 관리자 전용은 아니다"라고 못박아 뒀고, 그 lint 빚 정리와 함께 옮기는 게 맞다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **새 기능**
  - 대회 생성자 정보가 기록됩니다.
  - 대회 생성자 또는 관리자에게 대회 정보 수정 권한이 제공됩니다.
  - 대회 조회 및 팀별 대회 조회 결과에 단축 식별자와 생성자 정보가 포함됩니다.

- **버그 수정**
  - 대회 종목 검증 실패 시 기존 설정이 삭제되지 않도록 개선했습니다.
  - 생성자 정보가 없는 대회는 관리자만 수정할 수 있습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->