### PR TITLE
fix(gathering): 종료가 시작보다 앞선 모임을 입력 시점에 막는다

### DIFF
--- a/app/(info)/gatherings/new/gathering-form.tsx
+++ b/app/(info)/gatherings/new/gathering-form.tsx
@@ -9,7 +9,7 @@ import { useForm, useWatch } from "react-hook-form";
 import { z } from "zod";
 
 import { dayjs } from "@/lib/dayjs";
-import { GTHR_TYPES, gthrTypeLabels, createGthrSchema, type CreateGthrInput } from "@/lib/validations/gathering";
+import { GTHR_TYPES, gthrTypeLabels, createGthrFormSchema, type CreateGthrInput } from "@/lib/validations/gathering";
 
 import { createGathering, updateGathering } from "@/app/actions/gathering/manage-gathering";
 
@@ -33,7 +33,7 @@ import {
 import { AutoGrowTextarea } from "@/components/common/auto-grow-textarea";
 import { GatheringScheduleHint } from "@/components/schedule/gathering-schedule-hint";
 
-const formSchema = createGthrSchema.omit({ team_id: true });
+const formSchema = createGthrFormSchema;
 type FormValues = z.infer<typeof formSchema>;
 
 type Props = {

--- a/app/actions/gathering/manage-gathering.ts
+++ b/app/actions/gathering/manage-gathering.ts
@@ -9,7 +9,11 @@ import { isPastLockedFor, PAST_EVENT_ERROR } from "@/lib/past-event";
 import { insertNotiMany } from "@/lib/notifications/insert-noti";
 import { getRequestTeamContext } from "@/lib/queries/request-team";
 import { createUntypedAdminClient } from "@/lib/supabase/admin";
-import { createGthrSchema, updateGthrSchema } from "@/lib/validations/gathering";
+import {
+  createGthrSchema,
+  updateGthrSchema,
+  END_BEFORE_START_ERROR,
+} from "@/lib/validations/gathering";
 
 function toUtcIso(localDt: string | null | undefined): string | null {
   if (!localDt) return null;
@@ -131,6 +135,15 @@ export async function updateGathering(input: {
     }
     if (isPastLockedFor(member.admin, existing.stt_at, existing.end_at)) {
       throw new Error(PAST_EVENT_ERROR);
+    }
+
+    // 한쪽만 바꾸는 수정은 스키마가 못 잡는다 — `updateGthrSchema`는 `.partial()`이라
+    // `end_at`만 올라오면 견줄 `stt_at`이 없다. 기존값과 합쳐 여기서 다시 본다(#495).
+    // 입력은 KST 로컬 문자열이고 기존값은 UTC라, 양쪽을 UTC 절대시각으로 맞춘 뒤 비교한다.
+    const nextSttAt = stt_at !== undefined ? toUtcIso(stt_at) : existing.stt_at;
+    const nextEndAt = end_at !== undefined ? toUtcIso(end_at) : existing.end_at;
+    if (nextSttAt && nextEndAt && dayjs(nextEndAt).isBefore(dayjs(nextSttAt))) {
+      throw new Error(END_BEFORE_START_ERROR);
     }
 
     const { error } = await supabase

--- a/components/schedule/gathering-form-dialog.tsx
+++ b/components/schedule/gathering-form-dialog.tsx
@@ -18,7 +18,7 @@ import {
   GTHR_SPRT_TYPES,
   gthrTypeLabels,
   gthrSprtLabels,
-  createGthrSchema,
+  createGthrFormSchema,
   type CreateGthrInput,
 } from "@/lib/validations/gathering";
 
@@ -52,7 +52,7 @@ import { Separator } from "@/components/ui/separator";
 import { AutoGrowTextarea } from "@/components/common/auto-grow-textarea";
 import { GatheringScheduleHint } from "@/components/schedule/gathering-schedule-hint";
 
-const formSchema = createGthrSchema.omit({ team_id: true });
+const formSchema = createGthrFormSchema;
 type FormValues = z.infer<typeof formSchema>;
 
 /** 등록 직후 상세를 조회 없이 즉시 열기 위한 모임 데이터(폼 입력값 + 반환 id 기반). CalendarRace 호환. */

--- a/lib/__tests__/gathering-end-before-start.test.ts
+++ b/lib/__tests__/gathering-end-before-start.test.ts
@@ -1,0 +1,69 @@
+import { describe, it, expect } from "vitest";
+import {
+  createGthrSchema,
+  createGthrFormSchema,
+  updateGthrSchema,
+  END_BEFORE_START_ERROR,
+} from "@/lib/validations/gathering";
+
+const TEAM = "c0ffee00-0000-4000-8000-000000000001";
+const GID = "4b29b8f6-4f17-4a5b-a6d8-6e533c0a9a2e";
+const base = {
+  team_id: TEAM,
+  gthr_nm: "테스트 모임",
+  gthr_type_enm: "event" as const,
+  sprt_cd: "trail_run" as const,
+};
+
+describe("모임 종료<시작 원천 차단 (#495)", () => {
+  it("생성: 실제 사고 값(11월 시작 / 10월 종료)을 막는다", () => {
+    const r = createGthrSchema.safeParse({
+      ...base, stt_at: "2026-11-28T09:00", end_at: "2026-10-28T11:00",
+    });
+    expect(r.success).toBe(false);
+    expect(r.error!.issues[0].message).toBe(END_BEFORE_START_ERROR);
+    expect(r.error!.issues[0].path).toEqual(["end_at"]);
+  });
+
+  it("생성: 정상 구간은 통과", () => {
+    expect(createGthrSchema.safeParse({
+      ...base, stt_at: "2026-11-28T09:00", end_at: "2026-11-28T11:00",
+    }).success).toBe(true);
+  });
+
+  it("생성: 시작==종료는 허용", () => {
+    expect(createGthrSchema.safeParse({
+      ...base, stt_at: "2026-11-28T09:00", end_at: "2026-11-28T09:00",
+    }).success).toBe(true);
+  });
+
+  it("생성: end_at 없음은 그대로 허용(선택값)", () => {
+    expect(createGthrSchema.safeParse({ ...base, stt_at: "2026-11-28T09:00" }).success).toBe(true);
+    expect(createGthrSchema.safeParse({ ...base, stt_at: "2026-11-28T09:00", end_at: null }).success).toBe(true);
+  });
+
+  it("폼 스키마도 같은 규칙 (team_id 없이)", () => {
+    const { team_id: _omit, ...noTeam } = base;
+    expect(createGthrFormSchema.safeParse({
+      ...noTeam, stt_at: "2026-11-28T09:00", end_at: "2026-10-28T11:00",
+    }).success).toBe(false);
+    expect(createGthrFormSchema.safeParse({
+      ...noTeam, stt_at: "2026-11-28T09:00", end_at: "2026-11-28T11:00",
+    }).success).toBe(true);
+  });
+
+  it("수정: 둘 다 보내면 막는다", () => {
+    expect(updateGthrSchema.safeParse({
+      gthr_id: GID, stt_at: "2026-11-28T09:00", end_at: "2026-10-28T11:00",
+    }).success).toBe(false);
+  });
+
+  it("수정: 한쪽만 보내면 스키마는 통과 — 서버 액션이 병합해서 잡는 몫", () => {
+    expect(updateGthrSchema.safeParse({ gthr_id: GID, end_at: "2026-10-28T11:00" }).success).toBe(true);
+  });
+
+  it("파생 스키마 생성이 런타임에 던지지 않는다 (zod v4 omit-on-refined)", () => {
+    expect(typeof updateGthrSchema.safeParse).toBe("function");
+    expect(typeof createGthrFormSchema.safeParse).toBe("function");
+  });
+});

--- a/lib/validations/gathering.ts
+++ b/lib/validations/gathering.ts
@@ -1,5 +1,7 @@
 import { z } from "zod";
 
+import { dayjs } from "@/lib/dayjs";
+
 export const GTHR_TYPES = ["general", "regular", "event"] as const;
 export type GthrType = (typeof GTHR_TYPES)[number];
 
@@ -20,7 +22,40 @@ export const gthrSprtLabels: Record<GthrSprtType, string> = {
   cycling: "자전거",
 };
 
-export const createGthrSchema = z.object({
+export const END_BEFORE_START_ERROR = "종료 일시는 시작 일시보다 빠를 수 없어요.";
+
+/**
+ * 종료가 시작보다 앞선 모임을 입력 시점에 막는다.
+ *
+ * 실제로 뚫린 적이 있다(#495): 종료월 오타(11월→10월)로 들어간 모임이 달력 뷰에서만
+ * 통째로 사라졌다. 리스트·상세·공유 링크에서는 멀쩡히 보이고 신청도 계속 받아서,
+ * 운영자는 존재를 모르는 채 참가자만 쌓였다.
+ *
+ * 둘 다 있을 때만 판정한다 — `end_at`은 선택값이고, 수정(`updateGthrSchema`)은
+ * `.partial()`이라 한쪽만 올 수 있다. 한쪽만 온 수정은 스키마가 못 잡으므로
+ * 서버 액션이 기존값과 합쳐 다시 본다(`updateGathering`).
+ */
+function endNotBeforeStart(v: { stt_at?: string | null; end_at?: string | null }) {
+  if (!v.stt_at || !v.end_at) return true;
+  const stt = dayjs.tz(v.stt_at, "Asia/Seoul");
+  const end = dayjs.tz(v.end_at, "Asia/Seoul");
+  // 파싱 불가는 여기서 판정하지 않는다 — 형식 오류는 각 필드가 낼 몫이다.
+  if (!stt.isValid() || !end.isValid()) return true;
+  return !end.isBefore(stt);
+}
+
+const END_AFTER_START_CHECK = {
+  message: END_BEFORE_START_ERROR,
+  path: ["end_at"],
+};
+
+/**
+ * 모임 필드 원본. refinement 없는 순수 객체로 남겨 둔다 —
+ * zod v4는 refinement가 붙은 object에 `.omit()`/`.partial()`을 부르면 던진다
+ * (".omit() cannot be used on object schemas containing refinements").
+ * 파생 스키마는 여기서 뽑고, 검사는 끝단마다 각자 붙인다.
+ */
+const gthrBaseSchema = z.object({
   team_id: z.string().uuid(),
   gthr_nm: z.string().min(1, "제목을 입력해 주세요.").max(100, "제목은 100자 이내로 입력해 주세요."),
   gthr_type_enm: z.enum(GTHR_TYPES, { message: "유형을 선택해 주세요." }),
@@ -32,9 +67,19 @@ export const createGthrSchema = z.object({
   max_prt_cnt: z.number().int().min(1, "최대 인원은 1명 이상이어야 합니다.").nullable().optional(),
 });
 
-export const updateGthrSchema = createGthrSchema.omit({ team_id: true }).partial().extend({
-  gthr_id: z.string().uuid(),
-});
+export const createGthrSchema = gthrBaseSchema.refine(endNotBeforeStart, END_AFTER_START_CHECK);
+
+/** 폼용 — team_id는 서버가 채운다. `createGthrSchema.omit()`은 위 이유로 못 쓴다. */
+export const createGthrFormSchema = gthrBaseSchema
+  .omit({ team_id: true })
+  .refine(endNotBeforeStart, END_AFTER_START_CHECK);
+
+export const updateGthrSchema = gthrBaseSchema
+  .omit({ team_id: true })
+  .partial()
+  .extend({ gthr_id: z.string().uuid() })
+  .refine(endNotBeforeStart, END_AFTER_START_CHECK);
 
 export type CreateGthrInput = z.infer<typeof createGthrSchema>;
+export type CreateGthrFormInput = z.infer<typeof createGthrFormSchema>;
 export type UpdateGthrInput = z.infer<typeof updateGthrSchema>;


### PR DESCRIPTION
## 무슨 문제였나

`end_at < stt_at`인 모임(등록 시 오타)이 **일정 탭 달력 뷰에서만 통째로 사라진다.**
문제는 "안 보인다"로 끝나지 않는다 — DB에 살아 있고, 리스트 뷰·관리자 목록·상세·공유
링크에서는 멀쩡히 보이고, **신청도 계속 받는다.** 운영자 눈에는 없는 모임에 참가자만 쌓인다.

prd에서 실제로 발생했다(#495). 같은 모임을 두 번 만들었고 먼저 만든 쪽이 종료월 오타
(시작 `2026-11-28 09:00` / 종료 `2026-10-28 11:00`)였는데, 정상 모임을 다시 만든 **뒤에도**
두 명이 잘못된 쪽에 신청했다.

> prd 데이터는 이 PR과 별개로 이미 정리했다 — 두 명을 정상 모임으로 옮기고 잘못된 모임을
> 삭제했으며, 포인트 원장도 회수/재적립으로 정확히 20점씩 한 번만 남게 맞췄다.
> 현재 `end_at < stt_at`인 행은 0건이다.

## 무엇을 고쳤나

입력 시점에 원천 차단한다. 쓰기 경로가 전부 `createGthrSchema` 하나를 공유하고 있어
스키마에서 막으면 폼·서버 액션·운영 MCP가 함께 걸린다.

### zod v4 제약 때문에 구조를 바꿔야 했다

`createGthrSchema`에 `.refine()`을 그냥 얹으면 **모듈 로드 시점에 터진다.**

```
Error: .omit() cannot be used on object schemas containing refinements
```

파생 스키마(`updateGthrSchema`)와 폼 두 곳이 `.omit({ team_id: true })`를 부르기 때문이다.
그래서 refinement 없는 `gthrBaseSchema`를 남기고 **파생 끝단마다** 검사를 붙였다.

| 스키마 | 용도 |
|---|---|
| `gthrBaseSchema` | 필드 원본 (refinement 없음, 파생 전용) |
| `createGthrSchema` | 서버 액션 · 운영 MCP |
| `createGthrFormSchema` | 폼 2곳 (`team_id` 없이) — 신규 |
| `updateGthrSchema` | 수정 (`.partial()`) |

### 수정 경로는 스키마만으로 부족하다

`updateGthrSchema`는 `.partial()`이라 `end_at`만 올라오면 견줄 `stt_at`이 없다.
이미 기존 행을 조회하는 자리가 있어서 거기서 병합해 다시 본다.

입력은 KST 로컬 문자열이고 기존값은 UTC라, **양쪽을 UTC 절대시각으로 맞춘 뒤** 비교한다.

## 범위 밖으로 남긴 것

이슈가 함께 제안한 **표시 쪽 보정은 넣지 않았다** — 달력 `eventsByDate`·`weekEventLanes`의
`endDay` 보정과 `formatTimeRange`의 뒤집힌 구간 처리. 입력을 막으면 새로 생기지 않는다는
판단이고, 이슈에 항목으로 남아 있다.

## 검증

| 항목 | 결과 |
|---|---|
| `npx tsc --noEmit` | 통과 |
| 신규 회귀 테스트 8건 | 통과 |
| 전체 테스트 54파일 696건 | 통과 |
| `pnpm run lint` | 신규 오류 없음 (기존 8건은 무관한 admin `setState in effect`) |

회귀 테스트(`lib/__tests__/gathering-end-before-start.test.ts`)는 **실제 사고 값**
(11/28 시작 · 10/28 종료)을 포함하고, 시작==종료 허용 · `end_at` 없음 허용 ·
파생 스키마가 런타임에 안 던지는 것까지 못박는다.

Refs #495 — 표시 쪽 보정이 남아 있어 이 PR로 닫지 않는다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

