### PR TITLE
fix(profile): 페이스 P730_OVER 라벨을 슬로우러닝으로 변경

### DIFF
--- a/components/auth/member-onboarding-form.tsx
+++ b/components/auth/member-onboarding-form.tsx
@@ -333,7 +333,7 @@ export function MemberOnboardingForm({
     const paceMsg = !wizardProfile.avgPaceCd
       ? "페이스는 같이 뛰다 보면 금방 알게 돼요.\n잘 오셨어요!"
       : wizardProfile.avgPaceCd === "P730_OVER"
-        ? "여유로운 페이스 환영이에요.\n기강은 같이 달리는 게 전부예요 🙌"
+        ? "슬로우러닝 환영이에요.\n기강은 같이 달리는 게 전부예요 🙌"
         : wizardProfile.avgPaceCd === "UNKNOWN"
           ? "페이스는 같이 뛰다 보면 금방 알게 돼요.\n잘 오셨어요!"
           : `${PACE_LABELS[wizardProfile.avgPaceCd]} 페이스요? 기강이랑 딱 맞는 속도예요.\n첫 모임에서 봬요 🔥`;

--- a/lib/member-card.ts
+++ b/lib/member-card.ts
@@ -332,8 +332,10 @@ export function getRunningProfileLine(
   const paceCd = profile.avg_pace_cd as (typeof AVG_PACE_CODES)[number] | null;
   // UNKNOWN("잘 모르겠어요")은 정보가 없는 것과 같다.
   if (paceCd && paceCd !== "UNKNOWN" && PACE_LABELS[paceCd]) {
-    // P730_OVER만 문장형 라벨이라 "/km"를 붙이면 말이 안 된다.
-    parts.push(paceCd === "P730_OVER" ? `7'30" 이상` : `${PACE_LABELS[paceCd]}/km`);
+    // P730_OVER만 숫자가 아니라 구간 이름("슬로우러닝")이라 "/km"를 붙이면 말이 안 된다.
+    parts.push(
+      paceCd === "P730_OVER" ? PACE_LABELS[paceCd] : `${PACE_LABELS[paceCd]}/km`,
+    );
   }
   if (profile.avg_run_dist_km != null && profile.avg_run_dist_km > 0) {
     parts.push(`${profile.avg_run_dist_km}km`);
@@ -370,7 +372,8 @@ export function getRunningProfileChips(
   if (paceCd && paceCd !== "UNKNOWN" && PACE_LABELS[paceCd]) {
     chips.push({
       kind: "pace",
-      value: paceCd === "P730_OVER" ? `7'30"+` : `${PACE_LABELS[paceCd]}/km`,
+      // 한 줄(getRunningProfileLine)과 같은 이유로 P730_OVER만 "/km"를 안 붙인다.
+      value: paceCd === "P730_OVER" ? PACE_LABELS[paceCd] : `${PACE_LABELS[paceCd]}/km`,
     });
   }
   if (profile.avg_run_dist_km != null && profile.avg_run_dist_km > 0) {

--- a/lib/validations/member.ts
+++ b/lib/validations/member.ts
@@ -96,7 +96,7 @@ export const PACE_LABELS: Record<(typeof AVG_PACE_CODES)[number], string> = {
   P630: "6'30\"",
   P700: "7'00\"",
   P730: "7'30\"",
-  P730_OVER: "7'30\"보다 여유롭게",
+  P730_OVER: "슬로우러닝",
   UNKNOWN: "잘 모르겠어요",
 };
 


### PR DESCRIPTION
## 관련 이슈

관련 이슈 없음

## 요약

평균 페이스 선택지 `7'30"보다 여유롭게`를 **슬로우러닝**으로 바꿉니다. 문구가 길고 판정하는 말투라 고르기 부담스러웠습니다.
코드값(`P730_OVER`)은 그대로라 DB 마이그레이션·데이터 보정이 필요 없습니다.

## AS-IS (변경 전)

- 온보딩 4단계·프로필 편집의 페이스 셀렉트에 `7'30"보다 여유롭게`가 뜹니다. 다른 선택지가 전부 `5'30"` 같은 숫자인데 이 항목만 문장이라 목록에서 튀고, "여유롭게"가 느린 사람을 에둘러 부르는 말로 읽힙니다.
- 같은 구간을 **화면마다 다른 이름으로** 부르고 있었습니다.

  | 화면 | 표기 | 출처 |
  |---|---|---|
  | 온보딩·프로필 편집 셀렉트, 프로필 카드 도트리더, 관리자 회원관리, 운영 MCP | `7'30"보다 여유롭게` | `PACE_LABELS` |
  | 간단 카드 한 줄 | `7'30" 이상` | `member-card.ts` 하드코딩 |
  | 간단 카드 칩 | `7'30"+` | `member-card.ts` 하드코딩 |
  | 가입 완료 멘트 | `여유로운 페이스 환영이에요` | 온보딩 폼 하드코딩 |

- 하드코딩이 갈라진 이유는 `/km` 때문입니다. 다른 코드는 `5'30"/km`로 붙지만 이 항목만 문장이라 붙일 수 없어, 각자 자기 자리에서 짧은 문자열을 새로 지어 썼습니다.

## TO-BE (변경 후)

- 라벨을 `슬로우러닝` 한 단어로 바꿉니다. 짧은 명사라 셀렉트·한 줄·칩 어디에 놓아도 그대로 들어갑니다.
- 하드코딩 두 곳을 `PACE_LABELS`를 보도록 정리했습니다. `/km`를 안 붙이는 **예외만** 남습니다(숫자가 아니라 구간 이름이라서). 다음에 이름을 또 바꿔도 상수 한 줄만 고치면 전 화면이 따라옵니다.
- 가입 완료 멘트도 `슬로우러닝 환영이에요`로 맞췄습니다. 안 맞추면 같은 가입 흐름 안에서 셀렉트는 "슬로우러닝", 완료 화면은 "여유로운 페이스"로 한 구간을 두 이름으로 부르게 됩니다.

### 기존 데이터

**보정 작업이 필요 없습니다.** DB에는 라벨이 아니라 코드(`P730_OVER`)만 저장돼 있고, `cmm_cd_mst` 공통코드에도 페이스 그룹이 없으며, 마이그레이션·RPC 어디에도 이 문자열이 없습니다. 라벨은 전부 `PACE_LABELS`에서 나오므로 **prd에 이미 있는 해당 멤버 2명도 배포 즉시 새 이름으로 보입니다.**

코드값을 바꿨다면 `ck_mem_onbd_prf_avg_pace_cd` CHECK 제약과 기존 행까지 손봐야 했지만, 보이는 이름만 바꾸는 거라 그럴 필요가 없습니다.

## 주요 변경 사항

| 파일 | 내용 |
|---|---|
| `lib/validations/member.ts` | `PACE_LABELS.P730_OVER` → `"슬로우러닝"` (라벨 단일 정본) |
| `lib/member-card.ts` | `getRunningProfileLine`·`getRunningProfileChips`의 `7'30" 이상` / `7'30"+` 하드코딩 제거 → `PACE_LABELS` 참조 |
| `components/auth/member-onboarding-form.tsx` | 가입 완료 멘트 문구 정렬 |

## 확인

- `pnpm test` 442개 통과 (pre-commit 훅에서 전체 실행)
- `pnpm exec eslint` 클린
- 참고: `docs/design/2026-07-08-뉴비온보딩-유령회원방지.md`의 코드-라벨 표에는 옛 이름이 남아 있습니다. 당시 설계를 기록한 문서라 이번엔 건드리지 않았습니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **개선 사항**
  * 느린 페이스 관련 안내 문구가 ‘슬로우러닝’으로 통일되었습니다.
  * 러닝 프로필과 페이스 라벨에 ‘슬로우러닝’이 일관되게 표시됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->