### PR TITLE
fix(mcp): 토큰 발급 화면이 로컬 dev 에서 500 으로 죽던 것

### DIFF
--- a/app/(info)/mcp-tokens/mcp-tokens-client.tsx
+++ b/app/(info)/mcp-tokens/mcp-tokens-client.tsx
@@ -6,7 +6,8 @@ import { useRouter } from "next/navigation";
 
 import { Check, Copy, KeyRound, Trash2 } from "lucide-react";
 
-import { createMcpToken, revokeMcpToken, type McpTokenSummary } from "@/app/actions/mcp-token";
+import { createMcpToken, revokeMcpToken } from "@/app/actions/mcp-token";
+import type { McpTokenSummary } from "@/lib/mcp/issue-token";
 import { formatKST } from "@/lib/dayjs";
 import { MCP_TOKEN_LABEL_MAX } from "@/lib/validations/mcp-token";
 

--- a/app/actions/mcp-token.ts
+++ b/app/actions/mcp-token.ts
@@ -20,7 +20,13 @@ import { createMcpTokenSchema } from "@/lib/validations/mcp-token";
  * `verifyAdmin`은 요구하지 않는다 — 본인 토큰 발급/관리는 팀 멤버(가입 완료) 전원 허용(스펙 §3.1).
  */
 
-export type { McpTokenSummary };
+// ⚠️ `export type { McpTokenSummary }` 를 여기 두지 않는다.
+// `"use server"` 파일의 **별칭 재export 형태**(`export type { X }`)는 Turbopack 의 서버 액션
+// 변환이 값 export 로 취급해, dev 에서 `/mcp-tokens` 가 통째로 500 으로 죽는다
+// ("Export McpTokenSummary doesn't exist in target module"). 프로덕션 빌드는 통과해서
+// 배포는 멀쩡한데 **로컬 개발만** 막히는, 찾기 고약한 형태였다.
+// 타입이 필요한 쪽은 정본(`@/lib/mcp/issue-token`)에서 직접 가져온다.
+// 같은 파일의 `export type Foo = …` 선언형은 정상적으로 지워지므로 문제되지 않는다.
 
 export type CreateMcpTokenResult =
   | {


### PR DESCRIPTION
## 관련 이슈

관련 이슈 없음 — MCP 사용 안내 문서용 스크린샷을 찍으려고 로컬에서 `/mcp-tokens`를 열다 발견.

## 요약

토큰 발급 화면이 **로컬 dev에서 통째로 500**이었습니다. 프로덕션 빌드는 통과해서 배포는 멀쩡한데 로컬 개발만 막히는 형태입니다.

## AS-IS (변경 전)

```
Export McpTokenSummary doesn't exist in target module
> 4 | export {McpTokenSummary as '7fc2d0add...'} from 'ACTIONS_MODULE0'
```

`app/actions/mcp-token.ts`(`"use server"`)의 **별칭 재export**를 Turbopack의 서버 액션 변환이 값 export로 취급합니다. 타입이라 런타임엔 존재하지 않으니 컴파일이 깨집니다.

```ts
export type { McpTokenSummary };   // ← 이 형태가 원인
```

- `pnpm build`(프로덕션)는 통과 → **배포 환경은 정상**, 로컬만 막힘
- `.next`를 지워도 재현 → stale 캐시로 오해하기 쉬움 (실제로 한 번 헛짚었습니다)
- #444부터 있던 문제이고, 이번 MCP 작업(#498~#502)이 만든 건 아닙니다

## TO-BE (변경 후)

- `"use server"` 파일에서 재export를 걷어냈습니다.
- 타입이 필요한 클라이언트는 **정본**(`lib/mcp/issue-token`)에서 직접 가져옵니다.
- 같은 파일의 `export type Foo = …` **선언형**은 정상적으로 지워지므로 그대로 둡니다 — 문제는 별칭 재export 형태뿐입니다.
- 다시 넣지 않도록 이유를 주석으로 남겼습니다.

## 검증

로컬 dev에서 `/mcp-tokens` 500 → 정상 렌더 확인. 토큰 발급·목록·폐기 UI를 실제로 조작해 동작 확인(스크린샷 촬영 완료).

`tsc --noEmit` 0 · `eslint` 0