### PR TITLE
fix(schedule): 리스트뷰에서 특정 달 일정이 통째로 누락되는 문제 해결

### DIFF
--- a/components/home/schedule-list-view.tsx
+++ b/components/home/schedule-list-view.tsx
@@ -16,6 +16,7 @@ import { Caption, Micro, SectionLabel } from "@/components/common/typography";
 
 import type { CalendarRace } from "./mini-calendar";
 import { type FilterType, matchesFilter } from "@/components/home/schedule-filter";
+import { seedScheduleMonths } from "@/lib/schedule-list";
 
 type MonthData = {
   monthKey: string; // "YYYY-MM"
@@ -313,12 +314,12 @@ export const ScheduleListView = memo(function ScheduleListView({
   const supabase = useMemo(() => createClient(), []);
   const today = todayKST();
 
-  const [months, setMonths] = useState<MonthData[]>(() => {
-    // start_date의 실제 월(YYYY-MM)로 분류 — 월 경계에 걸친 일정을 올바른 월에 배치
-    const result = racesToMonths(initialRaces);
-    if (result.length === 0) return [{ monthKey: initialMonthKey, races: [] }];
-    return result.map((m) => ({ ...m, races: [...m.races].sort((a, b) => a.start_date.localeCompare(b.start_date)) }));
-  });
+  // 시드는 캘린더의 **그리드 범위** 데이터라 앞뒤 달이 며칠씩 딸려 온다. 그 부분 월을
+  // 남기면 무한스크롤 커서(월 경계)가 나머지 날짜를 건너뛰므로, 온전한 이번 달만 남긴다.
+  // 앞뒤 달은 마운트 직후 sentinel이 RPC로 통째로 받아 온다. (§lib/schedule-list)
+  const [months, setMonths] = useState<MonthData[]>(() =>
+    seedScheduleMonths(initialRaces, initialMonthKey),
+  );
   const [loadingPrev, setLoadingPrev] = useState(false);
   const [loadingNext, setLoadingNext] = useState(false);
   const oldestMonth = months[0].monthKey;

--- a/lib/__tests__/schedule-list.test.ts
+++ b/lib/__tests__/schedule-list.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from "vitest";
+
+import { seedScheduleMonths } from "@/lib/schedule-list";
+import type { CalendarRace } from "@/components/home/mini-calendar";
+
+function race(id: string, start_date: string): CalendarRace {
+  return { id, title: id, start_date, type: "gigang" };
+}
+
+/**
+ * 리스트뷰 시드는 캘린더가 들고 있던 **그리드 범위** 데이터다 —
+ * 이번 달 앞뒤로 며칠씩(+fetchStart 1주) 삐져나온다.
+ * 그 부분 월을 남기면 무한스크롤 커서(월 경계)가 나머지 날짜를 건너뛴다.
+ */
+describe("seedScheduleMonths", () => {
+  it("앞뒤 달로 삐져나온 부분 데이터는 버린다", () => {
+    // 2026-09 그리드(주 시작 일요일): 08-23 ~ 10-03
+    const seeded = seedScheduleMonths(
+      [
+        race("aug-25", "2026-08-25"),
+        race("sep-01", "2026-09-01"),
+        race("sep-30", "2026-09-30"),
+        race("oct-02", "2026-10-02"), // 10/2 트랜스제주 — 이게 남으면 10월이 "로드 완료"로 오인된다
+      ],
+      "2026-09",
+    );
+
+    expect(seeded.map((m) => m.monthKey)).toEqual(["2026-09"]);
+    expect(seeded[0].races.map((r) => r.id)).toEqual(["sep-01", "sep-30"]);
+  });
+
+  it("남은 월은 항상 하나 — oldest와 newest가 같아 커서가 온전한 월 경계에서 출발한다", () => {
+    const seeded = seedScheduleMonths(
+      [race("oct-31", "2026-10-31"), race("nov-01", "2026-11-01")],
+      "2026-10",
+    );
+
+    expect(seeded).toHaveLength(1);
+    expect(seeded[0].monthKey).toBe("2026-10");
+    expect(seeded[0].races.map((r) => r.id)).toEqual(["oct-31"]);
+  });
+
+  it("날짜 오름차순으로 정렬한다", () => {
+    const seeded = seedScheduleMonths(
+      [race("c", "2026-09-20"), race("a", "2026-09-03"), race("b", "2026-09-11")],
+      "2026-09",
+    );
+
+    expect(seeded[0].races.map((r) => r.id)).toEqual(["a", "b", "c"]);
+  });
+
+  it("이번 달에 일정이 하나도 없으면 빈 달 하나를 세운다 — 월 헤더가 사라지지 않게", () => {
+    const seeded = seedScheduleMonths([race("oct-02", "2026-10-02")], "2026-09");
+
+    expect(seeded).toEqual([{ monthKey: "2026-09", races: [] }]);
+  });
+
+  it("시드가 통째로 비어도 이번 달 하나를 세운다", () => {
+    expect(seedScheduleMonths([], "2026-09")).toEqual([{ monthKey: "2026-09", races: [] }]);
+  });
+});

--- a/lib/schedule-list.ts
+++ b/lib/schedule-list.ts
@@ -1,0 +1,36 @@
+import type { CalendarRace } from "@/components/home/mini-calendar";
+
+export type ScheduleMonth = {
+  /** "YYYY-MM" */
+  monthKey: string;
+  races: CalendarRace[];
+};
+
+/**
+ * 리스트뷰의 첫 화면(시드)을 만든다 — **온전한 한 달만** 남긴다.
+ *
+ * 시드로 넘어오는 건 캘린더가 들고 있던 **그리드 범위** 데이터다: 이번 달 앞으로 최대
+ * 13일(그리드 시작 + `fetchStart` 1주), 뒤로 며칠이 딸려 온다(`gridDateRange`). 이걸
+ * 그대로 월별로 버킷팅하면 양 끝의 **부분 월이 "다 불러온 달"로 등록**되고, 무한스크롤
+ * 커서는 월 경계에서 출발하므로(`get_schedule_paged`는 커서 **다음 달**부터 준다) 그 달의
+ * 나머지 날짜가 영영 조회되지 않는다.
+ *
+ * 실제로 그랬다 — 9월 달력에서 리스트로 바꾸면 시드 범위가 08-23~10-03이라 10월 버킷에
+ * 10/2 한 건만 담겼고, 그 뒤로는 11월부터 불러와 **10/4~10/31 대회 8건이 통째로 사라졌다**
+ * (10월 달력에서 바꾸면 멀쩡히 나온다). 위쪽도 같아서 8/1~8/22가 실종됐다.
+ * 주 시작 요일(일/월)에 따라 경계가 하루씩 밀려 재현 조건이 더 헷갈렸다.
+ *
+ * 버린 부분 월은 손실이 아니다 — 마운트 직후 상·하단 sentinel이 걸려 앞뒤 달을 RPC로
+ * **온전하게** 다시 받는다. 화면에 남는 건 같고, 달마다 빠지는 날이 없어진다.
+ */
+export function seedScheduleMonths(
+  races: CalendarRace[],
+  monthKey: string,
+): ScheduleMonth[] {
+  const own = races
+    .filter((race) => race.start_date.slice(0, 7) === monthKey)
+    .sort((a, b) => a.start_date.localeCompare(b.start_date));
+
+  // 이번 달이 비어도 달 하나는 세운다 — 월 헤더가 사라지면 "어디를 보고 있는지"가 없어진다.
+  return [{ monthKey, races: own }];
+}


### PR DESCRIPTION
## 관련 이슈

- 관련 이슈 없음

## 요약

일정탭에서 **달력 → 리스트로 전환할 때, 어느 달을 보고 있었느냐에 따라 특정 대회·모임이 목록에서 통째로 사라지는** 버그를 고칩니다.

리스트뷰가 달력의 **그리드 범위** 데이터를 시드로 받는데, 그 범위에 섞인 앞뒤 달의 부분 데이터가 "다 불러온 달"로 오인되면서 무한스크롤이 그 달의 나머지 날짜를 영영 건너뛰고 있었습니다.

## AS-IS (변경 전)

리스트뷰는 달력이 들고 있던 데이터를 그대로 시드로 받습니다.

```tsx
initialRaces={[...myRaces, ...schPosts, ...gigangRaces, ...gatherings]}
```

그런데 이 데이터는 한 달치가 아니라 **`gridDateRange`의 그리드 범위**입니다 — 이번 달 앞으로 최대 13일(그리드 시작 + `fetchStart` 1주), 뒤로 며칠이 딸려 옵니다. `racesToMonths()`가 이걸 `start_date`의 월로 버킷팅하면서 **양 끝의 "부분 월"이 온전히 로드된 달로 등록**됩니다.

무한스크롤 커서는 `oldestMonth` / `newestMonth`의 **월 경계**에서 출발하고, `get_schedule_paged`는 커서 *다음 달*부터 반환하므로 → **부분만 담긴 그 달의 나머지 날짜는 다시 조회되지 않습니다.**

**prd 실측 (주 시작 = 일요일):**

| 달력 월 | 시드 범위 | 10월 버킷에 담기는 것 | 결과 |
|---|---|---|---|
| **9월** | 08-23 ~ **10-03** | 10/2 트랜스제주 **1건뿐** | `newestMonth="2026-10"` → 다음 로드가 11월부터 |
| **10월** | 09-20 ~ 10-31 | 10월 전체 | 정상 |

9월에서 리스트로 바꾸면 이 8건이 사라졌습니다:
`10/04 서울 10K` · `10/04 구례 아이언맨` · `10/05 강남국제평화` · `10/11 서울레이스` · `10/17 경주국제` · `10/24 무주 트레일` · `10/25 춘천마라톤` · `10/30 UNTP`

위쪽도 같습니다 — 9월 시드의 가장 오래된 버킷은 `2026-08`인데 8/23~8/31만 들어있고 `loadPrev` 커서는 08-01이라 7월·6월을 가져옵니다 → **8/1~8/22 실종.**

재현 조건이 안 잡혔던 이유가 둘입니다:
1. 그 달 1~3일에 일정이 하나라도 있어야 부분 버킷이 생깁니다 (없으면 우연히 정상 동작)
2. **주 시작 요일**(일/월) 설정에 따라 경계가 하루씩 밀려 결과가 또 달라집니다

## TO-BE (변경 후)

시드에서 **온전한 이번 달만** 남기고 앞뒤 부분 월은 버립니다 (`seedScheduleMonths()`).

- `oldestMonth` / `newestMonth`가 항상 **온전한 월**이라 커서가 건너뛰는 날짜가 없습니다
- 버린 앞뒤 달은 **손실이 아닙니다** — 마운트 직후 상·하단 sentinel이 걸려 RPC로 **통째로** 다시 받아옵니다. 화면에 남는 내용은 같고, 달마다 빠지는 날만 없어집니다
- 이번 달에 일정이 하나도 없으면 빈 달 하나를 세웁니다 (월 헤더가 사라지지 않게)

**dev 실측 검증:** 9월 → 리스트 전환 시 10월 목록

| | 10월 항목 |
|---|---|
| 개발계 (수정 전) | 2건 (10/2, 10/4) ❌ |
| 로컬 (수정 후) | **4건** (10/2, 10/4, 10/26, 10/30) ✅ |

## 변경 흐름 (Mermaid)

```mermaid
flowchart TD
    A["달력 → 리스트 전환<br/>시드 = 그리드 범위 데이터"] --> B{"racesToMonths()<br/>start_date 월로 버킷팅"}

    B --> C["AS-IS: 부분 월까지 그대로 등록<br/>8월(23~31) · 9월(전체) · 10월(1~3)"]
    C --> D["newestMonth = 2026-10<br/>(사실은 3일치뿐)"]
    D --> E["loadNext 커서 = 10-31<br/>→ 11월부터 로드"]
    E --> F["10/4~10/31 영영 누락"]

    B --> G["TO-BE: seedScheduleMonths()<br/>온전한 이번 달만 남김"]
    G --> H["oldest = newest = 2026-09"]
    H --> I["sentinel → loadPrev/loadNext<br/>커서 = 09-01 / 09-30"]
    I --> J["8월·10월을 RPC로 통째로 로드<br/>빠지는 날 없음"]

    style F fill:#fee,stroke:#c00
    style J fill:#efe,stroke:#0a0
```

## 주요 변경 사항

| 파일 | 변경 |
|---|---|
| `lib/schedule-list.ts` (신규) | `seedScheduleMonths()` — 시드에서 온전한 이번 달만 남기는 순수 함수. **왜 부분 월을 버려야 하는지**(+실제로 뭐가 사라졌는지)를 주석으로 남겼습니다 |
| `components/home/schedule-list-view.tsx` | `months` state 초기화를 `seedScheduleMonths()`로 교체. `racesToMonths()`는 페이징 경로에서 계속 사용 |
| `lib/__tests__/schedule-list.test.ts` (신규) | 회귀 테스트 5케이스 — 9월 그리드 시드에 섞인 10/2가 버려지는지, 남는 월이 항상 하나인지(커서가 온전한 경계에서 출발), 날짜 정렬, 빈 달 폴백 |

## 검증

- `pnpm exec tsc --noEmit` — 통과
- `pnpm test` — **51 파일 / 628 테스트 전부 통과** (신규 5건 포함)
- `pnpm lint` — 30 problems (8 errors)로 **변경 전 dev와 동일**. 전부 기존 `react-hooks/set-state-in-effect` 에러이고 이번 변경과 무관합니다 (stash 대조 확인)
- 브라우저 — dev 환경 대비 확인 완료 (위 표)

🤖 Generated with [Claude Code](https://claude.com/claude-code)