### PR TITLE
fix(mcp): 범위를 벗어난 일시가 조용히 다른 날로 저장되던 것 차단

### DIFF
--- a/app/api/mcp/__tests__/create-gathering.test.ts
+++ b/app/api/mcp/__tests__/create-gathering.test.ts
@@ -168,6 +168,44 @@ describe("create_gathering — 일시는 KST 벽시계만 받는다(9시간 밀�
     expect(calls.gthrInsert?.stt_at).toBe("2026-08-28T22:00:00.000Z");
   });
 
+  it("범위를 벗어난 날짜·시각을 거부한다 — dayjs 는 굴려서 딴 날로 만든다", async () => {
+    // E2E(2026-08-21)에서 실제로 통과했던 값들. `isValid()` 는 전부 true 라 못 잡는다.
+    //   2026-13-05 → 2027-01-05 · 2026-02-31 → 2026-03-03 · 25:99 → 다음 날 02:39
+    // 월을 잘못 적은 벙이 에러 없이 딴 달에 서는 것이라, 오프셋 표기를 막은 것과 같은 사고다.
+    for (const bad of [
+      "2026-13-05 07:00",
+      "2026-13-45 07:00",
+      "2026-02-31 07:00",
+      "2026-09-05 25:99",
+      "2026-00-10 07:00",
+    ]) {
+      const { client, touched } = makeForbiddenSupabase();
+      await expect(
+        createGatheringViaMcp(client, ctxOf(), validInput({ stt_at: bad })),
+      ).rejects.toBeInstanceOf(ToolInputError);
+      expect(touched).toEqual([]);
+    }
+  });
+
+  it("거부 메시지가 '무엇으로 해석됐는지'를 알려준다(오타를 눈으로 잡게)", async () => {
+    const { client } = makeForbiddenSupabase();
+    await expect(
+      createGatheringViaMcp(client, ctxOf(), validInput({ stt_at: "2026-13-05 07:00" })),
+    ).rejects.toThrow(/2027-01-05/);
+  });
+
+  it("경계값(윤년 2/29·23:59·12/31)은 통과한다 — 되찍기 대조가 정상값을 막지 않게", async () => {
+    for (const good of ["2028-02-29 07:00", "2026-12-31 23:59", "2026-09-05 00:00"]) {
+      const { client } = makeSupabase();
+      const r = await createGatheringViaMcp(
+        client,
+        ctxOf(),
+        validInput({ stt_at: good, dry_run: true }),
+      );
+      expect(r.stt_at_kst).toContain(good.slice(0, 10));
+    }
+  });
+
   it("시간대 표기(Z·+09:00)가 붙으면 거부한다 — 통과시키면 9시간이 조용히 밀린다", async () => {
     for (const bad of [
       "2026-08-29T07:00:00Z",

--- a/app/api/mcp/__tests__/mileage-tools.test.ts
+++ b/app/api/mcp/__tests__/mileage-tools.test.ts
@@ -392,10 +392,17 @@ describe("get_my_mileage / list_my_activities / list_mileage_multipliers", () =>
     expect(row).toMatchObject({ goal_mlg: 50, achv_mlg: 0, achv_yn: false, remaining_mlg: 50 });
   });
 
-  it("목표 행이 없는 달은 안내와 함께 거부한다", async () => {
+  it("목표 행이 없는 달은 **있는 달을 알려주며** 거부한다", async () => {
+    // "참가 시작월 이후를 확인하라"는 안내는 도움이 안 됐다 — 시작월 뒤인데도 행이 없는
+    // 경우가 실제로 있어(dev 실측), 사용자가 이미 맞는 달을 넣고도 같은 말을 듣는다.
     await expect(getMyMileage(db.asClient(), ctxOf(), { month: "2019-01" })).rejects.toThrow(
-      /목표가 아직 없습니다/,
+      new RegExp(`목표가 있는 달: ${MONTH_START.slice(0, 7)}`),
     );
+  });
+
+  it("목표 행이 하나도 없으면 운영진 문의로 안내한다", async () => {
+    const d = seed({ evt_mlg_mth_snap: [] });
+    await expect(getMyMileage(d.asClient(), ctxOf())).rejects.toThrow(/운영진에게 문의/);
   });
 
   it("month 형식이 틀리면 무엇이 잘못됐는지 알려준다", async () => {

--- a/lib/mcp/create-gathering.ts
+++ b/lib/mcp/create-gathering.ts
@@ -76,18 +76,36 @@ export type CreateGatheringResult = {
   audit_id: string | null;
 };
 
-/** KST 벽시계 문자열 → UTC ISO. 형식 위반은 안전 에러로 되돌린다(9시간 밀림 방지). */
+/**
+ * KST 벽시계 문자열 → UTC ISO. 형식 위반은 안전 에러로 되돌린다(9시간 밀림 방지).
+ *
+ * **`isValid()` 로는 부족하다**(2026-08-21 E2E 에서 실제로 통과했다): dayjs 는 범위를 벗어난
+ * 값을 거부하지 않고 **굴린다**. `2026-13-05` → `2027-01-05`, `2026-02-31` → `2026-03-03`,
+ * `25:99` → 다음 날 `02:39`. 전부 `isValid() === true` 라, 월을 잘못 적은 벙이 **에러 하나
+ * 없이 딴 달에 선다** — 오프셋 표기를 막아 놓고 정작 같은 결과를 다른 문으로 들여보내는 꼴이다.
+ *
+ * 그래서 파싱 결과를 **되찍어 입력과 대조**한다. 굴러간 값은 원문과 달라지므로 여기서 걸린다.
+ */
 function toUtcIsoKst(label: string, localDt: string): string {
-  if (!KST_DATETIME_RE.test(localDt.trim())) {
+  const raw = localDt.trim();
+  if (!KST_DATETIME_RE.test(raw)) {
     throw new ToolInputError(
       `${label} 은 KST 기준 'YYYY-MM-DD HH:mm' 형식이어야 합니다(시간대 표기 없이). 받은 값: ${localDt}`,
     );
   }
-  const iso = dayjs.tz(localDt.trim().replace(" ", "T"), "Asia/Seoul");
-  if (!iso.isValid()) {
+  const normalized = raw.replace(" ", "T");
+  const parsed = dayjs.tz(normalized, "Asia/Seoul");
+  if (!parsed.isValid()) {
     throw new ToolInputError(`${label} 이 실제 존재하는 일시가 아닙니다. 받은 값: ${localDt}`);
   }
-  return iso.toISOString();
+  // 초 표기가 있으면 초까지, 없으면 분까지 되찍어 원문과 맞대본다.
+  const fmt = normalized.length > 16 ? "YYYY-MM-DDTHH:mm:ss" : "YYYY-MM-DDTHH:mm";
+  if (parsed.format(fmt) !== normalized) {
+    throw new ToolInputError(
+      `${label} 이 실제 존재하는 일시가 아닙니다(${parsed.format("YYYY-MM-DD HH:mm")} 으로 해석됨). 받은 값: ${localDt}`,
+    );
+  }
+  return parsed.toISOString();
 }
 
 /** UTC ISO → 사람이 확인하기 좋은 KST 표기. */

--- a/lib/mcp/mileage.ts
+++ b/lib/mcp/mileage.ts
@@ -304,8 +304,18 @@ export async function getMyMileage(
   if (error) throw error;
 
   if (!data) {
+    // "참가 시작월 이후를 확인하라"고만 하면 도움이 안 된다 — 시작월 뒤인데도 행이 없는 경우가
+    // 실제로 있다(참가 도중 합류·데이터 보정 등). **있는 달을 그대로 알려준다.**
+    const { data: months } = await db
+      .from("evt_mlg_mth_snap")
+      .select("base_dt")
+      .eq("prt_id", prt.prt_id)
+      .order("base_dt", { ascending: true });
+    const have = (months ?? []).map((m) => (m.base_dt as string).slice(0, 7));
     throw new ToolInputError(
-      `${baseDt.slice(0, 7)} 의 목표가 아직 없습니다. 참가 시작월(${prt.stt_mth.slice(0, 7)}) 이후의 달을 확인해 주세요.`,
+      have.length
+        ? `${baseDt.slice(0, 7)} 의 목표가 없습니다. 목표가 있는 달: ${have.join(", ")}`
+        : `${prt.evt_nm} 에 아직 월별 목표가 만들어지지 않았습니다. 운영진에게 문의해 주세요.`,
     );
   }
   return toMileageRow(data, prt.evt_nm);


### PR DESCRIPTION
## 관련 이슈

관련 이슈 없음 — dev 환경 **E2E 테스트 중 발견**(#498~#501 머지 후 도구 16개를 하나씩 실행).

## 요약

`create_gathering`이 **월/일이 범위를 벗어난 일시를 조용히 다른 날로 바꿔 저장**하고 있었습니다. 오프셋 표기(`Z`·`+09:00`)를 막아 9시간 밀림은 차단해 뒀는데, 같은 사고가 다른 문으로 들어오고 있었습니다.

## AS-IS (변경 전)

dayjs는 범위를 벗어난 값을 **거부하지 않고 굴립니다**. dev 서버 실측:

| 입력 | 저장될 값 |
|---|---|
| `2026-13-05 07:00` | **2027-01-05** (월 오타 하나에 해가 넘어감) |
| `2026-13-45 07:00` | 2027-02-14 |
| `2026-02-31 07:00` | 2026-03-03 |
| `2026-09-05 25:99` | 2026-09-06 02:39 |

넷 다 `isValid() === true`라 기존 검사를 그대로 통과했습니다. **에러가 하나도 안 납니다** — `dry_run`으로 확인하지 않으면 벙이 딴 달에 선 걸 알아챌 방법이 없습니다. AI가 자연어에서 날짜를 뽑을 때 정확히 나기 쉬운 오타입니다.

## TO-BE (변경 후)

- 파싱 결과를 **되찍어 원문과 대조**합니다. 굴러간 값은 원문과 달라지므로 걸립니다.
- 거부 메시지에 **무엇으로 해석됐는지**를 적습니다 — `"...실제 존재하는 일시가 아닙니다(2027-01-05 07:00 으로 해석됨)"`. 오타를 눈으로 잡는 게 목적이라 해석 결과가 있어야 합니다.
- 경계값(윤년 `2028-02-29` · `23:59` · `12/31`)이 막히지 않는지 테스트로 못박았습니다.

### 같이 고친 것 — `get_my_mileage` 안내문

`"참가 시작월(2026-04) 이후의 달을 확인해 주세요"`가 **시작월 뒤인 달을 물었는데도** 나왔습니다(dev 실측: 참가자에게 4월 목표 행만 있고 7·8월이 없음). 사용자는 이미 맞는 달을 넣고도 같은 말을 듣습니다.

→ 있는 달을 그대로 알려줍니다: `"2026-08 의 목표가 없습니다. 목표가 있는 달: 2026-04"`. 목표 행이 아예 없으면 운영진 문의로 안내합니다.

## 변경 흐름 (Mermaid)

```mermaid
flowchart TD
    A["stt_at 입력"] --> B{"KST 벽시계 형식?"}
    B -->|"Z·오프셋·자연어"| Z1["거부 (기존)"]
    B -->|OK| C["dayjs.tz 파싱"]
    C --> D{"isValid()?"}
    D -->|false| Z2["거부 (기존)"]
    D -->|true| E{"되찍어 원문과 같은가?<br/>(추가)"}
    E -->|"다름 = 굴러갔다"| Z3["거부 + 해석된 값 안내<br/>2026-13-05 → 2027-01-05"]
    E -->|같음| F["UTC 저장"]
```

## 검증

E2E로 실제 서버에 재확인:

```
"2026-13-45 07:00"  → 거부 (2027-02-14 으로 해석됨)
"2026-13-05 07:00"  → 거부 (2027-01-05 으로 해석됨)
"2026-02-31 07:00"  → 거부 (2026-03-03 으로 해석됨)
"2026-09-05 25:99"  → 거부 (2026-09-06 02:39 으로 해석됨)
"2028-02-29 07:00"  → 통과 ✓   "2026-12-31 23:59" → 통과 ✓
```

`pnpm test` 682 passed (신규 4) · `tsc --noEmit` 0 · `eslint` 0