### PR TITLE
fix(photo): 사진 입력 accept를 와일드카드로 바꿔 안드로이드 갤러리 노출

### DIFF
--- a/components/common/photo-picker.tsx
+++ b/components/common/photo-picker.tsx
@@ -169,7 +169,11 @@ export function PhotoPicker({
       <input
         ref={fileRef}
         type="file"
-        accept={POST_PHOTO_TYPES.join(",")}
+        // 안드로이드는 accept가 정확한 와일드카드일 때만 사진첩 그리드 피커를 띄우고,
+        // 구체적 MIME 나열(POST_PHOTO_TYPES.join(","))이면 카메라/파일뿐인 범용
+        // 초이서로 폴백한다. 실제 타입 검증은 handlePick의 POST_PHOTO_TYPES.includes가
+        // 하므로 여기선 UI 힌트로만 image/*를 쓴다.
+        accept="image/*"
         onChange={handlePick}
         className="hidden"
       />

--- a/components/profile/avatar-edit-dialog.tsx
+++ b/components/profile/avatar-edit-dialog.tsx
@@ -22,7 +22,10 @@ import { Button } from "@/components/ui/button";
 /** 클라이언트 선검증 — 서버(`validateAvatarFile`)와 같은 값. 넘치면 올리기 전에 잡는다 */
 const MAX_BYTES = 10 * 1024 * 1024;
 
-const ACCEPT = "image/jpeg,image/png,image/webp,image/heic,image/heif";
+// 안드로이드는 accept가 정확한 와일드카드일 때만 사진첩 그리드 피커를 띄우고,
+// 구체적 MIME 나열이면 카메라/파일뿐인 범용 초이서로 폴백한다. 실제 타입 검증은
+// validateAvatarFile이 하므로 여기선 UI 힌트로만 image/*를 쓴다.
+const ACCEPT = "image/*";
 
 type AvatarState =
   | { kind: "current" }

--- a/components/profile/profile-edit-form.tsx
+++ b/components/profile/profile-edit-form.tsx
@@ -276,7 +276,10 @@ export function ProfileEditForm({
         <input
           ref={fileInputRef}
           type="file"
-          accept="image/jpeg,image/png,image/webp,image/heic,image/heif"
+          // 안드로이드는 accept가 정확한 와일드카드일 때만 사진첩 그리드 피커를 띄우고,
+          // 구체적 MIME 나열이면 카메라/파일뿐인 범용 초이서로 폴백한다. 실제 타입
+          // 검증은 서버(validateAvatarFile)가 하므로 여기선 UI 힌트로만 image/*를 쓴다.
+          accept="image/*"
           onChange={handlePickFile}
           className="hidden"
         />


### PR DESCRIPTION
## Summary
- 안드로이드는 `<input type="file" accept="...">`가 정확한 와일드카드(`image/*`)일 때만 사진첩 그리드 피커를 띄우고, 구체적 MIME 나열이면 카메라/파일뿐인 범용 초이서로 폴백한다.
- 사진 입력 4곳(`photo-picker.tsx`, `avatar-edit-dialog.tsx`, `profile-edit-form.tsx`)의 `accept`를 `image/*`로 통일해 안드로이드에서도 갤러리가 뜨도록 함. (`race-record-dialog.tsx`는 이미 `image/*`라 변경 없음)
- `PhotoPicker`는 공용 컴포넌트라 이걸 쓰는 깅스타그램(기강이야기) 업로드, 마일리지런 단건/다건 기록 입력에도 함께 적용됨.
- 실제 파일 타입/용량 검증(JS `POST_PHOTO_TYPES.includes`, 서버 `validateAvatarFile`)은 그대로라 동작 변화 없음 — `accept`는 OS 피커 UI 힌트일 뿐.

## Test plan
- [x] `pnpm run lint` — 수정한 3개 파일 이상 없음 (다른 파일의 기존 warning/error는 무관)
- [x] `vitest run` (pre-commit hook) — 786 tests passed
- [ ] 안드로이드 실기기에서 깅스타그램/프로필사진/마일리지런 사진 입력 시 갤러리 피커가 뜨는지 확인
- [ ] 아이폰에서 기존과 동일하게 사진 보관함이 뜨는지 확인 (회귀 없는지)

🤖 Generated with [Claude Code](https://claude.com/claude-code)