### PR TITLE
feat(admin): 회원관리에서 회원 이름 변경

### DIFF
--- a/app/(info)/admin/members/admin-members-client.tsx
+++ b/app/(info)/admin/members/admin-members-client.tsx
@@ -13,6 +13,7 @@ import {
   ChevronDown,
   LogOut,
   Loader2,
+  Pencil,
 } from "lucide-react";
 
 import { dayjs } from "@/lib/dayjs";
@@ -32,6 +33,7 @@ import {
   deactivateMember,
   batchDeactivateMembers,
   batchReactivateMembers,
+  updateMemberName,
 } from "@/app/actions/admin/manage-member";
 import { revokeTitle } from "@/app/actions/admin/revoke-title";
 
@@ -788,6 +790,11 @@ export function AdminMembersClient({ teamId, initialTeamMemId }: { teamId: strin
   const [deactivateTarget, setDeactivateTarget] = useState<{ ids: string[] } | null>(null);
   const [deactivateReason, setDeactivateReason] = useState("");
   const [statusChangeMember, setStatusChangeMember] = useState<Member | null>(null);
+  // 이름 변경 — 상세 시트 이름 옆 연필로 연다
+  const [nameEditMember, setNameEditMember] = useState<Member | null>(null);
+  const [nameDraft, setNameDraft] = useState("");
+  const [nameError, setNameError] = useState<string | null>(null);
+  const [savingName, setSavingName] = useState(false);
 
   const loadMembers = useCallback(async () => {
     const supabase = createClient();
@@ -920,6 +927,37 @@ export function AdminMembersClient({ teamId, initialTeamMemId }: { teamId: strin
       alert(result.message);
     }
     setActioning(false);
+  };
+
+  function openNameEdit(member: Member) {
+    setNameEditMember(member);
+    setNameDraft(member.full_name ?? "");
+    setNameError(null);
+  }
+
+  const handleRenameMember = async () => {
+    if (!nameEditMember) return;
+    const next = nameDraft.trim();
+    // 안 바뀌었으면 서버까지 갈 이유가 없다 — 그냥 닫는다.
+    if (next === (nameEditMember.full_name ?? "")) {
+      setNameEditMember(null);
+      return;
+    }
+    setSavingName(true);
+    setNameError(null);
+    const result = await updateMemberName(nameEditMember.id, next);
+    if (result.ok) {
+      const memberId = nameEditMember.id;
+      setNameEditMember(null);
+      // 열려 있는 상세 시트도 같이 갱신 — loadMembers는 목록만 새로 만든다.
+      setSelectedMember((prev) =>
+        prev?.id === memberId ? { ...prev, full_name: result.name } : prev,
+      );
+      await loadMembers();
+    } else {
+      setNameError(result.message);
+    }
+    setSavingName(false);
   };
 
   const handleToggleAdmin = async (memberId: string, isAdmin: boolean) => {
@@ -1242,6 +1280,17 @@ export function AdminMembersClient({ teamId, initialTeamMemId }: { teamId: strin
                     <span className="text-lg font-bold text-foreground">
                       {selectedMember.full_name ?? "이름 없음"}
                     </span>
+                    {/* 이름 옆 연필 — 앱 공통 편집 어포던스(§DESIGN 프로필 카드)와 같은 어법 */}
+                    <Button
+                      variant="ghost"
+                      size="icon-sm"
+                      onClick={() => openNameEdit(selectedMember)}
+                      disabled={actioning || isPending}
+                      aria-label="이름 변경"
+                      className="text-muted-foreground"
+                    >
+                      <Pencil className="size-3.5" />
+                    </Button>
                     {selectedMember.admin && (
                       <Badge variant="default" className="text-[11px]">관리자</Badge>
                     )}
@@ -1370,6 +1419,56 @@ export function AdminMembersClient({ teamId, initialTeamMemId }: { teamId: strin
           </div>
         </div>
       )}
+
+      {/* 이름 변경 다이얼로그 */}
+      <Dialog
+        open={!!nameEditMember}
+        onOpenChange={(o) => {
+          if (!o) {
+            setNameEditMember(null);
+            setNameError(null);
+          }
+        }}
+      >
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>이름 변경</DialogTitle>
+          </DialogHeader>
+          <div className="flex flex-col gap-4 pt-2">
+            <div className="flex flex-col gap-1.5">
+              <Label htmlFor="member-name-input">이름</Label>
+              <Input
+                id="member-name-input"
+                value={nameDraft}
+                onChange={(e) => {
+                  setNameDraft(e.target.value);
+                  setNameError(null);
+                }}
+                onKeyDown={(e) => {
+                  if (e.key === "Enter" && !savingName) handleRenameMember();
+                }}
+                placeholder="한글 2~5자"
+                maxLength={5}
+                autoFocus
+              />
+              {nameError && (
+                <Micro className="text-destructive">{nameError}</Micro>
+              )}
+            </div>
+            {/* 회비 매칭이 이름을 보므로 미리 알린다 — 누른 뒤에 알면 늦다 */}
+            <Micro className="leading-relaxed">
+              아직 확정하지 않은 회비 입금의 이름 매칭이 새 이름 기준으로 다시
+              계산됩니다. 확정된 내역과 학습된 입금자 별칭은 그대로예요.
+            </Micro>
+            <Button
+              onClick={handleRenameMember}
+              disabled={savingName || !nameDraft.trim()}
+            >
+              {savingName ? <LoadingSpinner /> : "변경"}
+            </Button>
+          </div>
+        </DialogContent>
+      </Dialog>
 
       {/* 비활성 설정 다이얼로그 */}
       <Dialog

--- a/app/actions/admin/manage-member.ts
+++ b/app/actions/admin/manage-member.ts
@@ -8,6 +8,7 @@ import { dayjs } from "@/lib/dayjs";
 import { sealBalanceAnchor } from "@/lib/dues/seal-anchor";
 import { getRequestTeamContext } from "@/lib/queries/request-team";
 import { createAdminClient } from "@/lib/supabase/admin";
+import { koreanNameSchema } from "@/lib/validations/member";
 
 export async function approveMember(memberId: string) {
   return withAdmin(async () => {
@@ -54,6 +55,58 @@ export async function rejectMember(memberId: string) {
     });
     if (error) return { ok: false, message: "거절에 실패했습니다" };
     return { ok: true, message: null };
+  });
+}
+
+/**
+ * 이름 변경 — 관리자가 회원의 이름(`mem_mst.mem_nm`)을 고친다.
+ *
+ * 본인이 가입할 때 적은 이름이지만 오타·별명("효인" ↔ "김효인")으로 들어오는 일이 잦고,
+ * 본인은 프로필 수정에서 고칠 수 있어도 **관리자에겐 고칠 자리가 없었다**.
+ *
+ * ⚠️ **회비 입금자명 매칭이 이 이름을 본다**(`matchPayer`). 바꾸면 **아직 확정하지 않은**
+ * 거래의 자동 매칭이 새 이름 기준으로 다시 계산된다(인박스는 읽는 시점에 매칭한다).
+ * 이미 확정된 거래는 `mem_id`가 박혀 있어 영향이 없고, 학습된 별칭(`fee_payer_alias`)도
+ * 그대로 남아 **옛 이름으로 들어온 입금은 계속 붙는다** — 잔액·부과 로직은 건드리지 않는다.
+ *
+ * `mem_mst`는 팀에 매이지 않은 전역 신원이라, 우리 팀 소속인지 먼저 확인하고 손댄다.
+ */
+export async function updateMemberName(memberId: string, name: string) {
+  return withAdmin(async () => {
+    const parsed = koreanNameSchema.safeParse(name);
+    if (!parsed.success) {
+      return {
+        ok: false as const,
+        message: parsed.error.issues[0]?.message ?? "이름을 확인해 주세요",
+      };
+    }
+    const newName = parsed.data;
+
+    const { teamId } = await getRequestTeamContext();
+    const db = createAdminClient();
+
+    const { data: rel } = await db
+      .from("team_mem_rel")
+      .select("team_mem_id")
+      .eq("mem_id", memberId)
+      .eq("team_id", teamId)
+      .eq("vers", 0)
+      .eq("del_yn", false)
+      .maybeSingle();
+    if (!rel) return { ok: false as const, message: "변경할 수 있는 대상이 아닙니다" };
+
+    const { error } = await db
+      .from("mem_mst")
+      .update({ mem_nm: newName })
+      .eq("mem_id", memberId)
+      .eq("vers", 0)
+      .eq("del_yn", false);
+    if (error) return { ok: false as const, message: "이름 변경에 실패했습니다" };
+
+    revalidatePath("/admin/members");
+    // 회비 인박스가 이름으로 입금자를 맞추므로 함께 턴다(매칭 결과가 즉시 새 이름 기준이 되게).
+    revalidatePath("/admin/dues");
+    return { ok: true as const, message: null, name: newName };
   });
 }
 


### PR DESCRIPTION
## 관련 이슈

관련 이슈 없음

## 요약

관리자가 회원관리에서 회원 이름을 고칠 수 있게 합니다. 상세 시트의 **이름 옆 연필**로 그 자리에서 바꿉니다.

## AS-IS (변경 전)

- 가입 때 적은 이름이 오타나 별명으로 들어오는 일이 잦습니다(실제 사례: `효인` → 통장 실명은 `김효인`).
- 본인은 프로필 수정에서 고칠 수 있지만 **관리자에겐 고칠 자리가 없었습니다.** 회원관리 상세 시트가 할 수 있는 건 관리자 지정/해제 · 상태 변경 · 칭호 · 삭제뿐이고, 이름은 읽기 전용이었습니다.
- 결과적으로 운영자가 DB를 직접 건드려야 했습니다.
- 이름이 틀린 채로 남으면 **회비 입금자명 자동 매칭이 계속 빗나갑니다** — 인박스에서 매번 손으로 붙여야 합니다.

## TO-BE (변경 후)

- 회원관리 → 회원 탭 → 회원 클릭 → 상세 시트 **이름 옆 연필** → 다이얼로그에서 변경.
- 액션 버튼 목록(관리자 지정·상태 변경·삭제)을 늘리지 않고, 앱 공통 편집 어포던스(프로필 카드의 연필)와 같은 어법을 씁니다. 고칠 대상 바로 옆이 가장 짧은 경로이기도 합니다.
- 저장하면 열려 있는 상세 시트와 목록이 함께 갱신됩니다.

### 서버 쪽 방어

- `withAdmin` — 관리자만. 버튼을 감추는 건 안내일 뿐이라 서버가 다시 판정합니다(`memberId`만 알면 액션은 직접 호출됩니다).
- **`mem_mst`는 팀에 매이지 않은 전역 신원**이라, 다른 관리자 액션들과 같이 `team_mem_rel`로 우리 팀 소속인지 먼저 확인하고 손댑니다.
- 검증은 본인 프로필 수정과 **같은 `koreanNameSchema`**(한글 2~5자). 따로 만들면 관리자만 통과하는 이름이 생깁니다.

## ⚠️ 회비에 닿는 부분

회비 인박스는 입금자명을 **읽는 시점에** `mem_mst.mem_nm`과 맞춥니다(`matchPayer`). 이름을 바꾸면:

| 대상 | 영향 |
|---|---|
| **아직 확정 안 한 거래** | 자동 매칭이 **새 이름 기준으로 다시 계산됨** — 통장 실명과 맞추면 안 붙던 게 붙습니다(이 기능의 실질 효용) |
| 이미 확정한 거래 | **없음** — `mem_id`가 박혀 있음 |
| 학습된 입금자 별칭(`fee_payer_alias`) | **그대로 남음** — 옛 이름으로 들어온 입금도 계속 매칭됨 |
| 잔액 · 부과 · 면제 | **손대지 않음** — 재계산(`recalculateBalance`) 호출 없음 |

되돌리기도 이름을 다시 바꾸면 그만이라 소급 효과가 없습니다. 다만 관리자가 **누르기 전에** 알아야 해서 다이얼로그에 한 줄로 적었습니다("아직 확정하지 않은 회비 입금의 이름 매칭이 새 이름 기준으로 다시 계산됩니다. 확정된 내역과 학습된 입금자 별칭은 그대로예요").

캐시는 `/admin/members`와 함께 `/admin/dues`도 텁니다 — 인박스 매칭 결과가 즉시 새 이름 기준이 되도록.

## 변경 흐름 (Mermaid)

```mermaid
sequenceDiagram
    participant A as 관리자
    participant C as AdminMembersClient
    participant S as updateMemberName
    participant DB as Supabase

    A->>C: 상세 시트 이름 옆 연필
    C->>A: 이름 변경 다이얼로그 (회비 영향 안내)
    A->>C: 새 이름 입력 후 변경
    C->>S: updateMemberName(memberId, name)
    S->>S: withAdmin 권한 확인
    S->>S: koreanNameSchema 검증
    S->>DB: team_mem_rel 로 우리 팀 소속 확인
    alt 소속 아님
        S-->>C: ok:false "변경할 수 있는 대상이 아닙니다"
        C->>A: 다이얼로그에 에러 표시 (열린 채 유지)
    else 소속
        S->>DB: mem_mst.mem_nm 갱신
        S->>S: revalidatePath /admin/members, /admin/dues
        S-->>C: ok:true + 저장된 이름
        C->>C: 상세 시트 + 목록 갱신
    end
```

## 주요 변경 사항

| 파일 | 내용 |
|---|---|
| `app/actions/admin/manage-member.ts` | `updateMemberName(memberId, name)` 서버 액션 추가 |
| `app/(info)/admin/members/admin-members-client.tsx` | 상세 시트 이름 옆 연필 + 이름 변경 다이얼로그, 저장 후 로컬 상태 갱신 |

## 확인

- `pnpm exec tsc --noEmit` 클린
- `pnpm exec eslint` 클린
- `pnpm test` 442개 통과 (pre-commit 훅에서 전체 실행)
- `pnpm run build` 성공

⚠️ **실제 화면 클릭 경로는 미검증입니다.** `/admin/members`가 로그인 뒤라 dev 서버로는 리다이렉트까지만 확인했습니다. 빌드가 클라이언트 번들까지 컴파일하긴 했지만, 머지 전에 브라우저에서 한 번 눌러봐 주세요.

## 남겨둔 것

**이름 변경 이력이 남지 않습니다.** `mem_mst`는 `team_mem_rel`과 달리 `apply_*_change` 같은 이력 RPC가 없어, 누가 언제 무엇으로 바꿨는지 추적되지 않습니다. 지금 규모(관리자 소수)에선 과하다고 보고 넣지 않았습니다 — 필요하면 별건으로 얹겠습니다.
