### PR TITLE
chore(title): 신규 칭호 적용 시작일을 배포일(8/19)로 맞춤

### DIFF
--- a/supabase/migrations/20260814180000_seed_gathering_titles.sql
+++ b/supabase/migrations/20260814180000_seed_gathering_titles.sql
@@ -7,7 +7,7 @@
 --    고인물이 한 번에 대여섯 개를 받고 푸시가 그만큼 나간다.
 --      · 월 단위 조건 4종 → 2026-08-01 (달 경계에 맞춰야 "반쪽짜리 달"이 안 생긴다.
 --        8/14에 열면 프로참석러는 남은 모임 하나만 나가도 70%가 된다.)
---      · 나머지 9종      → 2026-08-14 (오늘부터 새로 쌓는다)
+--      · 나머지 9종      → 2026-08-19 (배포일. 이 날부터 새로 쌓는다)
 --
 -- ⚠️ **시드 후 sweep을 돌리지 않는다.** eff_stt_dt가 과거를 끊으므로 소급 부여가 없고,
 --    그래서 "대표 승격 트리거를 끄고 sweep" 절차도 필요 없다 — 애초에 무더기로 붙을 일이 없다.
@@ -38,23 +38,23 @@ FROM (VALUES
 
   -- 나머지 — 오늘부터
   ('다음엔꼭',   '모임 당일에 참석을 취소하기를 3번 한 멤버',
-   '{"type":"gthr_cancel_count","count":3,"same_day":true}', 'others', 3, 310, '2026-08-14'),
+   '{"type":"gthr_cancel_count","count":3,"same_day":true}', 'others', 3, 310, '2026-08-19'),
   ('회전문',     '한 모임에서 신청과 취소를 오간 멤버',
-   '{"type":"gthr_cancel_count","count":2,"same_gathering":true}', 'others', 5, 311, '2026-08-14'),
+   '{"type":"gthr_cancel_count","count":2,"same_gathering":true}', 'others', 5, 311, '2026-08-19'),
   ('월요병',     '월요일 모임만 골라 3번 취소한 멤버',
-   '{"type":"gthr_cancel_count","count":3,"weekday":1}', 'others', 5, 312, '2026-08-14'),
+   '{"type":"gthr_cancel_count","count":3,"weekday":1}', 'others', 5, 312, '2026-08-19'),
   ('3연벙',      '사흘 연속으로 모임에 나온 멤버',
-   '{"type":"gthr_attend_streak","days":3}', 'held', 4, 313, '2026-08-14'),
+   '{"type":"gthr_attend_streak","days":3}', 'held', 4, 313, '2026-08-19'),
   ('하루에두번', '하루에 서로 다른 모임 2개를 모두 참석한 멤버',
-   '{"type":"gthr_same_day_count","per_day":2,"count":1}', 'always', 5, 314, '2026-08-14'),
+   '{"type":"gthr_same_day_count","per_day":2,"count":1}', 'always', 5, 314, '2026-08-19'),
   ('막차',       '정원의 마지막 자리를 채워 모임을 마감시킨 멤버',
-   '{"type":"gthr_last_slot","count":2}', 'others', 6, 315, '2026-08-14'),
+   '{"type":"gthr_last_slot","count":2}', 'others', 6, 315, '2026-08-19'),
   ('칼퇴실패',   '야근 때문에 모임을 3번 취소한 멤버',
-   '{"type":"gthr_cancel_reason","count":3,"keyword":"야근"}', 'others', 6, 316, '2026-08-14'),
+   '{"type":"gthr_cancel_reason","count":3,"keyword":"야근"}', 'others', 6, 316, '2026-08-19'),
   ('구구절절',   '취소 사유를 40자 넘게 적은 멤버',
-   '{"type":"gthr_cancel_reason","count":1,"min_length":40}', 'held', 4, 317, '2026-08-14'),
+   '{"type":"gthr_cancel_reason","count":1,"min_length":40}', 'held', 4, 317, '2026-08-19'),
   ('생일축하해', '생일에 크루와 함께 뛴 멤버',
-   '{"type":"attend_on_birthday","count":1}', 'others', 6, 318, '2026-08-14')
+   '{"type":"attend_on_birthday","count":1}', 'others', 6, 318, '2026-08-19')
 ) AS v(ttl_nm, ttl_desc, cond_rule_json, desc_visibility, rarity_level, sort_ord, eff_stt_dt)
 CROSS JOIN (SELECT team_id FROM team_mst WHERE team_cd = 'gigang' AND del_yn = false LIMIT 1) t
 -- 재실행 안전: 같은 이름이 이미 있으면 넣지 않는다.

--- a/supabase/migrations/20260814190000_seed_social_titles.sql
+++ b/supabase/migrations/20260814190000_seed_social_titles.sql
@@ -5,7 +5,7 @@
 --
 -- eff_stt_dt(§7.5):
 --   · 월 단위 조건 2종(연재작가·투머치토커) → 2026-08-01 (달 경계에 맞춰야 반쪽짜리 달이 안 생긴다)
---   · 나머지 9종                            → 2026-08-14 (오늘부터)
+--   · 나머지 9종                            → 2026-08-19 (배포일)
 --   · **인간화로만 null(소급 허용)** — `rctn_mst`가 (팀 × 항목 × 누른사람) 1행에 rctn_cnt를
 --     누적하는 구조라 개별 탭의 시각이 없어 **기간 필터가 구조적으로 불가능**하다.
 --     문턱이 1,000이라 소급해도 받을 사람이 극소수다(실측 최대 85).
@@ -25,21 +25,21 @@ SELECT
 FROM (VALUES
   -- 깅스타그램
   ('오운완',      '깅스타그램에 사진을 3장 올린 멤버',
-   '{"type":"post_count","count":3}', 'always', 2, 320, '2026-08-14'),
+   '{"type":"post_count","count":3}', 'always', 2, 320, '2026-08-19'),
   ('깅플루언서',  '깅스타그램에 사진을 10장 올린 크루 인플루언서',
-   '{"type":"post_count","count":10}', 'always', 6, 321, '2026-08-14'),
+   '{"type":"post_count","count":10}', 'always', 6, 321, '2026-08-19'),
   ('연재작가',    '한 달에 5일 이상 사진을 올린 연재형 멤버',
    '{"type":"post_days_in_month","days":5}', 'others', 5, 322, '2026-08-01'),
   ('유물발굴',    '14일 넘게 지난 활동 사진을 뒤늦게 올린 멤버',
-   '{"type":"post_backfill_days","days":14,"count":1}', 'never', 5, 323, '2026-08-14'),
+   '{"type":"post_backfill_days","days":14,"count":1}', 'never', 5, 323, '2026-08-19'),
 
   -- 댓글
   ('자문자답',    '자기 게시물의 첫 댓글을 3번 직접 단 멤버',
-   '{"type":"post_self_first_comment","count":3}', 'others', 6, 330, '2026-08-14'),
+   '{"type":"post_self_first_comment","count":3}', 'others', 6, 330, '2026-08-19'),
   ('말대꾸',      '대댓글을 15개 이상 단 멤버',
-   '{"type":"cmnt_reply_count","count":15}', 'others', 4, 331, '2026-08-14'),
+   '{"type":"cmnt_reply_count","count":15}', 'others', 4, 331, '2026-08-19'),
   ('소환술사',    '댓글에서 @멘션으로 10번 사람을 부른 멤버',
-   '{"type":"cmnt_mention_count","count":10}', 'others', 5, 332, '2026-08-14'),
+   '{"type":"cmnt_mention_count","count":10}', 'others', 5, 332, '2026-08-19'),
   ('투머치토커',  '한 달 댓글 수 1위',
    '{"type":"cmnt_monthly_top","min_count":10}', 'never', 5, 333, '2026-08-01'),
 
@@ -49,11 +49,11 @@ FROM (VALUES
 
   -- 대회
   ('완벽한기록',  '완주 기록이 정확히 시간 단위로 떨어진 멤버',
-   '{"type":"race_time_exact_hour","count":1}', 'never', 10, 350, '2026-08-14'),
+   '{"type":"race_time_exact_hour","count":1}', 'never', 10, 350, '2026-08-19'),
   ('하수야~',     '같은 종목 맞대결에서 상대를 역전한 멤버',
-   '{"type":"race_pair_reversal","direction":"winner"}', 'others', 8, 351, '2026-08-14'),
+   '{"type":"race_pair_reversal","direction":"winner"}', 'others', 8, 351, '2026-08-19'),
   ('고수님..',    '같은 종목 맞대결에서 역전당한 멤버',
-   '{"type":"race_pair_reversal","direction":"loser"}', 'others', 8, 352, '2026-08-14')
+   '{"type":"race_pair_reversal","direction":"loser"}', 'others', 8, 352, '2026-08-19')
 ) AS v(ttl_nm, ttl_desc, cond_rule_json, desc_visibility, rarity_level, sort_ord, eff_stt_dt)
 CROSS JOIN (SELECT team_id FROM team_mst WHERE team_cd = 'gigang' AND del_yn = false LIMIT 1) t
 -- 재실행 안전: 같은 이름이 이미 있으면 넣지 않는다.


### PR DESCRIPTION
## 관련 이슈

관련 이슈 없음

## 요약

신규 칭호 25종을 **8/14에 배포하려고** `ttl_mst.eff_stt_dt`를 그 날짜로 시드해 뒀는데, 실제 배포가 **8/19**이 됐습니다. 그대로 두면 배포 전 5일치 활동이 소급 판정됩니다.

**prd에는 이미 8/19로 적용했습니다**(마이그레이션 15건 일괄 적용, `20260819064811`~`20260819065414`). 이 PR은 저장소 기록을 그 값에 맞추는 것입니다.

## AS-IS (변경 전)

| eff_stt_dt | 종수 | 성격 |
|---|---|---|
| `2026-08-14` | 18 | 일 단위 조건 |
| `2026-08-01` | 6 | 월 단위 조건 |
| `null` | 1 | `인간화로` (소급 허용) |

`eff_stt_dt`는 "이 날짜부터 발생한 활동만 센다"는 하한입니다. 8/14로 두고 8/19에 열면 **배포 전 5일이 통째로 소급**되어, "만든 뒤에 생긴 일만 센다"는 이 컬럼의 존재 이유(설계 §7.5)가 그만큼 샙니다.

## TO-BE (변경 후)

| eff_stt_dt | 종수 | 변경 |
|---|---|---|
| `2026-08-19` | 18 | **8/14에서 이동** |
| `2026-08-01` | 6 | 그대로 |
| `null` | 1 | 그대로 |

### 월 단위 6종을 8/01에 그대로 두는 이유

미라클·오픈런·올빼미·프로참석러·연재작가·투머치토커는 **그 달 전체가 모집단**인 조건입니다.

- **"달 경계에 맞춰야 반쪽짜리 달이 안 생긴다"**는 원래 근거가 배포일이 밀려도 그대로 성립합니다.
- 9/01로 미루면 이 6종은 **10/1 월배치까지 6주간 아무도 못 받는 죽은 칭호**가 됩니다.
- 소급 폭이 19일뿐이라 `eff_stt_dt`가 막으려던 것(몇 년치 소급 폭탄)과는 규모가 다릅니다.

### `인간화로`만 계속 `null`

`rctn_mst`가 (팀 × 항목 × 누른사람) 1행에 카운트를 누적하는 구조라 **개별 탭의 시각이 없어** 기간 필터가 구조적으로 불가능합니다. 문턱이 1,000이라 소급해도 받을 사람이 극소수입니다.

## dev DB는 8/14로 남습니다

시드 마이그레이션이 `WHERE NOT EXISTS (ttl_nm)`이라 **재실행해도 값이 안 바뀝니다.** dev는 8/14에 이미 들어갔으니 그대로 두고, 두 환경의 적용일이 갈리는 게 실제 이력입니다. 되돌릴 이유가 생기면 dev에서 `UPDATE` 한 번이면 됩니다.

## 검증

- prd 실측: `2026-08-19` 18종 / `2026-08-01` 6종 / `2026-08-14` **0종** / `인간화로` NULL
- 신규 칭호 수여 이력 **0건** — sweep을 안 돌렸으므로 소급 부여 없음
- `verify_title_batch_seeds` 어서션 통과 (배치 2건 + `eff_stt_dt` 있는 칭호 24종)
- pre-commit: 테스트 51파일 628건 통과

## 영향 범위

**런타임 영향 없음.** 이미 적용된 마이그레이션의 상수만 바꾼 것이고, `eff_stt_dt`는 앱이 DB에서 읽어 쓰므로 코드 변경이 없습니다. TS·테스트·문서 어디에도 이 날짜를 참조하는 곳이 없습니다.
