### PR TITLE
feat(title): 획득 이력 시트 + 실시간 수여 알림 + 즉시 평가 비동기화

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -276,6 +276,7 @@ import { H1, H2, Body, Caption, Micro, SectionLabel } from "@/components/common/
 | IntroEditDialog | `intro-edit-dialog.tsx` | `open`, `onOpenChange`, `initialValue`, `onSaved?`, `stacked?` | 한마디 한 줄 인라인 편집(페이지 이동 없음) |
 | AvatarEditDialog | `profile/avatar-edit-dialog.tsx` | `open`, `onOpenChange`, `memId`, `memNm`, `currentUrl`, `onSaved?` | 프로필 사진 인라인 변경 — 미리보기 + 기본 이미지로 되돌리기 |
 | ProfileTabCard | `profile/profile-tab-card.tsx` | `memId`, `teamMemId`, `teamId`, `card`, `utmb`, … | 프로필탭 본문 — `MemberCardDetail`에 `edit`을 물리고 편집 다이얼로그들을 연결 |
+| TitleHistorySheet | `profile/title-history-sheet.tsx` | `open`, `onOpenChange` | 칭호 획득 이력 — 수여 시각 역순. **본인 것만**(서버 액션이 세션 team_mem_id만 읽는다) |
 
 - **간단 vs 상세**: 간단 카드는 "이 사람이 누구인지"(한마디·러닝 프로필), 상세 카드는 "이 사람의 실적".
   실적이 없는 신규 멤버도 채워지도록 간단 카드에는 수치를 넣지 않는다.
@@ -367,6 +368,19 @@ import { H1, H2, Body, Caption, Micro, SectionLabel } from "@/components/common/
 - **활동 포인트**(`stats.activity_score`) — 최근활동 헤더 우측 primary pill + `HelpTip`
   ("모임 참석·대회 출전·기록 등록으로 쌓여요"). 적립 규칙 전문은 여전히 비공개.
   **남의 카드에는 절대 노출하지 않는다** — 공개되면 사실상 공개 랭킹 지표가 된다(렌더 테스트가 지킨다).
+- **칭호 획득 이력**(`TitleHistorySheet`) — 하단 칭호 섹션 헤더 우측 `획득 이력`.
+  **도감(`CollectionSheet`)과 축이 다르다**: 도감은 등급·카테고리 순으로 *뭘 모았나*를, 이력은
+  시간 역순으로 *언제 땄나*를 말한다. 칭호는 대부분 조용히 붙어서(알림을 놓치면 언제 생겼는지
+  알 길이 없다) 시간축이 따로 필요하고, 그래서 **`ttl_grnt` 알림의 딥링크가 이 시트로 온다**
+  (`/profile?ttl=history`). 프로필로만 보내면 "무엇이 새로 생겼는지"를 못 짚어 알림이 절반만 일한다.
+  - 우측 `획득 이력`은 **연필이 아니라서** "하단 칭호 섹션엔 연필을 달지 않는다"와 충돌하지 않는다 —
+    고치는 자리(대표 칭호)는 여전히 상단 하나뿐이고, 이건 훑는 자리다.
+  - **회수분은 안 싣는다**(`del_yn=true` 제외). 회수는 운영진 행위인데 알림이 따로 없어,
+    이력에 남기면 본인은 영문을 모른 채 빼앗긴 줄만 보게 된다(자동 회수를 안 넣은 것과 같은 태도).
+  - 수여 사유(`grnt_rsn_txt`)는 `자동수여 (trigger=…)`라 **내부 용어라 화면에 쓰지 않는다** —
+    드문 쪽(운영진 수여)에만 라벨을 달고 자동은 무표시다(전 줄에 붙으면 정보가 아니라 배경이 된다).
+  - `grnt_at`은 timestamptz라 **`formatKST`로 찍는다**. 목록이 여러 해에 걸치므로 연도까지 쓴다
+    (활동량 내역은 이번 달뿐이라 `M.DD`).
 - **편집 진입점**: 사진·한마디·칭호·기록 관리/추가·UTMB는 그 자리에서 다이얼로그로 열고,
   **러닝 프로필 + 가입 목적만 `/profile/edit#running-profile`로 보낸다.** 역 콤보박스·페이스 셀렉트·
   목적 칩을 다이얼로그로 다시 만들면 폼이 두 벌이 되어 한쪽만 고쳐 어긋난다. 사진은 파일 하나를

--- a/app/actions/__tests__/gathering-cancel-history.test.ts
+++ b/app/actions/__tests__/gathering-cancel-history.test.ts
@@ -36,6 +36,10 @@ const h = vi.hoisted(() => {
 });
 
 vi.mock("next/cache", () => ({ revalidatePath: vi.fn() }));
+// 액션은 뒷일(모임장 알림·칭호 평가)을 `after()`로 응답 밖에 넘긴다. 요청 스코프가 없는
+// 단위 테스트에서 진짜 `after`는 던지므로, 콜백을 그 자리에서 실행하는 스텁으로 바꾼다.
+// 콜백 본문의 Promise.all 배열은 동기적으로 만들어지므로 insertNoti 호출은 즉시 일어난다.
+vi.mock("next/server", () => ({ after: (fn: () => unknown) => { void fn(); } }));
 vi.mock("@/lib/past-event", () => ({ isPastLockedFor: () => false }));
 vi.mock("@/lib/queries/request-team", () => ({
   getRequestTeamContext: async () => ({ teamId: "team-1" }),
@@ -45,7 +49,8 @@ vi.mock("@/lib/gathering/join-gathering", () => ({
 }));
 // toggle-attendance.ts가 취소 성공 후 모임장 알림을 위해 import한다(SG-05) — 이 테스트는 알림 발송
 // 자체를 검증 대상으로 하지 않으므로 no-op으로 스텁(실제 발송 검증은 gathering-cancel-notify.test.ts).
-vi.mock("@/lib/notifications/insert-noti", () => ({ insertNoti: vi.fn() }));
+// 실제 insertNoti는 async — 호출부가 .catch()를 물리므로 모킹도 Promise를 돌려준다.
+vi.mock("@/lib/notifications/insert-noti", () => ({ insertNoti: vi.fn(async () => {}) }));
 vi.mock("@/lib/actions/auth", () => ({
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   withActive: async (fn: any) =>

--- a/app/actions/__tests__/gathering-cancel-notify.test.ts
+++ b/app/actions/__tests__/gathering-cancel-notify.test.ts
@@ -7,7 +7,9 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const h = vi.hoisted(() => {
   const rpc = vi.fn();
-  const insertNoti = vi.fn();
+  // 실제 insertNoti는 async — 호출부가 .catch()를 물리므로 모킹도 Promise를 돌려준다.
+  // (vi.fn(impl)은 mockReset 후에도 이 구현으로 복원된다)
+  const insertNoti = vi.fn(async () => {});
 
   const queryStub = (result: unknown) => {
     const p = Promise.resolve(result);
@@ -43,6 +45,10 @@ const h = vi.hoisted(() => {
 });
 
 vi.mock("next/cache", () => ({ revalidatePath: vi.fn() }));
+// 액션은 뒷일(모임장 알림·칭호 평가)을 `after()`로 응답 밖에 넘긴다. 요청 스코프가 없는
+// 단위 테스트에서 진짜 `after`는 던지므로, 콜백을 그 자리에서 실행하는 스텁으로 바꾼다.
+// 콜백 본문의 Promise.all 배열은 동기적으로 만들어지므로 insertNoti 호출은 즉시 일어난다.
+vi.mock("next/server", () => ({ after: (fn: () => unknown) => { void fn(); } }));
 vi.mock("@/lib/past-event", () => ({ isPastLockedFor: () => false }));
 vi.mock("@/lib/queries/request-team", () => ({
   getRequestTeamContext: async () => ({ teamId: "team-1" }),

--- a/app/actions/__tests__/gathering-cancel-reason-required.test.ts
+++ b/app/actions/__tests__/gathering-cancel-reason-required.test.ts
@@ -35,6 +35,10 @@ const h = vi.hoisted(() => {
 });
 
 vi.mock("next/cache", () => ({ revalidatePath: vi.fn() }));
+// 액션은 뒷일(모임장 알림·칭호 평가)을 `after()`로 응답 밖에 넘긴다. 요청 스코프가 없는
+// 단위 테스트에서 진짜 `after`는 던지므로, 콜백을 그 자리에서 실행하는 스텁으로 바꾼다.
+// 콜백 본문의 Promise.all 배열은 동기적으로 만들어지므로 insertNoti 호출은 즉시 일어난다.
+vi.mock("next/server", () => ({ after: (fn: () => unknown) => { void fn(); } }));
 vi.mock("@/lib/past-event", () => ({ isPastLockedFor: () => false }));
 vi.mock("@/lib/queries/request-team", () => ({
   getRequestTeamContext: async () => ({ teamId: "team-1" }),
@@ -44,7 +48,8 @@ vi.mock("@/lib/gathering/join-gathering", () => ({
 }));
 // toggle-attendance.ts가 취소 성공 후 모임장 알림을 위해 import한다(SG-05) — 이 테스트는 알림 발송
 // 자체를 검증 대상으로 하지 않으므로 no-op으로 스텁(실제 발송 검증은 gathering-cancel-notify.test.ts).
-vi.mock("@/lib/notifications/insert-noti", () => ({ insertNoti: vi.fn() }));
+// 실제 insertNoti는 async — 호출부가 .catch()를 물리므로 모킹도 Promise를 돌려준다.
+vi.mock("@/lib/notifications/insert-noti", () => ({ insertNoti: vi.fn(async () => {}) }));
 vi.mock("@/lib/actions/auth", () => ({
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   withActive: async (fn: any) =>

--- a/app/actions/comment/manage-comment.ts
+++ b/app/actions/comment/manage-comment.ts
@@ -152,12 +152,18 @@ export async function createComment(input: CreateCommentInput) {
     })
 
     // 댓글 칭호(말대꾸·소환술사·자문자답)는 댓글이 달리는 순간 확정된다.
+    //
+    // 위 알림과 같이 **응답 밖에서** 돈다 — 댓글은 이미 저장됐고 칭호는 그 성공 여부를
+    // 바꾸지 않는다. 이 세 조건은 내 댓글 목록·멘션·내 글의 첫 댓글을 보느라 왕복 4번을
+    // 쓰는데, `await`로 두면 그게 그대로 댓글이 화면에 붙는 시간이 된다.
     // catch가 삼키므로 칭호 부여 실패가 이미 저장된 댓글을 되돌리지 않는다.
-    await evaluateAndGrantTitles({
-      trigger: "comment_create",
-      teamId,
-      teamMemId: member.team_mem_id,
-    }).catch((e) => console.error("[title-engine] comment_create 평가 실패", e))
+    after(() =>
+      evaluateAndGrantTitles({
+        trigger: "comment_create",
+        teamId,
+        teamMemId: member.team_mem_id,
+      }).catch((e) => console.error("[title-engine] comment_create 평가 실패", e)),
+    )
 
     return { ok: true as const, data: cmnt }
   })

--- a/app/actions/gathering/toggle-attendance.ts
+++ b/app/actions/gathering/toggle-attendance.ts
@@ -1,6 +1,7 @@
 "use server";
 
 import { revalidatePath } from "next/cache";
+import { after } from "next/server";
 
 import { withActive } from "@/lib/actions/auth";
 import { dayjs } from "@/lib/dayjs";
@@ -77,42 +78,47 @@ export async function toggleGatheringAttendance(
       });
       if (cancelError) throw new Error("참석 취소에 실패했습니다.");
 
-      // 모임장(개설자)에게 취소 알림 — 본인이 자기 모임을 취소한 경우엔 자기 자신에게 보내지 않는다.
-      // 알림은 부가 기능이라 실패해도 이미 완료된 취소 자체는 되돌리지 않는다(insertNoti 실패는 내부에서 로깅만).
-      // 수신거부는 gthr_cncl 자체 설정으로 판단한다 — 모임 수정·삭제(gthr_upd)와는 별개 항목으로,
-      // 알림 설정 UI의 "내 모임 참석 취소" 토글로 제어한다. prefTypeEnm 미지정 시 insertNoti가
-      // notiTypeEnm(gthr_cncl)으로 수신거부를 판단한다.
-      if (gthr.crt_by && gthr.crt_by !== member.id) {
-        try {
-          await insertNoti({
-            teamId,
-            memId: gthr.crt_by,
-            notiTypeEnm: "gthr_cncl",
-            notiNm: `${member.full_name}님이 '${gthr.gthr_nm}' 참석을 취소했어요`,
-            notiCont: reasonCheck.value ? `사유: ${reasonCheck.value}` : null,
-            refId: gthr_id,
-            refTypeEnm: "gathering",
-          });
-        } catch (e) {
-          console.error("[gthr_cncl] 알림 발송 실패", e);
-        }
-      }
-
       // 홈(/)은 dynamic 렌더(getCurrentMember가 cookies 사용)라 매 요청 새로 조회되므로
       // revalidatePath("/")는 무효화할 캐시가 없어 불필요 — 모임 상세 직접 URL만 무효화한다.
       revalidatePath(`/gatherings/${gthr_id}`);
 
-      // 취소 계열 칭호(다음엔꼭·회전문·월요병·칼퇴실패·구구절절)는 **취소 액션에서만** 붙는다 —
-      // 참석 액션에 훅만 달면 영원히 안 붙는다(취소는 다른 액션이다, 설계 §7.2).
+      // 뒷일(모임장 알림 · 칭호 평가)은 **응답 밖에서** 돈다.
       //
-      // `after()`가 아니라 await + catch인 이유: `after`는 요청 스코프를 요구해 서버 액션을
-      // 직접 부르는 테스트에서 던진다. `save-race-record.ts`도 같은 이유로 이 형태다.
-      // catch가 삼키므로 칭호 부여 실패가 이미 끝난 취소를 롤백시키지 않는다.
-      await evaluateAndGrantTitles({
-        trigger: "gathering_attend",
-        teamId,
-        teamMemId: member.team_mem_id,
-      }).catch((e) => console.error("[title-engine] gathering_attend(취소) 평가 실패", e));
+      // 취소는 위 RPC에서 이미 끝났고 이 둘은 성공 여부를 바꾸지 않는데, `await`로 두면
+      // 모임장 푸시(웹푸시 외부 HTTP)와 칭호 조회 왕복이 그대로 **취소 모달이 닫히는 시간**이
+      // 된다 — 클라이언트가 액션이 끝나야 모달을 닫기 때문이다(gathering-attend-button.tsx).
+      // 참석 등록과 달리 취소는 낙관적 업데이트가 모달에 가려 체감이 그대로 드러난다.
+      //
+      // 둘은 서로 독립이라 같이 출발시킨다. 각자 catch를 물고 있어 한쪽 실패가 다른 쪽을
+      // 막지 않고, 이미 끝난 취소를 되돌리지도 않는다.
+      after(async () => {
+        await Promise.all([
+          // 모임장(개설자)에게 취소 알림 — 본인이 자기 모임을 취소한 경우엔 보내지 않는다.
+          // 수신거부는 gthr_cncl 자체 설정으로 판단한다 — 모임 수정·삭제(gthr_upd)와는 별개
+          // 항목으로, 알림 설정 UI의 "내 모임 참석 취소" 토글로 제어한다. prefTypeEnm 미지정 시
+          // insertNoti가 notiTypeEnm(gthr_cncl)으로 수신거부를 판단한다.
+          gthr.crt_by && gthr.crt_by !== member.id
+            ? insertNoti({
+                teamId,
+                memId: gthr.crt_by,
+                notiTypeEnm: "gthr_cncl",
+                notiNm: `${member.full_name}님이 '${gthr.gthr_nm}' 참석을 취소했어요`,
+                notiCont: reasonCheck.value ? `사유: ${reasonCheck.value}` : null,
+                refId: gthr_id,
+                refTypeEnm: "gathering",
+              }).catch((e) => console.error("[gthr_cncl] 알림 발송 실패", e))
+            : Promise.resolve(),
+
+          // 취소 계열 칭호(다음엔꼭·회전문·월요병·칼퇴실패·구구절절)는 **취소 액션에서만**
+          // 붙는다 — 참석 액션에 훅만 달면 영원히 안 붙는다(취소는 다른 액션이다, 설계 §7.2).
+          // 트리거가 `gathering_attend`와 갈려 있어 여기선 막차(신청 순번)를 평가하지 않는다.
+          evaluateAndGrantTitles({
+            trigger: "gathering_cancel",
+            teamId,
+            teamMemId: member.team_mem_id,
+          }).catch((e) => console.error("[title-engine] gathering_cancel 평가 실패", e)),
+        ]);
+      });
 
       return { attending: false };
     }
@@ -140,11 +146,16 @@ export async function toggleGatheringAttendance(
     // 신청 순간에 확정되는 것만 여기서 본다 — 실질적으로 `막차`(정확히 정원 번째) 하나다.
     // 참석 계열(미라클·3연벙 등)은 여기 없다: 아직 열리지도 않은 모임을 **신청만 해도**
     // 붙어 버리고, 엔진이 비회수라 취소해도 안 없어진다. 그건 일 배치가 3일 유예를 두고 센다.
-    await evaluateAndGrantTitles({
-      trigger: "gathering_attend",
-      teamId,
-      teamMemId: member.team_mem_id,
-    }).catch((e) => console.error("[title-engine] gathering_attend(참석) 평가 실패", e));
+    //
+    // 취소 경로와 같은 이유로 응답 밖에서 돈다 — 판정 대상은 이미 INSERT된 신청 순번이라
+    // 응답 직후에 봐도 결과가 같다. 아래 월 참석 횟수 조회는 반환값(토스트)이라 여기 남는다.
+    after(() =>
+      evaluateAndGrantTitles({
+        trigger: "gathering_attend",
+        teamId,
+        teamMemId: member.team_mem_id,
+      }).catch((e) => console.error("[title-engine] gathering_attend(참석) 평가 실패", e)),
+    );
 
     // 이번 달(모임 귀속월) 본인 총참석 횟수 — 토스트 안내용(실패해도 참석 등록엔 영향 없음)
     let monthlyAttendCnt: number | undefined;

--- a/app/actions/mileage-run.ts
+++ b/app/actions/mileage-run.ts
@@ -338,7 +338,11 @@ export async function logActivity(
         prevAchvYn,
       };
       console.info("[title-engine] ctx:", ctx);
-      await evaluateAndGrantTitles(ctx).catch((e) => console.error("[title-engine] mileage_run(log) 평가 실패", e));
+      // 응답 밖에서 — 기록은 이미 저장됐고 이 경로는 반환값(획득 칭호)을 쓰지 않는다.
+      // 획득 사실은 엔진이 보내는 인앱 알림+푸시(`ttl_grnt`)로 전해진다.
+      after(() =>
+        evaluateAndGrantTitles(ctx).catch((e) => console.error("[title-engine] mileage_run(log) 평가 실패", e)),
+      );
     }
 
     revalidatePath("/projects");

--- a/app/actions/profile/title-history.ts
+++ b/app/actions/profile/title-history.ts
@@ -1,0 +1,97 @@
+"use server";
+
+import { withActive } from "@/lib/actions/auth";
+import { createAdminClient } from "@/lib/supabase/admin";
+
+/** 이력 한 줄 — "언제 무슨 칭호를 땄나" */
+export type TitleHistoryEntry = {
+  id: string;
+  ttl_nm: string;
+  ttl_desc: string | null;
+  desc_visibility: "always" | "others" | "held" | "never";
+  rarity_level: number;
+  /** 수여 시각(timestamptz) — 표시는 반드시 `formatKST`로 (§CLAUDE.md 날짜 규칙) */
+  grnt_at: string;
+  /** 자동 획득인가(false면 운영진 수여) — 원문 사유는 내부 용어라 화면에 쓰지 않는다 */
+  auto: boolean;
+};
+
+export type TitleHistoryResult =
+  | { ok: false; message: string }
+  | { ok: true; entries: TitleHistoryEntry[] };
+
+/** 한 사람이 이보다 많이 받을 일은 없다(dev 최대 32개). 방어적 상한 */
+const MAX_ROWS = 200;
+
+type Row = {
+  mem_ttl_id: string;
+  grnt_at: string | null;
+  crt_at: string;
+  grnt_rsn_txt: string | null;
+  ttl_mst:
+    | { ttl_nm: string; ttl_desc: string | null; desc_visibility: string; rarity_level: number }
+    | { ttl_nm: string; ttl_desc: string | null; desc_visibility: string; rarity_level: number }[]
+    | null;
+};
+
+/**
+ * 내 칭호 획득 이력 — 수여 시각 역순.
+ *
+ * **본인 것만 돌려준다.** `team_mem_id`를 인자로 받지 않고 세션의 것을 쓰는 게 그 장치다 —
+ * 인자로 열어 두면 남의 id만 알면 남의 이력을 읽을 수 있고, 칭호는 "언제 무엇을 했나"가
+ * 드러나는 자리다(취소 계열 칭호를 생각하면 더 그렇다).
+ *
+ * **회수분(`del_yn=true`)은 뺀다.** 회수는 운영진 행위인데 "빼앗김"이 이력에 남으면
+ * 본인은 영문을 모른 채 그 줄만 보게 된다 — 회수 알림이 따로 없다는 점도 같이 작용한다
+ * (자동 회수를 안 넣은 것과 같은 태도, `sweepEvaluateAndGrant` 주석).
+ *
+ * 이 목록은 도감(`CollectionSheet`)과 축이 다르다. 도감은 등급·카테고리 순으로 "뭘 모았나"를,
+ * 여기는 시간 역순으로 "언제 땄나"를 보여준다.
+ */
+export async function getTitleHistory(): Promise<TitleHistoryResult> {
+  try {
+    return await withActive(async ({ member }) => {
+      const db = createAdminClient();
+
+      const { data, error } = await db
+        .from("mem_ttl_rel")
+        .select(
+          "mem_ttl_id, grnt_at, crt_at, grnt_rsn_txt, ttl_mst(ttl_nm, ttl_desc, desc_visibility, rarity_level)",
+        )
+        .eq("team_mem_id", member.team_mem_id)
+        .eq("vers", 0)
+        .eq("del_yn", false)
+        .order("grnt_at", { ascending: false, nullsFirst: false })
+        .limit(MAX_ROWS);
+
+      if (error) {
+        console.error("[getTitleHistory] 이력 조회 실패", error);
+        return { ok: false as const, message: "잠시 후 다시 시도해 주세요" };
+      }
+
+      const entries: TitleHistoryEntry[] = [];
+      for (const row of (data ?? []) as unknown as Row[]) {
+        const t = Array.isArray(row.ttl_mst) ? row.ttl_mst[0] : row.ttl_mst;
+        // 운영에서 내린 칭호(ttl_mst 행이 안 잡히는 경우)는 건너뛴다 — 이름 없는 줄을 세우지 않는다.
+        if (!t) continue;
+        entries.push({
+          id: row.mem_ttl_id,
+          ttl_nm: t.ttl_nm,
+          ttl_desc: t.ttl_desc,
+          desc_visibility: (t.desc_visibility ?? "always") as TitleHistoryEntry["desc_visibility"],
+          rarity_level: t.rarity_level,
+          // 옛 행에 grnt_at이 비어 있어도 줄이 사라지지 않게 생성 시각으로 받친다.
+          grnt_at: row.grnt_at ?? row.crt_at,
+          // 엔진이 남기는 사유는 `자동수여 (trigger=...)` 형태다 — 내부 용어라 그대로 쓰지 않고
+          // 자동/수여 두 갈래로만 접는다.
+          auto: (row.grnt_rsn_txt ?? "").startsWith("자동수여"),
+        });
+      }
+
+      return { ok: true as const, entries };
+    });
+  } catch (e) {
+    const message = e instanceof Error ? e.message : "잠시 후 다시 시도해 주세요";
+    return { ok: false, message };
+  }
+}

--- a/app/actions/profile/title-history.ts
+++ b/app/actions/profile/title-history.ts
@@ -25,8 +25,8 @@ const MAX_ROWS = 200;
 
 type Row = {
   mem_ttl_id: string;
-  grnt_at: string | null;
-  crt_at: string;
+  /** `mem_ttl_rel.grnt_at`은 **NOT NULL DEFAULT now()**라 비는 일이 없다(§아래 정렬 주석) */
+  grnt_at: string;
   grnt_rsn_txt: string | null;
   ttl_mst:
     | { ttl_nm: string; ttl_desc: string | null; desc_visibility: string; rarity_level: number }
@@ -56,12 +56,16 @@ export async function getTitleHistory(): Promise<TitleHistoryResult> {
       const { data, error } = await db
         .from("mem_ttl_rel")
         .select(
-          "mem_ttl_id, grnt_at, crt_at, grnt_rsn_txt, ttl_mst(ttl_nm, ttl_desc, desc_visibility, rarity_level)",
+          "mem_ttl_id, grnt_at, grnt_rsn_txt, ttl_mst(ttl_nm, ttl_desc, desc_visibility, rarity_level)",
         )
         .eq("team_mem_id", member.team_mem_id)
         .eq("vers", 0)
         .eq("del_yn", false)
-        .order("grnt_at", { ascending: false, nullsFirst: false })
+        // `grnt_at` 하나로 정렬한다. 이 컬럼은 **NOT NULL DEFAULT now()**라 비지 않으므로
+        // `crt_at` 폴백도, nulls 처리도 필요 없다. 예전엔 방어적으로 `?? crt_at`을 뒀는데
+        // 그게 오히려 "null일 수 있다"고 읽혀 **정렬 키(grnt_at)와 표시 값(crt_at)이 갈리는
+        // 버그처럼** 보였다 — 없는 예외를 막는 코드는 그 자체가 잘못된 신호가 된다.
+        .order("grnt_at", { ascending: false })
         .limit(MAX_ROWS);
 
       if (error) {
@@ -80,8 +84,7 @@ export async function getTitleHistory(): Promise<TitleHistoryResult> {
           ttl_desc: t.ttl_desc,
           desc_visibility: (t.desc_visibility ?? "always") as TitleHistoryEntry["desc_visibility"],
           rarity_level: t.rarity_level,
-          // 옛 행에 grnt_at이 비어 있어도 줄이 사라지지 않게 생성 시각으로 받친다.
-          grnt_at: row.grnt_at ?? row.crt_at,
+          grnt_at: row.grnt_at,
           // 엔진이 남기는 사유는 `자동수여 (trigger=...)` 형태다 — 내부 용어라 그대로 쓰지 않고
           // 자동/수여 두 갈래로만 접는다.
           auto: (row.grnt_rsn_txt ?? "").startsWith("자동수여"),

--- a/app/actions/story/create-record-flex.ts
+++ b/app/actions/story/create-record-flex.ts
@@ -1,6 +1,7 @@
 "use server";
 
 import { updateTag } from "next/cache";
+import { after } from "next/server";
 
 import { withActive } from "@/lib/actions/auth";
 import { getRequestTeamContext } from "@/lib/queries/request-team";
@@ -91,12 +92,16 @@ export async function createRecordFlex(
       updateTag("story-posts");
 
       // 깅스타그램 칭호(오운완·깅플루언서·연재작가·유물발굴)는 글이 올라가는 순간 확정된다.
+      // **응답 밖에서** 돈다 — 글은 이미 저장·캐시 갱신까지 끝났고, 칭호 평가를 기다리게 하면
+      // 사진 업로드로 이미 긴 대기가 그만큼 더 늘어난다.
       // catch가 삼키므로 칭호 부여 실패가 이미 올라간 글을 되돌리지 않는다.
-      await evaluateAndGrantTitles({
-        trigger: "post_create",
-        teamId,
-        teamMemId: member.team_mem_id,
-      }).catch((e) => console.error("[title-engine] post_create 평가 실패", e));
+      after(() =>
+        evaluateAndGrantTitles({
+          trigger: "post_create",
+          teamId,
+          teamMemId: member.team_mem_id,
+        }).catch((e) => console.error("[title-engine] post_create 평가 실패", e)),
+      );
 
       return { ok: true as const, post_id: data.post_id };
     });

--- a/components/members/__tests__/member-card-detail-render.test.ts
+++ b/components/members/__tests__/member-card-detail-render.test.ts
@@ -48,6 +48,7 @@ const EDIT = {
   onEditAvatar: () => {},
   onEditIntro: () => {},
   onEditTitles: () => {},
+  onOpenTitleHistory: () => {},
   onEditProfile: () => {},
   onManageRecords: () => {},
   onAddRecord: () => {},
@@ -140,6 +141,16 @@ describe("편집판(내 프로필탭)", () => {
     }
     // 플리커는 매번 들어오는 자리라 끈다
     expect(html).not.toContain("board-flicker");
+  });
+
+  // 획득 이력은 **본인만** 보는 자리다(서버 액션도 세션의 team_mem_id만 읽는다).
+  // 칭호가 있어야 섹션 자체가 뜨므로 빈 카드로는 이 회귀를 못 잡는다.
+  it("획득 이력 진입점은 편집판에만 뜨고 공개판엔 새지 않는다", () => {
+    const titles = [
+      { ttl_nm: "뉴비", ttl_desc: null, desc_visibility: "others" as const, rarity_level: 1, ttl_ctgr_cd: "base" },
+    ];
+    expect(render({ titles }, true)).toContain("획득 이력");
+    expect(render({ titles })).not.toContain("획득 이력");
   });
 
   it("칭호는 0개면 섹션째 빠진다(뉴비가 자동으로 붙어 사실상 0이 없다)", () => {

--- a/components/members/member-card-detail.tsx
+++ b/components/members/member-card-detail.tsx
@@ -83,6 +83,8 @@ export type MemberCardEdit = {
   onEditIntro: () => void;
   /** 대표 칭호 옆 연필 → 내 컬렉션 */
   onEditTitles: () => void;
+  /** 하단 칭호 섹션 우측 "획득 이력" → 언제 무엇을 땄나(시간축) */
+  onOpenTitleHistory: () => void;
   /** 러닝 프로필 + 가입 목적 — 같은 테이블·같은 액션이라 진입점도 하나다 */
   onEditProfile: () => void;
   onManageRecords: () => void;
@@ -879,9 +881,23 @@ export function MemberCardDetail({
               위 스크린 존의 `?` 껍데기가 맡으므로 여기엔 연필을 달지 않는다. */}
           {data.titles.length > 0 && (
             <section className="flex flex-col gap-2">
-              <SectionLabel>
-                칭호 ({data.titles.length})
-              </SectionLabel>
+              {/* 우측 "획득 이력"은 **연필이 아니다** — 고치는 자리가 아니라 시간축으로 훑는
+                  자리라 위 규칙("하단 칭호 섹션엔 연필을 달지 않는다")과 충돌하지 않는다.
+                  이 줄이 도감(등급·카테고리 순)과 이력(시간 역순)의 갈림길이다. */}
+              <div className="flex items-center justify-between gap-2">
+                <SectionLabel>
+                  칭호 ({data.titles.length})
+                </SectionLabel>
+                {edit && (
+                  <button
+                    type="button"
+                    onClick={edit.onOpenTitleHistory}
+                    className="shrink-0 text-[11px] text-muted-foreground underline underline-offset-2 transition-colors hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+                  >
+                    획득 이력
+                  </button>
+                )}
+              </div>
               <div className="flex flex-wrap items-center gap-1.5">
                 {visibleTitles.map((title) => (
                   <TitleBadge

--- a/components/profile/profile-tab-card.tsx
+++ b/components/profile/profile-tab-card.tsx
@@ -1,7 +1,7 @@
 "use client";
 
-import { useState } from "react";
-import { useRouter } from "next/navigation";
+import { useEffect, useState } from "react";
+import { useRouter, useSearchParams } from "next/navigation";
 
 import { IntroEditDialog } from "@/components/members/intro-edit-dialog";
 import { MemberCardDetail } from "@/components/members/member-card-detail";
@@ -9,6 +9,7 @@ import { MemberCardDialogDynamic as MemberCardDialog } from "@/components/member
 import { AvatarEditDialog } from "@/components/profile/avatar-edit-dialog";
 import { CollectionSheet } from "@/components/profile/collection-sheet";
 import { RaceHistoryDialog } from "@/components/profile/race-history-dialog";
+import { TitleHistorySheet } from "@/components/profile/title-history-sheet";
 import { RaceRecordDialog } from "@/components/profile/race-record-dialog";
 import {
   UtmbLinkDialog,
@@ -63,6 +64,16 @@ export function ProfileTabCard({
   const [recordOpen, setRecordOpen] = useState(false);
   const [historyOpen, setHistoryOpen] = useState(false);
   const [utmbOpen, setUtmbOpen] = useState(false);
+  const [titleHistoryOpen, setTitleHistoryOpen] = useState(false);
+
+  // 칭호 획득 알림(`ttl_grnt`)의 딥링크가 이 시트를 바로 연다 — 프로필로만 보내면
+  // "무엇이 새로 생겼는지"를 알 길이 없어 알림이 절반만 일한다(`lib/notifications/deep-link.ts`).
+  const searchParams = useSearchParams();
+  const wantTitleHistory = searchParams.get("ttl") === "history";
+  useEffect(() => {
+    // eslint-disable-next-line react-hooks/set-state-in-effect
+    if (wantTitleHistory) setTitleHistoryOpen(true);
+  }, [wantTitleHistory]);
 
   // 저장 직후 router.refresh()가 돌기 전에도 바뀐 값이 보이도록 낙관적으로 덮어쓴다.
   const [intro, setIntro] = useState(card.intro_txt ?? "");
@@ -89,6 +100,7 @@ export function ProfileTabCard({
           onEditAvatar: () => setAvatarOpen(true),
           onEditIntro: () => setIntroOpen(true),
           onEditTitles: () => setCollectionOpen(true),
+          onOpenTitleHistory: () => setTitleHistoryOpen(true),
           onEditProfile: () => router.push(RUNNING_PROFILE_HREF),
           onManageRecords: () => setHistoryOpen(true),
           onAddRecord: () => setRecordOpen(true),
@@ -123,6 +135,11 @@ export function ProfileTabCard({
         currentFrameCd={card.frame_cd}
         maxRarityLevel={maxRarityLevel}
         memberName={card.mem_nm}
+      />
+
+      <TitleHistorySheet
+        open={titleHistoryOpen}
+        onOpenChange={setTitleHistoryOpen}
       />
 
       {/* 남들에게 보이는 내 카드 — 같은 판의 공개 뷰라 편집 어포던스가 하나도 없다.

--- a/components/profile/title-history-sheet.tsx
+++ b/components/profile/title-history-sheet.tsx
@@ -1,0 +1,149 @@
+"use client";
+
+import { useCallback, useEffect, useRef, useState } from "react";
+
+import {
+  getTitleHistory,
+  type TitleHistoryEntry,
+} from "@/app/actions/profile/title-history";
+import { formatKST } from "@/lib/dayjs";
+
+import { TitleBadge } from "@/components/common/title-badge";
+import {
+  ResponsiveDrawer,
+  ResponsiveDrawerContent,
+  ResponsiveDrawerHeader,
+  ResponsiveDrawerTitle,
+} from "@/components/common/responsive-drawer";
+import { Body, Caption, Micro } from "@/components/common/typography";
+import { Button } from "@/components/ui/button";
+import { Skeleton } from "@/components/ui/skeleton";
+
+type LoadState =
+  | { status: "loading" }
+  | { status: "ready"; entries: TitleHistoryEntry[] }
+  | { status: "error"; message: string };
+
+/**
+ * 칭호 획득 이력 시트 — 언제 무슨 칭호를 땄나.
+ *
+ * **도감(`CollectionSheet`)과 축이 다르다.** 도감은 등급·카테고리 순으로 "뭘 모았나"를
+ * 보여주고 여기는 시간 역순으로 "언제 땄나"를 보여준다. 칭호는 대부분 조용히 붙기 때문에
+ * (알림을 놓치면 언제 생겼는지 알 길이 없다) 시간축이 따로 필요하다 —
+ * `ttl_grnt` 알림의 딥링크도 이 시트로 온다.
+ *
+ * 구조는 활동량 내역 시트(`ActvHistorySheet`)를 그대로 따른다: 같은 바텀시트, 같은
+ * 로딩·에러·빈 상태, 같은 좌측 날짜 열. 두 "내역"이 다르게 생길 이유가 없다.
+ */
+export function TitleHistorySheet({
+  open,
+  onOpenChange,
+}: {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+}) {
+  const [state, setState] = useState<LoadState>({ status: "loading" });
+
+  // 연속 탭으로 요청이 겹칠 때 늦게 온 응답이 화면을 덮어쓰지 않게 한다(ActvHistorySheet와 동일).
+  const reqIdRef = useRef(0);
+
+  const load = useCallback(async () => {
+    const reqId = ++reqIdRef.current;
+    setState({ status: "loading" });
+
+    const result = await getTitleHistory();
+    if (reqId !== reqIdRef.current) return;
+
+    setState(
+      result.ok
+        ? { status: "ready", entries: result.entries }
+        : { status: "error", message: result.message },
+    );
+  }, []);
+
+  useEffect(() => {
+    if (!open) return;
+    const timer = window.setTimeout(() => void load(), 0);
+    return () => window.clearTimeout(timer);
+  }, [open, load]);
+
+  return (
+    <ResponsiveDrawer open={open} onOpenChange={onOpenChange}>
+      {/* 스크롤은 안쪽 div가 건다 — 이 Content는 vaul이 "밀어서 닫기"를 잡는 판이라
+          여기에 overflow를 걸면 목록이 드래그에 먹힌다(ActvHistorySheet의 같은 주석). */}
+      <ResponsiveDrawerContent
+        className="flex flex-col gap-0 p-0"
+        dialogClassName="max-h-[85dvh] max-w-lg overflow-hidden"
+        drawerClassName="h-[80dvh] max-h-[80dvh]"
+      >
+        <ResponsiveDrawerHeader className="shrink-0 border-b border-border px-4 py-4 text-left">
+          <ResponsiveDrawerTitle>칭호 획득 이력</ResponsiveDrawerTitle>
+        </ResponsiveDrawerHeader>
+
+        <div className="flex-1 overflow-y-auto px-4 pb-6 pt-2">
+          {state.status === "loading" && (
+            <div className="flex flex-col gap-3 pt-2">
+              <Skeleton className="h-10 w-full rounded" />
+              <Skeleton className="h-10 w-full rounded" />
+              <Skeleton className="h-10 w-full rounded" />
+            </div>
+          )}
+
+          {state.status === "error" && (
+            <div className="flex flex-col items-center gap-3 py-8 text-center">
+              <div className="flex flex-col gap-1.5">
+                <Body className="font-semibold">이력을 불러오지 못했어요</Body>
+                <Caption>{state.message}</Caption>
+              </div>
+              <Button size="sm" variant="outline" onClick={() => void load()}>
+                다시 시도
+              </Button>
+            </div>
+          )}
+
+          {state.status === "ready" && state.entries.length === 0 && (
+            <div className="flex flex-col items-center gap-1.5 py-8 text-center">
+              <Body className="font-semibold">아직 획득한 칭호가 없어요</Body>
+              <Caption>모임 참석·대회 출전·기록 등록으로 하나씩 붙어요.</Caption>
+            </div>
+          )}
+
+          {state.status === "ready" && state.entries.length > 0 && (
+            <ul className="flex flex-col">
+              {state.entries.map((entry) => (
+                <li
+                  key={entry.id}
+                  className="flex items-center gap-3 border-b border-border py-2.5"
+                >
+                  {/* `grnt_at`은 timestamptz라 반드시 KST로 환산해 찍는다 — 그냥 format하면
+                      배포처(UTC) 기준으로 하루 밀린다(§CLAUDE.md 날짜 규칙). 연도까지 쓰는 건
+                      이 목록이 가입 시점부터 몇 해에 걸치기 때문이다(활동량 내역은 이번 달뿐이라 M.DD). */}
+                  <span className="w-[68px] shrink-0 font-numeric text-[12px] text-muted-foreground tabular-nums">
+                    {formatKST(entry.grnt_at, "YYYY.M.D")}
+                  </span>
+                  <div className="flex min-w-0 flex-1 items-center gap-1.5">
+                    <TitleBadge
+                      name={entry.ttl_nm}
+                      effect="none"
+                      size="xs"
+                      tooltip={{
+                        desc: entry.ttl_desc,
+                        visibility: entry.desc_visibility,
+                        isHeld: true,
+                      }}
+                    />
+                  </div>
+                  {/* 자동 획득이 대부분이라 그쪽엔 아무 말도 안 붙인다 — 전 줄에 "자동"이
+                      붙으면 정보가 아니라 배경이 된다. 드문 쪽(운영진 수여)만 표시한다. */}
+                  {!entry.auto && (
+                    <Micro className="shrink-0">운영진 수여</Micro>
+                  )}
+                </li>
+              ))}
+            </ul>
+          )}
+        </div>
+      </ResponsiveDrawerContent>
+    </ResponsiveDrawer>
+  );
+}

--- a/components/profile/title-history-sheet.tsx
+++ b/components/profile/title-history-sheet.tsx
@@ -51,7 +51,19 @@ export function TitleHistorySheet({
     const reqId = ++reqIdRef.current;
     setState({ status: "loading" });
 
-    const result = await getTitleHistory();
+    // 서버 액션은 결과값으로 실패를 돌려주지만(내부 try/catch), **전송 자체가 실패하면 던진다**
+    // — 오프라인·배포 중 등. 안 잡으면 화면이 스켈레톤에 갇히고 재시도 버튼도 없어
+    // 시트를 닫았다 여는 것 말고 빠져나갈 길이 없다.
+    let result: Awaited<ReturnType<typeof getTitleHistory>>;
+    try {
+      result = await getTitleHistory();
+    } catch (e) {
+      console.error("[TitleHistorySheet] 이력 요청 실패", e);
+      if (reqId === reqIdRef.current) {
+        setState({ status: "error", message: "잠시 후 다시 시도해 주세요" });
+      }
+      return;
+    }
     if (reqId !== reqIdRef.current) return;
 
     setState(

--- a/components/story/actv-history-sheet.tsx
+++ b/components/story/actv-history-sheet.tsx
@@ -54,7 +54,19 @@ export function ActvHistorySheet({
     const reqId = ++reqIdRef.current;
     setState({ status: "loading" });
 
-    const result = await getActvHistory(memId);
+    // 서버 액션은 결과값으로 실패를 돌려주지만(내부 try/catch), **전송 자체가 실패하면 던진다**
+    // — 오프라인·배포 중 등. 안 잡으면 화면이 스켈레톤에 갇히고 재시도 버튼도 없어
+    // 시트를 닫았다 여는 것 말고 빠져나갈 길이 없다(`TitleHistorySheet`와 같은 처리).
+    let result: Awaited<ReturnType<typeof getActvHistory>>;
+    try {
+      result = await getActvHistory(memId);
+    } catch (e) {
+      console.error("[ActvHistorySheet] 내역 요청 실패", e);
+      if (reqId === reqIdRef.current) {
+        setState({ status: "error", message: "잠시 후 다시 시도해 주세요" });
+      }
+      return;
+    }
     if (reqId !== reqIdRef.current) return;
 
     setState(

--- a/lib/notifications/deep-link.ts
+++ b/lib/notifications/deep-link.ts
@@ -67,7 +67,10 @@ const NOTI_ROUTE: Record<
   string,
   (refId: string | null, refType: string | null) => string | null
 > = {
-  ttl_grnt: () => "/profile",
+  // 프로필로만 보내면 "무엇이 새로 생겼는지"를 알 길이 없다 — 칭호는 조용히 붙고
+  // 카드의 칭호 줄은 이름만 나열하므로 방금 딴 게 어느 것인지 구분되지 않는다.
+  // 획득 이력 시트(시간 역순)를 바로 열어 맨 윗줄이 그 답이 되게 한다.
+  ttl_grnt: () => "/profile?ttl=history",
   adm_cust: () => null,
   dues_notice: () => "/profile/dues",
   dues_check_req: () => null,

--- a/lib/titles/engine.ts
+++ b/lib/titles/engine.ts
@@ -106,22 +106,38 @@ export async function evaluateAndGrantTitles(
   // 1. 이 트리거에서 평가할 조건 유형 목록
   const allowedCondTypes = new Set(TRIGGER_COND_MAP[ctx.trigger]);
 
-  // 2. team_mem_id → mem_id 변환
-  //    rec_race_hist 등 레거시 테이블이 mem_mst.mem_id 를 직접 참조하므로 필요하다.
-  const { data: relRow } = await db
-    .from("team_mem_rel")
-    .select("mem_id")
-    .eq("team_mem_id", ctx.teamMemId)
-    .eq("vers", 0)
-    .eq("del_yn", false)
-    .maybeSingle();
+  // 2~4. 서로 독립인 세 조회를 **한 번에** 보낸다. 직렬로 두면 왕복 3번이 그대로 응답
+  //       시간에 쌓이는데, 셋 중 어느 것도 앞의 결과를 쓰지 않는다.
+  //   ② team_mem_id → mem_id 변환 (rec_race_hist 등 레거시 테이블이 mem_id 를 직접 참조)
+  //   ③ 이 팀의 사용 중인 auto 칭호 전체 (배치가 미리 읽어 넘겼으면 그걸 쓴다)
+  //   ④ 현재 활성 보유 칭호 ID (vers=0, del_yn=false) — 중복 수여 방지
+  //
+  // ⚠️ 멤버가 없거나(탈퇴) 평가할 칭호가 0건이면 나머지 조회는 헛돈다 — 직렬일 땐
+  // early return으로 걸렀던 몫이다. 그 둘은 드물고(배치는 실존 멤버만 돈다) 왕복 2번은
+  // 매번 드는 비용이라, 늘 아끼는 쪽을 택했다.
+  const [relRow, allTitles, existing] = await Promise.all([
+    db
+      .from("team_mem_rel")
+      .select("mem_id")
+      .eq("team_mem_id", ctx.teamMemId)
+      .eq("vers", 0)
+      .eq("del_yn", false)
+      .maybeSingle()
+      .then((r) => r.data),
+    // 조회 실패는 여기서 던진다(loadAutoTitles 주석) — Promise.all이 그대로 전파하고
+    // 호출부의 .catch()가 로깅한다. 빈 배열로 눙치면 "평가 0건"으로 조용히 끝난다.
+    preloadedTitles ? Promise.resolve(preloadedTitles) : loadAutoTitles(db, ctx.teamId),
+    db
+      .from("mem_ttl_rel")
+      .select("ttl_id")
+      .eq("team_mem_id", ctx.teamMemId)
+      .eq("vers", 0)
+      .eq("del_yn", false)
+      .then((r) => r.data),
+  ]);
 
   if (!relRow?.mem_id) return [];
   const memId = relRow.mem_id;
-
-  // 3. 이 팀의 사용 중인 auto 칭호 전체 조회 후 이 트리거에서 평가할 조건 유형만 필터링
-  //    (배치가 미리 읽어 넘겼으면 그걸 쓴다 — 멤버마다 같은 조회를 반복하지 않는다)
-  const allTitles = preloadedTitles ?? (await loadAutoTitles(db, ctx.teamId));
 
   const titles = (allTitles as TtlMstRow[] ?? []).filter((t) => {
     const rule = t.cond_rule_json as CondRule | null;
@@ -132,14 +148,6 @@ export async function evaluateAndGrantTitles(
   console.info("[title-engine] 평가 대상 칭호:", titles.map(t => t.ttl_nm));
 
   if (titles.length === 0) return [];
-
-  // 4. 현재 활성 보유 칭호 ID (vers=0, del_yn=false) — 중복 수여 방지
-  const { data: existing } = await db
-    .from("mem_ttl_rel")
-    .select("ttl_id")
-    .eq("team_mem_id", ctx.teamMemId)
-    .eq("vers", 0)
-    .eq("del_yn", false);
 
   const activeIds = new Set((existing ?? []).map((r) => r.ttl_id));
 
@@ -154,6 +162,8 @@ export async function evaluateAndGrantTitles(
 
   // 5. 조건 평가 → 통과한 미보유 칭호 수여
   const granted: string[] = [];
+  /** 실제로 INSERT된 칭호 — 아래 알림 발송이 쓴다(이름만으론 딥링크 refId를 못 만든다). */
+  const grantedRows: { ttlId: string; ttlNm: string }[] = [];
 
   // 조건들이 나눠 쓰는 조회 캐시. 배치가 넘겨줬으면 그걸 쓴다(팀 공통 조회가 1번이 된다).
   // 모임 칭호 6종이 전부 같은 참석 목록을 보므로, 없으면 같은 쿼리가 6번 나간다.
@@ -197,7 +207,32 @@ export async function evaluateAndGrantTitles(
     }
 
     granted.push(title.ttl_nm);
+    grantedRows.push({ ttlId: title.ttl_id, ttlNm: title.ttl_nm });
     console.info(`[title-engine] 칭호 부여 완료: ${title.ttl_nm} → team_mem_id=${ctx.teamMemId}`);
+  }
+
+  // 6. 칭호 획득 알림(인앱 + 푸시).
+  //
+  // ⚠️ **이게 없어서 실시간 수여는 알림이 안 갔다.** `ttl_grnt`를 보내는 곳이 bulk 엔진
+  // (sweep · 마일리지 배치)과 관리자 수동수여뿐이라, 취소로 `월요병`을 딴 순간처럼 이 함수를
+  // 타고 붙은 칭호는 조용히 생겼다. 일·월 배치도 멤버마다 이 함수를 부르므로(batch/jobs/titles.ts)
+  // 같이 빠져 있었다 — 설계는 "칭호 부여는 insertNoti를 타고 푸시까지 나간다"가 전제다(§배치 09:00).
+  //
+  // 부여 0건이면 아무것도 안 한다 — 평상시(대부분의 호출)엔 비용이 0이고, 실제로 받은
+  // 순간에만 알림 왕복이 붙는다. 호출부가 `after()`로 응답 밖에서 돌리므로 사용자는 안 기다린다.
+  if (grantedRows.length > 0) {
+    await Promise.all(
+      grantedRows.map((g) =>
+        insertNoti({
+          teamId: ctx.teamId,
+          memId,
+          notiTypeEnm: "ttl_grnt",
+          notiNm: `'${g.ttlNm}' 칭호를 획득했습니다!`,
+          refId: g.ttlId,
+          refTypeEnm: "ttl",
+        }),
+      ),
+    ).catch((e) => console.error("[title-engine] 칭호 알림 발송 실패", e));
   }
 
   return granted;

--- a/lib/titles/types.ts
+++ b/lib/titles/types.ts
@@ -401,7 +401,8 @@ export type TriggerKind =
   | "attendance"        // 로그인 / 출석 체크
   | "manual_sweep"      // 관리자 수동 전체 재계산
   // --- 2026-08 신규 (설계 §7.2) ---
-  | "gathering_attend"  // 모임 참석·취소 액션 — 그 순간 확정되는 것만
+  | "gathering_attend"  // 모임 참석 액션 — 신청 순번의 사건(막차)만
+  | "gathering_cancel"  // 모임 취소 액션 — 취소 계열만
   | "gathering_daily"   // 일 배치 — 끝난 지 3일 지난 모임까지 (참석 계열)
   | "post_create"       // 깅스타그램 게시
   | "comment_create"    // 댓글 작성
@@ -494,10 +495,17 @@ export const TRIGGER_COND_MAP = {
 
   // --- 2026-08 신규 트리거 ---
 
-  // 그 순간 확정되는 것만: 취소 계열과 막차.
-  // 막차만 참석 액션에 남는 이유 — 신청 순번의 사건이라 3일 뒤로 미루면 그 사이 노쇼가
+  // 그 순간 확정되는 것만. **등록과 취소를 나눠 둔다** — 한 트리거로 묶으면 취소할 때마다
+  // 막차(신청 순번)까지 평가해 **취소와 무관한 조회 2번**이 응답 안에 그대로 얹힌다.
+  // 취소 계열 5종은 같은 취소 이력을 캐시로 나눠 쓰지만 막차는 그 캐시를 안 타므로
+  // (`evalGthrLastSlot`), 취소 경로에서 가장 무거운 몫이 정확히 필요 없는 몫이었다.
+  //
+  // 막차가 참석 액션에 남는 이유 — 신청 순번의 사건이라 3일 뒤로 미루면 그 사이 노쇼가
   // 지워져 "정확히 정원 번째" 행이 아예 사라진다(미루면 오히려 아무도 못 딴다).
-  gathering_attend: ["gthr_cancel_count", "gthr_cancel_reason", "gthr_last_slot"],
+  gathering_attend: ["gthr_last_slot"],
+
+  // 취소 계열 — 취소 이력(`gthr_attd_hist`)만 보므로 등록 액션에서 평가할 이유가 없다.
+  gathering_cancel: ["gthr_cancel_count", "gthr_cancel_reason"],
 
   // 참석 계열 — 끝난 지 3일 지난 모임만 본다. 운영진이 노쇼를 사후 취소 처리하는 시간이다.
   // 즉시 판정하면 ① 아직 안 열린 모임을 신청만 해도 붙고 ② 비회수라 취소해도 안 없어진다.
@@ -574,10 +582,12 @@ export type TitleEvalContextManualSweep = {
 
 /**
  * 그 순간 확정되는 조건만 평가하는 액션 트리거들 — 추가 데이터가 없어 한 모양을 공유한다.
- * (모임 참석·취소 / 깅스타그램 게시 / 댓글 작성)
+ * (모임 참석 / 모임 취소 / 깅스타그램 게시 / 댓글 작성)
+ *
+ * 참석과 취소는 **같은 모양이지만 다른 트리거다** — 보는 조건이 갈린다(TRIGGER_COND_MAP).
  */
 export type TitleEvalContextGatheringAttend = {
-  trigger: "gathering_attend" | "post_create" | "comment_create";
+  trigger: "gathering_attend" | "gathering_cancel" | "post_create" | "comment_create";
   teamId: string;
   teamMemId: string;
 };


### PR DESCRIPTION
## 관련 이슈

관련 이슈 없음 — #484(신규 칭호 25종) 후속입니다. 그 PR로 실시간 훅이 넷 늘면서 드러난 문제를 정리했습니다.

## 요약

**즉시 획득 칭호 평가가 사용자 응답 안에서 직렬로 돌던 것**을 응답 밖으로 걷어내고, **실시간 수여에 빠져 있던 획득 알림**을 채웠습니다. 그리고 그 알림을 눌렀을 때 "무엇이 새로 생겼는지" 알 수 있도록 **칭호 획득 이력 시트**를 추가했습니다.

시작은 "참석 취소가 칭호 로직 때문에 느려지는가"였고, 파보니 셋이 한 줄로 이어져 있었습니다.

## AS-IS (변경 전)

**칭호 평가가 사용자를 기다리게 했다**

취소·댓글·게시는 이미 DB에 반영이 끝났는데도 칭호 평가가 `await`로 응답 안에 있었다. 칭호는 본행동의 성공 여부를 바꾸지 않는 부수 효과라 기다릴 이유가 없다.

- **모임 취소**가 특히 나빴다 — 클라이언트가 액션 완료까지 취소 모달을 붙잡고 있어(`gathering-attend-button.tsx`) 지연이 그대로 드러났다. 참석 등록은 낙관적 업데이트로 버튼 색이 먼저 바뀌지만 취소는 모달에 가린다.
- 같은 응답 안에 **모임장 푸시 알림**(`insertNoti` → 웹푸시 외부 HTTP, 타임아웃 설정 없음)까지 `await`로 들어 있었다.

**취소할 때 취소와 무관한 칭호를 평가했다**

`gathering_attend` 트리거 하나를 등록과 취소가 공유했다. 그래서 취소할 때마다 **막차**(신청 순번이 정확히 정원 번째)까지 평가했는데, 이건 취소와 아무 상관이 없다. 게다가 취소 계열 5종은 취소 이력 조회를 캐시로 나눠 쓰는 반면 **막차만 그 캐시를 안 타서**, 취소 경로에서 가장 무거운 몫이 정확히 필요 없는 몫이었다.

**엔진 앞단 세 조회가 직렬이었다**

`team_mem_rel`(mem_id 변환) → `ttl_mst`(auto 칭호 전체) → `mem_ttl_rel`(보유 칭호). 서로 결과를 참조하지 않는데 순서대로 기다렸다. **모든 트리거가 공유하는 경로**다.

**실시간 수여는 알림이 안 갔다**

`ttl_grnt`를 보내는 곳이 bulk 엔진(`sweepEvaluateAndGrant`·`batchEvaluateAndGrant`)과 관리자 수동수여뿐이라, `evaluateAndGrantTitles`를 타고 붙은 칭호는 **조용히 생겼다**. 일·월 배치도 멤버마다 이 함수를 부르므로(`lib/batch/jobs/titles.ts`) 같이 빠져 있었다. 설계는 "칭호 부여는 `insertNoti`를 타고 푸시까지 나간다"가 전제였고(#484 배치 09:00 결정의 근거), `story-titles.ts` 주석도 "칭호 획득의 실시간성은 인앱 알림+푸시가 이미 맡고 있다"고 적혀 있다 — 그 전제가 실제로는 성립하지 않았다.

> dev에서 취소로 `월요병`을 획득했는데 인앱·푸시 어느 쪽도 오지 않아 발견했습니다.

**알림을 눌러도 무엇이 생겼는지 알 수 없었다**

`ttl_grnt` 딥링크가 `/profile`이라 프로필탭으로만 보냈다. 카드의 칭호 줄은 이름을 나열할 뿐이라 방금 딴 게 어느 것인지 구분되지 않는다.

## TO-BE (변경 후)

### 1. 즉시 평가를 응답 밖으로 (`after`)

| 액션 | 이전 | 지금 |
|---|---|---|
| 모임 취소 | 모임장 알림 + 칭호 `await` | `after()` 안에서 **둘을 병렬로** |
| 모임 참석 | 칭호 `await` | `after()` |
| 댓글 작성 | 칭호 `await` (4왕복) | `after()` |
| 깅스타그램 게시 | 칭호 `await` | `after()` |
| 마일리지런 단건 | 칭호 `await` | `after()` |

반환값(획득 칭호 토스트)을 쓰는 `save-race-record`·`mileage-run` 다건은 **그대로 뒀습니다** — 비동기로 빼면 그 토스트가 사라져 기존 UX가 줄어듭니다.

`after()`를 그동안 안 쓴 이유가 코드 주석에 "요청 스코프를 요구해 서버 액션을 직접 부르는 테스트에서 던진다"로 적혀 있었는데, 실제로는 **테스트 3개가 `next/server`를 모킹하지 않아서**였습니다. 스텁을 두어 풀었습니다(`mileage-run.ts`엔 이미 `after` 선례가 있었습니다).

### 2. 취소 트리거 분리 + 엔진 앞단 병렬화

```
gathering_attend : ["gthr_last_slot"]                        ← 등록
gathering_cancel : ["gthr_cancel_count", "gthr_cancel_reason"] ← 취소 (신규)
```

앞단 세 조회는 `Promise.all`로 묶었습니다. 멤버가 없거나(탈퇴) 평가할 칭호가 0건이면 나머지 조회가 헛도는데, 그 둘은 드물고(배치는 실존 멤버만 돕니다) 왕복 2번은 매번 드는 비용이라 늘 아끼는 쪽을 택했습니다.

**취소 기준 6왕복 → 3왕복, 그마저 응답 밖입니다.**

### 3. 실시간 수여 알림 (fix)

`evaluateAndGrantTitles` 안에 `ttl_grnt` 발송을 넣어 **실시간 훅과 일·월 배치를 한 번에** 덮습니다. 부여 0건이면 아무것도 안 하므로 **평상시 비용은 0**이고, 실제로 받은 순간에만 알림 왕복이 붙습니다(그마저 호출부가 `after`로 감쌉니다).

### 4. 칭호 획득 이력 (feat)

프로필탭 칭호 섹션 헤더 우측 `획득 이력` → 바텀시트(수여 시각 역순).

**도감(`CollectionSheet`)과 축이 다릅니다** — 도감은 등급·카테고리 순으로 *뭘 모았나*를, 이력은 시간 역순으로 *언제 땄나*를 말합니다. 칭호는 대부분 조용히 붙어서 알림을 놓치면 언제 생겼는지 알 길이 없어 시간축이 따로 필요합니다.

`ttl_grnt` 딥링크를 `/profile?ttl=history`로 바꿔 **알림을 누르면 이 시트가 열리고 맨 윗줄이 방금 딴 그 칭호**가 됩니다.

- **본인 것만** — 서버 액션이 `team_mem_id`를 인자로 받지 않고 세션 것을 씁니다. 인자로 열면 id만 알면 남의 이력을 읽을 수 있고, 취소 계열 칭호를 생각하면 "언제 무엇을 했나"가 드러나는 자리입니다. 공개판 카드에 진입점이 새지 않는 것은 렌더 테스트로 못박았습니다.
- **회수분은 안 싣습니다**(`del_yn=true` 제외) — 회수는 운영진 행위인데 알림이 따로 없어, 이력에 남기면 본인은 영문을 모른 채 빼앗긴 줄만 보게 됩니다.
- **내부 용어를 화면에 안 씁니다** — 엔진이 남기는 `자동수여 (trigger=gathering_cancel)` 대신 드문 쪽(운영진 수여)에만 라벨을 답니다. 전 줄에 "자동"이 붙으면 정보가 아니라 배경이 됩니다.
- `grnt_at`은 timestamptz라 `formatKST`로 찍습니다. 목록이 여러 해에 걸쳐 연도까지 씁니다(활동량 내역은 이번 달뿐이라 `M.DD`).

구조는 활동량 내역 시트(`ActvHistorySheet`)를 그대로 따릅니다 — 같은 바텀시트, 같은 로딩·에러·빈 상태. 두 "내역"이 다르게 생길 이유가 없습니다.

## 변경 흐름 (Mermaid)

```mermaid
flowchart TD
    subgraph BEFORE["AS-IS — 사용자가 전부 기다린다"]
        A1[취소 버튼] --> A2[cancel RPC]
        A2 --> A3["모임장 알림<br/>+ 웹푸시 외부 HTTP"]
        A3 --> A4["칭호 평가 6왕복<br/>(막차 2왕복 포함 — 취소와 무관)"]
        A4 --> A5[응답 · 모달 닫힘]
    end

    subgraph AFTER["TO-BE — 응답이 먼저 나간다"]
        B1[취소 버튼] --> B2[cancel RPC]
        B2 --> B3[응답 · 모달 닫힘]
        B3 -.after().-> B4{병렬}
        B4 --> B5["모임장 알림 + 푸시"]
        B4 --> B6["칭호 평가 3왕복<br/>gathering_cancel"]
        B6 --> B7{부여 있음?}
        B7 -->|예| B8["ttl_grnt 알림 + 푸시"]
        B7 -->|아니오| B9["끝 · 비용 0"]
        B8 --> B10["알림 탭 → /profile?ttl=history<br/>획득 이력 맨 윗줄"]
    end
```

## 주요 변경 사항

**칭호 엔진**
- `lib/titles/types.ts` — `gathering_cancel` 트리거 추가, `TRIGGER_COND_MAP` 분리
- `lib/titles/engine.ts` — 앞단 3조회 `Promise.all`, `ttl_grnt` 알림 발송 추가

**서버 액션 (after 이동)**
- `app/actions/gathering/toggle-attendance.ts` — 알림·칭호를 `after` 안에서 병렬로
- `app/actions/comment/manage-comment.ts` · `app/actions/story/create-record-flex.ts` · `app/actions/mileage-run.ts`

**획득 이력 (신규)**
- `app/actions/profile/title-history.ts` — 본인 이력 조회
- `components/profile/title-history-sheet.tsx` — 바텀시트
- `components/members/member-card-detail.tsx` — 칭호 섹션 헤더에 진입점(`edit`일 때만)
- `components/profile/profile-tab-card.tsx` — 시트 연결 + 딥링크 자동 오픈
- `lib/notifications/deep-link.ts` — `ttl_grnt` → `/profile?ttl=history`

**문서·테스트**
- `DESIGN.md` — 컴포넌트 카탈로그 + 프로필탭 규칙
- 테스트 4개 파일 — `next/server` 스텁, `insertNoti` 모킹을 async로, 공개판 유출 방지 테스트 추가

**마이그레이션 없음** — `grnt_at`은 `mem_ttl_rel`에 이미 있고 prd 848행 전부 채워져 있습니다.

## 검증

| 검증 | 결과 |
|---|---|
| `npx vitest run` | ✅ 590 → **591 passed** (45 files) |
| `npx tsc --noEmit` | ✅ clean (`.next` 캐시의 stale `keep-alive` 참조 제외) |
| `npx eslint` | ✅ 변경 파일 0 errors (기존 warning 1건은 무관 파일) |
| dev 실측 | ✅ 취소 → 렉 없이 모달 닫힘 확인 |

**인덱스 점검** — 신규 조건이 쓰는 `cmnt_mst(mem_id)`, `post_mst(mem_id)`, `cmnt_mention_rel(cmnt_id,mem_id)`, `gthr_attd_hist(mem_id)` 모두 존재합니다. 모임 칭호 6종의 `eff_stt_dt`가 전부 `2026-08-14`로 같아 취소 이력 조회 캐시도 정상 공유됩니다.

## 리뷰어가 봐줬으면 하는 것

1. **`after()` 안의 실패는 사용자에게 안 보입니다** — 이미 끝난 본행동을 되돌리면 안 되니 의도한 동작이고, 문제가 생기면 서버 로그(`[title-engine] … 평가 실패`)에만 남습니다. 이 경계가 맞는지 봐주세요.
2. **칭호가 붙어도 그 화면은 즉시 안 바뀝니다** — `revalidatePath`가 응답 전에 실행되므로. 획득 사실은 알림이 전달합니다(그래서 4번이 같이 필요했습니다).
3. **`save-race-record`·`mileage-run` 다건은 여전히 `await`입니다** — 반환값으로 토스트를 띄우기 때문입니다. 이제 알림이 나가므로 토스트를 버리고 이 둘도 뺄 수 있는데, UX 결정이라 별건으로 남겼습니다.
4. **알림이 늘어납니다** — 그동안 조용하던 실시간 수여와 일·월 배치가 이제 인앱+푸시를 보냅니다. 설계 의도대로지만 체감상 알림 빈도가 올라갑니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새로운 기능**
  * 프로필의 칭호 섹션에서 본인의 칭호 획득 이력을 확인할 수 있습니다.
  * 획득 이력은 최신순으로 표시되며, 운영진 수여 여부와 수여 일시를 확인할 수 있습니다.
  * 회수된 칭호와 자동 수여 내역은 이력에서 제외됩니다.
  * 알림이나 `/profile?ttl=history` 링크를 통해 획득 이력 화면을 바로 열 수 있습니다.

* **개선 사항**
  * 게시글·댓글 작성, 참석 변경 후 칭호 평가와 알림이 처리되는 동안 기본 작업 결과를 더 빠르게 확인할 수 있습니다.
  * 모임 참석 취소 관련 칭호 조건이 별도로 적용됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->